### PR TITLE
Remove `metadata/index.json` file

### DIFF
--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   get-all-metadata:
-    name: "📋 Get list of all supported libraries"
+    name: "📋 Get a list of all supported libraries"
     runs-on: "ubuntu-20.04"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -26,7 +26,7 @@ jobs:
       - name: "🕸️ Populate matrix"
         id: set-matrix
         run: |
-          gradle generateMatrixMatchingCoordinates -Pcoordinates=all
+          ./gradlew generateMatrixMatchingCoordinates -Pcoordinates=all
 
   test-all-metadata:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.version }} ${{ matrix.java-version }} @ ${{ matrix.os }})"
@@ -49,4 +49,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🧪 Run '${{ matrix.coordinates }}' tests"
         run: |
-          gradle test -Pcoordinates=${{ matrix.coordinates }}
+          ./gradlew test -Pcoordinates=${{ matrix.coordinates }}

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   get-changed-metadata:
-    name: "📋 Get list of all changed libraries"
+    name: "📋 Get a list of all changed libraries"
     runs-on: "ubuntu-20.04"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -26,7 +26,7 @@ jobs:
       - name: "🕸️ Populate matrix"
         id: set-matrix
         run: |
-          gradle generateMatrixDiffCoordinates -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.sha }}
+          ./gradlew generateMatrixDiffCoordinates -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.sha }} --stacktrace
 
   test-changed-metadata:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.version }} ${{ matrix.java-version }} @ ${{ matrix.os }})"
@@ -49,4 +49,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🧪 Run '${{ matrix.coordinates }}' tests"
         run: |
-          gradle test -Pcoordinates=${{ matrix.coordinates }}
+          ./gradlew test -Pcoordinates=${{ matrix.coordinates }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,11 +116,11 @@ and its included [JUnit Platform support](https://graalvm.github.io/native-build
   **Optionally** test directory may contain `index.json` with content as follows:
   ```json
   {
-    "test-command": ["gradle", "clean", "nativeTest", "-Pmetadata.dir=<metadata_dir>", "-Plibrary.version=<version>"]
+    "test-command": ["gradle", "clean", "nativeTest", "-Pmetadata.dirs=<metadata_dir1>:<metadata_dir2>", "-Plibrary.version=<version>"]
   }
   ```
   Supported template parameters for `test-command` are:
-  * `<metadata_dir>` - absolute path to directory where metadata is stored
+  * `<metadata_dirs>` - absolute paths to directories where metadata is stored (colon separated)
   * `<group_id>` - Maven groupID of artifact that is being tested
   * `<artifact_id>`- Maven artifactID of artifact that is being tested
   * `<version>` - Version of artifact that is being tested

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     }
 }
 
+
+import org.graalvm.internal.tck.harness.MetadataLookupLogic
+
 import static org.graalvm.internal.tck.TestUtils.metadataRoot
 import static org.graalvm.internal.tck.TestUtils.repoRoot
 import static org.graalvm.internal.tck.TestUtils.testRoot

--- a/metadata/org.jline/jline-console/index.json
+++ b/metadata/org.jline/jline-console/index.json
@@ -1,0 +1,12 @@
+[
+  {
+    "latest": true,
+    "module": "org.jline:jline-console",
+    "requires-metadata": [
+      "org.jline:jline:3.21.0"
+    ],
+    "tested-versions": [
+      "3.21.0"
+    ]
+  }
+]

--- a/metadata/org.jline/jline-terminal/index.json
+++ b/metadata/org.jline/jline-terminal/index.json
@@ -1,0 +1,12 @@
+[
+  {
+    "latest": true,
+    "module": "org.jline:jline-terminal",
+    "requires-metadata": [
+      "org.jline:jline:3.21.0"
+    ],
+    "tested-versions": [
+      "3.21.0"
+    ]
+  }
+]

--- a/tests/src/ch.qos.logback/logback-classic/1.2.11/gradle.properties
+++ b/tests/src/ch.qos.logback/logback-classic/1.2.11/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 1.2.11
-metadata.dir = ch.qos.logback/logback-classic/1.2.11/
+metadata.dirs = ch.qos.logback/logback-classic/1.2.11/

--- a/tests/src/com.h2database/h2/2.1.210/gradle.properties
+++ b/tests/src/com.h2database/h2/2.1.210/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 2.1.210
-metadata.dir = com.h2database/h2/2.1.210/
+metadata.dirs = com.h2database/h2/2.1.210/

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -18,6 +18,18 @@
         "versions": [
           "3.21.0"
         ]
+      },
+      {
+        "name": "org.jline:jline-console",
+        "versions": [
+          "3.21.0"
+        ]
+      },
+      {
+        "name": "org.jline:jline-terminal",
+        "versions": [
+          "3.21.0"
+        ]
       }
     ]
   },

--- a/tests/src/io.netty/netty-transport/4.1.76.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport/4.1.76.Final/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 4.1.76.Final
-metadata.dir = io.netty/netty-transport/4.1.76.Final/
+metadata.dirs = io.netty/netty-transport/4.1.76.Final/

--- a/tests/src/mysql/mysql-connector-java/8.0.29/gradle.properties
+++ b/tests/src/mysql/mysql-connector-java/8.0.29/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 8.0.29
-metadata.dir = mysql/mysql-connector-java/8.0.29/
+metadata.dirs = mysql/mysql-connector-java/8.0.29/

