### PR TITLE
Introducing metadataDescriptor class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ allprojects {
     }
 }
 
-import static org.graalvm.internal.tck.TestUtils.metadataRoot
-import static org.graalvm.internal.tck.TestUtils.repoRoot
-import static org.graalvm.internal.tck.TestUtils.testRoot
+import static org.graalvm.internal.tck.RepoScanner.metadataRoot
+import static org.graalvm.internal.tck.RepoScanner.repoRoot
+import static org.graalvm.internal.tck.RepoScanner.testRoot
 
 project.version("0.2.2-SNAPSHOT")
 

--- a/tests/src/ch.qos.logback/logback-classic/1.2.11/build.gradle
+++ b/tests/src/ch.qos.logback/logback-classic/1.2.11/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
 	id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation "ch.qos.logback:logback-classic:${libraryVersion}"

--- a/tests/src/ch.qos.logback/logback-classic/1.4.1/build.gradle
+++ b/tests/src/ch.qos.logback/logback-classic/1.4.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
 	id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation "ch.qos.logback:logback-classic:${libraryVersion}"

--- a/tests/src/com.h2database/h2/2.1.210/build.gradle
+++ b/tests/src/com.h2database/h2/2.1.210/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation("com.h2database:h2:$libraryVersion")

--- a/tests/src/com.sun.mail/jakarta.mail/2.0.1/build.gradle
+++ b/tests/src/com.sun.mail/jakarta.mail/2.0.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")

