### PR TITLE
Add initial set of hints for hibernate-envers

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -32,6 +32,13 @@
     "module": "org.hibernate.orm:hibernate-core"
   },
   {
+    "directory": "org.hibernate.orm/hibernate-envers",
+    "module": "org.hibernate.orm:hibernate-envers",
+    "requires": [
+      "org.hibernate.orm:hibernate-core"
+    ]
+  },
+  {
     "directory": "org.hibernate.validator/hibernate-validator",
     "module": "org.hibernate.validator:hibernate-validator"
   },

--- a/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/index.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/index.json
@@ -1,0 +1,5 @@
+[
+  "proxy-config.json",
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/proxy-config.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/proxy-config.json
@@ -1,0 +1,212 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": []
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.TypeContributorImpl"
+    },
+    "interfaces": []
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlAccessorType"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlAccessorType",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlAttribute"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElement"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElementDecl"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElementRef"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElementRefs"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElements"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlElements",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlEnum"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlEnumValue"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlEnumValue",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlMixed"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlMixed",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlRootElement"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlSeeAlso"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlSeeAlso",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlType"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.XmlValue"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
+      "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "interfaces": [
+      "jdk.internal.ValueBased"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.RevisionInfoConfiguration$RevisionEntityResolver"
+    },
+    "interfaces": [
+      "org.hibernate.envers.Audited"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "interfaces": [
+      "org.hibernate.envers.NotAudited"
+    ]
+  }
+]

