### PR TITLE
Add config for hibernate-validator

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -28,6 +28,10 @@
     "module": "org.hdrhistogram:HdrHistogram"
   },
   {
+    "directory": "org.hibernate.validator/hibernate-validator",
+    "module": "org.hibernate.validator:hibernate-validator"
+  },
+  {
     "directory": "org.apache.tomcat.embed/tomcat-embed-core",
     "module": "org.apache.tomcat.embed:tomcat-embed-core"
   },

--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/index.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/index.json
@@ -1,0 +1,5 @@
+[
+  "proxy-config.json",
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/proxy-config.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/proxy-config.json
@@ -1,0 +1,50 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.Min"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedFieldStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.NotNull"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.NotNull"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedParameterStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.NotNull"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedFieldStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.Size"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "interfaces": [
+      "jakarta.validation.constraints.Size"
+    ]
+  }
+]

--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
@@ -1,0 +1,2150 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.descriptor.CrossParameterDescriptorImpl"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.CrossParameterStaxBuilder"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[Ljavax.management.openmbean.CompositeData;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "[[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.fasterxml.jackson.core.JsonParser"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.fasterxml.jackson.databind.JsonNode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.fasterxml.jackson.databind.ObjectMapper"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator"
+    },
+    "name": "com.sun.el.ExpressionFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.GarbageCollectorMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.GcInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.HotSpotDiagnosticMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.ThreadMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.UnixOperatingSystemMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.VMOption",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.internal.HotSpotDiagnostic",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.internal.HotSpotThreadImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "com.sun.management.internal.OperatingSystemImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.privilegedactions.NewSchema"
+    },
+    "name": "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.config.ValidationXmlParser"
+    },
+    "name": "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.MappingXmlParser"
+    },
+    "name": "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.XmlParserHelper"
+    },
+    "name": "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "groovy.grape.GrabAnnotationTransformation",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator"
+    },
+    "name": "groovy.lang.Script",
+    "queriedMethods": [
+      {
+        "name": "getProperty",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory"
+    },
+    "name": "groovy.lang.Script"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "groovyjarjarantlr.CommonToken"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "jakarta.el.CompositeELResolver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.resolver.TraversableResolvers"
+    },
+    "name": "jakarta.persistence.Persistence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPersistenceUtil",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "jakarta.validation.constraints.Email",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "jakarta.validation.constraints.Future",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.FieldConstraintMappingContextImpl"
+    },
+    "name": "jakarta.validation.constraints.Min"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "jakarta.validation.constraints.Min",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.Min",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "jakarta.validation.constraints.NotEmpty",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "jakarta.validation.constraints.NotEmpty",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping"
+    },
+    "name": "jakarta.validation.constraints.NotNull"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.GetterConstraintMappingContextImpl"
+    },
+    "name": "jakarta.validation.constraints.NotNull"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.ParameterConstraintMappingContextImpl"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.TypeConstraintMappingContextImpl"
+    },
+    "name": "jakarta.validation.constraints.NotNull"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor$Builder"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "groups",
+        "parameterTypes": []
+      },
+      {
+        "name": "message",
+        "parameterTypes": []
+      },
+      {
+        "name": "payload",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedFieldStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.NotNull",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedParameterStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.NotNull"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "jakarta.validation.constraints.Pattern",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedFieldStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.Pattern",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.cfg.context.ParameterConstraintMappingContextImpl"
+    },
+    "name": "jakarta.validation.constraints.Size",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "jakarta.validation.constraints.Size",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedFieldStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.Size",
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "max",
+        "parameterTypes": []
+      },
+      {
+        "name": "min",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedGetterStaxBuilder"
+    },
+    "name": "jakarta.validation.constraints.Size",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.io.ObjectInputStream",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.io.Serializable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.io.Serializable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Boolean",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Byte",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Character",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.resourceloading.PlatformResourceBundleLocator"
+    },
+    "name": "java.lang.Class",
+    "methods": [
+      {
+        "name": "getModule",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.Comparable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.lang.Comparable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Deprecated",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Double",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.Double",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.lang.Enum",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Float",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Integer",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.lang.Integer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Long",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.lang.Long"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.resourceloading.PlatformResourceBundleLocator"
+    },
+    "name": "java.lang.Module",
+    "methods": [
+      {
+        "name": "isNamed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.Number",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Object",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorFactoryImpl"
+    },
+    "name": "java.lang.Object"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl"
+    },
+    "name": "java.lang.Object"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.lang.Object",
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider"
+    },
+    "name": "java.lang.Object",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.annotation.AnnotationProxy"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "hashCode",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.Record",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Short",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.StackTraceElement",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.String"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.lang.String"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "java.lang.annotation.Annotation"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.constant.Constable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.lang.constant.Constable",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.constant.ConstantDesc",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.BufferPoolMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.ClassLoadingMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.CompilationMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.LockInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.ManagementPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.MemoryMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.MemoryManagerMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.MemoryPoolMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.MemoryUsage",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.MonitorInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.PlatformLoggingMXBean",
+    "queryAllPublicMethods": true,
+    "queriedMethods": [
+      {
+        "name": "getLoggerLevel",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getLoggerNames",
+        "parameterTypes": []
+      },
+      {
+        "name": "getParentLoggerName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setLoggerLevel",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.RuntimeMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.lang.management.ThreadInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "java.lang.reflect.Method"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "java.lang.reflect.Proxy",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.math.BigDecimal"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.math.BigInteger"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.time.LocalDate"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.util.Date"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.PredefinedScopeBeanMetaDataManager"
+    },
+    "name": "java.util.Iterator",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.util.List"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.util.Map"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.mapping.ConstrainedMethodStaxBuilder"
+    },
+    "name": "java.util.Optional"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.util.PropertyPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.util.logging.LogManager",
+    "methods": [
+      {
+        "name": "getLoggingMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "java.util.logging.LoggingMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager"
+    },
+    "name": "javafx.beans.value.ObservableValue"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.MBeanOperationInfo",
+    "queryAllPublicMethods": true,
+    "queriedMethods": [
+      {
+        "name": "getSignature",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.MBeanServerBuilder",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.ObjectName"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.openmbean.CompositeData"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "javax.management.openmbean.TabularData"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.core.ConstraintHelper"
+    },
+    "name": "javax.money.MonetaryAmount"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "jdk.internal.reflect.DelegatingMethodAccessorImpl"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "jdk.internal.reflect.NativeMethodAccessorImpl"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.ConfigurationInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.EventTypeInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.FlightRecorderMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.FlightRecorderMXBeanImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.RecordingInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "jdk.management.jfr.SettingDescriptorInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "org.codehaus.groovy.antlr.GroovySourceAST",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.spi.scripting.ScriptEngineScriptEvaluator"
+    },
+    "name": "org.codehaus.groovy.ast.builder.AstBuilderTransformation",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator"
+    },
+    "name": "org.codehaus.groovy.runtime.ScriptBytecodeAdapter"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "org.glassfish.expressly.ValueExpressionImpl"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "org.glassfish.expressly.parser.AstValue"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.xml.config.ValidationBootstrapParameters"
+    },
+    "name": "org.hibernate.validator.HibernateValidator"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethodHandle"
+    },
+    "name": "org.hibernate.validator.cfg.AnnotationDef",
+    "methods": [
+      {
+        "name": "createAnnotationDescriptor",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "org.hibernate.validator.constraints.Range",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.constraints.ScriptAssert",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.aggregated.ClassMetaData$Builder"
+    },
+    "name": "org.hibernate.validator.constraints.ScriptAssert"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider"
+    },
+    "name": "org.hibernate.validator.constraints.URL",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.engine.HibernateValidatorEnhancedBean",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertTrueValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.DigitsValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotBlankValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl$CascadingValueReceiver"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.CurrencyValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArray",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForMap",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCollection",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCollection",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.CodePointLengthValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ISBNValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LengthValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LengthValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LuhnCheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LuhnCheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod10CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod10CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ModCheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.NormalizedValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.UUIDValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.UniqueElementsValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.NIPValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.PESELValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.REGONValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ru.INNValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMaxValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMinValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "org.hibernate.validator.internal.engine.messageinterpolation.el.BeanPropertiesELResolver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "org.hibernate.validator.internal.engine.messageinterpolation.el.NoOpElResolver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
+    },
+    "name": "org.hibernate.validator.internal.engine.messageinterpolation.el.RootResolver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.resolver.TraversableResolvers"
+    },
+    "name": "org.hibernate.validator.internal.engine.resolver.JPATraversableResolver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.LoggerFactory"
+    },
+    "name": "org.hibernate.validator.internal.util.logging.Log_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.util.logging.Messages"
+    },
+    "name": "org.hibernate.validator.internal.util.logging.Messages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.metadata.core.ConstraintHelper"
+    },
+    "name": "org.joda.time.ReadableInstant"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.ClassLoadingImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.CompilationImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.ManagementFactoryHelper$1",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.MemoryImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.MemoryManagerImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.MemoryPoolImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
+    },
+    "name": "sun.management.RuntimeImpl",
+    "queryAllPublicConstructors": true
+  }
+]

