### PR TITLE
Add metadata for kotlin-reflect

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -58,5 +58,9 @@
   {
     "directory": "com.zaxxer/HikariCP",
     "module": "com.zaxxer:HikariCP"
+  },
+  {
+    "directory": "org.jetbrains.kotlin/kotlin-reflect",
+    "module": "org.jetbrains.kotlin:kotlin-reflect"
   }
 ]

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
@@ -1,0 +1,93 @@
+[
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.descriptors.FindClassInModuleKt"
+    },
+    "name": "kotlin.Metadata",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.descriptors.runtime.components.ReflectClassStructure"
+    },
+    "name": "kotlin.Metadata",
+    "methods": [
+      {
+        "name": "bv",
+        "parameterTypes": []
+      },
+      {
+        "name": "d1",
+        "parameterTypes": []
+      },
+      {
+        "name": "d2",
+        "parameterTypes": []
+      },
+      {
+        "name": "k",
+        "parameterTypes": []
+      },
+      {
+        "name": "mv",
+        "parameterTypes": []
+      },
+      {
+        "name": "pn",
+        "parameterTypes": []
+      },
+      {
+        "name": "xi",
+        "parameterTypes": []
+      },
+      {
+        "name": "xs",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.descriptors.runtime.components.ReflectKotlinClass$Factory"
+    },
+    "name": "kotlin.Metadata"
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation"
+    },
+    "name": "kotlin.Metadata",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation"
+    },
+    "name": "kotlin.Unit"
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.KDeclarationContainerImpl"
+    },
+    "name": "kotlin.jvm.internal.DefaultConstructorMarker"
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.jvm.internal.Reflection"
+    },
+    "name": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter"
+    },
+    "name": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter",
+    "allPublicFields": true
+  }
+]

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/resource-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl"
+        },
+        "pattern": "kotlin/.+\\.kotlin_builtins"
+      }
+    ]
+  }
+}

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.7.10",
+    "module": "org.jetbrains.kotlin:kotlin-reflect",
+    "tested-versions": [
+      "1.7.10"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -141,5 +141,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path": "org.jetbrains.kotlin/kotlin-reflect/1.7.10",
+    "libraries": [
+      {
+        "name": "org.jetbrains.kotlin:kotlin-reflect",
+        "versions": [
+          "1.7.10"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "1.7.10"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.jetbrains.kotlin/kotlin-reflect")
+        }
+    }
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/gradle.properties
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.7.10
+metadata.dir = org.jetbrains.kotlin/kotlin-reflect/1.7.10

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/settings.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'kotlin-reflect-tests'

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
@@ -1,0 +1,68 @@
+package kotlinreflect
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.memberProperties
+
+class KotlinReflectTests {
+    @Test
+    fun test() {
+        val klass = Foo::class
+        val ctor = klass.constructors.first { it.parameters.isEmpty() }
+        val foo = ctor.call()
+
+        val method = klass.members.first { it.name == "method" }
+        assertThat(method.parameters).hasSize(1)
+        assertThat(method.parameters[0].kind).isEqualTo(KParameter.Kind.INSTANCE)
+
+        val methodWithArgs = klass.members.first { it.name == "methodWithArgs" }
+        assertThat(methodWithArgs.parameters).hasSize(2)
+        assertThat(methodWithArgs.parameters[1].type).isEqualTo(String::class.createType())
+
+        val methodWithResult = klass.members.first { it.name == "methodWithResult" }
+        assertThat(methodWithResult.returnType).isEqualTo(Int::class.createType())
+        val result = methodWithResult.call(foo)
+        assertThat(result).isEqualTo(1)
+
+        val annotatedMethod = klass.members.first { it.name == "annotatedMethod" }
+        assertThat(annotatedMethod.annotations).hasSize(1)
+        assertThat(annotatedMethod.annotations[0]).isInstanceOf(TestAnnotation::class.java)
+        assertThat((annotatedMethod.annotations[0] as TestAnnotation).value).isEqualTo("annotation-on-method")
+
+        val stringProperty = klass.memberProperties.first { it.name == "stringProperty" }
+        assertThat(stringProperty.returnType).isEqualTo(String::class.createType())
+        assertThat(stringProperty.get(foo)).isEqualTo("string-1")
+
+        val annotatedProperty = klass.memberProperties.first { it.name == "annotatedProperty" }
+        assertThat(annotatedProperty.annotations).hasSize(1)
+        assertThat(annotatedProperty.annotations[0]).isInstanceOf(TestAnnotation::class.java)
+        assertThat((annotatedProperty.annotations[0] as TestAnnotation).value).isEqualTo("annotation-on-field")
+    }
+}
+
+class Foo {
+    val stringProperty = "string-1"
+
+    @TestAnnotation("annotation-on-field")
+    val annotatedProperty = 1
+
+    fun method() {
+    }
+
+    fun methodWithArgs(first: String) {
+    }
+
+    fun methodWithResult(): Int = 1
+
+    @TestAnnotation("annotation-on-method")
+    fun annotatedMethod() {
+    }
+}
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR, AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestAnnotation(val value: String)
+

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/resources/META-INF/native-image/test/reflect-config.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/resources/META-INF/native-image/test/reflect-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "kotlinreflect.Foo",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredClasses": true
+  }
+]

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "kotlin.**"
+    }
+  ]
+}


### PR DESCRIPTION
Closes gh-20

Signed-off-by: Moritz Halbritter <mkammerer@vmware.com>

## What does this PR do?

Adds metadata for kotlin-reflect.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
