### PR TITLE
Add metadata for org.eclipse.jetty 11.0.12

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -106,5 +106,9 @@
   {
     "directory": "com.ecwid.consul/consul-api",
     "module": "com.ecwid.consul:consul-api"
+  },
+  {
+    "directory": "org.eclipse.jetty/jetty-server",
+    "module": "org.eclipse.jetty:jetty-server"
   }
 ]

--- a/metadata/org.eclipse.jetty/jetty-server/11.0.12/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/11.0.12/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.eclipse.jetty/jetty-server/11.0.12/reflect-config.json
+++ b/metadata/org.eclipse.jetty/jetty-server/11.0.12/reflect-config.json
@@ -1,0 +1,758 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Boolean",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Byte",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Double",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Float",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Integer",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Long",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "java.lang.Short",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.websocket.common.JettyWebSocketFrameHandlerFactory"
+    },
+    "name": "org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.eclipse.jetty.websocket.core.CoreSession",
+          "java.lang.invoke.MethodHandle"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.StandardDescriptorProcessor"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.ArrayUtil"
+    },
+    "name": "[Lorg.eclipse.jetty.servlet.FilterHolder;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.xml.XmlParser"
+    },
+    "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.security.SecurityHandler"
+    },
+    "name": "jakarta.servlet.GenericServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ServletHolder"
+    },
+    "name": "jakarta.servlet.GenericServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.security.SecurityHandler"
+    },
+    "name": "jakarta.servlet.http.HttpServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ServletHolder"
+    },
+    "name": "jakarta.servlet.http.HttpServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.annotations.AnnotationConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.JndiConfiguration"
+    },
+    "name": "org.eclipse.jetty.jndi.InitialContextFactory"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.plus.webapp.EnvConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.plus.webapp.PlusConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ServletContextHandler"
+    },
+    "name": "org.eclipse.jetty.security.ConstraintSecurityHandler",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ServletHolder"
+    },
+    "name": "org.eclipse.jetty.servlet.DefaultServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ServletHolder"
+    },
+    "name": "org.eclipse.jetty.servlet.NoJspServlet",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.server.handler.ContextHandler"
+    },
+    "name": "org.eclipse.jetty.servlet.ServletHandler$Default404Servlet",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ListenerHolder"
+    },
+    "name": "org.eclipse.jetty.servlet.listener.ELContextCleaner",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.servlet.ListenerHolder"
+    },
+    "name": "org.eclipse.jetty.servlet.listener.IntrospectorCleaner",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.IncludeExcludeSet"
+    },
+    "name": "org.eclipse.jetty.webapp.ClassMatcher$ByLocationOrModule",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.IncludeExcludeSet"
+    },
+    "name": "org.eclipse.jetty.webapp.ClassMatcher$ByPackageOrName",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.FragmentConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.JettyWebXmlConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.JndiConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.MetaInfConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.IterativeDescriptorProcessor"
+    },
+    "name": "org.eclipse.jetty.webapp.StandardDescriptorProcessor",
+    "methods": [
+      {
+        "name": "visitListener",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLocaleEncodingList",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityConstraint",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServlet",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServletMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSessionConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitWelcomeFileList",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.StandardDescriptorProcessor"
+    },
+    "name": "org.eclipse.jetty.webapp.StandardDescriptorProcessor",
+    "queriedMethods": [
+      {
+        "name": "visitContextParam",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDefaultContextPath",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDenyUncoveredHttpMethods",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDisplayName",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitErrorPage",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitFilter",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitFilterMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitJspConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitListener",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLocaleEncodingList",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLoginConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitMimeMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitRequestCharacterEncoding",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitResponseCharacterEncoding",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityConstraint",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityRole",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServlet",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServletMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSessionConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitTagLib",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitWelcomeFileList",
+        "parameterTypes": [
+          "org.eclipse.jetty.webapp.WebAppContext",
+          "org.eclipse.jetty.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.WebAppConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.WebInfConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.webapp.WebXmlConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.websocket.client.config.JettyWebSocketClientConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.websocket.common.JettyWebSocketFrameHandlerFactory"
+    },
+    "name": "org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.eclipse.jetty.websocket.core.CoreSession"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.webapp.Configurations"
+    },
+    "name": "org.eclipse.jetty.websocket.server.config.JettyWebSocketConfiguration",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.annotations.AnnotationParser"
+    },
+    "name": "org.objectweb.asm.Opcodes",
+    "allPublicFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.server.session.DefaultSessionIdManager"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.ssl.SslContextFactory"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.websocket.core.internal.WebSocketConnection"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.websocket.core.internal.WebSocketCore"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.ssl.SslContextFactory"
+    },
+    "name": "sun.security.ssl.SSLContextImpl$TLSContext",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.ssl.SslContextFactory"
+    },
+    "name": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.eclipse.jetty/jetty-server/11.0.12/resource-config.json
+++ b/metadata/org.eclipse.jetty/jetty-server/11.0.12/resource-config.json
@@ -1,0 +1,50 @@
+{
+  "bundles": [
+    {
+      "name": "jakarta.servlet.LocalStrings",
+      "locales": [
+        "und"
+      ]
+    },
+    {
+      "name": "jakarta.servlet.http.LocalStrings",
+      "locales": [
+        "und"
+      ]
+    }
+  ],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.server.handler.ResourceHandler"
+        },
+        "pattern": "\\Qjetty-dir.css\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.http.MimeTypes"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/http/encoding.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.http.MimeTypes"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/http/mime.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.util.Jetty"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/version/build.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.util.resource.Resource"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/webapp/webdefault.xml\\E"
+      }
+    ]
+  }
+}

