### PR TITLE
Set Java language level to 11

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -20,6 +20,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
 TestUtils.locateRepoDirs(project) // Find relevant directories for the test harness.
 
 checkstyle {


### PR DESCRIPTION
Signed-off-by: Moritz Halbritter <mkammerer@vmware.com>

## What does this PR do?

Sets the Java language level to 11 to catch language bugs locally.
