### PR TITLE
Fix H2 metadata

### DIFF
--- a/metadata/com.h2database/h2/2.1.210/index.json
+++ b/metadata/com.h2database/h2/2.1.210/index.json
@@ -1,3 +1,4 @@
 [
-  "reflect-config.json"
+  "reflect-config.json",
+  "resource-config.json"
 ]

--- a/metadata/com.h2database/h2/2.1.210/reflect-config.json
+++ b/metadata/com.h2database/h2/2.1.210/reflect-config.json
@@ -1,212 +1,225 @@
 [
   {
     "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.FilePathDisk"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.mem.FilePathMem"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.mem.FilePathMemLZF"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.niomem.FilePathNioMem"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.niomem.FilePathNioMemLZF"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.split.FilePathSplit"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.niomapped.FilePathNioMapped"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.async.FilePathAsync"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.zip.FilePathZip"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.store.fs.FilePath"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "name": "org.h2.store.fs.retry.FilePathRetryOnInterrupt"
-  },
-  {
-    "condition": {
       "typeReachable": "org.h2.mvstore.type.MetaType"
     },
+    "name": "org.h2.mvstore.db.LobStorageMap$BlobMeta$Type",
     "fields": [
       {
         "name": "INSTANCE"
       }
-    ],
-    "name": "org.h2.mvstore.type.ByteArrayDataType"
+    ]
   },
   {
     "condition": {
       "typeReachable": "org.h2.mvstore.type.MetaType"
     },
+    "name": "org.h2.mvstore.db.LobStorageMap$BlobReference$Type",
     "fields": [
       {
         "name": "INSTANCE"
       }
-    ],
-    "name": "org.h2.mvstore.type.LongDataType"
+    ]
   },
   {
     "condition": {
       "typeReachable": "org.h2.mvstore.type.MetaType"
     },
+    "name": "org.h2.mvstore.db.NullValueDataType",
     "fields": [
       {
         "name": "INSTANCE"
       }
-    ],
-    "name": "org.h2.mvstore.type.StringDataType"
+    ]
   },
   {
     "condition": {
-      "typeReachable": "org.h2.mvstore.type.MetaType"
+      "typeReachable": "org.h2.mvstore.tx.VersionedValueType$Factory"
     },
-    "fields": [
-      {
-        "name": "INSTANCE"
-      }
-    ],
-    "name": "org.h2.mvstore.db.NullValueDataType"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.mvstore.type.MetaType"
-    },
-    "fields": [
-      {
-        "name": "INSTANCE"
-      }
-    ],
-    "name": "org.h2.mvstore.db.LobStorageMap$BlobReference$Type"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.mvstore.type.MetaType"
-    },
-    "fields": [
-      {
-        "name": "INSTANCE"
-      }
-    ],
-    "name": "org.h2.mvstore.db.LobStorageMap$BlobMeta$Type"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.h2.mvstore.type.MetaType"
-    },
+    "name": "org.h2.mvstore.db.RowDataType$Factory",
     "methods": [
       {
         "name": "<init>",
         "parameterTypes": []
       }
-    ],
-    "name": "org.h2.mvstore.tx.VersionedValueType$Factory"
+    ]
   },
   {
     "condition": {
       "typeReachable": "org.h2.mvstore.type.MetaType"
     },
+    "name": "org.h2.mvstore.tx.VersionedValueType$Factory",
     "methods": [
       {
         "name": "<init>",
         "parameterTypes": []
       }
-    ],
-    "name": "org.h2.mvstore.db.RowDataType$Factory"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.mvstore.type.MetaType"
+    },
+    "name": "org.h2.mvstore.type.ByteArrayDataType",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.mvstore.type.MetaType"
+    },
+    "name": "org.h2.mvstore.type.LongDataType",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.async.FilePathAsync",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.disk.FilePathDisk",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.mem.FilePathMem",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.mem.FilePathMemLZF",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.niomapped.FilePathNioMapped",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.niomem.FilePathNioMem",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.niomem.FilePathNioMemLZF",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.retry.FilePathRetryOnInterrupt",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.split.FilePathSplit",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.store.fs.FilePath"
+    },
+    "name": "org.h2.store.fs.zip.FilePathZip",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.util.MathUtils"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.h2.util.MathUtils"
+    },
+    "name": "sun.security.provider.SecureRandom",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/metadata/com.h2database/h2/2.1.210/resource-config.json
+++ b/metadata/com.h2database/h2/2.1.210/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.h2.util.Utils"
+        },
+        "pattern": "\\Qorg/h2/util/data.zip\\E"
+      }
+    ]
+  }
+}

--- a/tests/src/com.h2database/h2/2.1.210/build.gradle
+++ b/tests/src/com.h2database/h2/2.1.210/build.gradle
@@ -19,9 +19,17 @@ dependencies {
 }
 
 graalvmNative {
-    binaries {
-        test {
-            buildArgs.add('--allow-incomplete-classpath')
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/com.h2database/h2")
         }
     }
 }

--- a/tests/src/com.h2database/h2/2.1.210/user-code-filter.json
+++ b/tests/src/com.h2database/h2/2.1.210/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.h2.**"
+    }
+  ]
+}


### PR DESCRIPTION
The existing metadata was referencing types which no longer exist in H2.

The new metadata has been generated by running the tests with the agent attached.

For example a h2 running in a native image using the old metadata was unable to write files to disk. `h2:mem:...` works without problems, but `h2:file:...` would not write any file.

I tried reproducing that behaviour in a test, but you have to shut down the whole JVM to observe it.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
