### PR TITLE
Update hibernate-orm hints to cover AttributeBinder & ValueGenerationTypes

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -1195,13 +1195,7 @@
     "name": "jakarta.persistence.Access",
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Access",
@@ -1239,26 +1233,14 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.AttributeOverrides",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Basic",
@@ -1295,13 +1277,7 @@
     "name": "jakarta.persistence.Basic",
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Basic",
@@ -1321,26 +1297,14 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Column",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Column",
@@ -1366,38 +1330,20 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Embeddable",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Embedded",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Entity",
@@ -1421,26 +1367,14 @@
     "name": "jakarta.persistence.Entity",
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Entity",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Entity",
@@ -1453,13 +1387,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.EnumType",
@@ -1484,25 +1412,13 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.GeneratedValue",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.GenerationType",
@@ -1544,26 +1460,14 @@
     "name": "jakarta.persistence.Id",
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Id",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.Id",
@@ -1606,25 +1510,13 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.PrePersist",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.persistence.TemporalType",
@@ -1669,10 +1561,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "value",
         "parameterTypes": []
       }
@@ -1683,38 +1571,20 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlAttribute",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlAttribute",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElement",
@@ -1722,10 +1592,6 @@
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
     },
     "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
       {
         "name": "type",
         "parameterTypes": []
@@ -1737,13 +1603,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElement$DEFAULT",
@@ -1758,10 +1618,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "scope",
         "parameterTypes": []
       }
@@ -1772,13 +1628,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElementDecl$GLOBAL",
@@ -1793,10 +1643,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "type",
         "parameterTypes": []
       }
@@ -1807,13 +1653,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElementRef$DEFAULT",
@@ -1825,26 +1665,14 @@
     "name": "jakarta.xml.bind.annotation.XmlElementRefs",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElementRefs",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlElements",
@@ -1854,10 +1682,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "value",
         "parameterTypes": []
       }
@@ -1870,10 +1694,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "value",
         "parameterTypes": []
       }
@@ -1884,13 +1704,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlEnumValue",
@@ -1898,10 +1712,6 @@
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
     },
     "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
       {
         "name": "value",
         "parameterTypes": []
@@ -1913,76 +1723,40 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlMixed",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlMixed",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlRootElement",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlRootElement",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlSchemaType",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlSchemaType$DEFAULT",
@@ -1997,10 +1771,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "value",
         "parameterTypes": []
       }
@@ -2011,13 +1781,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlType",
@@ -2025,10 +1789,6 @@
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
     },
     "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
       {
         "name": "factoryClass",
         "parameterTypes": []
@@ -2040,13 +1800,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlType$DEFAULT",
@@ -2058,26 +1812,14 @@
     "name": "jakarta.xml.bind.annotation.XmlValue",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.XmlValue",
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter",
@@ -2116,10 +1858,6 @@
     },
     "methods": [
       {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
         "name": "type",
         "parameterTypes": []
       },
@@ -2134,13 +1872,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT",
@@ -2202,13 +1934,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jdk.internal.misc.Unsafe",
@@ -2229,791 +1955,6 @@
     }
   },
   {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor10",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor11",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor12",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor13",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor14",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor15",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor16",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor17",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor18",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor19",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor20",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.cfgxml.spi.LoadedConfig"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor21",
-    "condition": {
-      "typeReachable": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor23",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.MetadataSources"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor24",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor25",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor26",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor27",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor28",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor29",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor30",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor31",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor32",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor33",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor34",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor35",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor36",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor37",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor38",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor39",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor40",
-    "condition": {
-      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor41",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor42",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor43",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor44",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor45",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor46",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor47",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor48",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor49",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor50",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor52",
-    "condition": {
-      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor54",
-    "condition": {
-      "typeReachable": "org.hibernate.event.internal.AbstractSaveEventListener"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor6",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor60",
-    "condition": {
-      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor61",
-    "condition": {
-      "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor7",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor8",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedConstructorAccessor9",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "unsafeAllocated": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor10",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor18",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor19",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor22",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor23",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor24",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor25",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor26",
-    "condition": {
-      "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor3",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor4",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor5",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor6",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor7",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor8",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "jdk.internal.reflect.GeneratedMethodAccessor9",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
     "name": "jdk.internal.reflect.NativeMethodAccessorImpl",
     "condition": {
       "typeReachable": "org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl"
@@ -3023,13 +1964,7 @@
     "name": "jdk.internal.vm.annotation.IntrinsicCandidate",
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "jdk.management.jfr.ConfigurationInfo",
@@ -3101,13 +2036,7 @@
     "name": "org.glassfish.jaxb.runtime.v2.ContextFactory",
     "condition": {
       "typeReachable": "org.hibernate.boot.jaxb.internal.MappingBinder"
-    },
-    "methods": [
-      {
-        "name": "createContext",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
@@ -3368,13 +2297,7 @@
     "queryAllDeclaredMethods": true,
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "org.hibernate.LockMode",
@@ -3410,13 +2333,7 @@
     "name": "org.hibernate.annotations.Columns",
     "condition": {
       "typeReachable": "org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
+    }
   },
   {
     "name": "org.hibernate.annotations.Columns",
@@ -11167,6 +10084,7 @@
       {
         "name": "<init>",
         "parameterTypes": [
+          "java.lang.Class",
           "int"
         ]
       }
@@ -11284,6 +10202,7 @@
       {
         "name": "<init>",
         "parameterTypes": [
+          "java.lang.Class",
           "int"
         ]
       }
@@ -11298,6 +10217,7 @@
       {
         "name": "<init>",
         "parameterTypes": [
+          "java.lang.Class",
           "int"
         ]
       }
@@ -11385,6 +10305,7 @@
         "name": "<init>",
         "parameterTypes": [
           "org.hibernate.annotations.UuidGenerator",
+          "java.lang.reflect.Member",
           "org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext"
         ]
       }
@@ -12721,7 +11642,11 @@
     "methods": [
       {
         "name": "<init>",
-        "parameterTypes": []
+        "parameterTypes": [
+          "org.hibernate.annotations.UuidGenerator",
+          "java.lang.reflect.Member",
+          "org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext"
+        ]
       }
     ]
   },
@@ -12733,7 +11658,11 @@
     "methods": [
       {
         "name": "<init>",
-        "parameterTypes": []
+        "parameterTypes": [
+          "org.hibernate.annotations.UuidGenerator",
+          "java.lang.reflect.Member",
+          "org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext"
+        ]
       }
     ]
   },

--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -12435,6 +12435,126 @@
     }
   },
   {
+    "name": "org.hibernate.tuple.GeneratedValueGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.Generated"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.GeneratedAlwaysValueGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GeneratedColumn"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.UpdateTimestampGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.UpdateTimestamp"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.CreationTimestampGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.CreationTimestamp"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.VmValueGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GeneratorType"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.annotations.CurrentTimestampGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.CurrentTimestamp"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.TenantIdGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.TenantId"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.TenantIdGeneration",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.GeneratorType"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.AttributeAccessorBinder",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.AttributeAccessor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.hibernate.tuple.TenantIdBinder",
+    "condition": {
+      "typeReachable": "org.hibernate.annotations.TenantId"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "org.hibernate.type.SqlTypes",
     "allPublicFields": true,
     "condition": {


### PR DESCRIPTION
## What does this PR do?

This PR adds hints for types created reflectively via `org.hibernate.cfg.annotations.PropertyBinder` based on types provided via (meta) annotation attributes via commit 0.

Additionally commit 1 updates the reflection config to reduce build time warnings due to invalid configuration which will close #107 .



## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
