### PR TITLE
Add all hibernate validator implementations to reflect-config.json

### DIFF
--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
@@ -1240,798 +1240,6 @@
   },
   {
     "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertTrueValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.DigitsValidatorForNumber",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotBlankValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl$CascadingValueReceiver"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NullValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.CurrencyValidatorForMonetaryAmount",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCharSequence",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArray",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForMap",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCollection",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCollection",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForDouble",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForLocalDate",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForInstant",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForLocalDate",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForInstant",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForLocalDate",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForInstant",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForLocalDate",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForInstant",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.CodePointLengthValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ISBNValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LengthValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LengthValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LuhnCheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LuhnCheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod10CheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod10CheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.constraintvalidation.ComposingConstraintTree"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ModCheckValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.NormalizedValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.UUIDValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.UniqueElementsValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.NIPValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.PESELValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.REGONValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ru.INNValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMaxValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
-    },
-    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMinValidator",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
       "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
     },
     "name": "org.hibernate.validator.internal.engine.messageinterpolation.el.BeanPropertiesELResolver"
@@ -2146,5 +1354,2633 @@
     },
     "name": "sun.management.RuntimeImpl",
     "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.URLValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.PositiveValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod10CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfChar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertTrueValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMinValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfChar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.MinValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotBlankValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LuhnCheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ru.INNValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.EANValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMaxValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.NegativeOrZeroValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.CodePointLengthValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMinValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForMap",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.LengthValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfBoolean",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.DigitsValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArray",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.DigitsValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.PESELValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfInt",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.br.CPFValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.br.CNPJValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfBoolean",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForCollection",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.UniqueElementsValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.NotBlankValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArraysOfInt",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.NegativeValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.PositiveOrZeroValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.NormalizedValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.MaxValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ISBNValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.NullValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.DigitsValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.money.CurrencyValidatorForMonetaryAmount",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.constraintvalidators.RegexpURLValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArray",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForMap",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ModCheckValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForArraysOfFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.REGONValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.pl.NIPValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.EmailValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForNumber",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForShort",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigDecimal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForLong",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForByte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForCharSequence",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForFloat",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForDouble",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ParameterScriptAssertValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.hv.ScriptAssertValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadableInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadablePartial",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadableInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadablePartial",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadablePartial",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadableInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadablePartial",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadableInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForYear",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForThaiBuddhistDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForLocalTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForJapaneseDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForHijrahDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForLocalDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForOffsetTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForOffsetDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForMinguoDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForZonedDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForYearMonth",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForMonthDay",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForLocalDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForHijrahDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForLocalTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForYear",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForOffsetTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForOffsetDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForMinguoDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForJapaneseDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForMonthDay",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForThaiBuddhistDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForZonedDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForYearMonth",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForMonthDay",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForThaiBuddhistDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForLocalDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForYearMonth",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForHijrahDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForYear",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForLocalTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForJapaneseDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForOffsetDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForZonedDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForOffsetTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForMinguoDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForLocalDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForYear",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForMinguoDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForThaiBuddhistDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForOffsetDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForLocalDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForYearMonth",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForJapaneseDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForHijrahDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForInstant",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForLocalTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForMonthDay",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForZonedDateTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForOffsetTime",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForCalendar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForCalendar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForCalendar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForCalendar",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+    },
