### PR TITLE
Add thymeleaf-extras-springsecurity6 metadata

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -110,5 +110,9 @@
   {
     "directory": "io.undertow/undertow-core",
     "module": "io.undertow:undertow-core"
+  },
+  {
+    "directory": "org.thymeleaf.extras/thymeleaf-extras-springsecurity6",
+    "module": "org.thymeleaf.extras:thymeleaf-extras-springsecurity6"
   }
 ]

--- a/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/index.json
+++ b/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/reflect-config.json
+++ b/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/reflect-config.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "org.thymeleaf.extras.springsecurity6.util.Spring6VersionSpecificUtility",
+    "allDeclaredConstructors": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.extras.springsecurity6.util.SpringVersionSpecificUtils"
+    }
+  },
+  {
+    "name": "org.springframework.web.servlet.View",
+    "condition": {
+      "typeReachable": "org.springframework.web.servlet.View"
+    }
+  },
+  {
+    "name": "org.springframework.web.reactive.result.view.View",
+    "condition": {
+      "typeReachable": "org.springframework.web.reactive.result.view.View"
+    }
+  }
+]

--- a/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
+++ b/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "3.1.0.M1",
+    "module": "org.thymeleaf.extras:thymeleaf-extras-springsecurity6",
+    "tested-versions": [
+      "3.1.0.M1"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -253,6 +253,17 @@
     ]
   },
   {
+    "test-project-path": "org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1",
+    "libraries": [
+      {
+        "name": "org.thymeleaf.extras:thymeleaf-extras-springsecurity6",
+        "versions": [
+          "3.1.0.M1"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.freemarker/freemarker/2.3.31",
     "libraries": [
       {

--- a/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/build.gradle
+++ b/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/build.gradle
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+tasks.withType(JavaCompile) {
+    options.release = 17
+}
+
+dependencies {
+    testImplementation("org.slf4j:slf4j-api:1.7.36")
+    testImplementation("org.slf4j:slf4j-simple:1.7.36")
+    testImplementation("org.thymeleaf:thymeleaf-spring6:3.1.0.M2")
+    testImplementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6:$libraryVersion")
+    testImplementation("org.springframework:spring-web:6.0.0-M6")
+    testImplementation("org.springframework:spring-webflux:6.0.0-M6")
+    testImplementation("org.springframework:spring-context:6.0.0-M6")
+    testImplementation('org.assertj:assertj-core:3.22.0')
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--no-fallback')
+        }
+    }
+}

--- a/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/gradle.properties
+++ b/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 3.1.0.M1
+metadata.dir = org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/

--- a/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/settings.gradle
+++ b/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'thymeleaf-springsecurity6-tests'

--- a/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/src/test/java/org/thymeleaf/extras/ThymeleafSpringSecurityTest.java
+++ b/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1/src/test/java/org/thymeleaf/extras/ThymeleafSpringSecurityTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.thymeleaf.extras;
+
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.context.WebContext;
+import org.thymeleaf.extras.springsecurity6.util.SpringVersionSpecificUtils;
+import org.thymeleaf.extras.springsecurity6.util.SpringVersionUtils;
+import org.thymeleaf.spring6.web.webflux.ISpringWebFluxWebApplication;
+import org.thymeleaf.spring6.web.webflux.ISpringWebFluxWebExchange;
+import org.thymeleaf.spring6.web.webflux.ISpringWebFluxWebRequest;
+import org.thymeleaf.spring6.web.webflux.ISpringWebFluxWebSession;
+import org.thymeleaf.web.servlet.IServletWebApplication;
+import org.thymeleaf.web.servlet.IServletWebExchange;
+import org.thymeleaf.web.servlet.IServletWebRequest;
+import org.thymeleaf.web.servlet.IServletWebSession;
+
+import org.springframework.core.SpringVersion;
+
+public class ThymeleafSpringSecurityTest {
+
+    @Test
+    void springVersion() {
+        Assertions.assertThat(SpringVersion.getVersion()).isNotNull();
+        Assertions.assertThat(SpringVersionUtils.isSpring60AtLeast()).isTrue();
+    }
+
+    @Test
+    void springVersionSpecificUtilsWebMvc() {
+        WebContext webContext = new WebContext(new IServletWebExchange() {
+
+            @Override
+            public IServletWebRequest getRequest() {
+                return null;
+            }
+
+            @Override
+            public IServletWebSession getSession() {
+                return null;
+            }
+
+            @Override
+            public IServletWebApplication getApplication() {
+                return null;
+            }
+
+            @Override
+            public Principal getPrincipal() {
+                return null;
+            }
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return null;
+            }
+
+            @Override
+            public Object getAttributeValue(String name) {
+                return null;
+            }
+
+            @Override
+            public void setAttributeValue(String name, Object value) {
+
+            }
+
+            @Override
+            public String transformURL(String url) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getAttributeNames() {
+                return null;
+            }
+
+            @Override
+            public Object getNativeRequestObject() {
+                return null;
+            }
+
+            @Override
+            public Object getNativeResponseObject() {
+                return null;
+            }
+        });
+        Assertions.assertThat(SpringVersionSpecificUtils.isWebMvcContext(webContext)).isTrue();
+        Assertions.assertThat(SpringVersionSpecificUtils.isWebContext(webContext)).isTrue();
+    }
+
+    @Test
+    void springVersionSpecificUtilsWebFlux() {
+        WebContext webContext = new WebContext(new ISpringWebFluxWebExchange() {
+            @Override
+            public ISpringWebFluxWebRequest getRequest() {
+                return null;
+            }
+
+            @Override
+            public ISpringWebFluxWebSession getSession() {
+                return null;
+            }
+
+            @Override
+            public ISpringWebFluxWebApplication getApplication() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> getAttributes() {
+                return null;
+            }
+
+            @Override
+            public Object getNativeExchangeObject() {
+                return null;
+            }
+
+            @Override
+            public Principal getPrincipal() {
+                return null;
+            }
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return null;
+            }
+
+            @Override
+            public void setAttributeValue(String name, Object value) {
+
+            }
+
+            @Override
+            public void removeAttribute(String name) {
+
+            }
+
+            @Override
+            public String transformURL(String url) {
+                return null;
+            }
+        });
+        Assertions.assertThat(SpringVersionSpecificUtils.isWebFluxContext(webContext)).isTrue();
+        Assertions.assertThat(SpringVersionSpecificUtils.isWebContext(webContext)).isTrue();
+    }
+}


### PR DESCRIPTION
## What does this PR do?
It adds support for `org.thymeleaf.extras:thymeleaf-extras-springsecurity6`.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