--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/resource-config.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/resource-config.json
@@ -1,0 +1,10 @@
+{
+  "bundles": [
+    {
+      "name": "org.hibernate.validator.ValidationMessages"
+    }
+  ],
+  "resources": {
+    "includes": []
+  }
+}

--- a/metadata/org.hibernate.validator/hibernate-validator/index.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "7.0.4.Final",
+    "module": "org.hibernate.validator:hibernate-validator",
+    "tested-versions": [
+      "7.0.4.Final"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -44,6 +44,17 @@
     ]
   },
   {
+    "test-project-path": "org.hibernate.validator/hibernate-validator/7.0.4.Final",
+    "libraries": [
+      {
+        "name": "org.hibernate.validator:hibernate-validator",
+        "versions": [
+          "7.0.4.Final"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.apache.tomcat.embed/tomcat-embed-core/10.0.20",
     "libraries": [
       {

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+	testImplementation("org.hibernate.validator:hibernate-validator:$libraryVersion")
+	testRuntimeOnly('org.glassfish:jakarta.el:4.0.2')
+	testImplementation('org.assertj:assertj-core:3.22.0')
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--no-fallback')
+        }
+    }
+}

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/gradle.properties
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 7.0.4.Final
+metadata.dir = org.hibernate.validator/hibernate-validator/7.0.4.Final/

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/settings.gradle
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org-hibernate-validator-tests'

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/Dto.java
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/Dto.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.validator;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.CreditCardNumber;
+import org.hibernate.validator.constraints.Range;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public class Dto {
+    @NotBlank
+    private final String notBlank;
+
+    @NotEmpty
+    private final List<String> notEmpty;
+
+    @Min(1)
+    private final int min;
+
+    @Max(-1)
+    private final int max;
+
+    @Email
+    private final String email;
+
+    @Pattern(regexp = "[a-z]")
+    private final String pattern;
+
+    @NotNull
+    private final Object notNull;
+
+    @Null
+    private final Object oNull;
+
+    @Future
+    private final Instant future;
+
+    @AssertTrue
+    private final boolean bTrue;
+
+    @AssertFalse
+    private final boolean bFalse;
+
+    @Digits(integer = 2, fraction = 0)
+    private final int digits;
+
+    @NotEmpty
+    private final String notEmptyString;
+
+    @NotEmpty
+    private final Map<String, String> notEmptyMap;
+
+    @NotEmpty
+    private final String[] notEmptyArray;
+
+    @Size(min = 1, max = 2)
+    private final String size;
+
+    @Positive
+    private final int positive;
+
+    @Negative
+    private final int negative;
+
+    @CreditCardNumber
+    private final String ccNumber;
+
+    @Range(min = 1, max = 10)
+    private final int range;
+
+    public Dto(
+            String notBlank, List<String> notEmpty, int min, int max, String email, String pattern, Object notNull,
+            Object oNull, Instant future, boolean bTrue, boolean bFalse, int digits, String notEmptyString,
+            Map<String, String> notEmptyMap, @NotEmpty String[] notEmptyArray, String size, int positive, int negative,
+            String ccNumber, int range
+    ) {
+        this.notBlank = notBlank;
+        this.notEmpty = notEmpty;
+        this.min = min;
+        this.max = max;
+        this.email = email;
+        this.pattern = pattern;
+        this.notNull = notNull;
+        this.oNull = oNull;
+        this.future = future;
+        this.bTrue = bTrue;
+        this.bFalse = bFalse;
+        this.digits = digits;
+        this.notEmptyString = notEmptyString;
+        this.notEmptyMap = notEmptyMap;
+        this.notEmptyArray = notEmptyArray;
+        this.size = size;
+        this.positive = positive;
+        this.negative = negative;
+        this.ccNumber = ccNumber;
+        this.range = range;
+    }
+
+    public static Dto createValid() {
+        return new Dto(
+                "not-blank", List.of("not-empty"), 2, -2, "some@example.com", "a",
+                new Object(), null, Instant.now().plusSeconds(60), true, false, 11,
+                "some-content", Map.of("a", "1"), new String[]{"some-string"}, "12", 1,
+                -2, "4539627380966582", 7
+        );
+    }
+
+    public static Dto createInvalid() {
+        return new Dto(
+                "", List.of(), 0, 0, "no-email", "1", null, new Object(),
+                Instant.now().minusSeconds(60), false, true, 111, "",
+                Map.of(), new String[0], "123", -1, 1, "", 11
+        );
+    }
+}

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/HibernateValidatorTest.java
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/HibernateValidatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.validator;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HibernateValidatorTest {
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        this.validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void shouldBeValid() {
+        Set<ConstraintViolation<Dto>> errors = this.validator.validate(Dto.createValid());
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void shouldBeInvalid() {
+        Set<ConstraintViolation<Dto>> errors = this.validator.validate(Dto.createInvalid());
+        assertThat(errors).extracting(ValidationError::of).containsExactlyInAnyOrder(
+                new ValidationError("notBlank", "{jakarta.validation.constraints.NotBlank.message}"),
+                new ValidationError("max", "{jakarta.validation.constraints.Max.message}"),
+                new ValidationError("notNull", "{jakarta.validation.constraints.NotNull.message}"),
+                new ValidationError("notEmpty", "{jakarta.validation.constraints.NotEmpty.message}"),
+                new ValidationError("oNull", "{jakarta.validation.constraints.Null.message}"),
+                new ValidationError("email", "{jakarta.validation.constraints.Email.message}"),
+                new ValidationError("pattern", "{jakarta.validation.constraints.Pattern.message}"),
+                new ValidationError("min", "{jakarta.validation.constraints.Min.message}"),
+                new ValidationError("future", "{jakarta.validation.constraints.Future.message}"),
+                new ValidationError("bFalse", "{jakarta.validation.constraints.AssertFalse.message}"),
+                new ValidationError("bTrue", "{jakarta.validation.constraints.AssertTrue.message}"),
+                new ValidationError("digits", "{jakarta.validation.constraints.Digits.message}"),
+                new ValidationError("notEmptyString", "{jakarta.validation.constraints.NotEmpty.message}"),
+                new ValidationError("notEmptyArray", "{jakarta.validation.constraints.NotEmpty.message}"),
+                new ValidationError("notEmptyMap", "{jakarta.validation.constraints.NotEmpty.message}"),
+                new ValidationError("negative", "{jakarta.validation.constraints.Negative.message}"),
+                new ValidationError("range", "{org.hibernate.validator.constraints.Range.message}"),
+                new ValidationError("size", "{jakarta.validation.constraints.Size.message}"),
+                new ValidationError("positive", "{jakarta.validation.constraints.Positive.message}"),
+                new ValidationError("ccNumber", "{org.hibernate.validator.constraints.CreditCardNumber.message}")
+        );
+    }
+
+    private static final class ValidationError {
+        private final String propertyPath;
+        private final String messageTemplate;
+
+        private ValidationError(java.lang.String propertyPath, java.lang.String messageTemplate) {
+            this.propertyPath = propertyPath;
+            this.messageTemplate = messageTemplate;
+        }
+
+        private static ValidationError of(ConstraintViolation<?> cv) {
+            return new ValidationError(cv.getPropertyPath().toString(), cv.getMessageTemplate());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ValidationError that = (ValidationError) o;
+            return Objects.equals(propertyPath, that.propertyPath) && Objects.equals(messageTemplate, that.messageTemplate);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(propertyPath, messageTemplate);
+        }
+    }
+}

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/resources/META-INF/native-image/dto-hints/reflect-config.json
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/resources/META-INF/native-image/dto-hints/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "org.hibernate.validator.Dto",
+    "allDeclaredFields": true
+  }
+]

--- a/tests/src/org.hibernate.validator/hibernate-validator/README.md
+++ b/tests/src/org.hibernate.validator/hibernate-validator/README.md
@@ -1,0 +1,93 @@
+# Hibernate Validator
+
+The metadata has been gathered by a combination of running the hibernate-validator tests with the agent attached and
+by tweaking and completing the output files.
+
+## Run tests with agent
+
+Put this in the `pom.xml`:
+
+```xml
+  <profile>
+    <id>native</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>native-maven-plugin</artifactId>
+          <version>0.9.13</version>
+          <extensions>true</extensions>
+          <configuration>
+            <agent>
+              <options>
+                <option>experimental-conditional-config-part</option>
+              </options>
+              <options name="test">
+                <option>access-filter-file=${project.basedir}/../access-filter.json</option>
+              </options>
+            </agent>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+```
+
+`access-filter.json` contains this:
+
+```json
+{
+  "rules": [
+    {
+      "includeClasses": "**"
+    },
+    {
+      "excludeClasses": "org.hibernate.validator.test.**"
+    },
+    {
+      "excludeClasses": "org.apache.logging.log4j.**"
+    }
+  ]
+}
+```
+
+Use this script to run the tests:
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running tests..."
+mvn clean test -Pnative -Dagent=true -pl engine
+
+echo "Post-processing native-image files"
+INPUT_DIR=(engine/target/native/agent-output/test/session-*)
+OUTPUT_DIR="engine/src/main/resources/META-INF/native-image/org.hibernate.validator/hibernate-validator"
+mkdir -p "$OUTPUT_DIR"
+native-image-configure generate-conditional --user-code-filter=user-code-filter.json --input-dir="$INPUT_DIR" --output-dir="$OUTPUT_DIR"
+```
+
+`user-code-filter.json` contains this:
+
+```json
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.hibernate.validator.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.validator.test.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.validator.testutil.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.validator.testutils.**"
+    }
+  ]
+}
+```


### PR DESCRIPTION
Signed-off-by: Moritz Halbritter <mkammerer@vmware.com>

## What does this PR do?

Adds metadata for hibernate validator. The readme in the tests explains how these files have been generated.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
