### PR TITLE
Metadata version fix

### DIFF
--- a/metadata/io.netty/netty-transport/index.json
+++ b/metadata/io.netty/netty-transport/index.json
@@ -5,8 +5,14 @@
     "metadata-version": "4.1.80.Final",
     "module": "io.netty:netty-transport",
     "tested-versions": [
-      "4.1.76.Final",
       "4.1.80.Final"
+    ]
+  },
+  {
+    "metadata-version": "4.1.76.Final",
+    "module": "io.netty:netty-transport",
+    "tested-versions": [
+      "4.1.76.Final"
     ]
   }
 ]

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/MetadataLookupLogic.groovy
@@ -96,7 +96,7 @@ class MetadataLookupLogic {
 
             for (def entry in metadataIndex) {
                 if (coordinatesMatch((String) entry["module"], groupId, artifactId) && ((List<String>) entry["tested-versions"]).contains(version)) {
-                    Path metadataDir = fullDir.resolve(version)
+                    Path metadataDir = fullDir.resolve((String) entry["metadata-version"])
                     return metadataDir
                 }
             }


### PR DESCRIPTION
## What does this PR do?
It reverts 40992cc18a69da5f395788a9ac56987ba5ad1c30 and update `netty-transport` metadata to provide 2 distinct entries for `4.1.76.Final` and `4.1.80.Final`.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
