### PR TITLE
Make sure that org.slf4j.impl.StaticLoggerBinder is available

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.2.11/reflect-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.2.11/reflect-config.json
@@ -292,5 +292,8 @@
     },
     "name": "ch.qos.logback.core.pattern.color.YellowCompositeConverter",
     "allPublicConstructors": true
+  },
+  {
+    "name": "org.slf4j.impl.StaticLoggerBinder"
   }
 ]

--- a/tests/src/ch.qos.logback/logback-classic/1.2.11/src/test/java/org/graalvm/logback/LogbackTests.java
+++ b/tests/src/ch.qos.logback/logback-classic/1.2.11/src/test/java/org/graalvm/logback/LogbackTests.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,21 @@ public class LogbackTests {
     logger.error(converterName, new IllegalArgumentException("test error"));
     assertThat(outputStreamCaptor.toString()).doesNotContain("PARSER_ERROR");
     cleanUp(encoder, consoleAppender, logger);
+  }
+
+  @Test
+  void slf4jCanBeDetected() {
+    boolean slf4jAvailable = isClassPresent("org.slf4j.Logger") && (isClassPresent("org.slf4j.impl.StaticLoggerBinder") || isClassPresent("org.slf4j.spi.SLF4JServiceProvider"));
+    assertThat(slf4jAvailable).isTrue();
+  }
+
+  private boolean isClassPresent(String className) {
+    try {
+      Class.forName(className);
+      return true;
+    } catch (ClassNotFoundException ex) {
+      return false;
+    }
   }
 
   private static Stream<Arguments> converterSource() {


### PR DESCRIPTION
This is often used for SLF4J detection.

See #41 for details.

Closes #41

## What does this PR do?

Adds `org.slf4j.impl.StaticLoggerBinder` to logback reflection hints.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
