### PR TITLE
fix the link to metadata docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GraalVM Reachability Metadata Repository
 
 When you use [GraalVM Native Image](https://www.graalvm.org/22.1/reference-manual/native-image/) to build a native executable it only includes the elements reachable from your application entry point, its dependent libraries, and the JDK classes discovered through static analysis. However, the reachability of some elements (such as classes, methods, or fields) may not be discoverable due to Java’s dynamic features including reflection, resource access, dynamic proxies, and serialization. If an element is not reachable, it is not included in the generated executable and this can lead to run time failures.
-To include elements whose reachability is undiscoverable, the Native Image builder requires externally provided [reachability metadata](https://www.graalvm.org/22.2/reference-manual/native-image/ReachabilityMetadata/).
+To include elements whose reachability is undiscoverable, the Native Image builder requires externally provided [reachability metadata](https://www.graalvm.org/reference-manual/native-image/metadata/).
 
 The GraalVM Reachability Metadata Repository enables Native Image users to share and reuse metadata for libraries and frameworks in the Java ecosystem, and thus simplify maintaining third-party dependencies. The repository is integrated with [GraalVM Native Build Tools](https://github.com/graalvm/native-build-tools) beginning with version 0.9.13: you can enable automatic use of the metadata repository for [Gradle projects](https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html#metadata-support) or for [Maven projects](https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#metadata-support).
 


### PR DESCRIPTION
I've noticed that the existing link (https://www.graalvm.org/22.2/reference-manual/native-image/ReachabilityMetadata/) returns 404, this fixed it. i also dropped the version number from the URL, this way the link will always redirect to the latest docs.

## What does this PR do?


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
