### PR TITLE
Add missing hibernate-orm hints for id generation.

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -384,6 +384,30 @@
     }
   },
   {
+    "condition": {
+      "typeReachable": "org.hibernate.id.IdentifierGeneratorHelper$BasicHolder"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.SequenceMismatchStrategy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.UUIDHexGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableStructure"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
     "name": "[Ljava.lang.Class;",
     "condition": {
       "typeReachable": "org.hibernate.internal.util.StringHelper"
@@ -11187,6 +11211,200 @@
     ]
   },
   {
+    "condition": {
+      "typeReachable": "org.hibernate.id.ForeignGenerator"
+    },
+    "name": "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.id.Assigned",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.Configuration"
+    },
+    "name": "org.hibernate.id.IdentityGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "name": "org.hibernate.id.IdentityGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.Configuration"
+    },
+    "name": "org.hibernate.id.SelectGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "name": "org.hibernate.id.SelectGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.LegacyNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    },
+    "name": "org.hibernate.id.enhanced.NoopOptimizer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.OptimizerFactory"
+    },
+    "name": "org.hibernate.id.enhanced.NoopOptimizer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.mapping.SimpleValue"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.SingleNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.StandardNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.UUIDGenerator"
+    },
+    "name": "org.hibernate.id.uuid.CustomVersionOneStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder$CustomIdGeneratorCreator"
+    },
+    "name": "org.hibernate.id.uuid.UuidGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.annotations.UuidGenerator",
+          "org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext"
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy",
     "condition": {
       "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
@@ -12475,6 +12693,30 @@
   },
   {
     "name": "org.hibernate.id.ForeignGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDHexGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDHexGenerator",
     "condition": {
       "typeReachable": "org.hibernate.annotations.GenericGenerator"
     },

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
@@ -35,16 +35,7 @@ public class HibernateOrmTest {
     @Test
     void hibernateBootstrap() {
 
-        Configuration config = new Configuration();
-
-        config.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
-        config.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
-        config.setProperty("hibernate.connection.username", "");
-        config.setProperty("hibernate.connection.password", "");
-        config.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
-        config.setProperty("hibernate.hbm2ddl.auto", "create-drop");
-
-        config.addAnnotatedClass(Event.class);
+        Configuration config = h2Config(Event.class);
 
         SessionFactory sessionFactory = config.buildSessionFactory();
         Session session = sessionFactory.openSession();
@@ -59,17 +50,7 @@ public class HibernateOrmTest {
     @Test
     void relations() {
 
-        Configuration config = new Configuration();
-
-        config.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
-        config.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
-        config.setProperty("hibernate.connection.username", "");
-        config.setProperty("hibernate.connection.password", "");
-        config.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
-        config.setProperty("hibernate.hbm2ddl.auto", "create-drop");
-
-        config.addAnnotatedClass(Cart.class);
-        config.addAnnotatedClass(Item.class);
+        Configuration config = h2Config(Cart.class, Item.class);
 
         SessionFactory sessionFactory = config.buildSessionFactory();
         Session session = sessionFactory.openSession();
@@ -86,5 +67,41 @@ public class HibernateOrmTest {
 
         session.close();
         sessionFactory.close();
+    }
+
+    @Test
+    void idGenerator() {
+
+        Configuration config = h2Config(User.class);
+
+        SessionFactory sessionFactory = config.buildSessionFactory();
+        Session session = sessionFactory.openSession();
+
+        User user = new User();
+        user.setUsername("u1");
+
+        session.persist(user);
+
+        User load = session.byId(User.class).load(user.getId());
+
+        session.close();
+        sessionFactory.close();
+    }
+
+    private static Configuration h2Config(Class<?>... entities) {
+
+        Configuration config = new Configuration();
+        config.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+        config.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+        config.setProperty("hibernate.connection.username", "");
+        config.setProperty("hibernate.connection.password", "");
+        config.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+        config.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+
+        for (Class<?> type : entities) {
+            config.addAnnotatedClass(type);
+        }
+
+        return config;
     }
 }

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/User.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/User.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.orm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.GenericGenerator;
+
+
+@Entity
+@Table(name = "USER")
+public class User {
+
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid")
+    @Column(columnDefinition = "CHAR(32)")
+    private String id;
+
+    private String username;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
@@ -13,5 +13,10 @@
     "name": "org.hibernate.orm.Item",
     "allDeclaredFields": true,
     "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.hibernate.orm.User",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
   }
 ]

--- a/tests/src/org.hibernate.orm/hibernate-core/README.md
+++ b/tests/src/org.hibernate.orm/hibernate-core/README.md
@@ -143,4 +143,7 @@ methodMap.forEach((type, methods) -> {
 });
 ```
 
+## Manually added hints
+
+- Add reflection entries (ctor) for types listed in `org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory`.
 


### PR DESCRIPTION
## What does this PR do?
Add missing hints for types potentially instantiated via `StandardIdentifierGeneratorFactory` and update test to make use of the now added generator.

Hints have been extracted by running test located in the `id` package of `hibernate-core` with the agent attached, filtering on `org.hibernate.id`. Since not all types used in `StandardIdentifierGeneratorFactory` got recorded, missing entries (like the ones for `SelectGenerator`) were added manually.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
