### PR TITLE
Add metadata for Netty MacOS specific nameserver resolution

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/jni-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/jni-config.json
@@ -596,5 +596,49 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+    },
+    "name": "[Lio.netty.resolver.dns.macos.DnsResolver;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+    },
+    "name": "[[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.resolver.dns.macos.DnsResolver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "byte[][]",
+          "int",
+          "java.lang.String[]",
+          "java.lang.String",
+          "int",
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
   }
 ]

--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -7359,5 +7359,23 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsServerAddressStreamProviders"
+    },
+    "name": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.resolver.dns.DnsServerAddressStreamProviders$1"
+    },
+    "name": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
   }
 ]

--- a/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
@@ -25,6 +25,18 @@
           "typeReachable": "io.netty.util.internal.logging.Slf4JLoggerFactory"
         },
         "pattern": "\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "io.netty.util.internal.NativeLibraryLoader"
+        },
+        "pattern": "\\QMETA-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "io.netty.util.internal.NativeLibraryLoader"
+        },
+        "pattern": "\\QMETA-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib\\E"
       }
     ]
   }


### PR DESCRIPTION
## What does this PR do?

Netty provides MacOS specific nameserver resolution - `resolver-dns-classes-macos` and `resolver-dns-native-macos`.

The PR adds metadata for Netty MacOS specific nameserver resolution.

The exception below is observed when there is no metadata for this functionality:

```
java.lang.NoSuchMethodException: io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider.<init>()
        at java.base@19.0.1/java.lang.Class.getConstructor0(DynamicHub.java:3641) ~[client:na]
        at java.base@19.0.1/java.lang.Class.getConstructor(DynamicHub.java:2324) ~[client:na]
        at io.netty.resolver.dns.DnsServerAddressStreamProviders.<clinit>(DnsServerAddressStreamProviders.java:63) ~[na:na]
        at io.netty.resolver.dns.DnsNameResolverBuilder.<init>(DnsNameResolverBuilder.java:60) ~[na:na]
```

Closes #100

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

Test is not provided because the fix is relevant only for MacOS. 