--- a/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/reflect-config.json
@@ -1,0 +1,4508 @@
+[
+  {
+    "name": "java.util.ServiceLoader$Provider",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "[Ljakarta.xml.bind.annotation.XmlElement;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "[Ljakarta.xml.bind.annotation.XmlElementRef;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.model.Column"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": "org.hibernate.envers.boot.internal.LegacyModifiedColumnNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": "org.hibernate.envers.boot.internal.ImprovedModifiedColumnNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": "org.hibernate.envers.strategy.DefaultAuditStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": " org.hibernate.envers.strategy.internal.DefaultAuditStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": "org.hibernate.envers.strategy.ValidityAuditStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversService"
+    },
+    "name": " org.hibernate.envers.strategy.internal.ValidityAuditStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.Configuration"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AbstractCollectionMetadataGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditEntityNameRegister"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.CollectionMappedByResolver"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.IdMetadataGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.JoinColumnCollectionMetadataGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.MiddleTableCollectionMetadataGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.enhanced.OrderedSequenceStructure$OrderedSequence"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.exception.RevisionDoesNotExistException"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.id.QueryParameterData"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.id.VirtualEntitySingleIdMapper"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.MiddleMapKeyEnumeratedComponentMapper"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.component.MiddleEmbeddableComponentMapper"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.component.MiddleMapElementNotKeyComponentMapper"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.component.MiddleSimpleComponentMapper"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.AbstractRelationQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.OneAuditEntityQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.OneEntityQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.ThreeEntityQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.TwoEntityOneAuditedQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.query.TwoEntityQueryGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.ArgumentsTools"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.MappingTools"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.Parameters"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.QueryBuilder"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.AuditQueryCreator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.criteria.AggregatedAuditExpression"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.criteria.MatchMode$4"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.criteria.internal.CriteriaTools"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.criteria.internal.SimpleAuditExpression"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditAssociationQuery"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.DefaultAuditStrategy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "[Ljava.lang.annotation.Annotation;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.enhanced.OrderedSequenceStructure$OrderedSequence"
+    },
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.DefaultAuditStrategy"
+    },
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.CollectionMappedByResolver"
+    },
+    "name": "[Ljava.util.Iterator;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.PersistentPropertiesSource$1"
+    },
+    "name": "[Ljava.util.Iterator;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Ljava.util.Map$Entry;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "[Ljava.util.Map$Entry;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.ATNConfig;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.ATNConfig;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.QueryBuilder"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.ATNConfig;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.ATNConfig;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.ATNConfig;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.PredictionContext;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.PredictionContext;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.QueryBuilder"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.PredictionContext;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.PredictionContext;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.atn.PredictionContext;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.dfa.DFAState$PredPrediction;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.antlr.v4.runtime.dfa.DFAState;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "[Lorg.antlr.v4.runtime.dfa.DFAState;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.dfa.DFAState;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "[Lorg.antlr.v4.runtime.dfa.DFAState;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.BaseEnversCollectionEventListener"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.h2.expression.Expression;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "[Lorg.h2.table.Column;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.BaseEnversCollectionEventListener"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.h2.table.TableFilter;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "[Lorg.h2.value.Value;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PostCollectionRecreateEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PostDeleteEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PostInsertEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PostUpdateEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PreCollectionRemoveEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PreCollectionUpdateEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversIntegrator"
+    },
+    "name": "[Lorg.hibernate.event.spi.PreUpdateEventListener;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.BaseEnversCollectionEventListener"
+    },
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.EntityTools"
+    },
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "ee.estonia.entities.Child",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostCollectionRecreateEventListenerImpl"
+    },
+    "name": "ee.estonia.entities.Child",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy"
+    },
+    "name": "ee.estonia.entities.Child",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "data"
+      },
+      {
+        "name": "id"
+      }
+    ],
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "ee.estonia.entities.Parent",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "ee.estonia.entities.Parent",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "collection"
+      },
+      {
+        "name": "data"
+      }
+    ],
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.JAXBElement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlAccessType",
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlAccessorType",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlAttribute",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElement",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElement$DEFAULT"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElementDecl",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "scope",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElementDecl$GLOBAL"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElementRef",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElementRef$DEFAULT"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElementRefs",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlElements",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlEnum",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlEnumValue",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlMixed",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlRootElement",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlSeeAlso",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlType",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "factoryClass",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlType$DEFAULT"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.XmlValue",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.adapters.XmlAdapter"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "jdk.internal.ValueBased",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.ContextFactory",
+    "methods": [
+      {
+        "name": "createContext",
+        "parameterTypes": [
+          "[Ljava.lang.Class;",
+          "java.util.Map"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.core.v2.model.nav.ReflectionNavigator",
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.ContextFactory",
+    "methods": [
+      {
+        "name": "createContext",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.ContextFactory",
+    "methods": [
+      {
+        "name": "createContext",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
+    "queryAllPublicConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty",
+    "queryAllPublicConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayReferenceNodeProperty",
+    "queryAllPublicConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeReferencePropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementLeafProperty",
+    "queryAllPublicConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty",
+    "queryAllPublicConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleMapNodeProperty",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleReferenceNodeProperty",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.CacheMode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.FlushMode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.LockMode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter1",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter2",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter3",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter4",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter5",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter6",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter7",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter8",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter9",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAnyAssociationType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAnyValueMappingType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmArrayType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAuxiliaryDatabaseObjectType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAuxiliaryDatabaseObjectType$JaxbHbmDefinition",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBagCollectionType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBaseVersionAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBasicAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBasicCollectionElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCacheInclusionEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCacheType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmClassRenameType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCollectionIdType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmColumnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeCollectionElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeIdType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeIndexType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeKeyBasicAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeKeyManyToOneType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmConfigParameterContainer",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmConfigParameterType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCustomSqlDmlType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDialectScopeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDynamicComponentType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmEntityBaseDefinition",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmEntityDiscriminatorType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchProfileType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchProfileType$JaxbHbmFetch",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleWithSubselectEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterAliasMappingType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterDefinitionType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterParameterType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmGeneratorSpecificationType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIdBagCollectionType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIdentifierGeneratorDefinitionType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexManyToAnyType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexManyToManyType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmJoinedSubclassEntityType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmKeyType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyWithExtraEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyWithNoProxyEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmListIndexType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmListType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLoaderType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToAnyCollectionElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToManyCollectionElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToOneType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyBasicType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyCompositeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyManyToManyType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMultiTenancyType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNamedNativeQueryType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNamedQueryType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryCollectionLoadReturnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryJoinReturnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryPropertyReturnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryPropertyReturnType$JaxbHbmReturnColumn",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryReturnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryReturnType$JaxbHbmReturnDiscriminator",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryScalarReturnType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNaturalIdCacheType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNaturalIdType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNestedCompositeElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNotFoundEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOnDeleteEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOneToManyCollectionElementType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOneToOneType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOuterJoinEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmParentType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPolymorphismEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPrimitiveArrayType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPropertiesType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmQueryParamType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmResultSetMappingType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmRootEntityType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSecondaryTableType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSetType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSimpleIdType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSubclassEntityBaseDefinition",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSynchronizeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTimestampAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTimestampSourceEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmToolingHintContainer",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmToolingHintType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTuplizerType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTypeDefinitionType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTypeSpecificationType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnionSubclassEntityType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueCompositeIdEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueTimestampEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueVersionEnum",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmVersionAttributeType",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.ObjectFactory",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.PluralAttributeInfoIdBagAdapter",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.boot.jaxb.hbm.spi.PluralAttributeInfoPrimitiveArrayAdapter",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.cache.spi.access.AccessType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.engine.OptimisticLockStyle"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.RevisionInfoConfiguration"
+    },
+    "name": "org.hibernate.envers.DefaultRevisionEntity",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.RevisionInfoConfiguration"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversServiceImpl$1"
+    },
+    "name": "org.hibernate.envers.DefaultRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "timestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "org.hibernate.envers.DefaultRevisionEntity",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoNumberReader"
+    },
+    "name": "org.hibernate.envers.DefaultRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.envers.DefaultRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "timestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.EnversBootLogger"
+    },
+    "name": "org.hibernate.envers.boot.EnversBootLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.TypeContributorImpl"
+    },
+    "name": "org.hibernate.envers.boot.internal.EnversServiceImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.PersistentEntityInstantiator"
+    },
+    "name": "org.hibernate.envers.boot.model.DiscriminatorPersistentEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.configuration.internal.metadata.AuditTableData",
+          "org.hibernate.mapping.PersistentClass"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.PersistentEntityInstantiator"
+    },
+    "name": "org.hibernate.envers.boot.model.JoinedSubclassPersistentEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.configuration.internal.metadata.AuditTableData",
+          "org.hibernate.mapping.PersistentClass"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.PersistentEntityInstantiator"
+    },
+    "name": "org.hibernate.envers.boot.model.RootPersistentEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.configuration.internal.metadata.AuditTableData",
+          "org.hibernate.mapping.PersistentClass"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.PersistentEntityInstantiator"
+    },
+    "name": "org.hibernate.envers.boot.model.UnionSubclassPersistentEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.configuration.internal.metadata.AuditTableData",
+          "org.hibernate.mapping.PersistentClass"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversServiceImpl$1"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "timestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setTimestamp",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.CrossTypeRevisionChangesReaderImpl"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setTimestamp",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestamp",
+        "parameterTypes": []
+      },
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoNumberReader"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "timestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getId",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestamp",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.SessionCacheCleaner$1"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "getId",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestamp",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.ReflectionTools"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "timestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesModifiedAtRevisionQuery"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "getId",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.DefaultAuditStrategy"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "getId",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdRevisionEntity",
+    "methods": [
+      {
+        "name": "getId",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestamp",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversServiceImpl$1"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.CrossTypeRevisionChangesReaderImpl"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setModifiedEntityNames",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultTrackingModifiedEntitiesRevisionInfoGenerator"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoNumberReader"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getModifiedEntityNames",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.SessionCacheCleaner$1"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "methods": [
+      {
+        "name": "getModifiedEntityNames",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity",
+    "methods": [
+      {
+        "name": "getModifiedEntityNames",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.ClassesAuditingData"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.CollectionMappedByResolver"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.JoinColumnCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.MiddleTableCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.FirstLevelCache"
+    },
+    "name": "org.hibernate.envers.internal.EnversMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AbstractCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.JoinColumnCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.MiddleTableCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.EntityInstantiator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.ComponentPropertyMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.AbstractCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.BasicCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.ListCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.BasicCollectionInitializor"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.ListCollectionInitializor"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.RevisionsOfEntityQuery"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.ListProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.EntityInstantiator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.AbstractCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.MapCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.RevisionsOfEntityQuery"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.JoinColumnCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.MiddleTableCollectionMetadataGenerator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.EntityInstantiator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.AbstractCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.BasicCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.ToOneDelegateSessionImplementor"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.BasicCollectionInitializor"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.EntityInstantiator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SortedMapProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.SortedMapCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SortedMapProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.EntityInstantiator"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SortedSetProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.SortedSetCollectionMapper"
+    },
+    "name": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.SortedSetProxy",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.envers.internal.entities.mapper.relation.lazy.initializor.Initializor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversServiceImpl$1"
+    },
+    "name": "org.hibernate.envers.test.entities.reventity.CustomLocalDateTimeRevEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "localDateTimestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "org.hibernate.envers.test.entities.reventity.CustomLocalDateTimeRevEntity",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoNumberReader"
+    },
+    "name": "org.hibernate.envers.test.entities.reventity.CustomLocalDateTimeRevEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.envers.test.entities.reventity.CustomLocalDateTimeRevEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "localDateTimestamp"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "org.hibernate.envers.test.integration.data.DateTestEntity",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.AbstractMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.DateTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.SinglePropertyMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.DateTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "dateValue"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "org.hibernate.envers.test.integration.data.EnumTestEntity",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.AbstractMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.EnumTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.SinglePropertyMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.EnumTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "enum1"
+      },
+      {
+        "name": "enum2"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "org.hibernate.envers.test.integration.data.LobSerializableTestEntity",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.AbstractMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.LobSerializableTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.SinglePropertyMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.LobSerializableTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "obj"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.envers.test.integration.data.SerObject"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesReader"
+    },
+    "name": "org.hibernate.envers.test.integration.data.SerializableTestEntity",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.AbstractMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.SerializableTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "id"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.SinglePropertyMapper"
+    },
+    "name": "org.hibernate.envers.test.integration.data.SerializableTestEntity",
+    "queryAllDeclaredMethods": true,
+    "fields": [
+      {
+        "name": "obj"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.AuditMetadataGenerator"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.configuration.internal.metadata.ValueMetadataGenerator"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.enhanced.OrderedSequenceGenerator"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.AuditProcess"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.synchronization.SessionCacheCleaner$1"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.QueryBuilder"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy"
+    },
+    "name": "org.hibernate.internal.EntityManagerMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.MapProxy"
+    },
+    "name": "org.hibernate.internal.EntityManagerMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.metamodel.RepresentationMode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.EnversServiceImpl$1"
+    },
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionTimestampValueResolver"
+    },
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.ReflectionTools"
+    },
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.revisioninfo.RevisionInfoQueryCreator"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.tools.query.QueryBuilder"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy"
+    },
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl"
+    },
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.internal.reader.AuditReaderImpl"
+    },
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.AbstractAuditQuery"
+    },
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery"
+    },
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+    },
+    "name": "org.hibernate.tuple.GenerationTiming"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.envers.strategy.internal.ValidityAuditStrategy$QueryParameterBinding"
+    },
+    "name": "sun.util.resources.provider.NonBaseLocaleDataMetaInfo",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/resource-config.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/6.1.1.Final/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.hibernate.envers.boot.internal.AdditionalJaxbMappingProducerImpl$1"
+        },
+        "pattern": "\\QMETA-INF/services/jakarta.xml.bind.JAXBContext\\E"
+      }
+    ]
+  }
+}

