### PR TITLE
Add metadata for Eclipse Angus Jakarta Mail reference implementation

### DIFF
--- a/metadata/org.eclipse.angus/jakarta.mail/1.0.0/index.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/1.0.0/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.eclipse.angus/jakarta.mail/1.0.0/reflect-config.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/1.0.0/reflect-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "condition": {
+      "typeReachable": "jakarta.mail.Session"
+    },
+    "allDeclaredConstructors": true,
+    "name": "com.sun.mail.smtp.SMTPTransport"
+  }
+]

--- a/metadata/org.eclipse.angus/jakarta.mail/1.0.0/resource-config.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/1.0.0/resource-config.json
@@ -1,0 +1,24 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/hk2-locator/default\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/gfprobe-provider.xml\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/javamail.charset.map\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/javamail.default.address.map\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/javamail.default.providers\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/mailcap\\E"
+      }
+    ]
+  }
+}

--- a/metadata/org.eclipse.angus/jakarta.mail/index.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.0.0",
+    "module": "org.eclipse.angus:jakarta.mail",
+    "tested-versions": [
+      "1.0.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -231,6 +231,17 @@
     ]
   },
   {
+    "test-project-path": "org.eclipse.angus/jakarta.mail/1.0.0",
+    "libraries": [
+      {
+        "name": "org.eclipse.angus:jakarta.mail",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.glassfish.jaxb/jaxb-runtime/3.0.2",
     "libraries": [
       {

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/build.gradle
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.graalvm.internal.tck.TestUtils
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = TestUtils.testedLibraryVersion
+
+dependencies {
+    testImplementation("org.slf4j:slf4j-api:1.7.36")
+    testImplementation("org.slf4j:slf4j-simple:1.7.36")
+    testImplementation("org.eclipse.angus:jakarta.mail:$libraryVersion")
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'commons-io:commons-io:2.11.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--no-fallback')
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/gradle.properties
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.0.0
+metadata.dir = org.eclipse.angus/jakarta.mail/1.0.0/

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/settings.gradle
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta-mail-tests'

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/src/test/java/com/sun/mail/JakartaMailTest.java
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/src/test/java/com/sun/mail/JakartaMailTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.sun.mail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Properties;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JakartaMailTest {
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting email server ...");
+        new ProcessBuilder("docker", "run", "--cidfile", "greenmail.cid", "-p", "3025:3025", "--rm", "-e",
+                "GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose", "greenmail/standalone:1.6.10")
+                .redirectOutput(new File("greenmail-stdout.txt"))
+                .redirectError(new File("greenmail-stderr.txt")).start();
+        Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> {
+            String logs = FileUtils.readFileToString(new File("greenmail-stdout.txt"), StandardCharsets.UTF_8);
+            return logs.contains("smtp.SmtpServer| Started") && logs.contains("pop3.Pop3Server| Started") && logs.contains("imap.ImapServer| Started");
+        });
+    }
+
+    @AfterAll
+    static void tearDown() throws InterruptedException, IOException {
+        File cidFile = new File("greenmail.cid");
+        String cid = FileUtils.readFileToString(cidFile, StandardCharsets.UTF_8);
+        Files.delete(cidFile.toPath());
+        new ProcessBuilder("docker", "kill", cid).start().waitFor();
+        Files.delete(Path.of("greenmail-stdout.txt"));
+        Files.delete(Path.of("greenmail-stderr.txt"));
+    }
+
+    @Test
+    void sendMailWithSmtp() throws MessagingException {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.host", "localhost");
+        properties.put("mail.smtp.port", "3025");
+        Session session = Session.getInstance(properties);
+        Message message = new MimeMessage(session);
+        message.setFrom(new InternetAddress("alice@localhost"));
+        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse("bob@localhost"));
+        message.setSubject("This is a test");
+        message.setText("Dear Bob, hello world! Alice.");
+        Transport.send(message);
+    }
+
+    @Test
+    void resources() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        Assertions.assertThat(classLoader.getResource("META-INF/hk2-locator/default")).isNotNull();
+        Assertions.assertThat(classLoader.getResource("META-INF/gfprobe-provider.xml")).isNotNull();
+        Assertions.assertThat(classLoader.getResource("META-INF/javamail.charset.map")).isNotNull();
+        Assertions.assertThat(classLoader.getResource("META-INF/javamail.default.address.map")).isNotNull();
+        Assertions.assertThat(classLoader.getResource("META-INF/javamail.default.providers")).isNotNull();
+        Assertions.assertThat(classLoader.getResource("META-INF/mailcap")).isNotNull();
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?

As part of Jakarta EE 10, the coordinates of the Jakarta Mail reference implementation have been updated with the group ID changing from `com.sun.mail` to `org.eclipse.angus`. This makes the existing metadata for `com.sun.mail:jakarta.mail` ineffective.

This PR adds metadata for the the new artifact, focusing on SMTP as the [existing metadata](https://github.com/oracle/graalvm-reachability-metadata/pull/44) does.



## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
