### PR TITLE
Fix default test metadata lookup paths

### DIFF
--- a/tests/src/ch.qos.logback/logback-classic/1.2.11/gradle.properties
+++ b/tests/src/ch.qos.logback/logback-classic/1.2.11/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 1.2.11
-metadata.dir = ch/qos/logback/logback-classic/1/
+metadata.dir = ch.qos.logback/logback-classic/1.2.11/

--- a/tests/src/com.h2database/h2/2.1.210/gradle.properties
+++ b/tests/src/com.h2database/h2/2.1.210/gradle.properties
@@ -1,2 +1,2 @@
-library.version=2.1.210
-metadata.dir=com/h2database/h2/1/
+library.version = 2.1.210
+metadata.dir = com.h2database/h2/2.1.210/

--- a/tests/src/io.netty/netty-transport/4.1.76.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport/4.1.76.Final/gradle.properties
@@ -1,2 +1,2 @@
-library.version=4.1.76.Final
-metadata.dir=io/netty/netty-transport/1/
+library.version = 4.1.76.Final
+metadata.dir = io.netty/netty-transport/4.1.76.Final/

--- a/tests/src/mysql/mysql-connector-java/8.0.29/gradle.properties
+++ b/tests/src/mysql/mysql-connector-java/8.0.29/gradle.properties
@@ -1,2 +1,2 @@
-library.version=8.0.29
-metadata.dir=mysql/mysql-connector-java/1/
+library.version = 8.0.29
+metadata.dir = mysql/mysql-connector-java/8.0.29/

--- a/tests/src/org.apache.commons/commons-pool2/2.11.1/gradle.properties
+++ b/tests/src/org.apache.commons/commons-pool2/2.11.1/gradle.properties
@@ -1,2 +1,2 @@
-library.version=2.11.1
-metadata.dir=org/apache/commons/commons-pool2/1/
+library.version = 2.11.1
+metadata.dir = org.apache.commons/commons-pool2/2.11.1/

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/gradle.properties
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/gradle.properties
@@ -1,2 +1,2 @@
 library.version=10.0.20
-metadata.dir=org/apache/tomcat/embed/tomcat-embed-core/1/
+metadata.dir=org.apache.tomcat.embed/tomcat-embed-core/10.0.20/

--- a/tests/src/org.example/library/0.0.1/gradle.properties
+++ b/tests/src/org.example/library/0.0.1/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 0.0.1
-metadata.dir = org/example/library/1/
+metadata.dir = org.example/library/0.0.1/

--- a/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/gradle.properties
+++ b/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/gradle.properties
@@ -1,2 +1,2 @@
-library.version=2.1.12
-metadata.dir=org/hdrhistogram/HdrHistogram/1/
+library.version = 2.1.12
+metadata.dir = org.hdrhistogram/HdrHistogram/2.1.12/

--- a/tests/src/org.jline/jline/3.21.0/gradle.properties
+++ b/tests/src/org.jline/jline/3.21.0/gradle.properties
@@ -1,2 +1,2 @@
 library.version = 3.21.0
-metadata.dir = org/jline/jline/1/
+metadata.dir = org.jline/jline/3.21.0/

--- a/tests/src/org.postgresql/postgresql/42.3.4/gradle.properties
+++ b/tests/src/org.postgresql/postgresql/42.3.4/gradle.properties
@@ -1,2 +1,2 @@
-library.version=42.3.4
-metadata.dir=org/postgresql/postgresql/1/
+library.version = 42.3.4
+metadata.dir = org.postgresql/postgresql/42.3.4/


### PR DESCRIPTION
## What does this PR do?
This PR fixes default tests metadata lookup paths

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