--- a/tests/src/org.apache.commons/commons-pool2/2.11.1/gradle.properties
+++ b/tests/src/org.apache.commons/commons-pool2/2.11.1/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 2.11.1
-metadata.dir = org.apache.commons/commons-pool2/2.11.1/
+metadata.dirs = org.apache.commons/commons-pool2/2.11.1/

--- a/tests/src/org.example/library/0.0.1/gradle.properties
+++ b/tests/src/org.example/library/0.0.1/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 0.0.1
-metadata.dir = org.example/library/0.0.1/
+metadata.dirs = org.example/library/0.0.1/

--- a/tests/src/org.example/library/0.0.1/index.json
+++ b/tests/src/org.example/library/0.0.1/index.json
@@ -2,7 +2,7 @@
   "test-command": [
     "gradle",
     "nativeTest",
-    "-Pmetadata.dir=<metadata_dir>",
+    "-Pmetadata.dirs=<metadata_dirs>",
     "-Plibrary.version=<version>"
   ]
 }

--- a/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/gradle.properties
+++ b/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 2.1.12
-metadata.dir = org.hdrhistogram/HdrHistogram/2.1.12/
+metadata.dirs = org.hdrhistogram/HdrHistogram/2.1.12/

--- a/tests/src/org.jline/jline/3.21.0/gradle.properties
+++ b/tests/src/org.jline/jline/3.21.0/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 3.21.0
-metadata.dir = org.jline/jline/3.21.0/
+metadata.dirs = org.jline/jline/3.21.0/

--- a/tests/src/org.postgresql/postgresql/42.3.4/gradle.properties
+++ b/tests/src/org.postgresql/postgresql/42.3.4/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 42.3.4
-metadata.dir = org.postgresql/postgresql/42.3.4/
+metadata.dirs = org.postgresql/postgresql/42.3.4/

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -32,16 +32,18 @@ task checkstyle() {
     dependsOn tasks.withType(Checkstyle)
 }
 
-def metadataPath = Objects.requireNonNullElse(
-        System.getenv("GVM_TCK_MD"),
-        providers.gradleProperty('metadata.dir').get()
+def metadataPaths = Objects.requireNonNullElse(
+        System.getenv("GVM_TCK_MD").split(":"),
+        providers.gradleProperty('metadata.dirs').get().split(":")
 )
 
-File metadataFile
-if (!metadataPath.startsWith("/")) {
-    metadataFile = metadataRoot.resolve(metadataPath).toFile()
-} else {
-    metadataFile = file(metadataPath)
+List<File> metadataFiles = []
+for (def metadataPath : metadataPaths) {
+    if (!metadataPath.startsWith("/")) {
+        metadataFiles.add(metadataRoot.resolve(metadataPath).toFile())
+    } else {
+        metadataFiles.add(file(metadataPath))
+    }
 }
 
 String libraryVersion = Objects.requireNonNullElse(
@@ -65,7 +67,9 @@ tasks.named('test') {
 graalvmNative {
     binaries {
         test {
-            configurationFileDirectories.from(metadataFile)
+            metadataFiles.forEach(metadataFile -> {
+                configurationFileDirectories.from(metadataFile)
+            })
             buildArgs.add('-H:+StrictConfiguration') // Necessary in order to test metadata properly
             verbose = true
         }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.groovy
@@ -51,9 +51,11 @@ abstract class TestInvocationTask extends AbstractSubprojectTask {
                 return DEFAULT_ARGS
             }
 
-            Path metadataDir = MetadataLookupLogic.getMetadataDir(coordinates)
+            List<Path> metadataDirs = MetadataLookupLogic.getMetadataDirs(coordinates)
+            String metadataCp = String.join(":", metadataDirs.stream().map(m -> m.toAbsolutePath().toString()).toList())
+
             return testIndex.get("test-command").stream()
-                    .map(c -> processCommand(c, metadataDir, coordinates))
+                    .map(c -> processCommand(c, metadataCp, coordinates))
                     .collect(Collectors.toList())
         } catch (FileNotFoundException ignored) {
             return DEFAULT_ARGS
@@ -65,13 +67,13 @@ abstract class TestInvocationTask extends AbstractSubprojectTask {
      * Parameters are defined as <param_name> in cmd.
      *
      * @param cmd command line with parameters
-     * @param metadataDir metadata directory location
+     * @param metadataDirs metadata directory locations (colon separated)
      * @param coordinates
      * @return final command
      */
-    static String processCommand(String cmd, Path metadataDir, String coordinates) {
+    static String processCommand(String cmd, String metadataDirs, String coordinates) {
         def (String groupId, String artifactId, String version) = splitCoordinates(coordinates)
-        return cmd.replace("<metadata_dir>", metadataDir.toAbsolutePath().toString())
+        return cmd.replace("<metadata_dirs>", metadataDirs)
                 .replace("<group_id>", groupId)
                 .replace("<artifact_id>", artifactId)
                 .replace("<version>", version)


### PR DESCRIPTION
This commit removes `metadata/index.json` file and instead
fetches the metadata list by crawling `/metadata/<groupId>/<artifactId>`.

## What does this PR do?


## Checklist before merging
- [ ] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