--- a/metadata/org.eclipse.jetty/jetty-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "11.0.12",
+    "module": "org.eclipse.jetty:jetty-server",
+    "tested-versions": [
+      "11.0.12"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -273,5 +273,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path": "org.eclipse.jetty/jetty-server/11.0.12",
+    "libraries": [
+      {
+        "name": "org.eclipse.jetty:jetty-server",
+        "versions": [
+          "11.0.12"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/.gitignore
@@ -1,0 +1,4 @@
+gradlew
+gradlew.bat
+build/
+gradle/

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-server:$libraryVersion"
+    testImplementation "org.eclipse.jetty:jetty-servlet:$libraryVersion"
+    testImplementation "org.eclipse.jetty:jetty-webapp:$libraryVersion"
+    testImplementation "org.eclipse.jetty.websocket:websocket-jetty-server:$libraryVersion"
+    testImplementation "org.eclipse.jetty.websocket:websocket-jetty-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.3'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.eclipse.jetty/jetty-server")
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/gradle.properties
@@ -1,0 +1,2 @@
+library.version=11.0.12
+metadata.dir=org.eclipse.jetty/jetty-server/11.0.12/

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jetty-tests'

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/HelloWorldServlet.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/HelloWorldServlet.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class HelloWorldServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(200);
+        resp.setHeader("Content-Type", "text/plain");
+        resp.getWriter().print("Hello world");
+        resp.getWriter().flush();
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/JettyTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.plus.webapp.EnvConfiguration;
+import org.eclipse.jetty.plus.webapp.PlusConfiguration;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JettyTests {
+
+    private static final int PORT = 8080;
+
+    private static boolean DEBUG = false;
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", DEBUG ? "debug" : "warn");
+    }
+
+    @Test
+    void typeUtilWorks() {
+        assertThat(TypeUtil.fromName("java.lang.String")).isEqualTo(String.class);
+    }
+
+    @Test
+    void http() throws Exception {
+        Server server = new Server(PORT);
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+                response.setStatus(200);
+                response.setHeader("Content-Type", "text/plain");
+                response.getWriter().print("Hello world");
+                response.getWriter().flush();
+                baseRequest.setHandled(true);
+            }
+        });
+        server.start();
+        try {
+            doHttpRequest();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void servlet() throws Exception {
+        Server server = new Server(PORT);
+        ServletContextHandler handler = new ServletContextHandler();
+        handler.setContextPath("/");
+        handler.addServlet(HelloWorldServlet.class, "/*");
+        server.setHandler(handler);
+        server.start();
+        try {
+            doHttpRequest();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void webapp(@TempDir File tempDir) throws Exception {
+        Server server = new Server(PORT);
+        WebAppContext context = new WebAppContext();
+        // EnvConfiguration and PlusConfiguration uses JNDI, which is not what we want to include
+        context.getConfigurations().remove(EnvConfiguration.class, PlusConfiguration.class);
+        context.setContextPath("/");
+        context.setResourceBase(tempDir.getAbsolutePath());
+        context.getServletContext().addServlet("HelloWorld", HelloWorldServlet.class).addMapping("/*");
+        server.setHandler(context);
+        server.start();
+        try {
+            doHttpRequest();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void websocket() throws Exception {
+        Server server = new Server(PORT);
+        ServletContextHandler handler = new ServletContextHandler(server, "/");
+        server.setHandler(handler);
+        JettyWebSocketServletContainerInitializer.configure(handler, (servletContext, container) ->
+                container.addMapping("/websocket", WebSocketServerEndpoint.class));
+        server.start();
+        try {
+            WebSocketClient client = new WebSocketClient();
+            client.start();
+            try {
+                WebSocketClientEndpoint endpoint = new WebSocketClientEndpoint();
+                Session session = client.connect(endpoint, URI.create(String.format("ws://localhost:%d/websocket", PORT))).get(1, TimeUnit.SECONDS);
+                session.getRemote().sendString("Hello world");
+                String message = endpoint.awaitMessage();
+                assertThat(message).isEqualTo("Hello world");
+                session.close();
+            } finally {
+                client.stop();
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static void doHttpRequest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("Hello world");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/WebSocketClientEndpoint.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/WebSocketClientEndpoint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@WebSocket
+public class WebSocketClientEndpoint {
+    private final CountDownLatch countDownLatch = new CountDownLatch(1);
+    private final AtomicReference<String> received = new AtomicReference<>();
+
+    @OnWebSocketMessage
+    public void onMessage(String message) {
+        received.set(message);
+        countDownLatch.countDown();
+    }
+
+    String awaitMessage() throws InterruptedException {
+        if (!countDownLatch.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Failed to await message in time");
+        }
+        return received.get();
+    }
+
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/WebSocketServerEndpoint.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/WebSocketServerEndpoint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+
+import java.io.IOException;
+
+@WebSocket
+public class WebSocketServerEndpoint {
+    @OnWebSocketConnect
+    public void onConnect(Session session) {
+        System.out.printf("onConnect(%s)%n", session.getRemoteAddress());
+    }
+
+    @OnWebSocketClose
+    public void onClose(Session session, int statusCode, String reason) {
+        System.out.printf("onClose(%s, %d, %s)%n", session.getRemoteAddress(), statusCode, reason);
+    }
+
+    @OnWebSocketMessage
+    public void onMessage(Session session, String message) throws IOException {
+        System.out.printf("onMessage(%s, %s)%n", session.getRemoteAddress(), message);
+        session.getRemote().sendString(message);
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/resources/META-INF/native-image/test/reflect-config.json
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/resources/META-INF/native-image/test/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "jetty.HelloWorldServlet",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "jetty.WebSocketClientEndpoint",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "jetty.WebSocketServerEndpoint",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  }
+]

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Add metadata for jetty.

It tests the standard handler, servlets, web app and websockets.

I triggered some bugs in the agent (https://github.com/oracle/graal/issues/5204, https://github.com/oracle/graal/issues/5203), so the generated metadata wasn't complete. I had to add some entries by hand.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