--- a/metadata/org.hibernate.orm/hibernate-envers/index.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "6.1.1.Final",
+    "module": "org.hibernate.orm:hibernate-envers",
+    "tested-versions": [
+      "6.1.1.Final"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -55,6 +55,17 @@
     ]
   },
   {
+    "test-project-path": "org.hibernate.orm/hibernate-envers/6.1.1.Final",
+    "libraries": [
+      {
+        "name": "org.hibernate.orm:hibernate-envers",
+        "versions": [
+          "6.1.1.Final"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.hibernate.validator/hibernate-validator/7.0.4.Final",
     "libraries": [
       {

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/build.gradle
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+    testImplementation("org.hibernate.orm:hibernate-envers:$libraryVersion")
+    testImplementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
+    testImplementation("com.h2database:h2:2.1.214")
+    testImplementation('org.assertj:assertj-core:3.22.0')
+    testImplementation('org.apache.logging.log4j:log4j-core:2.18.0')
+    testCompileOnly("org.graalvm.nativeimage:graal-hotspot-library:22.0.0")
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--no-fallback')
+        }
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/gradle.properties
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 6.1.1.Final
+metadata.dir = org.hibernate.orm/hibernate-envers/6.1.1.Final/

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/settings.gradle
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'hibernate-envers-tests'

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/Event.java
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/Event.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.envers;
+
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "EVENTS")
+@Audited
+public class Event {
+
+    @Id
+    @GeneratedValue(generator = "increment")
+    @GenericGenerator(name = "increment", strategy = "increment")
+    private Long id;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "EVENT_DATE")
+    private Date date;
+
+    private String title;
+
+    protected Event() {
+    }
+
+    public Event(String title, Date date) {
+
+        this.title = title;
+        this.date = date;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/HibernateOrmTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/HibernateOrmTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.envers;
+
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class HibernateOrmTest {
+
+    @Test
+    void auditingTest() {
+
+        Event event = new Event("Our very first event!", new Date());
+
+        Configuration config = h2Config(Event.class);
+        SessionFactory sessionFactory = config.buildSessionFactory();
+        Session session = sessionFactory.openSession();
+
+        session.getTransaction().begin();
+        session.persist(event);
+        session.getTransaction().commit();
+
+        AuditReader auditReader = AuditReaderFactory.get(session);
+        List<Number> revisionNumbers = auditReader.getRevisions(Event.class, event.getId());
+        Assert.assertTrue(revisionNumbers.size() == 1);
+
+        session.close();
+        sessionFactory.close();
+    }
+
+    private static Configuration h2Config(Class<?>... entities) {
+
+        Configuration config = new Configuration();
+        config.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+        config.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+        config.setProperty("hibernate.connection.username", "");
+        config.setProperty("hibernate.connection.password", "");
+        config.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+        config.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+
+        for (Class<?> type : entities) {
+            config.addAnnotatedClass(type);
+        }
+
+        return config;
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/Target_Environment.java
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/java/org/hibernate/envers/Target_Environment.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.envers;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.hibernate.bytecode.internal.none.BytecodeProviderImpl;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+
+@TargetClass(className = "org.hibernate.cfg.Environment")
+final class Target_Environment {
+
+    @Substitute
+    private static BytecodeProvider buildBytecodeProvider(String providerName) {
+        return new BytecodeProviderImpl();
+    }
+}

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/reflect-config.json
@@ -1,0 +1,13595 @@
+[
+  {
+    "name": "org.hibernate.envers.Event",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreInsertEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionRecreateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.ClearEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionRecreateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreCollectionRemoveEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostCollectionRemoveEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreDeleteEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.entity.JoinedSubclassEntityPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.entity.UnionSubclassEntityPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.collection.OneToManyPersister",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.type.EnumType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "[B",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[C",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[D",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[F",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[I",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[J",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lcom.sun.jmx.mbeanserver.ClassLoaderRepositorySupport$LoaderEntry;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljakarta.xml.bind.annotation.XmlElement;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "[Ljakarta.xml.bind.annotation.XmlElementRef;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "[Ljakarta.xml.bind.annotation.XmlElementRef;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.stax.LocalXmlResourceResolver$DtdDescriptor"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.naming.Identifier"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.hbm.EntityHierarchySourceImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.hbm.MappingDocument"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.hbm.ModelBinder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.spi.AbstractAttributeKey"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.registry.classloading.internal.AggregatedServiceLoader"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.ComponentPropertyHolder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.ToOneFkSecondPass"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.H2Dialect"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.ANSISequenceSupport"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.H2V2SequenceSupport"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.SequenceSupport"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.BasicFormatterImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.DDLFormatterImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.HighlightingFormatter"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.StandardNamingStrategy"
+    }
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.IdentifierGeneratorHelper$BasicHolder"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.SequenceMismatchStrategy"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.UUIDHexGenerator"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableStructure"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.StringHelper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.loader.internal.AliasConstantsHelper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.mapping.Column"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.mapping.Component"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.mapping.internal.MappingModelCreationHelper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.model.domain.NavigableRole"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.persister.entity.AbstractEntityPersister"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.query.QueryLogging"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan$1"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.spi.NavigablePath"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.SimpleSelect"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.ast.spi.SqlAliasBaseImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.ast.tree.expression.ColumnReference"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.results.LoadingLogger"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator$ActionGrouping"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.tuple.entity.EntityMetamodel"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.BasicTypeReference"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Class;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.ComponentType"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Object;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.Object;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerRegistryImpl$Builder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.collections.ArrayHelper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.stat.internal.StatisticsImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.StandardTableExporter"
+    }
+  },
+  {
+    "name": "[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.JacksonJsonFormatMapper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.annotation.Annotation;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.annotation.Annotation;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.annotation.ElementType;",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    }
+  },
+  {
+    "name": "[Ljava.lang.annotation.ElementType;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.annotation.ElementType;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.event.internal.CallbackDefinitionResolverLegacyImpl"
+    }
+  },
+  {
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.naming.Identifier"
+    }
+  },
+  {
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.spi.AbstractAttributeKey"
+    }
+  },
+  {
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.SequenceSupport"
+    }
+  },
+  {
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.invoke.LambdaForm$Name;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "[Ljava.lang.reflect.Field;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.lang.reflect.Field;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.JdbcTypeNameMapper"
+    }
+  },
+  {
+    "name": "[Ljava.lang.reflect.Method;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljava.time.format.DateTimeFormatterBuilder$DateTimePrinterParser;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.java.JdbcTimestampJavaType"
+    }
+  },
+  {
+    "name": "[Ljava.time.format.DateTimeFormatterBuilder$DateTimePrinterParser;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.java.YearJavaType"
+    }
+  },
+  {
+    "name": "[Ljava.util.Iterator;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.collections.JoinedIterator"
+    }
+  },
+  {
+    "name": "[Ljava.util.Map$Entry;",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl"
+    }
+  },
+  {
+    "name": "[Ljavax.management.MBeanAttributeInfo;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljavax.management.MBeanOperationInfo;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Ljavax.management.openmbean.CompositeData;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.Appender;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.config.AppenderControl;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.config.AppenderRef;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.config.LoggerConfig;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.config.Property;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.apache.logging.log4j.core.pattern.PatternFormatter;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.h2.engine.SessionLocal;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.h2.expression.Expression;",
+    "condition": {
+      "typeReachable": "org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan"
+    }
+  },
+  {
+    "name": "[Lorg.h2.expression.Expression;",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl"
+    }
+  },
+  {
+    "name": "[Lorg.h2.expression.Expression;",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.extract.spi.ExtractionContext"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.Column;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.Table;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.Table;",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaDropperImpl$DelayedDropActionImpl"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.TableFilter;",
+    "condition": {
+      "typeReachable": "org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.TableFilter;",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl"
+    }
+  },
+  {
+    "name": "[Lorg.h2.table.TableFilter;",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.extract.spi.ExtractionContext"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.SessionFactoryObserver;",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryOptionsBuilder"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.AutoFlushEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.DeleteEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.DirtyCheckEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.EvictEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.FlushEntityEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.FlushEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.InitializeCollectionEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.LoadEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.LockEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.MergeEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PersistEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostDeleteEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostInsertEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostLoadEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PostUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.PreLoadEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.RefreshEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.ReplicateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.ResolveNaturalIdEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.event.spi.SaveOrUpdateEventListener;",
+    "condition": {
+      "typeReachable": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.jpa.event.spi.Callback;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.collections.ArrayHelper"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.jpa.event.spi.Callback;",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.metamodel.mapping.SelectableMapping;",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.mapping.internal.SelectableMappingsImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.sql.ast.spi.SqlSelection;",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.results.jdbc.internal.JdbcValuesResultSetImpl"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.type.Type;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.collections.ArrayHelper"
+    }
+  },
+  {
+    "name": "[Lorg.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType$TypeEntry;",
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType"
+    }
+  },
+  {
+    "name": "[S",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[Z",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "[[Ljava.lang.String;",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.collections.ArrayHelper"
+    }
+  },
+  {
+    "name": "com.fasterxml.jackson.core.JsonParser",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.DeserializationFeature",
+    "condition": {
+      "typeReachable": "org.hibernate.type.JacksonJsonFormatMapper"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.JsonNode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.ObjectMapper",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.SerializationFeature",
+    "condition": {
+      "typeReachable": "org.hibernate.type.JacksonJsonFormatMapper"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.type.JacksonJsonFormatMapper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.oracle.truffle.js.scriptengine.GraalJSEngineFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.management.GarbageCollectorMXBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.GcInfo",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.HotSpotDiagnosticMXBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.ThreadMXBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.UnixOperatingSystemMXBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.VMOption",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.internal.HotSpotDiagnostic",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.internal.HotSpotThreadImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.internal.OperatingSystemImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "com.sun.management.internal.PlatformMBeanProviderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.org.apache.xerces.internal.impl.dv.xs.ExtendedSchemaDVFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.xml.internal.stream.events.XMLEventFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.enterprise.inject.spi.BeanManager",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess$1"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.annotations.AnnotationMetadataSourceProcessorImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Access",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.AccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.mapping.marshall.AccessTypeMarshalling"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.AccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.AttributeOverride",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.AttributeOverrides",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess$1"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.annotations.AnnotationMetadataSourceProcessorImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.InheritanceState"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Basic",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Cacheable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Column",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Column",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jakarta.persistence.ConstraintMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.DiscriminatorType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Embeddable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Embeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Embedded",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess$1"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.annotations.AnnotationMetadataSourceProcessorImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Entity",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.EntityListeners",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.EnumType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.FetchType",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    }
+  },
+  {
+    "name": "jakarta.persistence.FetchType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.GeneratedValue",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.GeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.GenerationType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess$1"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.source.internal.annotations.AnnotationMetadataSourceProcessorImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.InheritanceState"
+    }
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.Id",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "jakarta.persistence.InheritanceType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.LockModeType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.ParameterMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.persistence.PessimisticLockScope",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.internal.util.LockOptionsHelper"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.PrePersist",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.PrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.persistence.TemporalType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.servlet.Servlet",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.JAXBElement",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAccessorType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAccessorType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAttribute",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlAttribute",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElement",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElement",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElement$DEFAULT",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementDecl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "scope",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementDecl",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementDecl$GLOBAL",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementRef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementRef",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementRef$DEFAULT",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementRefs",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElementRefs",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlElements",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlEnum",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlEnumValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlEnumValue",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlMixed",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlMixed",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlRootElement",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlRootElement",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlSchemaType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlSchemaType$DEFAULT",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlSeeAlso",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlSeeAlso",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "factoryClass",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlType$DEFAULT",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.XmlValue",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.XmlAdapter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.XmlAdapter",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "javax.management.MBeanOperationInfo",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "queriedMethods": [
+      {
+        "name": "getSignature",
+        "parameterTypes": []
+      }
+    ],
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "javax.management.MBeanServerBuilder",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "javax.management.ObjectName",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "javax.management.openmbean.CompositeData",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "javax.management.openmbean.TabularData",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.internal.ValueBased",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.misc.Unsafe",
+    "condition": {
+      "typeReachable": "org.hibernate.integrator.internal.IntegratorServiceImpl"
+    }
+  },
+  {
+    "name": "jdk.internal.misc.Unsafe",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.internal.reflect.DelegatingMethodAccessorImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor10",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor11",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor12",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor13",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor14",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor15",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor16",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor17",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor18",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor19",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor20",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.cfgxml.spi.LoadedConfig"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor21",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor23",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor24",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor25",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor26",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor27",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor28",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor29",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor30",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor31",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor32",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor33",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor34",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor35",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor36",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor37",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor38",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor39",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor40",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor41",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor42",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor43",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor44",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor45",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor46",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor47",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor48",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor49",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor50",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor52",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor54",
+    "condition": {
+      "typeReachable": "org.hibernate.event.internal.AbstractSaveEventListener"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor6",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor60",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor61",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor7",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor8",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedConstructorAccessor9",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor10",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor18",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor19",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor22",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor23",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor24",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor25",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor26",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor3",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor4",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor5",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor6",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor7",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor8",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.GeneratedMethodAccessor9",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.reflect.NativeMethodAccessorImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "jdk.internal.vm.annotation.IntrinsicCandidate",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "jdk.management.jfr.ConfigurationInfo",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.EventTypeInfo",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.FlightRecorderMXBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.FlightRecorderMXBeanImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.RecordingInfo",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.SettingDescriptorInfo",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "jdk.management.jfr.internal.FlightRecorderMXBeanProvider",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.core.v2.model.nav.ReflectionNavigator",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.ContextFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "createContext",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayReferenceNodeProperty",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeReferencePropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayReferenceNodeProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementLeafProperty",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementLeafProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
+          "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleMapNodeProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleReferenceNodeProperty",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.h2.Driver",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.h2.command.Parser",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.h2.engine.SessionLocal",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.h2.jdbc.JdbcClob",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    }
+  },
+  {
+    "name": "org.h2.jdbc.JdbcConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    }
+  },
+  {
+    "name": "org.h2.jdbc.JdbcConnection",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.h2.jdbc.JdbcLob",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.h2.jdbc.JdbcStatement",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.h2.message.DbException",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.h2.mvstore.MVStore$TxCounter",
+    "fields": [
+      {
+        "name": "counter"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.h2.mvstore.Page",
+    "fields": [
+      {
+        "name": "pos"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.CacheMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.CacheMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.FlushMode",
+    "condition": {
+      "typeReachable": "org.hibernate.FlushMode"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.FlushMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.FlushMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.Internal",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.LockMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.LockMode",
+    "condition": {
+      "typeReachable": "org.hibernate.loader.ast.internal.SingleIdEntityLoaderStandardImpl"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.annotations.CascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.annotations.Columns",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.annotations.Columns",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.annotations.OnDeleteAction",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.annotations.PolymorphismType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.internal.SessionFactoryBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter1",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter2",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter3",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter4",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter5",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter6",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter7",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter8",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.Adapter9",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAnyAssociationType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAnyValueMappingType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmArrayType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAuxiliaryDatabaseObjectType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAuxiliaryDatabaseObjectType$JaxbHbmDefinition",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBagCollectionType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBaseVersionAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBasicAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBasicCollectionElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCacheInclusionEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "ALL"
+      },
+      {
+        "name": "NON_LAZY"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCacheType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmClassRenameType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCollectionIdType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmColumnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeCollectionElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeIdType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeIndexType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeKeyBasicAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeKeyManyToOneType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmConfigParameterContainer",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmConfigParameterType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCustomSqlDmlType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDialectScopeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDynamicComponentType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmEntityBaseDefinition",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmEntityDiscriminatorType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchProfileType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchProfileType$JaxbHbmFetch",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "JOIN"
+      },
+      {
+        "name": "SELECT"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleWithSubselectEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "JOIN"
+      },
+      {
+        "name": "SELECT"
+      },
+      {
+        "name": "SUBSELECT"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterAliasMappingType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterDefinitionType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterParameterType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmGeneratorSpecificationType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIdBagCollectionType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIdentifierGeneratorDefinitionType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexManyToAnyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexManyToManyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmJoinedSubclassEntityType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmKeyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "FALSE"
+      },
+      {
+        "name": "PROXY"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyWithExtraEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "EXTRA"
+      },
+      {
+        "name": "FALSE"
+      },
+      {
+        "name": "TRUE"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLazyWithNoProxyEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "FALSE"
+      },
+      {
+        "name": "NO_PROXY"
+      },
+      {
+        "name": "PROXY"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmListIndexType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmListType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmLoaderType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToAnyCollectionElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToManyCollectionElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToOneType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyBasicType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyCompositeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyManyToManyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMultiTenancyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNamedNativeQueryType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNamedQueryType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryCollectionLoadReturnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryJoinReturnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryPropertyReturnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryPropertyReturnType$JaxbHbmReturnColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryReturnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryReturnType$JaxbHbmReturnDiscriminator",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNativeQueryScalarReturnType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNaturalIdCacheType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNaturalIdType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNestedCompositeElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNotFoundEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "EXCEPTION"
+      },
+      {
+        "name": "IGNORE"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOnDeleteEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "CASCADE"
+      },
+      {
+        "name": "NOACTION"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOneToManyCollectionElementType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOneToOneType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOuterJoinEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "AUTO"
+      },
+      {
+        "name": "FALSE"
+      },
+      {
+        "name": "TRUE"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmParentType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPolymorphismEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "EXPLICIT"
+      },
+      {
+        "name": "IMPLICIT"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPrimitiveArrayType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmPropertiesType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmQueryParamType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmResultSetMappingType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmRootEntityType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSecondaryTableType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSetType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSimpleIdType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSubclassEntityBaseDefinition",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmSynchronizeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTimestampAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTimestampSourceEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "DB"
+      },
+      {
+        "name": "VM"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmToolingHintContainer",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmToolingHintType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTuplizerType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTypeDefinitionType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTypeSpecificationType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnionSubclassEntityType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueCompositeIdEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "ANY"
+      },
+      {
+        "name": "NONE"
+      },
+      {
+        "name": "UNDEFINED"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueTimestampEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "NULL"
+      },
+      {
+        "name": "UNDEFINED"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnsavedValueVersionEnum",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "NEGATIVE"
+      },
+      {
+        "name": "NULL"
+      },
+      {
+        "name": "UNDEFINED"
+      }
+    ],
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.JaxbHbmVersionAttributeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.ObjectFactory",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.PluralAttributeInfoIdBagAdapter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.hbm.spi.PluralAttributeInfoPrimitiveArrayAdapter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter1",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter1",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter10",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter11",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter12",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter13",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter14",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter15",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter16",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter17",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter18",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter2",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter3",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter4",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter5",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter6",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter7",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter8",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.Adapter9",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAssociationOverride",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributeOverride",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbAttributes",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbBasic",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCacheInclusionType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "ALL"
+      },
+      {
+        "name": "NON_LAZY"
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCacheInclusionType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCaching",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCascadeType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCollectionTable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbColumnResult",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConstructorResult",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConvert",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbConverter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomLoader",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbCustomSql",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObject$JaxbDefinition",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDatabaseObjectScope",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbDiscriminatorColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbElementCollection",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddableAttributes",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbedded",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEmptyType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntity",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListener",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityListeners",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityMappings",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbEntityResult",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFetchProfile$JaxbFetch",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFieldResult",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbFilterDef$JaxbFilterParam",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbForeignKey",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGeneratedValue",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbGenericIdGenerator",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminator",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyDiscriminatorValueMapping",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyKey",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmAnyMapping",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmFilter$JaxbAliases",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHbmManyToAny",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbHqlImport",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbId",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIdClass",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbIndex",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbInheritance",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbJoinTable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbLob",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToMany",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbManyToOne",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKey",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyClass",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMapKeyJoinColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMappedSuperclass",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbMultiTenancy",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedAttributeNode",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedEntityGraph",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedNativeQuery",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedQuery",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedStoredProcedureQuery",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNamedSubgraph",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNationalized",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbNaturalId",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToMany",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOneToOne",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbOrderColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitDefaults",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPersistenceUnitMetadata",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPluralFetchMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "JOIN"
+      },
+      {
+        "name": "SELECT"
+      },
+      {
+        "name": "SUBSELECT"
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPluralFetchMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostLoad",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostPersist",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostRemove",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPostUpdate",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrePersist",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreRemove",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPreUpdate",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbPrimaryKeyJoinColumn",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryHint",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbQueryParamType",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSecondaryTable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSequenceGenerator",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSingularFetchMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "JOIN"
+      },
+      {
+        "name": "SELECT"
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSingularFetchMode",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSqlResultSetMapping",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTable",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTableGenerator",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTenantId",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbTransient",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    },
+    "allDeclaredFields": true,
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.JaxbVersion",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.InputStreamXmlSource"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.internal.ScanningCoordinator"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.spi.XmlMappingBinderAccess"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.jaxb.mapping.ObjectFactory",
+    "queryAllDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl$1"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.cache.internal.EnabledCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.cache.internal.EnabledCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.cache.internal.EnabledCaching",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.cache.internal.EnabledCaching",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.cache.spi.access.AccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.cache.spi.access.AccessType",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.cfg.beanvalidation.ValidationMode",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.beanvalidation.ValidationMode"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.dialect.H2Dialect",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.dialect.H2Dialect",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.ReflectHelper"
+    }
+  },
+  {
+    "name": "org.hibernate.dialect.H2Dialect",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.registry.selector.internal.StrategySelectorImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.engine.OptimisticLockStyle",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.OptimisticLockStyle",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.OptimisticLockStyle"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.engine.OptimisticLockStyle",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.config.internal.ConfigurationServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.beans.internal.Helper"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.InFlightMetadataCollectorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.relational.Database"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.InFlightMetadataCollectorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.relational.Database"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.InFlightMetadataCollectorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.relational.Database"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.InFlightMetadataCollectorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.relational.Database"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jndi.internal.JndiServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jndi.internal.JndiServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jndi.internal.JndiServiceImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.jndi.internal.JndiServiceImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.query.spi.QueryEngine"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.spi.Status",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.internal.AbstractEntityEntry$EnumState"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.WildFlyStandAloneJtaPlatform",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.WildFlyStandAloneJtaPlatform",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.WildFlyStandAloneJtaPlatform",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.engine.transaction.jta.platform.internal.WildFlyStandAloneJtaPlatform",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.event.spi.EventType",
+    "condition": {
+      "typeReachable": "org.hibernate.event.spi.EventType"
+    },
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.hibernate.id.Assigned",
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.enhanced.PooledOptimizer",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.OptimizerFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.enhanced.StandardNamingStrategy",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.SequenceStyleGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.ForeignGenerator"
+    },
+    "name": "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.id.Assigned",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.Configuration"
+    },
+    "name": "org.hibernate.id.IdentityGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "name": "org.hibernate.id.IdentityGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.Configuration"
+    },
+    "name": "org.hibernate.id.SelectGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    },
+    "name": "org.hibernate.id.SelectGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.LegacyNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    },
+    "name": "org.hibernate.id.enhanced.NoopOptimizer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.OptimizerFactory"
+    },
+    "name": "org.hibernate.id.enhanced.NoopOptimizer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.mapping.SimpleValue"
+    },
+    "name": "org.hibernate.id.enhanced.SequenceStyleGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.SingleNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.TableGenerator"
+    },
+    "name": "org.hibernate.id.enhanced.StandardNamingStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.id.UUIDGenerator"
+    },
+    "name": "org.hibernate.id.uuid.CustomVersionOneStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder$CustomIdGeneratorCreator"
+    },
+    "name": "org.hibernate.id.uuid.UuidGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.annotations.UuidGenerator",
+          "org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.Version"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotatedColumn"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.Environment"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.PropertyContainer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.BasicValueBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.EntityBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.PropertyBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.QueryBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.annotations.TableBinder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.beanvalidation.BeanValidationIntegrator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.context.internal.JTASessionContext"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.Dialect"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.config.internal.ConfigurationServiceImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.internal.StatefulPersistenceContext"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.internal.Versioning"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.spi.SqlExceptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jndi.internal.JndiServiceImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.spi.CascadingActions"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.event.internal.AbstractFlushingEventListener"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.event.internal.DefaultAutoFlushEventListener"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.event.internal.DefaultLockEventListener"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.OptimizerFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.PooledOptimizer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.SequenceStructure"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.id.enhanced.SequenceStyleGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.CoreLogging"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.stat.internal.StatisticsInitiator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.java.DbTimestampJavaType"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.EntityManagerMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.HEMLogging"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.EntityManagerMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.internal.util.LogHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.SessionFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.internal.log.ConnectionAccessLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.log.ConnectionAccessLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.log.ConnectionPoolingLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.log.ConnectionPoolingLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.log.DeprecationLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.log.DeprecationLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.internal.log.UrlMessageBundle_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.log.UrlMessageBundle"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.metamodel.RepresentationMode",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.metamodel.mapping.MappingModelCreationLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.mapping.MappingModelCreationLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.collection.BasicCollectionPersister",
+    "condition": {
+      "typeReachable": "org.hibernate.persister.internal.PersisterFactoryImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.Collection",
+          "org.hibernate.cache.spi.access.CollectionDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.entity.SingleTableEntityPersister",
+    "condition": {
+      "typeReachable": "org.hibernate.persister.internal.PersisterFactoryImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.mapping.PersistentClass",
+          "org.hibernate.cache.spi.access.EntityDataAccess",
+          "org.hibernate.cache.spi.access.NaturalIdDataAccess",
+          "org.hibernate.persister.spi.PersisterCreationContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.internal.RuntimeMetamodelsImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.PersisterFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.internal.RuntimeMetamodelsImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.persister.internal.StandardPersisterClassResolver",
+    "condition": {
+      "typeReachable": "org.hibernate.persister.internal.PersisterFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.InFlightMetadataCollectorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.process.spi.MetadataBuildingProcess"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.cfg.AnnotationBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.event.internal.CallbackDefinitionResolverLegacyImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.mapping.Property"
+    }
+  },
+  {
+    "name": "org.hibernate.query.hql.HqlLogging_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.query.hql.HqlLogging"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.query.QueryLogging_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.query.QueryLogging"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.BeansMessageLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.beans.internal.BeansMessageLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.MetadataSources"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryOptionsBuilder"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.SessionFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.sql.ast.tree.SqlAstTreeLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.ast.tree.SqlAstTreeLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.sql.exec.SqlExecLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.exec.SqlExecLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.sql.results.LoadingLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.results.LoadingLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.sql.results.ResultsLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.sql.results.ResultsLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.stat.internal.StatisticsImpl",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.internal.SessionFactoryImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tool.schema.TargetType",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator$2"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.SchemaCreatorImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaCreatorImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.SchemaDropperImpl",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaDropperImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tool.schema.internal.script.SingleLineSqlScriptExtractor",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaDropperImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator",
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    }
+  },
+  {
+    "name": "org.hibernate.tuple.GenerationTiming",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+    }
+  },
+  {
+    "name": "org.hibernate.tuple.GenerationTiming",
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+    }
+  },
+  {
+    "name": "org.hibernate.type.SqlTypes",
+    "allPublicFields": true,
+    "condition": {
+      "typeReachable": "org.hibernate.type.descriptor.JdbcTypeNameMapper"
+    }
+  },
+  {
+    "name": "org.wildfly.transaction.client.ContextTransactionManager",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+    }
+  },
+  {
+    "name": "org.wildfly.transaction.client.ContextTransactionManager",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.transaction.jta.platform.internal.WildFlyStandAloneJtaPlatform"
+    },
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.wildfly.transaction.client.LocalUserTransaction",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+    }
+  },
+  {
+    "name": "sun.management.ClassLoadingImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.CompilationImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.ManagementFactoryHelper$1",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.MemoryImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.MemoryManagerImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.MemoryPoolImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.management.RuntimeImpl",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+    }
+  },
+  {
+    "name": "sun.security.provider.MD5",
+    "condition": {
+      "typeReachable": "org.hibernate.boot.model.naming.NamingHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.NativePRNG",
+    "condition": {
+      "typeReachable": "org.hibernate.id.uuid.LocalObjectUuidHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA",
+    "condition": {
+      "typeReachable": "org.hibernate.id.uuid.LocalObjectUuidHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.SHA2$SHA256",
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.IncrementGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.IncrementGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.uuid.UuidGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.uuid.UuidGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.GUIDGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.GUIDGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.ForeignGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.ForeignGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDHexGenerator",
+    "condition": {
+      "typeReachable": "jakarta.persistence.GeneratedValue"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.id.UUIDHexGenerator",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GenericGenerator"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.cfg.beanvalidation.TypeSafeActivator",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "jakarta.validation.ValidatorFactory"
+    }
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.PostgreSQLSequenceSupport"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.PostgreSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.PostgreSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.postgresql.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.postgresql.jdbc.PgConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter"
+    },
+    "name": "org.postgresql.jdbc.PgStatement",
+    "fields": [
+      {
+        "name": "cancelTimerTask"
+      },
+      {
+        "name": "statementState"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLIntervalSecondJdbcType"
+    },
+    "name": "org.postgresql.util.PGInterval",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "int",
+          "int",
+          "int",
+          "int",
+          "double"
+        ]
+      },
+      {
+        "name": "getDays",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHours",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMicroSeconds",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMinutes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getWholeSeconds",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.PostgreSQLPGObjectJdbcType"
+    },
+    "name": "org.postgresql.util.PGobject",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.internal.util.ReflectHelper"
+    },
+    "name": "org.postgresql.util.PGobject",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MariaDBDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MariaDBDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.mariadb.jdbc.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbBlob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbClob"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.mariadb.jdbc.MariaDbConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.MariaDbStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.util.LogQueryTool"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "org.mariadb.jdbc.internal.util.Options",
+    "fields": [
+      {
+        "name": "password"
+      },
+      {
+        "name": "user"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "org.mariadb.jdbc.internal.util.exceptions.ExceptionMapper"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.MySQLDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "com.mysql.cj.jdbc.Clob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "com.mysql.cj.jdbc.ConnectionImpl",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "com.mysql.cj.jdbc.Driver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.mysql.cj.log.StandardLogger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.mysql.cj.protocol.StandardSocketFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.MySQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.CockroachDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.CockroachDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.sequence.HSQLSequenceSupport"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaCreatorImpl"
+    },
+    "name": "[Lorg.hsqldb.Constraint;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.StatementPreparerImpl$1"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.extract.spi.ExtractionContext"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.SchemaCreatorImpl"
+    },
+    "name": "[Lorg.hsqldb.index.Index;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.registry.selector.internal.StrategySelectorImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl$$Lambda$499/0x00000008010a5ee8"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.HSQLDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.HSQLDialect"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "org.hsqldb.jdbc.JDBCClob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "org.hsqldb.jdbc.JDBCConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "org.hsqldb.jdbc.JDBCDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.HSQLDialect"
+    },
+    "name": "org.hsqldb.persist.HsqlDatabaseProperties",
+    "fields": [
+      {
+        "name": "THIS_VERSION"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.OracleDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.temptable.StandardTemporaryTableExporter"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.OracleArrayJdbcType"
+    },
+    "name": "oracle.jdbc.OracleConnection",
+    "queriedMethods": [
+      {
+        "name": "createOracleArray",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.jdbc.OracleDriver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "oracle.jdbc.OracleDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.OracleStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.OracleStatementWrapper"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "oracle.jdbc.driver.PhysicalConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4C8Oall"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "oracle.jdbc.driver.T4CConnection"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
+    },
+    "name": "oracle.jdbc.driver.T4CDriverExtension",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CTTIfun"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "oracle.jdbc.driver.T4CTTIoer11"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
+    },
+    "name": "oracle.jdbc.internal.OracleConnection$TransactionState",
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.Ano",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.AuthenticationService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.DataIntegrityService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.EncryptionService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "oracle.net.ano.SupervisorService",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "oracle.sql.CLOB",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.OracleDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.OracleDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.SQLServerDialect"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.pagination.SQLServer2005LimitHandler"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.dialect.pagination.SQLServer2005LimitHandler$Keyword"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerClob",
+    "methods": [
+      {
+        "name": "free",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerConnection",
+    "queriedMethods": [
+      {
+        "name": "getSchema",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerConnection"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerException"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerStatement"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerStatement$StmtExecCmd"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.SSType$Category",
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
+    },
+    "name": "com.microsoft.sqlserver.jdbc.TDSCommand"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.internal.MetadataBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl"
+    },
+    "name": "org.hibernate.dialect.SQLServerDialect",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/resource-config.json
+++ b/tests/src/org.hibernate.orm/hibernate-envers/6.1.1.Final/src/test/resources/META-INF/native-image/dto-runtime-hints/resource-config.json
@@ -1,0 +1,164 @@
+{
+  "bundles": [
+    {
+      "name": "com.sun.org.apache.xerces.internal.impl.xpath.regex.message",
+      "locales": [
+        "und"
+      ]
+    }
+  ],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/services/jakarta.xml.bind.JAXBContext\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
+        }
+      },
+      {
+        "pattern": "\\QMETA-INF/services/org.apache.logging.log4j.spi.Provider\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+        }
+      },
+      {
+        "pattern": "\\QMETA-INF/services/org.apache.logging.log4j.util.PropertySource\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+        }
+      },
+      {
+        "pattern": "\\QMETA-INF/services/org.hibernate.boot.registry.selector.StrategyRegistrationProvider\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.registry.selector.internal.StrategySelectorBuilder"
+        }
+      },
+      {
+        "pattern": "\\QMETA-INF/services/org.jboss.logging.LoggerProvider\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+        }
+      },
+      {
+        "pattern": "\\Qhibernate.properties\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.internal.util.ConfigHelper"
+        }
+      },
+      {
+        "pattern": "\\Qlog4j2.properties\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/hibernate-configuration-3.0.dtd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/hibernate-mapping-3.0.dtd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/hibernate-mapping-4.0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_1_0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_2_0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_2_1.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_2_2.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_3_0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/orm_3_1.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/orm/test/jpa/xml/versions/invalid-orm-1_0.xml\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/orm/test/jpa/xml/versions/valid-orm-1_0.xml\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/orm/test/jpa/xml/versions/valid-orm-2_0.xml\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/orm/test/jpa/xml/versions/valid-orm-2_1.xml\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/orm/test/jpa/xml/versions/valid-orm-2_2.xml\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/xsd/mapping/legacy-mapping-4.0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/xsd/mapping/mapping-3.1.0.xsd\\E",
+        "condition": {
+          "typeReachable": "org.hibernate.boot.xsd.LocalXsdResolver"
+        }
+      },
+      {
+        "pattern": "\\QMETA-INF/persistence.xml\\E",
+        "condition": {
+          "typeReachable": "jakarta.persistence.Persistence"
+        }
+      },
+      {
+        "pattern": "\\Qorg/hibernate/jpa/persistence_2_0.xsd\\E",
+        "condition": {
+          "typeReachable": "jakarta.persistence.Persistence"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/org.hibernate.orm/hibernate-envers/README.md
+++ b/tests/src/org.hibernate.orm/hibernate-envers/README.md
@@ -1,0 +1,70 @@
+# Hibernate Envers
+
+The metadata has been gathered by a combination of running the hibernate-orm:hibernate-envers integration tests for H2, package by package with the agent attached, combining the results and by tweaking and completing the output files.
+
+**WARNING**: Features that require runtime proxy creation will not work.
+
+## Run tests with agent
+
+**Note**: Provide extra memory (`-Xmx8g`) to `native-image-configure`.
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for PACKAGE_PATH in hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/*; do
+
+  PACKAGE=$(basename "$PACKAGE_PATH")
+
+  ./gradlew hibernate-core:test --tests "org.hibernate.orm.test.envers.integration.$PACKAGE.*" -Pdb=h2 -Pagent
+  ./gradlew hibernate-core:metadataCopy
+done  
+```
+
+`access-filter.json` contains this:
+
+```json
+{
+  "rules": [
+    {
+      "includeClasses": "**"
+    },
+    {
+      "excludeClasses": "org.hibernate.orm.test.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.testing.**"
+    },
+    {
+      "excludeClasses": "org.apache.logging.log4j.**"
+    }
+  ]
+}
+
+```
+
+`user-code-filter.json` contains this:
+
+```json
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.hibernate.envers.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.orm.test.**"
+    },
+    {
+      "excludeClasses": "org.hibernate.testing.**"
+    },
+    {
+      "excludeClasses": "net.bytebuddy.**"
+    }
+  ]
+}
+```
+


### PR DESCRIPTION
## What does this PR do?
This PR provides an initial set of hints extracted from running integration tests of `hibernate-envers` with the agent attached as well a set of manually added ones that turned out to be missing when testing the generated metadata.

Any hibernate-envers features that requires runtime hint proxy creation will not work.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

Closes: #82