### PR TITLE
Liquibase: XML changelogs, call all features

### DIFF
--- a/metadata/org.liquibase/liquibase-core/4.17.0/reflect-config.json
+++ b/metadata/org.liquibase/liquibase-core/4.17.0/reflect-config.json
@@ -49,28 +49,9 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "java.beans.PropertyVetoException"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "java.lang.Object",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "java.lang.ObjectBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "java.lang.ObjectCustomizer"
   },
   {
     "condition": {
@@ -110,95 +91,31 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.AbstractExtensibleObject",
     "queryAllPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.AbstractExtensibleObjectBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.AbstractExtensibleObjectCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.AbstractChange",
     "queryAllPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractChangeCustomizer"
-  },
-  {
-    "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.AbstractSQLChange",
-    "methods": [
-      {
-        "name": "isSplitStatements",
-        "parameterTypes": []
-      },
-      {
-        "name": "isStripComments",
-        "parameterTypes": []
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractSQLChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractSQLChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractSQLChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.AbstractTableChange",
     "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractTableChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.AbstractTableChangeCustomizer"
   },
   {
     "condition": {
@@ -248,1222 +165,227 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AbstractModifyDataChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AbstractModifyDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AbstractModifyDataChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddAutoIncrementChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddAutoIncrementChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddAutoIncrementChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddAutoIncrementChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.AddColumnChange",
-    "methods": [
-      {
-        "name": "getCatalogName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getColumns",
-        "parameterTypes": []
-      },
-      {
-        "name": "getSchemaName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "setTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.changelog.visitor.ValidatingVisitor"
-    },
-    "name": "liquibase.change.core.AddColumnChange",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
-        "name": "getColumns",
-        "parameterTypes": []
-      },
-      {
-        "name": "getTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "setCatalogName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setSchemaName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddColumnChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddColumnChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddDefaultValueChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddDefaultValueChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddDefaultValueChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddDefaultValueChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddForeignKeyConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddForeignKeyConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddForeignKeyConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddForeignKeyConstraintChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.AddLookupTableChange",
-    "methods": [
-      {
-        "name": "getConstraintName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingColumnName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingTableCatalogName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingTableSchemaName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewColumnDataType",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewColumnName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewTableCatalogName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewTableSchemaName",
-        "parameterTypes": []
-      },
-      {
-        "name": "setExistingColumnName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setExistingTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewColumnDataType",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewColumnName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.change.core.AddLookupTableChange"
-    },
-    "name": "liquibase.change.core.AddLookupTableChange",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingColumnName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getExistingTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewColumnName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getNewTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "setConstraintName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setExistingColumnName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setExistingTableCatalogName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setExistingTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setExistingTableSchemaName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewColumnDataType",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewColumnName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewTableCatalogName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setNewTableSchemaName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddLookupTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddLookupTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddLookupTableChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddLookupTableChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddNotNullConstraintChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddNotNullConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddNotNullConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddNotNullConstraintChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddPrimaryKeyChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddPrimaryKeyChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddPrimaryKeyChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddPrimaryKeyChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.AddUniqueConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddUniqueConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddUniqueConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AddUniqueConstraintChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.AlterSequenceChange",
-    "methods": [
-      {
-        "name": "isOrdered",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AlterSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AlterSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AlterSequenceChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.AlterSequenceChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.CreateIndexChange",
-    "methods": [
-      {
-        "name": "isUnique",
-        "parameterTypes": []
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateIndexChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateIndexChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateIndexChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateIndexChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.change.AbstractChange"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.CreateProcedureChange",
-    "methods": [
-      {
-        "name": "isRelativeToChangelogFile",
-        "parameterTypes": []
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateProcedureChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateProcedureChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateProcedureChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateProcedureChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.change.AbstractChange"
+      "typeReachable": "liquibase.change.core.CreateSequenceChange"
     },
     "name": "liquibase.change.core.CreateSequenceChange",
-    "methods": [
-      {
-        "name": "isOrdered",
-        "parameterTypes": []
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateSequenceChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateSequenceChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.change.AbstractChange"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.CreateTableChange",
-    "methods": [
-      {
-        "name": "getCatalogName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getColumns",
-        "parameterTypes": []
-      },
-      {
-        "name": "getRemarks",
-        "parameterTypes": []
-      },
-      {
-        "name": "getSchemaName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "getTablespace",
-        "parameterTypes": []
-      },
-      {
-        "name": "setTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.change.core.CreateTableChange"
-    },
-    "name": "liquibase.change.core.CreateTableChange",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      },
-      {
-        "name": "getColumns",
-        "parameterTypes": []
-      },
-      {
-        "name": "getTableName",
-        "parameterTypes": []
-      },
-      {
-        "name": "setCatalogName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setRemarks",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setSchemaName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setTableName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setTablespace",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateTableChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateTableChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.change.core.CreateViewChange"
     },
     "name": "liquibase.change.core.CreateViewChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateViewChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateViewChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.CreateViewChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DeleteDataChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DeleteDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DeleteDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DeleteDataChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropAllForeignKeyConstraintsChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropAllForeignKeyConstraintsChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropAllForeignKeyConstraintsChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropAllForeignKeyConstraintsChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropColumnChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropColumnChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropColumnChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropDefaultValueChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropDefaultValueChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropDefaultValueChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropDefaultValueChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropForeignKeyConstraintChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropForeignKeyConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropForeignKeyConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropForeignKeyConstraintChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropIndexChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropIndexChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropIndexChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropIndexChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropNotNullConstraintChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropNotNullConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropNotNullConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropNotNullConstraintChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropPrimaryKeyChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropPrimaryKeyChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropPrimaryKeyChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropPrimaryKeyChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.DropProcedureChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropProcedureChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropProcedureChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropProcedureChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.DropSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropSequenceChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropSequenceChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.DropTableChange",
-    "methods": [
-      {
-        "name": "isCascadeConstraints",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropTableChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropTableChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropUniqueConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropUniqueConstraintChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropUniqueConstraintChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropUniqueConstraintChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropViewChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropViewChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropViewChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.DropViewChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.EmptyChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.EmptyChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.EmptyChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.EmptyChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ExecuteShellCommandChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ExecuteShellCommandChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ExecuteShellCommandChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ExecuteShellCommandChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.InsertDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.InsertDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.InsertDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.InsertDataChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
-    "name": "liquibase.change.core.LoadDataChange",
-    "methods": [
-      {
-        "name": "isRelativeToChangelogFile",
-        "parameterTypes": []
-      }
-    ]
+    "name": "liquibase.change.core.DropUniqueConstraintChange",
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.change.AbstractChange"
+    },
+    "name": "liquibase.change.core.DropViewChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.change.AbstractChange"
+    },
+    "name": "liquibase.change.core.EmptyChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.change.AbstractChange"
+    },
+    "name": "liquibase.change.core.ExecuteShellCommandChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.change.AbstractChange"
+    },
+    "name": "liquibase.change.core.InsertDataChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.LoadDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadDataChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
@@ -1473,107 +395,24 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadUpdateDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadUpdateDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadUpdateDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.LoadUpdateDataChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.MergeColumnChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.MergeColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.MergeColumnChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.MergeColumnChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.ModifyDataTypeChange",
-    "queryAllPublicMethods": true
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ModifyDataTypeChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ModifyDataTypeChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.ModifyDataTypeChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.change.core.OutputChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.OutputChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.OutputChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.OutputChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
@@ -1583,327 +422,228 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RawSQLChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RawSQLChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RawSQLChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RawSQLChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.core.RenameColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameColumnChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameColumnChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameColumnChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameSequenceChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameSequenceChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameSequenceChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameTableChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameTableChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameTableChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameViewChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameViewChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameViewChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.RenameViewChangeCustomizer"
+    "allPublicMethods": true
   },
   {
     "condition": {
       "typeReachable": "liquibase.change.AbstractChange"
     },
+    "name": "liquibase.change.core.RenameSequenceChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.change.AbstractChange"
+    },
+    "name": "liquibase.change.core.RenameTableChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.core.RenameViewChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
     "name": "liquibase.change.core.SQLFileChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.core.SetColumnRemarksChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.core.SetTableRemarksChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
+    },
+    "name": "liquibase.change.core.StopChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.core.TagDatabaseChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.core.UpdateDataChange",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.change.custom.CustomChangeWrapper",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.precondition.AbstractPrecondition",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.precondition.core.AndPrecondition",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.precondition.core.ChangeLogPropertyDefinedPrecondition",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
     "methods": [
       {
-        "name": "isRelativeToChangelogFile",
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setProperty",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setValue",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.precondition.core.DBMSPrecondition",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setType",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.Liquibase"
+    },
+    "name": "liquibase.precondition.core.OrPrecondition",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
         "parameterTypes": []
       }
     ]
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
-    "name": "liquibase.change.core.SQLFileChange",
-    "queryAllPublicMethods": true
+    "name": "liquibase.precondition.core.PreconditionContainer",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "allPublicMethods": true
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
-    "name": "liquibase.change.core.SQLFileChange",
-    "queryAllPublicMethods": true
+    "name": "liquibase.precondition.core.RunningAsPrecondition",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setUsername",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
-    "name": "liquibase.change.core.SQLFileChangeBeanInfo"
+    "name": "liquibase.precondition.core.SqlPrecondition",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setExpectedResult",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setSql",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
-    "name": "liquibase.change.core.SQLFileChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetColumnRemarksChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetColumnRemarksChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetColumnRemarksChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetColumnRemarksChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetTableRemarksChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetTableRemarksChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetTableRemarksChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.SetTableRemarksChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.StopChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.StopChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.StopChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.StopChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.TagDatabaseChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.TagDatabaseChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.TagDatabaseChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.TagDatabaseChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.UpdateDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.core.UpdateDataChange",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.UpdateDataChangeBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.core.UpdateDataChangeCustomizer"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.custom.CustomChangeWrapper",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$FluentPropertyBeanIntrospector"
-    },
-    "name": "liquibase.change.custom.CustomChangeWrapper",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.custom.CustomChangeWrapperBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.change.custom.CustomChangeWrapperCustomizer"
+    "name": "liquibase.precondition.core.TableExistsPrecondition",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setTableName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   },
   {
     "condition": {
@@ -2246,22 +986,10 @@
   },
   {
     "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
+      "typeReachable": "liquibase.Liquibase"
     },
     "name": "liquibase.plugin.AbstractPlugin",
     "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.plugin.AbstractPluginBeanInfo"
-  },
-  {
-    "condition": {
-      "typeReachable": "liquibase.util.ObjectUtil$DefaultBeanIntrospector"
-    },
-    "name": "liquibase.plugin.AbstractPluginCustomizer"
   },
   {
     "condition": {
@@ -2353,6 +1081,54 @@
       "typeReachable": "liquibase.database.AbstractJdbcDatabase"
     },
     "name": "sun.security.provider.SecureRandom",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.sql.visitor.SqlVisitorFactory"
+    },
+    "name": "liquibase.sql.visitor.PrependSqlVisitor",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.sql.visitor.SqlVisitorFactory"
+    },
+    "name": "liquibase.sql.visitor.AppendSqlVisitor",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.sql.visitor.SqlVisitorFactory"
+    },
+    "name": "liquibase.sql.visitor.RegExpReplaceSqlVisitor",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.sql.visitor.SqlVisitorFactory"
+    },
+    "name": "liquibase.sql.visitor.ReplaceSqlVisitor",
     "methods": [
       {
         "name": "<init>",

--- a/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
+++ b/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
@@ -17,7 +17,7 @@
       },
       {
         "condition": {
-          "typeReachable": "iquibase.parser.core.xml.LiquibaseEntityResolver"
+          "typeReachable": "liquibase.parser.core.xml.LiquibaseEntityResolver"
         },
         "pattern": "^www.liquibase.org/xml/ns/dbchangelog/dbchangelog-.*"
       }

--- a/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
+++ b/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
@@ -14,6 +14,9 @@
           "typeReachable": "liquibase.util.LiquibaseUtil"
         },
         "pattern": "\\Qliquibase.build.properties\\E"
+      },
+      {
+        "pattern": "^www.liquibase.org/xml/ns/dbchangelog/dbchangelog-.*"
       }
     ]
   }

--- a/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
+++ b/metadata/org.liquibase/liquibase-core/4.17.0/resource-config.json
@@ -16,6 +16,9 @@
         "pattern": "\\Qliquibase.build.properties\\E"
       },
       {
+        "condition": {
+          "typeReachable": "iquibase.parser.core.xml.LiquibaseEntityResolver"
+        },
         "pattern": "^www.liquibase.org/xml/ns/dbchangelog/dbchangelog-.*"
       }
     ]

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/build.gradle
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/build.gradle
@@ -32,3 +32,7 @@ graalvmNative {
         }
     }
 }