+    "name": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForDate",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/build.gradle
@@ -14,9 +14,10 @@ plugins {
 String libraryVersion = TestUtils.testedLibraryVersion
 
 dependencies {
-	testImplementation("org.hibernate.validator:hibernate-validator:$libraryVersion")
-	testRuntimeOnly('org.glassfish:jakarta.el:4.0.2')
-	testImplementation('org.assertj:assertj-core:3.22.0')
+    implementation('org.reflections:reflections:0.10.2')
+    implementation("org.hibernate.validator:hibernate-validator:$libraryVersion")
+    testRuntimeOnly('org.glassfish:jakarta.el:4.0.2')
+    testImplementation('org.assertj:assertj-core:3.22.0')
 }
 
 graalvmNative {

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/main/java/org/hibernate/validator/FindValidators.java
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/main/java/org/hibernate/validator/FindValidators.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.hibernate.validator;
+
+import jakarta.validation.ConstraintValidator;
+import org.reflections.Reflections;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import static org.reflections.scanners.Scanners.SubTypes;
+
+// Uses Reflections to find all subtypes of ConstraintValidator and formats them as reflect-config.json entries
+class FindValidators {
+    public static void main(String[] args) throws IOException {
+        Reflections reflections = new Reflections("org.hibernate.validator");
+        Set<Class<?>> subTypes = reflections.get(SubTypes.of(ConstraintValidator.class).asClass());
+        String template = new String(FindValidators.class.getResourceAsStream("/template.txt").readAllBytes(), StandardCharsets.UTF_8);
+
+        for (Class<?> subType : subTypes) {
+            if (!Modifier.isPublic(subType.getModifiers()) || subType.isInterface() || Modifier.isAbstract(subType.getModifiers())) {
+                continue;
+            }
+            System.out.printf(template, subType.getName());
+        }
+    }
+}

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/main/resources/template.txt
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/main/resources/template.txt
@@ -1,0 +1,12 @@
+{
+  "condition": {
+    "typeReachable": "org.hibernate.validator.internal.engine.ValidatorImpl"
+  },
+  "name": "%s",
+  "methods": [
+    {
+      "name": "<init>",
+      "parameterTypes": []
+    }
+  ]
+},

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/Dto.java
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/Dto.java
@@ -65,6 +65,9 @@ public class Dto {
     @Digits(integer = 2, fraction = 0)
     private final int digits;
 
+    @Digits(integer = 2, fraction = 0)
+    private final String digitsString;
+
     @NotEmpty
     private final String notEmptyString;
 
@@ -91,7 +94,7 @@ public class Dto {
 
     public Dto(
             String notBlank, List<String> notEmpty, int min, int max, String email, String pattern, Object notNull,
-            Object oNull, Instant future, boolean bTrue, boolean bFalse, int digits, String notEmptyString,
+            Object oNull, Instant future, boolean bTrue, boolean bFalse, int digits, String digitsString, String notEmptyString,
             Map<String, String> notEmptyMap, @NotEmpty String[] notEmptyArray, String size, int positive, int negative,
             String ccNumber, int range
     ) {
@@ -107,6 +110,7 @@ public class Dto {
         this.bTrue = bTrue;
         this.bFalse = bFalse;
         this.digits = digits;
+        this.digitsString = digitsString;
         this.notEmptyString = notEmptyString;
         this.notEmptyMap = notEmptyMap;
         this.notEmptyArray = notEmptyArray;
@@ -121,7 +125,7 @@ public class Dto {
         return new Dto(
                 "not-blank", List.of("not-empty"), 2, -2, "some@example.com", "a",
                 new Object(), null, Instant.now().plusSeconds(60), true, false, 11,
-                "some-content", Map.of("a", "1"), new String[]{"some-string"}, "12", 1,
+                "11", "some-content", Map.of("a", "1"), new String[]{"some-string"}, "12", 1,
                 -2, "4539627380966582", 7
         );
     }
@@ -129,7 +133,7 @@ public class Dto {
     public static Dto createInvalid() {
         return new Dto(
                 "", List.of(), 0, 0, "no-email", "1", null, new Object(),
-                Instant.now().minusSeconds(60), false, true, 111, "",
+                Instant.now().minusSeconds(60), false, true, 111, "111", "",
                 Map.of(), new String[0], "123", -1, 1, "", 11
         );
     }

--- a/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/HibernateValidatorTest.java
+++ b/tests/src/org.hibernate.validator/hibernate-validator/7.0.4.Final/src/test/java/org/hibernate/validator/HibernateValidatorTest.java
@@ -47,6 +47,7 @@ public class HibernateValidatorTest {
                 new ValidationError("bFalse", "{jakarta.validation.constraints.AssertFalse.message}"),
                 new ValidationError("bTrue", "{jakarta.validation.constraints.AssertTrue.message}"),
                 new ValidationError("digits", "{jakarta.validation.constraints.Digits.message}"),
+                new ValidationError("digitsString", "{jakarta.validation.constraints.Digits.message}"),
                 new ValidationError("notEmptyString", "{jakarta.validation.constraints.NotEmpty.message}"),
                 new ValidationError("notEmptyArray", "{jakarta.validation.constraints.NotEmpty.message}"),
                 new ValidationError("notEmptyMap", "{jakarta.validation.constraints.NotEmpty.message}"),

--- a/tests/src/org.hibernate.validator/hibernate-validator/README.md
+++ b/tests/src/org.hibernate.validator/hibernate-validator/README.md
@@ -3,6 +3,8 @@
 The metadata has been gathered by a combination of running the hibernate-validator tests with the agent attached and
 by tweaking and completing the output files.
 
+To find all validator implementations, a small tool named `FindValidators` has been written, which resides in `src/main/java`.
+
 ## Run tests with agent
 
 Put this in the `pom.xml`:


### PR DESCRIPTION
I've added all of the validator implementations into the `reflect-config.json` file.

I auto-generated the JSON snippets with `FindValidators`, which is included in the PR.
