### PR TITLE
Add Netty 4 ChannelHandler metadata

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -1,33 +1,6 @@
 [
   {
     "condition": {
-      "typeReachable": "io.netty.util.internal.PlatformDependent0"
-    },
-    "name": "java.nio.DirectByteBuffer",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "long",
-          "int"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.netty.channel.socket.nio.NioServerSocketChannel"
-    },
-    "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
       "typeReachable": "io.netty.internal.tcnative.Library"
     },
     "name": "[B"
@@ -1142,6 +1115,20 @@
   },
   {
     "condition": {
+      "typeReachable": "io.netty.bootstrap.ServerBootstrap$1"
+    },
+    "name": "io.netty.bootstrap.ServerBootstrap$1",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor"
+    },
+    "name": "io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.buffer.AbstractByteBufAllocator"
     },
     "name": "io.netty.buffer.AbstractByteBufAllocator"
@@ -1258,9 +1245,107 @@
   },
   {
     "condition": {
+      "typeReachable": "io.netty.channel.ChannelDuplexHandler"
+    },
+    "name": "io.netty.channel.ChannelDuplexHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelHandler"
+    },
+    "name": "io.netty.channel.ChannelHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelHandlerAdapter"
+    },
+    "name": "io.netty.channel.ChannelHandlerAdapter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInboundHandler"
+    },
+    "name": "io.netty.channel.ChannelInboundHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInboundHandlerAdapter"
+    },
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelInitializer"
+    },
+    "name": "io.netty.channel.ChannelInitializer",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelOutboundHandler"
+    },
+    "name": "io.netty.channel.ChannelOutboundHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ChannelOutboundHandlerAdapter"
+    },
+    "name": "io.netty.channel.ChannelOutboundHandlerAdapter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.CombinedChannelDuplexHandler"
+    },
+    "name": "io.netty.channel.CombinedChannelDuplexHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    "name": "io.netty.channel.DefaultChannelPipeline$HeadContext",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    "name": "io.netty.channel.DefaultChannelPipeline$TailContext",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
     },
     "name": "io.netty.channel.DefaultFileRegion"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.SimpleChannelInboundHandler"
