### PR TITLE
Remove MBean-related entries from hibernate-core's metadata

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -678,24 +678,6 @@
     }
   },
   {
-    "name": "[Ljavax.management.MBeanAttributeInfo;",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "[Ljavax.management.MBeanOperationInfo;",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "[Ljavax.management.openmbean.CompositeData;",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
     "name": "[Lorg.apache.logging.log4j.core.Appender;",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
@@ -1027,88 +1009,6 @@
   },
   {
     "name": "com.oracle.truffle.js.scriptengine.GraalJSEngineFactory",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "com.sun.management.GarbageCollectorMXBean",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.GcInfo",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.HotSpotDiagnosticMXBean",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.ThreadMXBean",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.UnixOperatingSystemMXBean",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.VMOption",
-    "queryAllPublicMethods": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
-    "queryAllPublicConstructors": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.internal.HotSpotDiagnostic",
-    "queryAllPublicConstructors": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.internal.HotSpotThreadImpl",
-    "queryAllPublicConstructors": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.internal.OperatingSystemImpl",
-    "queryAllPublicConstructors": true,
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "com.sun.management.internal.PlatformMBeanProviderImpl",
     "condition": {
       "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
     },
@@ -1878,55 +1778,6 @@
     "name": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT",
     "condition": {
       "typeReachable": "org.hibernate.jpa.boot.spi.Bootstrap"
-    }
-  },
-  {
-    "name": "javax.management.MBeanOperationInfo",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "queriedMethods": [
-      {
-        "name": "getSignature",
-        "parameterTypes": []
-      }
-    ],
-    "queryAllPublicMethods": true
-  },
-  {
-    "name": "javax.management.MBeanServerBuilder",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    },
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "name": "javax.management.ObjectName",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "javax.management.openmbean.CompositeData",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
-    }
-  },
-  {
-    "name": "javax.management.openmbean.TabularData",
-    "condition": {
-      "typeReachable": "org.hibernate.jpa.HibernatePersistenceProvider"
     }
   },
   {


### PR DESCRIPTION
## What does this PR do?

Hibernate's metadata contains entries for various MBean-related classes. This metadata causes a call to
`ManagementFactory.getPlatformMBeanServer()` to [fail with a `javax.management.openmbean.OpenDataException`](https://github.com/spring-projects/spring-boot/issues/33210). It would appear that the metadata is sufficient for the bootstrapping of the MBean server to take a different code path to normal and this path fails. This PR removes the offending metadata which fixes `ManagementFactory.getPlatformMBeanServer()` and has no adverse effects on the existing tests for hibernate-core.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

No new tests have been added but the existing tests are unaffected by the changes.