+
+nativeTest {
+    buildArgs.add('--enable-url-protocols=http')
+}

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/ExampleCustomSqlChange.java
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/ExampleCustomSqlChange.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_liquibase.liquibase_core;
+
+import liquibase.change.custom.CustomSqlChange;
+import liquibase.change.custom.CustomSqlRollback;
+import liquibase.database.Database;
+import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.Table;
+
+public class ExampleCustomSqlChange implements CustomSqlChange, CustomSqlRollback {
+
+    private String schemaName;
+    private String tableName;
+    private String columnName;
+    private String newValue;
+
+    @SuppressWarnings("unused")
+    private ResourceAccessor resourceAccessor;
+
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    public String getNewValue() {
+        return newValue;
+    }
+
+    public void setNewValue(String newValue) {
+        this.newValue = newValue;
+    }
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) {
+        return new SqlStatement[]{
+                new RawSqlStatement("UPDATE " + database.escapeObjectName(null, schemaName, tableName, Table.class)
+                        + " SET " + database.escapeObjectName(columnName, Column.class) + " = " + newValue)
+        };
+    }
+
+    @Override
+    public SqlStatement[] generateRollbackStatements(Database database) throws RollbackImpossibleException {
+        return new SqlStatement[]{
+                new RawSqlStatement("UPDATE " + database.escapeObjectName(null, schemaName, tableName, Table.class)
+                        + " SET " + database.escapeObjectName(columnName, Column.class) + " = NULL")
+        };
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Custom class updated " + tableName + "." + columnName;
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+        this.resourceAccessor = resourceAccessor;
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return new ValidationErrors();
+    }
+
+}

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/ExampleCustomTaskChange.java
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/ExampleCustomTaskChange.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_liquibase.liquibase_core;
+
+import liquibase.Scope;
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.change.custom.CustomTaskRollback;
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+
+public class ExampleCustomTaskChange implements CustomTaskChange, CustomTaskRollback {
+
+    private String helloTo;
+
+    @SuppressWarnings({"UnusedDeclaration", "FieldCanBeLocal"})
+    private ResourceAccessor resourceAccessor;
+
+
+    public String getHelloTo() {
+        return helloTo;
+    }
+
+    public void setHelloTo(String helloTo) {
+        this.helloTo = helloTo;
+    }
+
+    @Override
+    public void execute(Database database) {
+        Scope.getCurrentScope().getLog(getClass()).info("Hello " + getHelloTo());
+    }
+
+    @Override
+    public void rollback(Database database) {
+        Scope.getCurrentScope().getLog(getClass()).info("Goodbye " + getHelloTo());
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Said Hello";
+    }
+
+    @Override
+    public void setUp() {
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+        this.resourceAccessor = resourceAccessor;
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return new ValidationErrors();
+    }
+}

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/LiquibaseCoreTest.java
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/java/org_liquibase/liquibase_core/LiquibaseCoreTest.java
@@ -18,11 +18,11 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 
 class LiquibaseCoreTest {
-    private static final String JDBC_URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
 
     @Test
-    void test() throws Exception {
-        withConnection(JDBC_URL, (connection) -> {
+    void testYaml() throws Exception {
+        final String jdbcUrl = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
+        withConnection(jdbcUrl, (connection) -> {
             Database database = new H2Database();
             database.setConnection(new JdbcConnection(connection));
 
@@ -30,7 +30,7 @@ class LiquibaseCoreTest {
             liquibase.update();
         });
 
-        withConnection(JDBC_URL, (connection) -> {
+        withConnection(jdbcUrl, (connection) -> {
             PreparedStatement statement = connection.prepareStatement("INSERT INTO state (id) VALUES (?)");
             statement.setString(1, "CO");
             statement.execute();
@@ -40,6 +40,25 @@ class LiquibaseCoreTest {
             statement.setString(2, "last-1");
             statement.setString(3, "CO");
             statement.setString(4, "user-1");
+            statement.execute();
+        });
+    }
+
+    @Test
+    void fullChangelogTest() throws Exception {
+        final String jdbcUrl = "jdbc:h2:mem:db2;DB_CLOSE_DELAY=-1";
+        withConnection(jdbcUrl, (connection) -> {
+            Database database = new H2Database();
+            database.setConnection(new JdbcConnection(connection));
+
+            Liquibase liquibase = new Liquibase("changelog.xml", new ClassLoaderResourceAccessor(), database);
+            liquibase.update();
+        });
+
+        withConnection(jdbcUrl, (connection) -> {
+            PreparedStatement statement = connection.prepareStatement("INSERT INTO person (fullname, employer_id) VALUES (?, ?)");
+            statement.setString(1, "first-1 last-1");
+            statement.setInt(2, 10);
             statement.execute();
         });
     }

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/META-INF/native-image/test/reflect-config.json
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/META-INF/native-image/test/reflect-config.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "org_liquibase.liquibase_core.ExampleCustomSqlChange",
+    "allPublicConstructors": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_liquibase.liquibase_core.ExampleCustomTaskChange",
+    "allPublicConstructors": true,
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/META-INF/native-image/test/resource-config.json
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/META-INF/native-image/test/resource-config.json
@@ -3,6 +3,15 @@
     "includes": [
       {
         "pattern": "\\Qchangelog.yaml\\E"
+      },
+      {
+        "pattern": "\\Qchangelog.xml\\E"
+      },
+      {
+        "pattern": "\\Qincluded.changelog.xml\\E"
+      },
+      {
+        "pattern": "\\Qrenamed.changelog.xml\\E"
       }
     ]
   }

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/changelog.xml
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/changelog.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <preConditions onSqlOutput="IGNORE" >
+            <dbms type="h2"/>
+            <runningAs username=""/>
+            <changeLogPropertyDefined property="database.databaseProductName" value="H2"/>
+    </preConditions>
+
+    <changeSet id="1" author="nvoxland">
+        <preConditions onSqlOutput="TEST">
+                <dbms type="h2"/>
+                <runningAs username=""/>
+        </preConditions>
+        <comment>
+            You can add comments to changeSets.
+            They can even be multiple lines if you would like.
+            They aren't used to compute the changeSet MD5Sum, so you can update them whenever you want without causing problems.
+        </comment>        
+        <createTable tableName="person">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="firstname" type="varchar(50)"/>
+            <column name="lastname" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="1.1" author="nvoxland">
+        <preConditions>
+            <or>
+                <dbms type="h2"/>
+                <sqlCheck expectedResult="3">INVALID SQL HERE, SHOULD NOT HIT DUE TO SHORT CIRCUT</sqlCheck>
+            </or>
+        </preConditions>
+        <createSequence sequenceName="seq_person"/>
+    </changeSet>
+
+    <changeSet id="2" author="nvoxland">
+        <comment>Add a username column so we can use "person" for authentication</comment>
+        <addColumn tableName="person">
+            <column name="usernae" type="varchar(8)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="3" author="nvoxland">
+        <comment>Fix misspelled "username" column</comment>
+        <renameColumn tableName="person" oldColumnName="usernae" newColumnName="username" columnDataType="varchar(8)"/>
+    </changeSet>
+    <changeSet id="5" author="nvoxland" contextFilter="test">
+        <insert tableName="person">
+            <column name="firstname" value="John"/>
+            <column name="lastname" value="Doe"/>
+            <column name="username" value="jdoe"/>
+        </insert>
+        <insert tableName="person">
+            <column name="firstname" value="Jane"/>
+            <column name="lastname" value="Doe"/>
+            <column name="username" value="janedoe"/>
+        </insert>
+        <insert tableName="person">
+            <column name="firstname" value="Bob"/>
+            <column name="lastname" value="Johnson"/>
+            <column name="username" value="bjohnson"/>
+        </insert>
+    </changeSet>
+    <changeSet id="6" author="nvoxland">
+        <comment>Don't keep username in the person table</comment>
+        <dropColumn tableName="person" columnName="username"/>
+    </changeSet>
+    <changeSet id="7" author="nvoxland">
+        <createTable tableName="employee">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="7" author="bjohnson" contextFilter="test">
+        <insert tableName="employee">
+            <column name="name" value="ACME Corp"/>
+        </insert>
+        <insert tableName="employee">
+            <column name="name" value="Widgets Inc."/>
+        </insert>
+    </changeSet>
+    <changeSet id="7a" author="nvoxland">
+        <addColumn tableName="employee">
+            <column name="company_id" type="int">
+                <constraints nullable="true" foreignKeyName="fk_employee_company" references="employee(id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="8" author="bjohnson">
+        <dropNotNullConstraint tableName="employee" columnName="name" columnDataType="varchar(50)"/>
+    </changeSet>
+    <!--<changeSet id="8.1" author="bjohnson">-->
+        <!--<comment>I guess name needs to be not-null</comment>-->
+        <!--<addNotNullConstraint tableName='employee' columnName="name" defaultNullValue="UNKNOWN" columnDataType="varchar(50)"/>-->
+    <!--</changeSet>-->
+    <changeSet id="9" author="nvoxland">
+        <renameTable oldTableName="employee" newTableName="company"/>
+    </changeSet>
+    <changeSet id="10" author="nvoxland">
+        <createTable tableName="testtable">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="value" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="person_id" type="int">
+                <constraints nullable="false" foreignKeyName="fk_test_person" referencedTableName="person" referencedColumnNames="id"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="11" author="nvoxland">
+        <dropTable tableName="testtable"/>
+    </changeSet>
+
+    <changeSet id="12" author="nvoxland">
+        <createIndex indexName="idx_company_name" tableName="company">
+            <column name="name"/>
+        </createIndex>
+        <createIndex indexName="idx_person_lastname" tableName="person">
+            <column name="lastname"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="13" author="nvoxland">
+        <dropIndex indexName="idx_person_lastname" tableName="person"/>
+    </changeSet>
+
+    <changeSet id="14" author="nvoxland">
+        <createTable tableName="liquibaseRunInfo">
+            <column name="timesRan" type="int"/>
+        </createTable>
+        <insert tableName="liquibaseRunInfo">
+            <column name="timesRan" valueNumeric="1"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="15" author="nvoxland">
+        <sql>update liquibaseRunInfo set timesRan=timesRan+1</sql>
+    </changeSet>
+
+    <changeSet id="16" author="nvoxland">
+        <createView viewName="personView">
+            select * from person
+        </createView>
+    </changeSet>
+
+    <changeSet id="16a" author="nvoxland">
+        <createSequence sequenceName="seq_test" startValue="1000" incrementBy="2" dataType="int" />
+    </changeSet>
+
+    <changeSet id="17" author="nvoxland">
+        <alterSequence sequenceName="seq_test"/>
+    </changeSet>
+
+    <changeSet id="18a" author="nvoxland">
+        <dropSequence sequenceName="seq_test"/>
+    </changeSet>
+
+    <changeSet id="18" author="nvoxland">
+        <dropView viewName="personView"/>
+    </changeSet>
+
+    <changeSet id="19" author="nvoxland">
+        <mergeColumns
+                tableName="person"
+                column1Name="firstname"
+                joinString=" "
+                column2Name="lastname"
+                finalColumnName="fullname"
+                finalColumnType="varchar(100)"/>
+    </changeSet>
+
+    <changeSet id="22" author="nvoxland">
+        <addColumn tableName="person">
+            <column name="employer_id" type="int"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="23" author="nvoxland">
+        <addForeignKeyConstraint
+                baseTableName="person" baseColumnNames="employer_id"
+                constraintName="fk_person_employer"
+                referencedTableName="company" referencedColumnNames="id"
+                deleteCascade="true"/>
+    </changeSet>
+
+    <changeSet id="24" author="nvoxland">
+        <dropForeignKeyConstraint baseTableName="person" constraintName="fk_person_employer"/>
+    </changeSet>
+
+    <changeSet id="25" author="nvoxland">
+        <createTable tableName="address">
+            <column name="id" type="int"/>
+            <column name="line1" type="varchar(255)"/>
+            <column name="line2" type="varchar(255)"/>
+            <column name="city" type="varchar(255)"/>
+            <column name="state" type="char(2)"/>
+            <column name="postalcode" type="varchar(15)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="25.1" author="nvoxland">
+        <addNotNullConstraint tableName="address" columnName="id" columnDataType="int"/>
+    </changeSet>
+
+    <changeSet id="25.2" author="nvoxland">
+        <addPrimaryKey tableName="address" columnNames="id" constraintName="pk_address"/>
+    </changeSet>
+
+    <changeSet id="25.3" author="nvoxland">
+        <addAutoIncrement tableName="address" columnName="id" columnDataType="int"/>
+    </changeSet>
+
+    <changeSet id="28" author="nvoxland">
+        <addDefaultValue tableName="address" columnName="line2" defaultValue="N/A"/>
+    </changeSet>
+
+    <changeSet id="29" author="nvoxland">
+        <dropDefaultValue tableName="address" columnName="line2"/>
+    </changeSet>
+
+    <changeSet id="30" author="nvoxland">
+        <createTable tableName="pkTest">
+            <column name="id" type="int"/>
+            <column name="value" type="varchar(50)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="31.1" author="nvoxland">
+        <addNotNullConstraint tableName="pkTest" columnName="id" columnDataType="varchar(50)"/>
+    </changeSet>
+
+    <changeSet id="31.2" author="nvoxland">
+        <addPrimaryKey tableName="pkTest" columnNames="id" constraintName="pk_pktest"/>
+    </changeSet>
+
+    <changeSet id="32" author="nvoxland">
+        <dropPrimaryKey tableName="pkTest" constraintName="pk_pktest"/>
+    </changeSet>
+
+    <changeSet id="33" author="nvoxland">
+        <addUniqueConstraint tableName="address" columnNames="line1, line2" constraintName="uq_address_line1line2"/>
+    </changeSet>
+
+    <changeSet id="34" author="nvoxland">
+        <dropUniqueConstraint tableName="address" constraintName="uq_address_line1line2"/>
+    </changeSet>
+
+
+    <changeSet id="35" author="nvoxland">
+        <createTable tableName="tableToRollback">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="50" author="nvoxland">
+        <modifyDataType tableName="address" columnName="postalcode" newDataType="varchar(20)"/>
+    </changeSet>
+
+    <changeSet id="51" author="nvoxland">
+        <createView viewName="personView">
+            select id, fullname from person
+        </createView>
+    </changeSet>
+
+    
+    <include file="included.changelog.xml"/>
+
+    <include file="renamed.changelog.xml"/>
+
+    <changeSet id="56" author="nvoxland">
+        <customChange class="org_liquibase.liquibase_core.ExampleCustomSqlChange">
+            <param name="tableName" value="person"/>
+            <param name="columnName" value="employer_id"/>
+            <param name="newValue" value="3"/>
+        </customChange>
+    </changeSet>
+    <changeSet id="57" author="nvoxland">
+        <customChange class="org_liquibase.liquibase_core.ExampleCustomSqlChange">
+            <param name="tableName" value="person"/>
+            <param name="columnName" value="employer_id"/>
+            <param name="newValue" value="4"/>
+        </customChange>
+    </changeSet>
+    <changeSet id="58" author="nvoxland">
+        <customChange class="org_liquibase.liquibase_core.ExampleCustomTaskChange">
+            <param name="helloTo" value="world"/>
+        </customChange>
+    </changeSet>
+
+    <changeSet id="failingPrecondition" author="pcleto">
+      <preConditions onFail="MARK_RAN" onError="WARN">
+         <dbms type="oracle"/>
+      </preConditions>
+      <createSequence sequenceName="liquidbase_applicationuserSQ" startValue="1" />
+    </changeSet>
+
+    <changeSet id="failingColumnNameSince197" author="tholu">
+        <createTable tableName="columnTest">
+            <column name="table" type="varchar(50)"/>
+        </createTable>
+        <update tableName="columnTest">
+            <column name="table" value="test"/>
+            <where>1</where>
+        </update>
+    </changeSet>
+
+    <changeSet id="addcolumn before after" author="nvoxland">
+        <createTable tableName="before_after">
+            <column name="id" type="int"/>
+            <column name="name" type="int"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="addcolumn before after 2" author="nvoxland">
+        <addColumn tableName="before_after">
+            <column name="before_name" type="int" beforeColumn="name"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="addcolumn before after 3" author="nvoxland">
+        <addColumn tableName="before_after">
+            <column name="after_name" type="int" afterColumn="name"/>
+        </addColumn>
+    </changeSet>
+
+    <!-- changesets with ids 2659 are testing if creating a view camel case with quotes won't break subsequent
+     preConditions snapshots of it -->
+    <changeSet id="2659-Create-MyView-with-quotes" author="flautert" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+        <createView viewName="MyViewBreakDb" replaceIfExists="true">select 1</createView>
+    </changeSet>
+
+    <changeSet id="2659-Create-MyView-with-quotes-test-must-MARK_RAN" author="flautert" >
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN"><tableExists tableName="NOT_EXISTENT_TABLE"/></preConditions>
+        <dropTable tableName="NOT_EXISTENT_TABLE_DOESNT_MATTER"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/included.changelog.xml
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/included.changelog.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <preConditions>
+            <dbms type="h2"/>
+    </preConditions>
+    
+    <changeSet id="1" author="nvoxland">
+        <createTable tableName="news">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="title" type="varchar(50)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="1.2" author="nvoxland">
+        <createSequence sequenceName="seq_news"/>
+    </changeSet>
+
+    <changeSet id="2" author="nvoxland" contextFilter="test">
+        <insert tableName="news">
+            <column name="title" value="Liquibase 0.8 Released"/>
+        </insert>
+        <insert tableName="news">
+            <column name="title" value="Liquibase 0.9 Released"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="3" author="nvoxland" contextFilter="demo">
+        <insert tableName="news">
+            <column name="title" value="Liquibase 1.0 Released"/>
+        </insert>
+    </changeSet>    
+</databaseChangeLog>

--- a/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/renamed.changelog.xml
+++ b/tests/src/org.liquibase/liquibase-core/4.17.0/src/test/resources/renamed.changelog.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+        
+        logicalFilePath="changelogs/h2/complete/oldname.changelog.xml">
+    <preConditions>
+            <dbms type="h2"/>
+    </preConditions>
+
+    <changeSet id="1" author="nvoxland">
+        <createTable tableName="book">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="title" type="varchar(50)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This adds a complete test for all features of Liquibase and fixes the configs to make it run. It also removes the unnecessary `BeanInfo` and `Customizer` classes.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