+    },
+    "name": "io.netty.channel.SimpleChannelInboundHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.SimpleUserEventChannelHandler"
+    },
+    "name": "io.netty.channel.SimpleUserEventChannelHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$2"
+    },
+    "name": "io.netty.channel.embedded.EmbeddedChannel$2",
+    "queryAllPublicMethods": true
   },
   {
     "condition": {
@@ -1291,6 +1376,13 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.pool.SimpleChannelPool$1"
+    },
+    "name": "io.netty.channel.pool.SimpleChannelPool$1",
+    "queryAllPublicMethods": true
   },
   {
     "condition": {
@@ -1334,6 +1426,18 @@
     },
     "name": "io.netty.channel.socket.nio.NioDatagramChannel",
     "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.socket.nio.NioServerSocketChannel"
+    },
+    "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
+    "methods": [
       {
         "name": "<init>",
         "parameterTypes": []
@@ -1432,6 +1536,1630 @@
   },
   {
     "condition": {
+      "typeReachable": "io.netty.handler.address.DynamicAddressConnectHandler"
+    },
+    "name": "io.netty.handler.address.DynamicAddressConnectHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.address.ResolveAddressHandler"
+    },
+    "name": "io.netty.handler.address.ResolveAddressHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec"
+    },
+    "name": "io.netty.handler.codec.ByteToMessageCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$1"
+    },
+    "name": "io.netty.handler.codec.ByteToMessageCodec$1",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageCodec$Encoder"
+    },
+    "name": "io.netty.handler.codec.ByteToMessageCodec$Encoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ByteToMessageDecoder"
+    },
+    "name": "io.netty.handler.codec.ByteToMessageDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketDecoder"
+    },
+    "name": "io.netty.handler.codec.DatagramPacketDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DatagramPacketEncoder"
+    },
+    "name": "io.netty.handler.codec.DatagramPacketEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.DelimiterBasedFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.DelimiterBasedFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.FixedLengthFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.FixedLengthFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldBasedFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.LengthFieldBasedFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LengthFieldPrepender"
+    },
+    "name": "io.netty.handler.codec.LengthFieldPrepender",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.LineBasedFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.LineBasedFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageAggregator"
+    },
+    "name": "io.netty.handler.codec.MessageAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToByteEncoder"
+    },
+    "name": "io.netty.handler.codec.MessageToByteEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec"
+    },
+    "name": "io.netty.handler.codec.MessageToMessageCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$1"
+    },
+    "name": "io.netty.handler.codec.MessageToMessageCodec$1",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageCodec$2"
+    },
+    "name": "io.netty.handler.codec.MessageToMessageCodec$2",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageDecoder"
+    },
+    "name": "io.netty.handler.codec.MessageToMessageDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.MessageToMessageEncoder"
+    },
+    "name": "io.netty.handler.codec.MessageToMessageEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.ReplayingDecoder"
+    },
+    "name": "io.netty.handler.codec.ReplayingDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Decoder"
+    },
+    "name": "io.netty.handler.codec.base64.Base64Decoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.base64.Base64Encoder"
+    },
+    "name": "io.netty.handler.codec.base64.Base64Encoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayDecoder"
+    },
+    "name": "io.netty.handler.codec.bytes.ByteArrayDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.bytes.ByteArrayEncoder"
+    },
+    "name": "io.netty.handler.codec.bytes.ByteArrayEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.BrotliDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.BrotliEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.BrotliEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Decoder"
+    },
+    "name": "io.netty.handler.codec.compression.Bzip2Decoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Bzip2Encoder"
+    },
+    "name": "io.netty.handler.codec.compression.Bzip2Encoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.FastLzFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.FastLzFrameEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.FastLzFrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.JZlibDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JZlibEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.JZlibEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.JdkZlibDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.JdkZlibEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.JdkZlibEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.Lz4FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.Lz4FrameEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.Lz4FrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.LzfDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzfEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.LzfEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.LzmaFrameEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.LzmaFrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.SnappyFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFrameEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.SnappyFrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.SnappyFramedDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.SnappyFramedEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.SnappyFramedEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibDecoder"
+    },
+    "name": "io.netty.handler.codec.compression.ZlibDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZlibEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.ZlibEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.compression.ZstdEncoder"
+    },
+    "name": "io.netty.handler.codec.compression.ZstdEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsQueryDecoder"
+    },
+    "name": "io.netty.handler.codec.dns.DatagramDnsQueryDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsQueryEncoder"
+    },
+    "name": "io.netty.handler.codec.dns.DatagramDnsQueryEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.dns.DatagramDnsResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.DatagramDnsResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.dns.DatagramDnsResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsQueryDecoder"
+    },
+    "name": "io.netty.handler.codec.dns.TcpDnsQueryDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsQueryEncoder"
+    },
+    "name": "io.netty.handler.codec.dns.TcpDnsQueryEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.dns.TcpDnsResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.dns.TcpDnsResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.haproxy.HAProxyMessageDecoder"
+    },
+    "name": "io.netty.handler.codec.haproxy.HAProxyMessageDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.haproxy.HAProxyMessageEncoder"
+    },
+    "name": "io.netty.handler.codec.haproxy.HAProxyMessageEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec"
+    },
+    "name": "io.netty.handler.codec.http.HttpClientCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec$Decoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpClientCodec$Decoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientCodec$Encoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpClientCodec$Encoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpClientUpgradeHandler"
+    },
+    "name": "io.netty.handler.codec.http.HttpClientUpgradeHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentCompressor"
+    },
+    "name": "io.netty.handler.codec.http.HttpContentCompressor",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentDecoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpContentDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentDecompressor"
+    },
+    "name": "io.netty.handler.codec.http.HttpContentDecompressor",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentEncoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpContentEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectAggregator"
+    },
+    "name": "io.netty.handler.codec.http.HttpObjectAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectDecoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpObjectDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpObjectEncoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpObjectEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpRequestEncoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpRequestEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerCodec$HttpServerResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerExpectContinueHandler"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerExpectContinueHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerKeepAliveHandler"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerKeepAliveHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpServerUpgradeHandler"
+    },
+    "name": "io.netty.handler.codec.http.HttpServerUpgradeHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.cors.CorsHandler"
+    },
+    "name": "io.netty.handler.codec.http.cors.CorsHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.Utf8FrameValidator"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.Utf8FrameValidator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket07FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket07FrameEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket07FrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket08FrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandshakeHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketFrameEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketFrameEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketProtocolHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketProtocolHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandshakeHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.DeflateEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerFrameDeflateEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler"
+    },
+    "name": "io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler"
+    },
+    "name": "io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler"
+    },
+    "name": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2ConnectionHandler"
+    },
+    "name": "io.netty.handler.codec.http2.Http2ConnectionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2FrameCodec"
+    },
+    "name": "io.netty.handler.codec.http2.Http2FrameCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2FrameLogger"
+    },
+    "name": "io.netty.handler.codec.http2.Http2FrameLogger",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2MultiplexCodec"
+    },
+    "name": "io.netty.handler.codec.http2.Http2MultiplexCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2MultiplexHandler"
+    },
+    "name": "io.netty.handler.codec.http2.Http2MultiplexHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec"
+    },
+    "name": "io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler"
+    },
+    "name": "io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.InboundHttpToHttp2Adapter"
+    },
+    "name": "io.netty.handler.codec.http2.InboundHttpToHttp2Adapter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.json.JsonObjectDecoder"
+    },
+    "name": "io.netty.handler.codec.json.JsonObjectDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder"
+    },
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder"
+    },
+    "name": "io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingDecoder"
+    },
+    "name": "io.netty.handler.codec.marshalling.MarshallingDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.marshalling.MarshallingEncoder"
+    },
+    "name": "io.netty.handler.codec.marshalling.MarshallingEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator"
+    },
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder"
+    },
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder"
+    },
+    "name": "io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Decoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Decoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Encoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec$Encoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestEncoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.memcache.binary.BinaryMemcacheServerCodec"
+    },
+    "name": "io.netty.handler.codec.memcache.binary.BinaryMemcacheServerCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.mqtt.MqttDecoder"
+    },
+    "name": "io.netty.handler.codec.mqtt.MqttDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.mqtt.MqttEncoder"
+    },
+    "name": "io.netty.handler.codec.mqtt.MqttEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoder"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufDecoderNano"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufDecoderNano",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoder"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufEncoderNano"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufEncoderNano",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender"
+    },
+    "name": "io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisArrayAggregator"
+    },
+    "name": "io.netty.handler.codec.redis.RedisArrayAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisBulkStringAggregator"
+    },
+    "name": "io.netty.handler.codec.redis.RedisBulkStringAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisDecoder"
+    },
+    "name": "io.netty.handler.codec.redis.RedisDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.redis.RedisEncoder"
+    },
+    "name": "io.netty.handler.codec.redis.RedisEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspDecoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspEncoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspObjectDecoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspObjectDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspObjectEncoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspObjectEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspRequestEncoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspRequestEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.rtsp.RtspResponseEncoder"
+    },
+    "name": "io.netty.handler.codec.rtsp.RtspResponseEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpInboundByteStreamHandler"
+    },
+    "name": "io.netty.handler.codec.sctp.SctpInboundByteStreamHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpMessageCompletionHandler"
+    },
+    "name": "io.netty.handler.codec.sctp.SctpMessageCompletionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpMessageToMessageDecoder"
+    },
+    "name": "io.netty.handler.codec.sctp.SctpMessageToMessageDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler"
+    },
+    "name": "io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.CompatibleObjectEncoder"
+    },
+    "name": "io.netty.handler.codec.serialization.CompatibleObjectEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectDecoder"
+    },
+    "name": "io.netty.handler.codec.serialization.ObjectDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.serialization.ObjectEncoder"
+    },
+    "name": "io.netty.handler.codec.serialization.ObjectEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+    },
+    "name": "io.netty.handler.codec.smtp.SmtpRequestEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.smtp.SmtpResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.smtp.SmtpResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksAuthRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksAuthRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksAuthResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksAuthResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksCmdRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksCmdRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksCmdResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksCmdResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksInitRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksInitRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksInitResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksInitResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socks.SocksMessageEncoder"
+    },
+    "name": "io.netty.handler.codec.socks.SocksMessageEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+    },
+    "name": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder"
+    },
+    "name": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyFrameCodec"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdyFrameCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpCodec"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdyHttpCodec",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpDecoder"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdyHttpDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpEncoder"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdyHttpEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdyHttpResponseStreamIdHandler"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdyHttpResponseStreamIdHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.spdy.SpdySessionHandler"
+    },
+    "name": "io.netty.handler.codec.spdy.SpdySessionHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeAggregator"
+    },
+    "name": "io.netty.handler.codec.stomp.StompSubframeAggregator",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeDecoder"
+    },
+    "name": "io.netty.handler.codec.stomp.StompSubframeDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.stomp.StompSubframeEncoder"
+    },
+    "name": "io.netty.handler.codec.stomp.StompSubframeEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.LineEncoder"
+    },
+    "name": "io.netty.handler.codec.string.LineEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringDecoder"
+    },
+    "name": "io.netty.handler.codec.string.StringDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.string.StringEncoder"
+    },
+    "name": "io.netty.handler.codec.string.StringEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlDecoder"
+    },
+    "name": "io.netty.handler.codec.xml.XmlDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.xml.XmlFrameDecoder"
+    },
+    "name": "io.netty.handler.codec.xml.XmlFrameDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.flow.FlowControlHandler"
+    },
+    "name": "io.netty.handler.flow.FlowControlHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.flush.FlushConsolidationHandler"
+    },
+    "name": "io.netty.handler.flush.FlushConsolidationHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.AbstractRemoteAddressFilter"
+    },
+    "name": "io.netty.handler.ipfilter.AbstractRemoteAddressFilter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.IpSubnetFilter"
+    },
+    "name": "io.netty.handler.ipfilter.IpSubnetFilter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.RuleBasedIpFilter"
+    },
+    "name": "io.netty.handler.ipfilter.RuleBasedIpFilter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ipfilter.UniqueIpFilter"
+    },
+    "name": "io.netty.handler.ipfilter.UniqueIpFilter",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.logging.LoggingHandler"
+    },
+    "name": "io.netty.handler.logging.LoggingHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.pcap.PcapWriteHandler"
+    },
+    "name": "io.netty.handler.pcap.PcapWriteHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.HttpProxyHandler"
+    },
+    "name": "io.netty.handler.proxy.HttpProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper"
+    },
+    "name": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.ProxyHandler"
+    },
+    "name": "io.netty.handler.proxy.ProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.Socks4ProxyHandler"
+    },
+    "name": "io.netty.handler.proxy.Socks4ProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.proxy.Socks5ProxyHandler"
+    },
+    "name": "io.netty.handler.proxy.Socks5ProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.AbstractSniHandler"
+    },
+    "name": "io.netty.handler.ssl.AbstractSniHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.ApplicationProtocolNegotiationHandler"
+    },
+    "name": "io.netty.handler.ssl.ApplicationProtocolNegotiationHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.OptionalSslHandler"
+    },
+    "name": "io.netty.handler.ssl.OptionalSslHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SniHandler"
+    },
+    "name": "io.netty.handler.ssl.SniHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslClientHelloHandler"
+    },
+    "name": "io.netty.handler.ssl.SslClientHelloHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslHandler"
+    },
+    "name": "io.netty.handler.ssl.SslHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslMasterKeyHandler"
+    },
+    "name": "io.netty.handler.ssl.SslMasterKeyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler"
+    },
+    "name": "io.netty.handler.ssl.SslMasterKeyHandler$WiresharkSslMasterKeyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.ssl.ocsp.OcspClientHandler"
+    },
+    "name": "io.netty.handler.ssl.ocsp.OcspClientHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.stream.ChunkedWriteHandler"
+    },
+    "name": "io.netty.handler.stream.ChunkedWriteHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.IdleStateHandler"
+    },
+    "name": "io.netty.handler.timeout.IdleStateHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.ReadTimeoutHandler"
+    },
+    "name": "io.netty.handler.timeout.ReadTimeoutHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.timeout.WriteTimeoutHandler"
+    },
+    "name": "io.netty.handler.timeout.WriteTimeoutHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.AbstractTrafficShapingHandler"
+    },
+    "name": "io.netty.handler.traffic.AbstractTrafficShapingHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.ChannelTrafficShapingHandler"
+    },
+    "name": "io.netty.handler.traffic.ChannelTrafficShapingHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.GlobalChannelTrafficShapingHandler"
+    },
+    "name": "io.netty.handler.traffic.GlobalChannelTrafficShapingHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.handler.traffic.GlobalTrafficShapingHandler"
+    },
+    "name": "io.netty.handler.traffic.GlobalTrafficShapingHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.internal.tcnative.Library"
     },
     "name": "io.netty.internal.tcnative.CertificateCallback"