--- a/tests/src/com.zaxxer/HikariCP/5.0.1/build.gradle
+++ b/tests/src/com.zaxxer/HikariCP/5.0.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 // This value should be used to declare a dependency to specific library version here.
 
 dependencies {

--- a/tests/src/io.netty/netty-common/4.1.80.Final/build.gradle
+++ b/tests/src/io.netty/netty-common/4.1.80.Final/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation "io.netty:netty-codec-http:$libraryVersion"

--- a/tests/src/io.netty/netty-transport/4.1.76.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport/4.1.76.Final/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation "io.netty:netty-codec-http:$libraryVersion"

--- a/tests/src/mysql/mysql-connector-java/8.0.29/build.gradle
+++ b/tests/src/mysql/mysql-connector-java/8.0.29/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation "mysql:mysql-connector-java:$libraryVersion"

--- a/tests/src/org.apache.commons/commons-pool2/2.11.1/build.gradle
+++ b/tests/src/org.apache.commons/commons-pool2/2.11.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation("org.apache.commons:commons-pool2:$libraryVersion")

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$libraryVersion"

--- a/tests/src/org.example/library/0.0.1/build.gradle
+++ b/tests/src/org.example/library/0.0.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 println("Testing example library version: ${libraryVersion}")
 // This value should be used to declare a dependency to specific library version here.
 

--- a/tests/src/org.flywaydb/flyway-core/9.0.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-core/9.0.1/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation "org.flywaydb:flyway-core:$libraryVersion"

--- a/tests/src/org.glassfish.jaxb/jaxb-runtime/3.0.2/build.gradle
+++ b/tests/src/org.glassfish.jaxb/jaxb-runtime/3.0.2/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")

--- a/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/build.gradle
+++ b/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation("org.hdrhistogram:HdrHistogram:$libraryVersion")

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/build.gradle
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/build.gradle
@@ -5,7 +5,7 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 buildscript {
     repositories {
@@ -17,7 +17,7 @@ plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation("org.hibernate.orm:hibernate-core:$libraryVersion")

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
 	testImplementation("org.hibernate.validator:hibernate-validator:$libraryVersion")

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -5,14 +5,14 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
     id "org.jetbrains.kotlin.jvm" version "1.7.10"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"

--- a/tests/src/org.jline/jline/3.21.0/build.gradle
+++ b/tests/src/org.jline/jline/3.21.0/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation("org.jline:jline:${libraryVersion}")

--- a/tests/src/org.mariadb.jdbc/mariadb-java-client/3.0.6/build.gradle
+++ b/tests/src/org.mariadb.jdbc/mariadb-java-client/3.0.6/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     implementation "org.mariadb.jdbc:mariadb-java-client:$libraryVersion"

--- a/tests/src/org.postgresql/postgresql/42.3.4/build.gradle
+++ b/tests/src/org.postgresql/postgresql/42.3.4/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation "org.postgresql:postgresql:$libraryVersion"

--- a/tests/src/org.quartz-scheduler/quartz/2.3.2/build.gradle
+++ b/tests/src/org.quartz-scheduler/quartz/2.3.2/build.gradle
@@ -5,13 +5,13 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
 plugins {
     id "org.graalvm.internal.tck"
 }
 
-String libraryVersion = TestUtils.testedLibraryVersion
+String libraryVersion = RepoScanner.testedLibraryVersion
 
 dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -13,8 +13,7 @@ import org.graalvm.internal.tck.harness.MetadataLookupLogic
 import org.graalvm.internal.tck.harness.TestLookupLogic
 import org.graalvm.internal.tck.harness.tasks.CheckstyleInvocationTask
 import org.graalvm.internal.tck.harness.tasks.TestInvocationTask
-
-import static org.graalvm.internal.tck.Utils.generateTaskName
+import java.util.stream.Collectors
 
 TestUtils.locateRepoDirs(project) // Find relevant directories for the test harness.
 
@@ -22,9 +21,8 @@ logger.lifecycle("GraalVM Reachability Metadata TCK")
 logger.lifecycle("---------------------------------")
 
 
-String coordinatesArg = project.findProperty("coordinates")
-List<MetadataTest> metadataTests = coordinatesArg != null ?
-        MetadataLookupLogic.getTestsForCoordinates(coordinatesArg) :
+List<MetadataTest> metadataTests = project.hasProperty("coordinates") ?
+        MetadataLookupLogic.getTestsForCoordinates(project.findProperty("coordinates")) :
         MetadataLookupLogic.getAllTests()
 
 // gradle test -Pcoordinates=<maven-coordinates>
@@ -47,7 +45,7 @@ tasks.named("check").configure {
 for (MetadataTest metadataTest in metadataTests) {
     String testTaskName = metadataTest.generateTaskName("test")
     if ((!tasks.getNames().contains(testTaskName))) {
-        tasks.register(testTaskName, TestInvocationTask, coordinates)
+        tasks.register(testTaskName, TestInvocationTask, metadataTest)
     }
     test.configure {
         dependsOn(testTaskName)
@@ -55,7 +53,7 @@ for (MetadataTest metadataTest in metadataTests) {
 
     String checkstyleTaskName = metadataTest.generateTaskName("checkstyle")
     if ((!tasks.getNames().contains(checkstyleTaskName))) {
-        tasks.register(checkstyleTaskName, CheckstyleInvocationTask, coordinates)
+        tasks.register(checkstyleTaskName, CheckstyleInvocationTask, metadataTest)
     }
     checkstyle.configure {
         dependsOn(checkstyleTaskName)
@@ -74,13 +72,13 @@ Provider<Task> diff = tasks.register("diff", DefaultTask) { task ->
     }
 }
 
-List<String> diffCoordinates = new ArrayList<>()
+List<MetadataTest> diffTasks = new ArrayList<>()
 if (project.hasProperty("baseCommit")) {
     String baseCommit = project.findProperty("baseCommit")
     String newCommit = Objects.requireNonNullElse(project.findProperty("newCommit"), "HEAD")
-    for (def coordinates in TestLookupLogic.diffCoordinates(baseCommit, newCommit)) {
-        diffCoordinates.add(coordinates)
-        String taskTaskName = generateTaskName("test", coordinates)
+    for (def metadataTest in TestLookupLogic.diffTests(baseCommit, newCommit)) {
+        diffTasks.add(metadataTest)
+        String taskTaskName = metadataTest.generateTaskName("test")
         if ((!tasks.getNames().contains(taskTaskName))) {
             tasks.register(taskTaskName, TestInvocationTask, coordinates)
         }
@@ -102,7 +100,7 @@ Provider<Task> generateMatrixMatchingCoordinates = tasks.register("generateMatri
     task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
     task.doFirst {
         def matrix = [
-                "coordinates": matchingCoordinates
+                "coordinates": diffTasks.stream().map(t -> t.getGAVCoordinates()).collect(Collectors.toList()).toList()
         ]
         matrix.putAll(matrixDefault)
         println "::set-output name=matrix::${JsonOutput.toJson(matrix)}"
@@ -117,7 +115,7 @@ Provider<Task> generateMatrixDiffCoordinates = tasks.register("generateMatrixDif
         if (!project.hasProperty("baseCommit")) {
             throw new GradleException("Missing 'baseCommit' property! Rerun Gradle with '-PbaseCommit=<commit-hash>'")
         }
-        if (diffCoordinates.isEmpty()) {
+        if (diffTasks.isEmpty()) {
             def matrix = [
                 "coordinates": ["No matches found!"]
             ]
@@ -127,7 +125,7 @@ Provider<Task> generateMatrixDiffCoordinates = tasks.register("generateMatrixDif
             println "::set-output name=none-found::true"
         } else {
             def matrix = [
-                    "coordinates": diffCoordinates
+                    "coordinates": diffTasks.stream().map(t -> t.getGAVCoordinates()).collect(Collectors.toList()).toList()
             ]
             matrix.putAll(matrixDefault)
             println "::set-output name=matrix::${JsonOutput.toJson(matrix)}"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -7,23 +7,23 @@
 
 
 import groovy.json.JsonOutput
-import org.graalvm.internal.common.MetadataTest
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.common.MetadataDescriptor
+import org.graalvm.internal.tck.RepoScanner
 import org.graalvm.internal.tck.harness.MetadataLookupLogic
 import org.graalvm.internal.tck.harness.TestLookupLogic
 import org.graalvm.internal.tck.harness.tasks.CheckstyleInvocationTask
 import org.graalvm.internal.tck.harness.tasks.TestInvocationTask
 import java.util.stream.Collectors
 
-TestUtils.locateRepoDirs(project) // Find relevant directories for the test harness.
+RepoScanner.locateRepoDirs(project) // Find relevant directories for the test harness.
 
 logger.lifecycle("GraalVM Reachability Metadata TCK")
 logger.lifecycle("---------------------------------")
 
 
-List<MetadataTest> metadataTests = project.hasProperty("coordinates") ?
-        MetadataLookupLogic.getTestsForCoordinates(project.findProperty("coordinates")) :
-        MetadataLookupLogic.getAllTests()
+List<MetadataDescriptor> metadataDescriptors = project.hasProperty("coordinates") ?
+        MetadataLookupLogic.getDescriptorsForCoordinates(project.findProperty("coordinates")) :
+        MetadataLookupLogic.getAllDescriptors()
 
 // gradle test -Pcoordinates=<maven-coordinates>
 Provider<Task> test = tasks.register("test", DefaultTask) { task ->
@@ -42,18 +42,18 @@ tasks.named("check").configure {
 }
 
 // Here we want to configure all test and checkstyle tasks for all filtered subprojects
-for (MetadataTest metadataTest in metadataTests) {
-    String testTaskName = metadataTest.generateTaskName("test")
+for (MetadataDescriptor metadataDescriptor in metadataDescriptors) {
+    String testTaskName = metadataDescriptor.generateTaskName("test")
     if ((!tasks.getNames().contains(testTaskName))) {
-        tasks.register(testTaskName, TestInvocationTask, metadataTest)
+        tasks.register(testTaskName, TestInvocationTask, metadataDescriptor)
     }
     test.configure {
         dependsOn(testTaskName)
     }
 
-    String checkstyleTaskName = metadataTest.generateTaskName("checkstyle")
+    String checkstyleTaskName = metadataDescriptor.generateTaskName("checkstyle")
     if ((!tasks.getNames().contains(checkstyleTaskName))) {
-        tasks.register(checkstyleTaskName, CheckstyleInvocationTask, metadataTest)
+        tasks.register(checkstyleTaskName, CheckstyleInvocationTask, metadataDescriptor)
     }
     checkstyle.configure {
         dependsOn(checkstyleTaskName)
@@ -72,13 +72,13 @@ Provider<Task> diff = tasks.register("diff", DefaultTask) { task ->
     }
 }
 
-List<MetadataTest> diffTasks = new ArrayList<>()
+List<MetadataDescriptor> diffDescriptors = new ArrayList<>()
 if (project.hasProperty("baseCommit")) {
     String baseCommit = project.findProperty("baseCommit")
     String newCommit = Objects.requireNonNullElse(project.findProperty("newCommit"), "HEAD")
-    for (def metadataTest in TestLookupLogic.diffTests(baseCommit, newCommit)) {
-        diffTasks.add(metadataTest)
-        String taskTaskName = metadataTest.generateTaskName("test")
+    for (def metadataDescriptor in TestLookupLogic.diffDescriptors(baseCommit, newCommit)) {
+        diffDescriptors.add(metadataDescriptor)
+        String taskTaskName = metadataDescriptor.generateTaskName("test")
         if ((!tasks.getNames().contains(taskTaskName))) {
             tasks.register(taskTaskName, TestInvocationTask, coordinates)
         }
@@ -100,7 +100,7 @@ Provider<Task> generateMatrixMatchingCoordinates = tasks.register("generateMatri
     task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
     task.doFirst {
         def matrix = [
-                "coordinates": diffTasks.stream().map(t -> t.getGAVCoordinates()).collect(Collectors.toList()).toList()
+                "coordinates": diffDescriptors.stream().map(d -> d.getGAVCoordinates()).collect(Collectors.toList()).toList()
         ]
         matrix.putAll(matrixDefault)
         println "::set-output name=matrix::${JsonOutput.toJson(matrix)}"
@@ -115,7 +115,7 @@ Provider<Task> generateMatrixDiffCoordinates = tasks.register("generateMatrixDif
         if (!project.hasProperty("baseCommit")) {
             throw new GradleException("Missing 'baseCommit' property! Rerun Gradle with '-PbaseCommit=<commit-hash>'")
         }
-        if (diffTasks.isEmpty()) {
+        if (diffDescriptors.isEmpty()) {
             def matrix = [
                 "coordinates": ["No matches found!"]
             ]
@@ -125,7 +125,7 @@ Provider<Task> generateMatrixDiffCoordinates = tasks.register("generateMatrixDif
             println "::set-output name=none-found::true"
         } else {
             def matrix = [
-                    "coordinates": diffTasks.stream().map(t -> t.getGAVCoordinates()).collect(Collectors.toList()).toList()
+                    "coordinates": diffDescriptors.stream().map(d -> d.getGAVCoordinates()).collect(Collectors.toList()).toList()
             ]
             matrix.putAll(matrixDefault)
             println "::set-output name=matrix::${JsonOutput.toJson(matrix)}"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -7,6 +7,7 @@
 
 
 import groovy.json.JsonOutput
+import org.graalvm.internal.common.MetadataTest
 import org.graalvm.internal.tck.TestUtils
 import org.graalvm.internal.tck.harness.MetadataLookupLogic
 import org.graalvm.internal.tck.harness.TestLookupLogic
@@ -20,8 +21,11 @@ TestUtils.locateRepoDirs(project) // Find relevant directories for the test harn
 logger.lifecycle("GraalVM Reachability Metadata TCK")
 logger.lifecycle("---------------------------------")
 
-String coordinateFilter = Objects.requireNonNullElse(project.findProperty("coordinates"), "")
-List<String> matchingCoordinates = MetadataLookupLogic.getMatchingCoordinates(coordinateFilter)
+
+String coordinatesArg = project.findProperty("coordinates")
+List<MetadataTest> metadataTests = coordinatesArg != null ?
+        MetadataLookupLogic.getTestsForCoordinates(coordinatesArg) :
+        MetadataLookupLogic.getAllTests()
 
 // gradle test -Pcoordinates=<maven-coordinates>
 Provider<Task> test = tasks.register("test", DefaultTask) { task ->
@@ -40,8 +44,8 @@ tasks.named("check").configure {
 }
 
 // Here we want to configure all test and checkstyle tasks for all filtered subprojects
-for (String coordinates in matchingCoordinates) {
-    String testTaskName = generateTaskName("test", coordinates)
+for (MetadataTest metadataTest in metadataTests) {
+    String testTaskName = metadataTest.generateTaskName("test")
     if ((!tasks.getNames().contains(testTaskName))) {
         tasks.register(testTaskName, TestInvocationTask, coordinates)
     }
@@ -49,7 +53,7 @@ for (String coordinates in matchingCoordinates) {
         dependsOn(testTaskName)
     }
 
-    String checkstyleTaskName = generateTaskName("checkstyle", coordinates)
+    String checkstyleTaskName = metadataTest.generateTaskName("checkstyle")
     if ((!tasks.getNames().contains(checkstyleTaskName))) {
         tasks.register(checkstyleTaskName, CheckstyleInvocationTask, coordinates)
     }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -5,10 +5,10 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.tck.RepoScanner
 
-import static org.graalvm.internal.tck.TestUtils.metadataRoot
-import static org.graalvm.internal.tck.TestUtils.repoRoot
+import static org.graalvm.internal.tck.RepoScanner.metadataRoot
+import static org.graalvm.internal.tck.RepoScanner.repoRoot
 
 plugins {
     id 'checkstyle'
@@ -24,7 +24,7 @@ tasks.withType(JavaCompile) {
     options.release = 11
 }
 
-TestUtils.locateRepoDirs(project) // Find relevant directories for the test harness.
+RepoScanner.locateRepoDirs(project) // Find relevant directories for the test harness.
 
 checkstyle {
     configFile repoRoot.resolve("gradle").resolve("checkstyle.xml").toFile()
@@ -57,7 +57,7 @@ String overrideVal = System.getenv("GVM_TCK_EXCLUDE") ?: providers.gradlePropert
 overrideVal = overrideVal ?: "false"
 boolean override = overrideVal.toBoolean()
 
-TestUtils.testedLibraryVersion = libraryVersion
+RepoScanner.testedLibraryVersion = libraryVersion
 // This value can be used to request specific library version to test with.
 
 dependencies {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataDescriptor.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataDescriptor.groovy
@@ -5,10 +5,10 @@ import org.graalvm.internal.tck.harness.MetadataLookupLogic
 
 import java.nio.file.Path
 
-import static org.graalvm.internal.tck.TestUtils.metadataRoot
-import static org.graalvm.internal.tck.TestUtils.testRoot
+import static org.graalvm.internal.tck.RepoScanner.metadataRoot
+import static org.graalvm.internal.tck.RepoScanner.testRoot
 
-class MetadataTest {
+class MetadataDescriptor {
 
     private static String INDEX_FILE = "index.json"
 
@@ -19,7 +19,7 @@ class MetadataTest {
     private Path testDir
     private boolean override
 
-    MetadataTest(String coordinates) {
+    MetadataDescriptor(String coordinates) {
         def (String group, String artifact, String version) = Utils.splitCoordinates(coordinates)
         this.group = group
         this.artifact = artifact

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataDescriptor.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataDescriptor.groovy
@@ -15,7 +15,7 @@ class MetadataDescriptor {
     private String group
     private String artifact
     private String version
-    private Path metadataDir
+    private Path metadataDir // TODO this should be List<Path>
     private Path testDir
     private boolean override
 
@@ -122,11 +122,12 @@ class MetadataDescriptor {
             def metadataIndex = Utils.extractJsonFile(index)
             for (def entry in metadataIndex) {
                 if (Utils.coordinatesMatch((String) entry["module"], group, artifact) && ((List<String>) entry["tested-versions"]).contains(version)) {
+                    // TODO extract logic for override to make the function cleaner
                     if (entry.containsKey("override")) {
                         this.override = entry["override"] as boolean
                     }
-                    Path metadataDir = fullDir.resolve(version)
-                    return metadataDir
+                    // TODO as we are in class, we don't need to have return value, just append list (once we have List<Path> instead of Path), there is no need for return value
+                    return fullDir.resolve((String) entry["metadata-version"])
                 }
             }
         }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataTest.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/common/MetadataTest.groovy
@@ -1,0 +1,147 @@
+package org.graalvm.internal.common
+
+import org.graalvm.internal.tck.Utils
+import org.graalvm.internal.tck.harness.MetadataLookupLogic
+
+import java.nio.file.Path
+
+import static org.graalvm.internal.tck.TestUtils.metadataRoot
+import static org.graalvm.internal.tck.TestUtils.testRoot
+
+class MetadataTest {
+
+    private static String INDEX_FILE = "index.json"
+
+    private String group
+    private String artifact
+    private String version
+    private Path metadataDir
+    private Path testDir
+    private boolean override
+
+    MetadataTest(String group, String artifact, String version, boolean override = false) {
+        this.group = group
+        this.artifact = artifact
+        this.version = version
+        this.override = override
+        this.metadataDir = findMetadataDir()
+        this.testDir = findTestDir()
+    }
+
+    MetadataTest(String coordinates, boolean override = false) {
+        def (String group, String artifact, String version) = Utils.splitCoordinates(coordinates)
+        this.MetadataTest(group, artifact, version, override)
+    }
+
+    /**
+     *  Generates GAV coordinate
+     *
+     * @return GAV coordinates
+     */
+    String getGAVCoordinates() {
+        return "${group}:${artifact}:${version}"
+    }
+
+    Path getMetadataDir() {
+        return metadataDir
+    }
+
+    Path getTestDir() {
+        return testDir
+    }
+
+    /**
+     * Generates coordinate specific task name.
+     *
+     * @param prefix
+     * @return coordinate specific task name
+     */
+    String generateTaskName(String prefix) {
+        return "${prefix}-${getGAVCoordinates().replace(":", "-")}"
+    }
+
+    /**
+     * Returns a set of all directories that match given group ID and artifact ID.
+     * null values match every possible value (null artifact ID matches all artifacts in given group).
+     *
+     * @return set of all directories that match given criteria
+     */
+    private Set<String> getMatchingMetadataDirs() {
+        Set<String> dirs = new HashSet<String>()
+        for (Map<String, ?> library in (Utils.readIndexFile(metadataRoot) as List<Map<String, ?>>)) {
+            if (Utils.coordinatesMatch((String) library["module"], group, artifact)) {
+                if (library.containsKey("directory")) {
+                    dirs.add((String) library["directory"])
+                }
+                if (library.containsKey("requires")) {
+                    for (String dep in library["requires"]) {
+                        def (String depGroup, String depArtifact) = Utils.splitCoordinates((String) dep)
+                        dirs.addAll(MetadataLookupLogic.getMatchingMetadataDirs(depGroup, depArtifact))
+                    }
+                }
+            }
+        }
+
+        if (group != null && artifact != null) {
+            // Let's see if library wasn't added to index but is present on the disk.
+            Path defaultDir = metadataRoot.resolve(group).resolve(artifact)
+            if (defaultDir.resolve("index.json").toFile().exists()) {
+                dirs.add(defaultDir.toString())
+            }
+        }
+        return dirs
+    }
+
+
+    /**
+     * Returns metadata directory for given full coordinates
+     *
+     * @return path to metadata directory
+     */
+    private Path findMetadataDir() {
+        Objects.requireNonNull(group, "Group ID must be specified")
+        Objects.requireNonNull(artifact, "Artifact ID must be specified")
+        Objects.requireNonNull(version, "Version must be specified")
+
+        Set<String> matchingDirs = getMatchingMetadataDirs()
+        for (String directory in matchingDirs) {
+            Path fullDir = metadataRoot.resolve(directory)
+            Path index = fullDir.resolve(INDEX_FILE)
+
+            def metadataIndex = Utils.extractJsonFile(index)
+            for (def entry in metadataIndex) {
+                if (Utils.coordinatesMatch((String) entry["module"], group, artifact) && ((List<String>) entry["tested-versions"]).contains(version)) {
+                    return fullDir.resolve((String) entry["metadata-version"])
+                }
+            }
+        }
+        throw new RuntimeException("Missing metadata for ${getGAVCoordinates()}")
+    }
+
+    /**
+     * Given full coordinates returns matching test directory
+     *
+     * @return matching test directory
+     */
+    private Path findTestDir() {
+        Objects.requireNonNull(group, "Group ID must be specified")
+        Objects.requireNonNull(artifact, "Artifact ID must be specified")
+        Objects.requireNonNull(version, "Version must be specified")
+
+        // First, let's try if we can find test directory from the new `tests/src/index.json` file.
+        List<Map<String, ?>> index = Utils.readIndexFile(testRoot) as List<Map<String, ?>>
+        for (Map<String, ?> entry in index) {
+            boolean found = ((List<Map<String, ?>>) entry.get("libraries")).stream().anyMatch(
+                    lib -> {
+                        return Utils.coordinatesMatch((String) lib.get("name"), group, artifact) &&
+                                ((List<String>) lib.get("versions")).contains(version)
+                    }
+            )
+            if (found) {
+                return testRoot.resolve((String) entry.get("test-project-path"))
+            }
+        }
+        throw new RuntimeException("Missing test-directory for coordinates `${getGAVCoordinates()}`")
+    }
+
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/RepoScanner.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/RepoScanner.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.Project
 import java.nio.file.Path
 
 @SuppressWarnings("unused")
-class TestUtils {
+class RepoScanner {
     public static Path repoRoot
     public static Path metadataRoot
     public static Path testRoot

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/Utils.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/Utils.groovy
@@ -49,16 +49,6 @@ class Utils {
     }
 
     /**
-     * Generates coordinate specific task name.
-     * @param taskName
-     * @param coordinates
-     * @return coordinate specific task name
-     */
-    static String generateTaskName(String taskName, String coordinates) {
-        return "${taskName}-${coordinates.replace(":", "-")}"
-    }
-
-    /**
      * Checks if given coordinates string matches given group ID and artifact ID.
      * null values match every possible value (null artifact ID matches all artifacts in given group).
      *

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
@@ -7,14 +7,14 @@
 
 package org.graalvm.internal.tck.harness
 
-import org.graalvm.internal.common.MetadataTest
+import org.graalvm.internal.common.MetadataDescriptor
 
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
-import static org.graalvm.internal.tck.TestUtils.metadataRoot
+import static org.graalvm.internal.tck.RepoScanner.metadataRoot
 import static org.graalvm.internal.tck.Utils.coordinatesMatch
 import static org.graalvm.internal.tck.Utils.extractJsonFile
 import static org.graalvm.internal.tck.Utils.readIndexFile
@@ -89,7 +89,7 @@ class MetadataLookupLogic {
      * @param coordinateFilter
      * @return list of all coordinates that
      */
-    static List<MetadataTest> getTestsForCoordinates(String coordinateFilter = "") {
+    static List<MetadataDescriptor> getDescriptorsForCoordinates(String coordinateFilter = "") {
         def (String groupId, String artifactId, String version) = splitCoordinates(coordinateFilter)
 
         Set<String> matchingCoordinates = new HashSet<>()
@@ -115,11 +115,11 @@ class MetadataLookupLogic {
             }
         }
 
-        return matchingCoordinates.stream().map(c -> new MetadataTest(c)).collect(Collectors.toList()).toList()
+        return matchingCoordinates.stream().map(c -> new MetadataDescriptor(c)).collect(Collectors.toList()).toList()
     }
 
-    static List<MetadataTest> getAllTests() {
-        return getTestsForCoordinates()
+    static List<MetadataDescriptor> getAllDescriptors() {
+        return getDescriptorsForCoordinates()
     }
 
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
@@ -11,6 +11,7 @@ import org.graalvm.internal.common.MetadataTest
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.stream.Collectors
 import java.util.stream.Stream
 
 import static org.graalvm.internal.tck.TestUtils.metadataRoot
@@ -91,24 +92,30 @@ class MetadataLookupLogic {
     static List<MetadataTest> getTestsForCoordinates(String coordinateFilter = "") {
         def (String groupId, String artifactId, String version) = splitCoordinates(coordinateFilter)
 
-        Set<MetadataTest> matchingCoordinates = new HashSet<>()
+        Set<String> matchingCoordinates = new HashSet<>()
 
         for (String directory in getMatchingMetadataDirs(groupId, artifactId)) {
             Path index = metadataRoot.resolve(directory).resolve(INDEX_FILE)
             def metadataIndex = extractJsonFile(index)
 
             for (def entry in metadataIndex) {
+                List<String> coordinates = splitCoordinates((String) entry["module"])
                 List<String> testedVersions = entry["tested-versions"] as List<String>
                 if (coordinatesMatch((String) entry["module"], groupId, artifactId) && (version == null || testedVersions.contains(version))) {
                     if (version == null) { // We want all library versions, so let's add them.
-                        testedVersions.stream().forEach(t -> matchingCoordinates.add(new MetadataTest("${entry["module"]}:${t}")))
+                        testedVersions.stream()
+                                .filter(t -> metadataRoot.resolve(coordinates.get(0)).resolve(coordinates.get(1)).resolve(t).toFile().exists())
+                                .forEach(t -> matchingCoordinates.add("${entry["module"]}:${t}"))
                     } else { // We have a specific version pinned.
-                        matchingCoordinates.add(new MetadataTest("${entry["module"]}:${version}"))
+                        if (metadataRoot.resolve(coordinates.get(0)).resolve(coordinates.get(1)).resolve(version).toFile().exists()) {
+                            matchingCoordinates.add("${entry["module"]}:${version}")
+                        }
                     }
                 }
             }
         }
-        return matchingCoordinates.toList()
+
+        return matchingCoordinates.stream().map(c -> new MetadataTest(c)).collect(Collectors.toList()).toList()
     }
 
     static List<MetadataTest> getAllTests() {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
@@ -7,6 +7,8 @@
 
 package org.graalvm.internal.tck.harness
 
+import org.graalvm.internal.common.MetadataTest
+
 import java.nio.file.Path
 import java.util.stream.Collectors
 
@@ -24,7 +26,7 @@ class TestLookupLogic {
      * @return List of coordinates
      */
     @SuppressWarnings("unused")
-    static List<String> diffCoordinates(String baseCommit, String newCommit) {
+    static List<MetadataTest> diffTests(String baseCommit, String newCommit) {
         String cmd = "git diff --name-only --diff-filter=ACMRT ${baseCommit} ${newCommit}"
 
         Process p = cmd.execute()
@@ -52,10 +54,6 @@ class TestLookupLogic {
         if (testAll) {
             // If tck was changed we should retest everything, just to be safe.
             return MetadataLookupLogic.getAllTests()
-                    .stream()
-                    .map(t -> t.getGAVCoordinates())
-                    .collect(Collectors.toSet())
-                    .toList()
         }
 
         // First get all available tests, then filter them by if their corresponding metadata / tests directories
@@ -70,6 +68,6 @@ class TestLookupLogic {
                 return true
             }
             return false
-        }).map(t -> t.getGAVCoordinates()).collect(Collectors.toSet()).toList()
+        }).collect(Collectors.toSet()).toList()
     }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
@@ -10,48 +10,13 @@ package org.graalvm.internal.tck.harness
 import java.nio.file.Path
 import java.util.stream.Collectors
 
-import static org.graalvm.internal.tck.TestUtils.metadataRoot
-import static org.graalvm.internal.tck.TestUtils.repoRoot
-import static org.graalvm.internal.tck.TestUtils.tckRoot
-import static org.graalvm.internal.tck.TestUtils.testRoot
-import static org.graalvm.internal.tck.Utils.coordinatesMatch
-import static org.graalvm.internal.tck.Utils.readIndexFile
-import static org.graalvm.internal.tck.Utils.splitCoordinates
-import static org.graalvm.internal.tck.harness.MetadataLookupLogic.getMetadataDir
+import static org.graalvm.internal.tck.TestUtils.*
 
 /**
  * Class that provides static methods that are used to fetch tests for metadata.
  */
 @SuppressWarnings("unused")
 class TestLookupLogic {
-    /**
-     * Given full coordinates returns matching test directory
-     * @param coordinates
-     * @return
-     */
-    static Path getTestDir(String coordinates) {
-        def (String groupId, String artifactId, String version) = splitCoordinates(coordinates)
-        Objects.requireNonNull(groupId, "Group ID must be specified")
-        Objects.requireNonNull(artifactId, "Artifact ID must be specified")
-        Objects.requireNonNull(version, "Version must be specified")
-
-        // First, let's try if we can find test directory from the new `tests/src/index.json` file.
-
-        List<Map<String, ?>> index = readIndexFile(testRoot) as List<Map<String, ?>>
-        for (Map<String, ?> entry in index) {
-            boolean found = ((List<Map<String, ?>>) entry.get("libraries")).stream().anyMatch(
-                    lib -> {
-                        return coordinatesMatch((String) lib.get("name"), groupId, artifactId) &&
-                                ((List<String>) lib.get("versions")).contains(version)
-                    }
-            )
-            if (found) {
-                return testRoot.resolve((String) entry.get("test-project-path"))
-            }
-        }
-        throw new RuntimeException("Missing test-directory for coordinates `${coordinates}`")
-    }
-
     /**
      * Returns a list of coordinates that match changed files between baseCommit and newCommit.
      * @param baseCommit
@@ -86,21 +51,25 @@ class TestLookupLogic {
 
         if (testAll) {
             // If tck was changed we should retest everything, just to be safe.
-            return MetadataLookupLogic.getMatchingCoordinates("")
+            return MetadataLookupLogic.getAllTests()
+                    .stream()
+                    .map(t -> t.getGAVCoordinates())
+                    .collect(Collectors.toSet())
+                    .toList()
         }
 
-        // First get all available coordinates, then filter them by if their corresponding metadata / tests directories
+        // First get all available tests, then filter them by if their corresponding metadata / tests directories
         // contain changed files.
-        return MetadataLookupLogic.getMatchingCoordinates("").stream().filter(c -> {
-            Path metadataDir = getMetadataDir(c)
+        return MetadataLookupLogic.getAllTests().stream().filter(t -> {
+            Path metadataDir = t.getMetadataDir()
             if (changed["metadata"].stream().anyMatch(f -> f.startsWith(metadataDir))) {
                 return true
             }
-            Path testDir = getTestDir(c)
+            Path testDir = t.getTestDir()
             if (changed["test"].stream().anyMatch(f -> f.startsWith(testDir))) {
                 return true
             }
             return false
-        }).collect(Collectors.toSet()).toList()
+        }).map(t -> t.getGAVCoordinates()).collect(Collectors.toSet()).toList()
     }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TestLookupLogic.groovy
@@ -7,12 +7,12 @@
 
 package org.graalvm.internal.tck.harness
 
-import org.graalvm.internal.common.MetadataTest
+import org.graalvm.internal.common.MetadataDescriptor
 
 import java.nio.file.Path
 import java.util.stream.Collectors
 
-import static org.graalvm.internal.tck.TestUtils.*
+import static org.graalvm.internal.tck.RepoScanner.*
 
 /**
  * Class that provides static methods that are used to fetch tests for metadata.
@@ -26,7 +26,7 @@ class TestLookupLogic {
      * @return List of coordinates
      */
     @SuppressWarnings("unused")
-    static List<MetadataTest> diffTests(String baseCommit, String newCommit) {
+    static List<MetadataDescriptor> diffDescriptors(String baseCommit, String newCommit) {
         String cmd = "git diff --name-only --diff-filter=ACMRT ${baseCommit} ${newCommit}"
 
         Process p = cmd.execute()
@@ -53,17 +53,17 @@ class TestLookupLogic {
 
         if (testAll) {
             // If tck was changed we should retest everything, just to be safe.
-            return MetadataLookupLogic.getAllTests()
+            return MetadataLookupLogic.getAllDescriptors()
         }
 
         // First get all available tests, then filter them by if their corresponding metadata / tests directories
         // contain changed files.
-        return MetadataLookupLogic.getAllTests().stream().filter(t -> {
-            Path metadataDir = t.getMetadataDir()
+        return MetadataLookupLogic.getAllDescriptors().stream().filter(d -> {
+            Path metadataDir = d.getMetadataDir()
             if (changed["metadata"].stream().anyMatch(f -> f.startsWith(metadataDir))) {
                 return true
             }
-            Path testDir = t.getTestDir()
+            Path testDir = d.getTestDir()
             if (changed["test"].stream().anyMatch(f -> f.startsWith(testDir))) {
                 return true
             }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.groovy
@@ -8,7 +8,7 @@
 package org.graalvm.internal.tck.harness.tasks
 
 import groovy.transform.Internal
-import org.graalvm.internal.common.MetadataTest
+import org.graalvm.internal.common.MetadataDescriptor
 import org.graalvm.internal.tck.harness.MetadataLookupLogic
 import org.gradle.api.tasks.Exec
 
@@ -17,7 +17,7 @@ import java.nio.file.Path
 import java.util.stream.Collectors
 
 import static groovy.io.FileType.FILES
-import static org.graalvm.internal.tck.TestUtils.tckRoot
+import static org.graalvm.internal.tck.RepoScanner.tckRoot
 
 /**
  * Abstract task that is used to invoke test subprojects.
@@ -26,15 +26,15 @@ import static org.graalvm.internal.tck.TestUtils.tckRoot
 abstract class AbstractSubprojectTask extends Exec {
 
     @Inject
-    AbstractSubprojectTask(MetadataTest test, List<String> cmd) {
-        Path metadataDir = test.getMetadataDir()
-        Path testDir = test.getTestDir()
+    AbstractSubprojectTask(MetadataDescriptor metadataDescriptor, List<String> cmd) {
+        Path metadataDir = metadataDescriptor.getMetadataDir()
+        Path testDir = metadataDescriptor.getTestDir()
 
         Map<String, String> env = new HashMap<>(System.getenv())
         // Environment variables for setting up TCK
-        env.put("GVM_TCK_LC", test.getGAVCoordinates())
-        env.put("GVM_TCK_EXCLUDE", test.getOverride().toString())
-        env.put("GVM_TCK_LV", test.getVersion())
+        env.put("GVM_TCK_LC", metadataDescriptor.getGAVCoordinates())
+        env.put("GVM_TCK_EXCLUDE", metadataDescriptor.getOverride().toString())
+        env.put("GVM_TCK_LV", metadataDescriptor.getVersion())
         env.put("GVM_TCK_MD", metadataDir.toAbsolutePath().toString())
         env.put("GVM_TCK_TCKDIR", tckRoot.toAbsolutePath().toString())
         environment(env)

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.groovy
@@ -18,9 +18,6 @@ import java.util.stream.Collectors
 
 import static groovy.io.FileType.FILES
 import static org.graalvm.internal.tck.TestUtils.tckRoot
-import static org.graalvm.internal.tck.Utils.coordinatesMatch
-import static org.graalvm.internal.tck.Utils.readIndexFile
-import static org.graalvm.internal.tck.Utils.splitCoordinates
 
 /**
  * Abstract task that is used to invoke test subprojects.

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
@@ -8,6 +8,7 @@
 package org.graalvm.internal.tck.harness.tasks
 
 import org.graalvm.internal.common.MetadataTest
+import org.graalvm.internal.tck.TestUtils
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
@@ -19,11 +20,11 @@ import javax.inject.Inject
 @SuppressWarnings("unused")
 abstract class CheckstyleInvocationTask extends AbstractSubprojectTask {
 
-    static final CHECKSTYLE_COMMAND = List.of("gradle", "checkstyle")
+    static final CHECKSTYLE_COMMAND = List.of(TestUtils.repoRoot.resolve("gradlew").toString(), "checkstyle")
 
     @Inject
-    CheckstyleInvocationTask(String coordinates, List<String> cmd) {
-        super(new MetadataTest(coordinates), CHECKSTYLE_COMMAND)
+    CheckstyleInvocationTask(MetadataTest test, List<String> cmd) {
+        super(test, CHECKSTYLE_COMMAND)
     }
 
     @TaskAction

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
@@ -7,8 +7,8 @@
 
 package org.graalvm.internal.tck.harness.tasks
 
-import org.graalvm.internal.common.MetadataTest
-import org.graalvm.internal.tck.TestUtils
+import org.graalvm.internal.common.MetadataDescriptor
+import org.graalvm.internal.tck.RepoScanner
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
@@ -20,11 +20,11 @@ import javax.inject.Inject
 @SuppressWarnings("unused")
 abstract class CheckstyleInvocationTask extends AbstractSubprojectTask {
 
-    static final CHECKSTYLE_COMMAND = List.of(TestUtils.repoRoot.resolve("gradlew").toString(), "checkstyle")
+    static final CHECKSTYLE_COMMAND = List.of(RepoScanner.repoRoot.resolve("gradlew").toString(), "checkstyle")
 
     @Inject
-    CheckstyleInvocationTask(MetadataTest test, List<String> cmd) {
-        super(test, CHECKSTYLE_COMMAND)
+    CheckstyleInvocationTask(MetadataDescriptor metadataDescriptor, List<String> cmd) {
+        super(metadataDescriptor, CHECKSTYLE_COMMAND)
     }
 
     @TaskAction

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckstyleInvocationTask.groovy
@@ -7,6 +7,7 @@
 
 package org.graalvm.internal.tck.harness.tasks
 
+import org.graalvm.internal.common.MetadataTest
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
@@ -22,7 +23,7 @@ abstract class CheckstyleInvocationTask extends AbstractSubprojectTask {
 
     @Inject
     CheckstyleInvocationTask(String coordinates, List<String> cmd) {
-        super(coordinates, CHECKSTYLE_COMMAND)
+        super(new MetadataTest(coordinates), CHECKSTYLE_COMMAND)
     }
 
     @TaskAction

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.groovy
@@ -7,9 +7,8 @@
 
 package org.graalvm.internal.tck.harness.tasks
 
+import org.graalvm.internal.common.MetadataTest
 import org.graalvm.internal.tck.TestUtils
-import org.graalvm.internal.tck.harness.MetadataLookupLogic
-import org.graalvm.internal.tck.harness.TestLookupLogic
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -34,7 +33,7 @@ abstract class TestInvocationTask extends AbstractSubprojectTask {
 
     @Inject
     TestInvocationTask(String coordinates) {
-        super(coordinates, getArguments(coordinates))
+        super(new MetadataTest(coordinates), getArguments(coordinates))
         dependsOn("check")
         this.coordinates = coordinates
     }
@@ -45,13 +44,14 @@ abstract class TestInvocationTask extends AbstractSubprojectTask {
      * @return list of processed arguments
      */
     static List<String> getArguments(String coordinates) {
+        MetadataTest test = new MetadataTest(coordinates)
         try {
-            Map<String, List<String>> testIndex = readIndexFile(TestLookupLogic.getTestDir(coordinates)) as Map<String, List<String>>
+            Map<String, List<String>> testIndex = readIndexFile(test.getTestDir()) as Map<String, List<String>>
             if (!testIndex.containsKey("test-command")) {
                 return DEFAULT_ARGS
             }
 
-            Path metadataDir = MetadataLookupLogic.getMetadataDir(coordinates)
+            Path metadataDir = test.getMetadataDir()
             return testIndex.get("test-command").stream()
                     .map(c -> processCommand(c, metadataDir, coordinates))
                     .collect(Collectors.toList())


### PR DESCRIPTION
## What does this PR do?

- Replace coordinate string usage with class that should hold whole logic for coordinate manipulation and also provide additional flexibility for using metadata.
- Extract logic for finding metadataDir and testDir because they only depends on GAV coordinates (now we calculate this only once on metadataDescriptor instantiation)
- Makes code more readable and more flexible for possible changes

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
