### PR TITLE
Upgrade to GraalVM `22.3.0`.

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -88,7 +88,7 @@ if (project.hasProperty("baseCommit")) {
 }
 
 def matrixDefault = [
-        "version"     : ["22.2.0", "dev"], // TODO: Add other supported versions
+        "version"     : ["22.3.0", "dev"], // TODO: Add other supported versions
         "java-version": ["17"], // TODO: Add "17", "19"
         "os"          : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"
 ]


### PR DESCRIPTION
## What does this PR do?
 Upgrades the GraalVM version used to run the tests to `22.3.0`. This should fix the build jobs that have the new Native Image build reports enabled.

## Checklist before merging
n/a
