### PR TITLE
Metadata for undertow

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -106,5 +106,9 @@
   {
     "directory": "com.ecwid.consul/consul-api",
     "module": "com.ecwid.consul:consul-api"
+  },
+  {
+    "directory": "io.undertow/undertow-core",
+    "module": "io.undertow:undertow-core"
   }
 ]

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/index.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
@@ -151,6 +151,28 @@
   },
   {
     "condition": {
+      "typeReachable": "io.undertow.UndertowMessages"
+    },
+    "name": "io.undertow.UndertowMessages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.client.UndertowClientMessages"
+    },
+    "name": "io.undertow.client.UndertowClientMessages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
       "typeReachable": "io.undertow.server.protocol.http.HttpRequestParser"
     },
     "name": "io.undertow.server.protocol.http.HttpRequestParser$$generated",
@@ -165,10 +187,47 @@
   },
   {
     "condition": {
+      "typeReachable": "io.undertow.servlet.UndertowServletLogger"
+    },
+    "name": "io.undertow.servlet.UndertowServletLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.UndertowServletMessages"
+    },
+    "name": "io.undertow.servlet.UndertowServletMessages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
       "typeReachable": "io.undertow.servlet.api.ServletInfo"
     },
     "name": "io.undertow.servlet.handlers.DefaultServlet",
     "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.core.ManagedServlet$DefaultInstanceStrategy"
+    },
+    "name": "io.undertow.servlet.handlers.DefaultServlet",
+    "methods": [
       {
         "name": "<init>",
         "parameterTypes": []
@@ -263,6 +322,128 @@
     },
     "name": "io.undertow.util.Protocols",
     "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.core.WebSocketLogger"
+    },
+    "name": "io.undertow.websockets.core.WebSocketLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.core.WebSocketMessages"
+    },
+    "name": "io.undertow.websockets.core.WebSocketMessages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.api.ListenerInfo"
+    },
+    "name": "io.undertow.websockets.jsr.Bootstrap$WebSocketListener",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.core.ApplicationListeners"
+    },
+    "name": "io.undertow.websockets.jsr.Bootstrap$WebSocketListener",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.core.ManagedFilter"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketFilter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.spec.ServletContextImpl"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketFilter",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.core.ApplicationListeners"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketFilter$LogoutListener",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.spec.ServletContextImpl"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketFilter$LogoutListener",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.jsr.JsrWebSocketLogger"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.jsr.JsrWebSocketMessages"
+    },
+    "name": "io.undertow.websockets.jsr.JsrWebSocketMessages_$bundle",
+    "fields": [
+      {
+        "name": "INSTANCE"
+      }
+    ]
   },
   {
     "condition": {
@@ -623,6 +804,42 @@
       "typeReachable": "io.undertow.server.session.SecureRandomSessionIdGenerator"
     },
     "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.client.WebSocket13ClientHandshake"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.client.WebSocket13ClientHandshake"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.websockets.core.protocol.version07.Hybi07Handshake"
+    },
+    "name": "sun.security.provider.SHA",
     "methods": [
       {
         "name": "<init>",

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
@@ -3,6 +3,48 @@
     "condition": {
       "typeReachable": "io.undertow.Undertow"
     },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
     "name": "[Ljavax.management.ObjectName;"
   },
   {
@@ -10,6 +52,88 @@
       "typeReachable": "io.undertow.Undertow"
     },
     "name": "[Ljavax.management.openmbean.CompositeData;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.GarbageCollectorMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.GcInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.HotSpotDiagnosticMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.ThreadMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.UnixOperatingSystemMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.VMOption",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.internal.HotSpotDiagnostic",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.internal.HotSpotThreadImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "com.sun.management.internal.OperatingSystemImpl",
+    "queryAllPublicConstructors": true
   },
   {
     "condition": {
@@ -36,6 +160,68 @@
         "parameterTypes": [
           "org.xnio.OptionMap"
         ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.api.ServletInfo"
+    },
+    "name": "io.undertow.servlet.handlers.DefaultServlet",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.spec.ServletPrintWriterDelegate"
+    },
+    "name": "io.undertow.servlet.spec.ServletPrintWriterDelegate",
+    "unsafeAllocated": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.ConcurrentDirectDeque"
+    },
+    "name": "io.undertow.util.FastConcurrentDirectDeque",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.FastConcurrentDirectDeque"
+    },
+    "name": "io.undertow.util.FastConcurrentDirectDeque",
+    "fields": [
+      {
+        "name": "head"
+      },
+      {
+        "name": "tail"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.FastConcurrentDirectDeque$Node"
+    },
+    "name": "io.undertow.util.FastConcurrentDirectDeque$Node",
+    "fields": [
+      {
+        "name": "item"
+      },
+      {
+        "name": "next"
+      },
+      {
+        "name": "prev"
       }
     ]
   },
