### PR TITLE
Add hints for additional hibernate-orm dialects

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12980,5 +12980,225 @@
         "name": "THIS_VERSION"
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.OracleDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.temptable.StandardTemporaryTableExporter"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.OracleArrayJdbcType"
+    },
+    "name": "oracle.jdbc.OracleConnection",
+    "queriedMethods": [
+      {
+        "name": "createOracleArray",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.jdbc.OracleDriver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "oracle.jdbc.OracleDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.OracleStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.OracleStatementWrapper"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "oracle.jdbc.driver.PhysicalConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4C8Oall"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "oracle.jdbc.driver.T4CConnection"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
+    },
+    "name": "oracle.jdbc.driver.T4CDriverExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CTTIfun"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CTTIoer11"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
+    },
+    "name": "oracle.jdbc.internal.OracleConnection$TransactionState",
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.Ano",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.AuthenticationService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.DataIntegrityService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.EncryptionService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.SupervisorService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "oracle.sql.CLOB",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.OracleDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.OracleDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12491,5 +12491,141 @@
     "condition": {
       "typeReachable": "jakarta.validation.ValidatorFactory"
     }
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.PostgreSQLSequenceSupport"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.PostgreSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.PostgreSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.postgresql.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.postgresql.jdbc.PgConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter"
+    },
+    "name": "org.postgresql.jdbc.PgStatement",
+    "fields": [
+      {
+        "name": "cancelTimerTask"
+      },
+      {
+        "name": "statementState"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLIntervalSecondJdbcType"
+    },
+    "name": "org.postgresql.util.PGInterval",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "int",
+          "int",
+          "int",
+          "int",
+          "double"
+        ]
+      },
+      {
+        "name": "getDays",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHours",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMicroSeconds",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMinutes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getWholeSeconds",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLPGObjectJdbcType"
+    },
+    "name": "org.postgresql.util.PGobject",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.ReflectHelper"
+    },
+    "name": "org.postgresql.util.PGobject",
+    "queryAllDeclaredMethods": true
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12815,5 +12815,33 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.CockroachDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.CockroachDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -13200,5 +13200,149 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.SQLServerDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.pagination.SQLServer2005LimitHandler"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.pagination.SQLServer2005LimitHandler$Keyword"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerClob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerConnection"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerException"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerStatement$StmtExecCmd"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SSType$Category",
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.TDSCommand"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12735,5 +12735,85 @@
       "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
     },
     "name": "org.mariadb.jdbc.internal.util.exceptions.ExceptionMapper"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.MySQLDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "com.mysql.cj.jdbc.Clob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "com.mysql.cj.jdbc.ConnectionImpl",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "com.mysql.cj.jdbc.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.mysql.cj.log.StandardLogger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.mysql.cj.protocol.StandardSocketFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MySQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12627,5 +12627,113 @@
     },
     "name": "org.postgresql.util.PGobject",
     "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MariaDBDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MariaDBDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.mariadb.jdbc.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbBlob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbClob"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.mariadb.jdbc.MariaDbConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.util.LogQueryTool"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "org.mariadb.jdbc.internal.util.Options",
+    "fields": [
+      {
+        "name": "password"
+      },
+      {
+        "name": "user"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.util.exceptions.ExceptionMapper"
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12843,5 +12843,142 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.HSQLSequenceSupport"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaCreatorImpl"
+    },
+    "name": "[Lorg.hsqldb.Constraint;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.StatementPreparerImpl$1"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.extract.spi.ExtractionContext"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaCreatorImpl"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.registry.selector.internal.StrategySelectorImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl$$Lambda$499/0x00000008010a5ee8"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.HSQLDialect"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.hsqldb.jdbc.JDBCClob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.hsqldb.jdbc.JDBCConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.hsqldb.jdbc.JDBCDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.HSQLDialect"
+    },
+    "name": "org.hsqldb.persist.HsqlDatabaseProperties",
+    "fields": [
+      {
+        "name": "THIS_VERSION"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## What does this PR do?
Provide reflection metadata for hibernate orm dialects:
- postgresql
- mariadb
- mysql
- cockroachdb
- hsqldb
- oracle
- sqlserver

Run tests located in `hibernate-core` package `dialect` against the defined target database with the agent attached filtering on types of the corresponding drivers/dialects. Additionally diff the things and add only non existing ones.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
