### PR TITLE
Output versioned zip in `package` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ import static org.graalvm.internal.tck.TestUtils.metadataRoot
 import static org.graalvm.internal.tck.TestUtils.repoRoot
 import static org.graalvm.internal.tck.TestUtils.testRoot
 
+project.version("0.1.0")
+
 // gradle check
 spotless {
     json {
@@ -36,9 +38,10 @@ spotless {
 
 // gradle package
 tasks.register('package', Zip) { task ->
-    task.setDescription("Packages current repository to 'build/repository.zip'")
+    String outputFileName = "graalvm-reachability-metadata-${project.version}.zip"
+    task.setDescription("Packages current repository to 'build/${outputFileName}'")
     task.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP)
-    task.archiveFileName = "repository.zip"
+    task.archiveFileName = outputFileName
     task.destinationDirectory = layout.buildDirectory
     from(metadataRoot)
 }


### PR DESCRIPTION
## What does this PR do?
This PR makes sure that `gradle package` outputs versioned zip to the build directory.
Fixes #3

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
