### PR TITLE
Add missing hints extracted from org.hibernate.orm:hibernate-graalvm:6.1.1.Final

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -1,5 +1,209 @@
 [
   {
+    "name": "[Lorg.hibernate.event.spi.PreInsertEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionRecreateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.ClearEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionRecreateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionRemoveEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionRemoveEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreDeleteEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.entity.JoinedSubclassEntityPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.entity.UnionSubclassEntityPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.collection.OneToManyPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.type.EnumType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "[B",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
@@ -11595,6 +11799,14 @@
           "org.hibernate.cache.spi.access.CollectionDataAccess",
           "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
         ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
       }
     ]
   },
@@ -11611,6 +11823,15 @@
           "org.hibernate.cache.spi.access.EntityDataAccess",
           "org.hibernate.cache.spi.access.NaturalIdDataAccess",
           "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
         ]
       }
     ]

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/Cart.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/Cart.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.orm;
+
+import java.util.Set;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.GenericGenerator;
+
+
+@Entity
+@Table(name = "CART")
+public class Cart {
+
+    @Id
+    @GeneratedValue(generator = "increment")
+    @GenericGenerator(name = "increment", strategy = "increment")
+    private Long id;
+
+    @OneToMany(mappedBy = "cart")
+    private Set<Item> items;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Set<Item> getItems() {
+        return items;
+    }
+
+    public void setItems(Set<Item> items) {
+        this.items = items;
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm;
 
+import java.util.Collections;
 import java.util.Date;
 
 import jakarta.persistence.EntityManager;
@@ -50,6 +51,38 @@ public class HibernateOrmTest {
 
         session.persist(new Event("Our very first event!", new Date()));
         session.persist(new Event("A follow up event", new Date()));
+
+        session.close();
+        sessionFactory.close();
+    }
+
+    @Test
+    void relations() {
+
+        Configuration config = new Configuration();
+
+        config.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+        config.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+        config.setProperty("hibernate.connection.username", "");
+        config.setProperty("hibernate.connection.password", "");
+        config.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+        config.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+
+        config.addAnnotatedClass(Cart.class);
+        config.addAnnotatedClass(Item.class);
+
+        SessionFactory sessionFactory = config.buildSessionFactory();
+        Session session = sessionFactory.openSession();
+
+        Cart cart = new Cart();
+        Item item = new Item();
+        item.setCart(cart);
+        cart.setItems(Collections.singleton(item));
+
+        session.persist(cart);
+        session.persist(item);
+
+        Cart load = session.byId(Cart.class).load(cart.getId());
 
         session.close();
         sessionFactory.close();

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/Item.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/Item.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.orm;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "ITEMS")
+public class Item {
+
+    @Id
+    @GeneratedValue(generator = "increment")
+    @GenericGenerator(name = "increment", strategy = "increment")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    public Item() {
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Cart getCart() {
+        return cart;
+    }
+
+    public void setCart(Cart cart) {
+        this.cart = cart;
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
@@ -3,5 +3,15 @@
     "name": "org.hibernate.orm.Event",
     "allDeclaredFields": true,
     "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.hibernate.orm.Cart",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.hibernate.orm.Item",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
   }
 ]

--- a/tests/src/org.hibernate.orm/hibernate-core/README.md
+++ b/tests/src/org.hibernate.orm/hibernate-core/README.md
@@ -2,6 +2,8 @@
 
 The metadata has been gathered by a combination of running the hibernate-orm:hibernate-core tests for H2, package by package with the agent attached, combining the results and by tweaking and completing the output files.
 
+Additionally extract and manually merge hints provided by the `org.hibernate.orm:hibernate-graalvm` artifact by capturing hints contribuited via `org.hibernate.graalvm.internal.GraalVMStaticAutofeature`.
+
 ## Run tests with agent
 
 **Note**: Provide extra memory (`-Xmx12g`) to `native-image-configure`.
@@ -65,4 +67,80 @@ done
   ]
 }
 ```
+
+## Extract AutomaticFeature hints
+
+```java
+
+// trick native environment
+HostedManagement hostedManagement = new HostedManagement();
+ReflectionTestUtils.setField(HostedManagement.class, "singletonDuringImageBuild", hostedManagement);
+Constructor<ReflectionDataBuilder> declaredConstructor = ReflectionDataBuilder.class.getDeclaredConstructor(SubstrateAnnotationExtracter.class);
+ReflectionUtils.makeAccessible(declaredConstructor);
+ReflectionDataBuilder reflectionDataBuilder = declaredConstructor.newInstance(
+    new SubstrateAnnotationExtracter() {
+      @Override
+      public boolean hasAnnotation(AnnotatedElement element, Class<? extends Annotation> annotationType) {
+        return false;
+      }
+      @Override
+      public <T extends Annotation> T extractAnnotation(AnnotatedElement element, Class<T> annotationType, boolean declaredOnly) {
+        return null;
+      }
+    });
+ReflectionTestUtils.invokeMethod(hostedManagement, "doAdd", RuntimeReflectionSupport.class, reflectionDataBuilder);
+
+// invoke writing hints
+GraalVMStaticAutofeature feature = new GraalVMStaticAutofeature();
+feature.beforeAnalysis(null);
+
+// extract & render classes
+Map<Class<?>, ReflectionDataBuilder> configObjects = (Map<Class<?>, ReflectionDataBuilder>) ReflectionTestUtils.getField(HostedManagement.get(), "configObjects");
+Set<Class<?>> reflectionClasses = (Set<Class<?>>) ReflectionTestUtils.getField(configObjects.get(RuntimeReflectionSupport.class), "reflectionClasses");
+
+reflectionClasses.forEach(type -> {
+  System.out.print(
+      String.format("""
+          {
+             "name": "%s",
+             "condition": {
+               "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+             }
+          },
+          """, type.getName())
+  );
+});
+
+// etract & render methods
+Map<Executable, Object> reflectionMethods = (Map<Executable, Object>) ReflectionTestUtils.getField(configObjects.get(RuntimeReflectionSupport.class), "reflectionMethods");
+MultiValueMap<Class<?>, Executable> methodMap = new LinkedMultiValueMap<>();
+reflectionMethods.forEach((method, access) -> {
+  methodMap.add(method.getDeclaringClass(), method);
+});
+methodMap.forEach((type, methods) -> {
+  String methodParam = methods.stream()
+      .map(method -> {
+        String methodName = method.getName().equals(type.getName()) ? "<init>" : method.getName();
+            return String.format("    {\n" +
+                         "      \"name\": \"%s\",\n"+
+                         "      \"parameterTypes\": [%s]\n" +
+                         "    }"
+                , methodName, Arrays.asList(method.getParameterTypes()).stream().map(it -> "\"" + it.getName() + "\"").collect(Collectors.joining(",")));
+          }
+      ).collect(Collectors.joining(",\n"));
+  System.out.print(
+      String.format(
+          "{\n"+
+            "  \"name\": \"%s\",\n" +
+            "  \"queryAllDeclaredMethods\": true,\n" +
+            "  \"condition\": {\n" +
+            "    \"typeReachable\": \"org.hibernate.jpa.HibernatePersistenceProvider\"\n" +
+            "  },\n" +
+            "  \"methods\": [\n" +
+            "%s\n" +
+            "  ]\n" +
+          "},\n",type.getName(), methodParam));
+});
+```
+
 


### PR DESCRIPTION
## What does this PR do?
Add missing hibernate-orm metadata extracted from the `org.hibernate.orm:hibernate-graalvm` artifact. This allows users to operate without having to add the extra dependency.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
