### PR TITLE
Enable Native Image build reports for build jobs and PRs

### DIFF
--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -51,6 +51,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
       - name: "🧪 Run '${{ matrix.coordinates }}' tests"
         run: |
           ./gradlew test -Pcoordinates=${{ matrix.coordinates }}

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -53,6 +53,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: "🧪 Run '${{ matrix.coordinates }}' tests"
         run: |
           ./gradlew test -Pcoordinates=${{ matrix.coordinates }}


### PR DESCRIPTION
## What does this PR do?
Enable the new `native-image-job-reports` and `native-image-pr-reports` options, which post Native Image build reports as job summaries and as comments on pull requests (see https://github.com/graalvm/setup-graalvm/pull/20).

## Checklist before merging
n/a