@@ -330,10 +516,117 @@
     "condition": {
       "typeReachable": "io.undertow.Undertow"
     },
+    "name": "sun.management.ClassLoadingImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.CompilationImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.ManagementFactoryHelper$1",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.MemoryImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.MemoryManagerImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.MemoryPoolImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.management.RuntimeImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
     "name": "sun.misc.Unsafe",
     "fields": [
       {
         "name": "theUnsafe"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.DirectByteBufferDeallocator"
+    },
+    "name": "sun.misc.Unsafe",
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ],
+    "methods": [
+      {
+        "name": "invokeCleaner",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.servlet.spec.ServletPrintWriterDelegate"
+    },
+    "name": "sun.misc.Unsafe",
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.FastConcurrentDirectDeque"
+    },
+    "name": "sun.misc.Unsafe",
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.session.SecureRandomSessionIdGenerator"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
       }
     ]
   }

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
@@ -1,0 +1,340 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[Ljavax.management.ObjectName;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "[Ljavax.management.openmbean.CompositeData;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.UndertowLogger"
+    },
+    "name": "io.undertow.UndertowLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.protocol.http.HttpRequestParser"
+    },
+    "name": "io.undertow.server.protocol.http.HttpRequestParser$$generated",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.xnio.OptionMap"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.protocol.http.HttpRequestParser"
+    },
+    "name": "io.undertow.util.Headers",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.Headers$1"
+    },
+    "name": "io.undertow.util.Headers",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.util.HttpString"
+    },
+    "name": "io.undertow.util.HttpString",
+    "fields": [
+      {
+        "name": "hashCode"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.protocol.http.HttpRequestParser"
+    },
+    "name": "io.undertow.util.Methods",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.server.protocol.http.HttpRequestParser"
+    },
+    "name": "io.undertow.util.Protocols",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.MBeanOperationInfo",
+    "queryAllPublicMethods": true,
+    "queriedMethods": [
+      {
+        "name": "getSignature",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.MBeanServerBuilder",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.ObjectName"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.openmbean.CompositeData"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "javax.management.openmbean.TabularData"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.ConfigurationInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.EventTypeInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.FlightRecorderMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.FlightRecorderMXBeanImpl",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.RecordingInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "jdk.management.jfr.SettingDescriptorInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.EnhancedQueueExecutor",
+    "fields": [
+      {
+        "name": "activeCount"
+      },
+      {
+        "name": "peakQueueSize"
+      },
+      {
+        "name": "peakThreadCount"
+      },
+      {
+        "name": "queueSize"
+      },
+      {
+        "name": "sequence"
+      },
+      {
+        "name": "terminationWaiters"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.EnhancedQueueExecutor$QNode",
+    "fields": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.EnhancedQueueExecutorBase1",
+    "fields": [
+      {
+        "name": "tail"
+      },
+      {
+        "name": "tailLock"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.EnhancedQueueExecutorBase3",
+    "fields": [
+      {
+        "name": "head"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.EnhancedQueueExecutorBase5",
+    "fields": [
+      {
+        "name": "threadStatus"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.jboss.threads.Messages_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio._private.Messages_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.management.XnioProviderMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.management.XnioServerMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.management.XnioWorkerMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.nio.Log_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.nio.NioTcpServer$1",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.nio.NioXnio$3",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "org.xnio.nio.NioXnioWorker$NioWorkerMetrics",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.undertow.Undertow"
+    },
+    "name": "sun.misc.Unsafe",
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ]
+  }
+]

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
@@ -9,7 +9,7 @@
     {
       "name": "javax.servlet.http.LocalStrings",
       "locales": [
-        "en_US"
+        "und"
       ]
     }
   ],

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
@@ -1,5 +1,18 @@
 {
-  "bundles": [],
+  "bundles": [
+    {
+      "name": "javax.servlet.LocalStrings",
+      "locales": [
+        "und"
+      ]
+    },
+    {
+      "name": "javax.servlet.http.LocalStrings",
+      "locales": [
+        "en_US"
+      ]
+    }
+  ],
   "resources": {
     "includes": [
       {

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
@@ -1,0 +1,31 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "io.undertow.Version"
+        },
+        "pattern": "\\Qio/undertow/version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "io.undertow.Undertow"
+        },
+        "pattern": "\\Qorg/jboss/threads/Version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "io.undertow.Undertow"
+        },
+        "pattern": "\\Qorg/xnio/Version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "io.undertow.Undertow"
+        },
+        "pattern": "\\Qorg/xnio/nio/Version.properties\\E"
+      }
+    ]
+  }
+}

--- a/metadata/io.undertow/undertow-core/index.json
+++ b/metadata/io.undertow/undertow-core/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "2.2.19.Final",
+    "module": "io.undertow:undertow-core",
+    "tested-versions": [
+      "2.2.19.Final"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -273,5 +273,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path": "io.undertow/undertow-core/2.2.19.Final",
+    "libraries": [
+      {
+        "name": "io.undertow:undertow-core",
+        "versions": [
+          "2.2.19.Final"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/.gitignore
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew
+gradlew.bat
+build/
+gradle/

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+    testImplementation "io.undertow:undertow-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/io.undertow/undertow-core")
+        }
+    }
+}

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
@@ -16,6 +16,7 @@ String libraryVersion = TestUtils.testedLibraryVersion
 dependencies {
     testImplementation "io.undertow:undertow-core:$libraryVersion"
     testImplementation "io.undertow:undertow-servlet:$libraryVersion"
+    testImplementation "io.undertow:undertow-websockets-jsr:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
@@ -15,6 +15,7 @@ String libraryVersion = TestUtils.testedLibraryVersion
 
 dependencies {
     testImplementation "io.undertow:undertow-core:$libraryVersion"
+    testImplementation "io.undertow:undertow-servlet:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/gradle.properties
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version=2.2.19.Final
+metadata.dir=io.undertow/undertow-core/2.2.19.Final

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/settings.gradle
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'undertow-tests'

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/MessageServlet.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/MessageServlet.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package undertow;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+class MessageServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().print("Hello world");
+        resp.getWriter().flush();
+    }
+}

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
@@ -8,19 +8,41 @@ package undertow;
 
 import io.undertow.Handlers;
 import io.undertow.Undertow;
+import io.undertow.UndertowMessages;
+import io.undertow.client.UndertowClientMessages;
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.DefaultByteBufferPool;
 import io.undertow.server.handlers.PathHandler;
 import io.undertow.servlet.Servlets;
+import io.undertow.servlet.UndertowServletLogger;
+import io.undertow.servlet.UndertowServletMessages;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.util.ImmediateInstanceFactory;
 import io.undertow.util.Headers;
+import io.undertow.websockets.client.WebSocketClient;
+import io.undertow.websockets.core.AbstractReceiveListener;
+import io.undertow.websockets.core.BufferedTextMessage;
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSocketMessages;
+import io.undertow.websockets.core.WebSockets;
+import io.undertow.websockets.jsr.JsrWebSocketMessages;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.xnio.IoFuture;
+import org.xnio.XnioWorker;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,6 +75,21 @@ public class UndertowTests {
     }
 
     @Test
+    void loggersWork() {
+        UndertowServletLogger.ROOT_LOGGER.log(Logger.Level.INFO, "test");
+        UndertowServletLogger.REQUEST_LOGGER.log(Logger.Level.INFO, "test");
+    }
+
+    @Test
+    void messagesWork() {
+        assertThat(UndertowMessages.MESSAGES.expectedContinuationFrame()).isNotNull();
+        assertThat(UndertowClientMessages.MESSAGES.connectionClosed()).isNotNull();
+        assertThat(UndertowServletMessages.MESSAGES.asyncAlreadyStarted().getMessage()).isNotNull();
+        assertThat(WebSocketMessages.MESSAGES.channelClosed().getMessage()).isNotNull();
+        assertThat(JsrWebSocketMessages.MESSAGES.clientNotSupported().getMessage()).isNotNull();
+    }
+
+    @Test
     void servlet() throws Exception {
         // Start server
         DeploymentInfo servletBuilder = Servlets.deployment()
@@ -82,6 +119,94 @@ public class UndertowTests {
         } finally {
             // Cleanup
             server.stop();
+        }
+    }
+
+    @Test
+    void websocket() throws Exception {
+        // Start server
+        Undertow server = Undertow.builder()
+                .addHttpListener(PORT, "localhost")
+                .setHandler(Handlers.websocket((exchange, channel) -> {
+                    System.out.printf("onConnect: %s%n", channel);
+                    channel.getReceiveSetter().set(new AbstractReceiveListener() {
+                        @Override
+                        protected void onFullTextMessage(WebSocketChannel channel, BufferedTextMessage message) {
+                            String data = message.getData();
+                            System.out.printf("Server: onFullTextMessage: %s %s%n", channel, data);
+                            WebSockets.sendText(data, channel, null);
+                        }
+                    });
+                    channel.resumeReceives();
+                })).build();
+        server.start();
+        try {
+            String received = sendWebSocketRequest(server.getWorker(), "/", "Hello websocket");
+            assertThat(received).isEqualTo("Hello websocket");
+        } finally {
+            // Cleanup
+            server.stop();
+        }
+    }
+
+    @Test
+    void websocketJsr() throws Exception {
+        // Start server
+        PathHandler path = Handlers.path();
+        Undertow server = Undertow.builder()
+                .addHttpListener(PORT, "localhost")
+                .setHandler(path)
+                .build();
+        ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(WebSocketHandler.class.getClassLoader())
+                .setContextPath("/")
+                .addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME,
+                        new WebSocketDeploymentInfo()
+                                .setBuffers(new DefaultByteBufferPool(true, 100))
+                                .addEndpoint(WebSocketHandler.class)
+                )
+                .setDeploymentName("websocket-jsr");
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        path.addPrefixPath("/", manager.start());
+        server.start();
+        try {
+            String received = sendWebSocketRequest(server.getWorker(), "/websocket", "Hello websocket");
+            assertThat(received).isEqualTo("Hello websocket");
+        } finally {
+            // Cleanup
+            server.stop();
+        }
+    }
+
+    private String sendWebSocketRequest(XnioWorker worker, String path, String text) throws IOException, InterruptedException {
+        try (ByteBufferPool pool = new DefaultByteBufferPool(false, 8192)) {
+            IoFuture<WebSocketChannel> future = WebSocketClient.connectionBuilder(worker, pool, URI.create(String.format("ws://localhost:%d%s", PORT, path))).connect();
+            IoFuture.Status status = future.await(1, TimeUnit.SECONDS);
+            if (status != IoFuture.Status.DONE) {
+                throw new IOException("Failed to establish websocket client connection");
+            }
+            try (WebSocketChannel channel = future.get()) {
+                CountDownLatch countDownLatch = new CountDownLatch(1);
+                AtomicReference<String> received = new AtomicReference<>();
+                channel.getReceiveSetter().set(new AbstractReceiveListener() {
+                    @Override
+                    protected void onFullTextMessage(WebSocketChannel channel, BufferedTextMessage message) throws IOException {
+                        String data = message.getData();
+                        System.out.printf("Client: onFullTextMessage: %s %s%n", channel, data);
+                        received.set(data);
+                        countDownLatch.countDown();
+                    }
+                });
+                channel.resumeReceives();
+                WebSockets.sendText(text, channel, null);
+                if (!countDownLatch.await(2, TimeUnit.SECONDS)) {
+                    throw new IOException("Failed to receive echo websocket message");
+                }
+                return received.get();
+            }
         }
     }
 }

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
@@ -6,7 +6,13 @@
  */
 package undertow;
 
