### PR TITLE
Remove Log4j2 entries from netty-common's reflection metadata

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -4310,63 +4310,6 @@
   },
   {
     "condition": {
-      "typeReachable": "io.netty.util.internal.logging.Log4J2Logger$1"
-    },
-    "name": "org.apache.logging.log4j.Logger",
-    "queriedMethods": [
-      {
-        "name": "debug",
-        "parameterTypes": [
-          "java.lang.String",
-          "java.lang.Object"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.netty.util.internal.logging.Log4JLoggerFactory"
-    },
-    "name": "org.apache.logging.log4j.core.LoggerContext"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.netty.util.internal.logging.Log4J2Logger"
-    },
-    "name": "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.netty.util.internal.logging.Log4JLoggerFactory"
-    },
-    "name": "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.netty.util.internal.logging.Log4JLoggerFactory"
-    },
-    "name": "org.apache.logging.log4j.message.ReusableMessageFactory",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
       "typeReachable": "io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator"
     },
     "name": "org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",


### PR DESCRIPTION
## What does this PR do?

Apache Log4j2 does not work in a native image and that will be the case [until Log4j2 3.0 at the earliest](https://issues.apache.org/jira/browse/LOG4J2-2649). Furthermore, Netty's `InternalLoggerFactory` is written such that SLF4J is preferred. As such, it does not make sense for Netty to provide reflection metadata for Log4j2 – in must cases the code that tries to use Log4j2 won't be reached and when it is, Log4j2 will not be usable anyway.

In addition to the reflection metadata for Log4j2 not being beneficial to Netty, it's also harmful when using JBoss Logging. The metadata is sufficient for JBoss Logging's attempt to use Log4j2 to reach the point where error-level logging of stack traces is performed before falling back to another logging framework. Without Netty's metadata for Log4j2, this fallback is performed silently as intended.

To address these problems, this PR removes the Apache Log4j2 entries from netty-common's reflection metadata.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

I haven't added any new tests but the existing tests continue to pass with the reduced metadata.