@@ -1465,6 +3193,34 @@
       "typeReachable": "io.netty.internal.tcnative.Library"
     },
     "name": "io.netty.internal.tcnative.SSLTask"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$1"
+    },
+    "name": "io.netty.resolver.dns.DnsNameResolver$1",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$3"
+    },
+    "name": "io.netty.resolver.dns.DnsNameResolver$3",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler"
+    },
+    "name": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler$1$1"
+    },
+    "name": "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler$1$1",
+    "queryAllPublicMethods": true
   },
   {
     "condition": {
@@ -1739,11 +3495,6 @@
     },
     "name": "java.lang.String",
     "allDeclaredFields": true,
-    "fields": [
-      {
-        "name": "serialPersistentFields"
-      }
-    ],
     "queriedMethods": [
       {
         "name": "<init>",
@@ -1977,6 +3728,21 @@
       {
         "name": "alignedSlice",
         "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.util.internal.PlatformDependent0"
+    },
+    "name": "java.nio.DirectByteBuffer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long",
           "int"
         ]
       }

--- a/tests/src/io.netty/netty-common/4.1.80.Final/build.gradle
+++ b/tests/src/io.netty/netty-common/4.1.80.Final/build.gradle
@@ -11,12 +11,6 @@ plugins {
     id "org.graalvm.internal.tck"
 }
 
-repositories {
-    maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 String libraryVersion = TestUtils.testedLibraryVersion
 
 dependencies {


### PR DESCRIPTION
## What does this PR do?
This PR adds missing metadata for different `ChannelHandler` implementations in Netty 4.1.80.
We also no longer need a snapshot repo for Netty 4.1.80 as this version has been officially released

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