+import io.undertow.Handlers;
 import io.undertow.Undertow;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
 import io.undertow.util.Headers;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +29,7 @@ public class UndertowTests {
     private static final int PORT = 8080;
 
     @Test
-    void test() throws Exception {
+    void core() throws Exception {
         // Start server
         Undertow server = Undertow.builder()
                 .addHttpListener(PORT, "localhost")
@@ -40,6 +46,39 @@ public class UndertowTests {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World");
+        } finally {
+            // Cleanup
+            server.stop();
+        }
+    }
+
+    @Test
+    void servlet() throws Exception {
+        // Start server
+        DeploymentInfo servletBuilder = Servlets.deployment()
+                .setClassLoader(MessageServlet.class.getClassLoader())
+                .setContextPath("/myapp")
+                .setDeploymentName("test")
+                .addServlets(
+                        Servlets.servlet("MessageServlet", MessageServlet.class, new ImmediateInstanceFactory<>(new MessageServlet())).addMapping("/hello")
+                );
+        DeploymentManager manager = Servlets.defaultContainer().addDeployment(servletBuilder);
+        manager.deploy();
+        PathHandler path = Handlers.path(Handlers.redirect("/myapp"))
+                .addPrefixPath("/myapp", manager.start());
+        Undertow server = Undertow.builder()
+                .addHttpListener(PORT, "localhost")
+                .setHandler(path)
+                .build();
+        server.start();
+        try {
+            // Make request
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/myapp/hello", PORT)))
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("Hello world");
         } finally {
             // Cleanup
             server.stop();

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package undertow;
+
+import io.undertow.Undertow;
+import io.undertow.util.Headers;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UndertowTests {
+
+    private static final int PORT = 8080;
+
+    @Test
+    void test() throws Exception {
+        // Start server
+        Undertow server = Undertow.builder()
+                .addHttpListener(PORT, "localhost")
+                .setHandler(exchange -> {
+                    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+                    exchange.getResponseSender().send("Hello World");
+                }).build();
+        server.start();
+        try {
+            // Make request
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("Hello World");
+        } finally {
+            // Cleanup
+            server.stop();
+        }
+    }
+}

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/WebSocketHandler.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/WebSocketHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package undertow;
+
+import javax.websocket.CloseReason;
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import java.io.IOException;
+
+@ServerEndpoint("/websocket")
+public class WebSocketHandler {
+    @OnOpen
+    public void onOpen(Session session) {
+        System.out.printf("onOpen(%s)%n", session);
+    }
+
+    @OnClose
+    public void onClose(Session session, CloseReason closeReason) {
+        System.out.printf("onClose(%s, %s)%n", session, closeReason);
+    }
+
+    @OnMessage
+    public void onMessage(Session session, String text) throws IOException {
+        System.out.printf("onMessage(%s, %s)%n", session, text);
+        session.getBasicRemote().sendText(text);
+    }
+}

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/resources/META-INF/native-image/test/reflect-config.json
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/resources/META-INF/native-image/test/reflect-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "undertow.WebSocketHandler",
+    "allPublicMethods": true,
+    "allPublicConstructors": true
+  }
+]

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/user-code-filter.json
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.undertow.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Adds metadata for undertow. It supports `undertow-core`, `undertow-servlet`, `undertow-websockets` and `undertow-websockets-jsr`.

Closes #75 

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
