### PR TITLE
Add metadata for Mockito 4.8.1

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -149,5 +149,9 @@
   {
     "directory": "org.testcontainers/testcontainers",
     "module": "org.testcontainers:testcontainers"
+  },
+  {
+    "directory": "org.mockito/mockito-core",
+    "module": "org.mockito:mockito-core"
   }
 ]

--- a/metadata/org.mockito/mockito-core/4.8.1/index.json
+++ b/metadata/org.mockito/mockito-core/4.8.1/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.mockito/mockito-core/4.8.1/reflect-config.json
+++ b/metadata/org.mockito/mockito-core/4.8.1/reflect-config.json
@@ -1,0 +1,201 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.Java9PlusLocationImpl$MetadataShim"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.Java9PlusLocationImpl"
+    },
+    "name": "java.lang.StackWalker",
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": [
+          "java.util.Set",
+          "int"
+        ]
+      },
+      {
+        "name": "walk",
+        "parameterTypes": [
+          "java.util.function.Function"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.LocationFactory"
+    },
+    "name": "java.lang.StackWalker"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.Java9PlusLocationImpl"
+    },
+    "name": "java.lang.StackWalker$Option"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.Java9PlusLocationImpl"
+    },
+    "name": "java.lang.StackWalker$StackFrame"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.debugging.Java9PlusLocationImpl$MetadataShim"
+    },
+    "name": "java.lang.StackWalker$StackFrame",
+    "methods": [
+      {
+        "name": "getClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFileName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLineNumber",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMethodName",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.creation.proxy.InvokeDefaultProxy"
+    },
+    "name": "java.lang.reflect.InvocationHandler",
+    "methods": [
+      {
+        "name": "invokeDefault",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.reflect.Method",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.util.KotlinInlineClassUtil"
+    },
+    "name": "kotlin.jvm.JvmInline"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.ClassPathLoader"
+    },
+    "name": "org.mockito.configuration.MockitoConfiguration"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.configuration.DefaultDoNotMockEnforcer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.configuration.InjectingAnnotationEngine",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.configuration.plugins.DefaultPluginSwitch",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.creation.instance.DefaultInstantiatorProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.PluginInitializer"
+    },
+    "name": "org.mockito.internal.creation.proxy.ProxyMockMaker",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.exceptions.stacktrace.DefaultStackTraceCleanerProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.util.ConsoleMockitoLogger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
+    },
+    "name": "org.mockito.internal.util.reflection.ReflectionMemberAccessor",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.mockito/mockito-core/4.8.1/resource-config.json
+++ b/metadata/org.mockito/mockito-core/4.8.1/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.mockito.internal.configuration.plugins.PluginInitializer"
+        },
+        "pattern": "\\Qmockito-extensions/org.mockito.plugins.MockMaker\\E"
+      }
+    ]
+  },
+  "bundles": []
+}

--- a/metadata/org.mockito/mockito-core/index.json
+++ b/metadata/org.mockito/mockito-core/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "4.8.1",
+    "module": "org.mockito:mockito-core",
+    "tested-versions": [
+      "4.8.1"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -405,5 +405,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path": "org.mockito/mockito-core/4.8.1",
+    "libraries": [
+      {
+        "name": "org.mockito:mockito-core",
+        "versions": [
+          "4.8.1"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/org.mockito/mockito-core/4.8.1/.gitignore
+++ b/tests/src/org.mockito/mockito-core/4.8.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.mockito/mockito-core/4.8.1/README.md
+++ b/tests/src/org.mockito/mockito-core/4.8.1/README.md
@@ -1,0 +1,6 @@
+# Mockito
+
+Mockito works in GraalVM when using the `org.mockito.internal.creation.proxy.ProxyMockMaker`, which uses JDK proxies
+to mock interfaces, and interfaces only.
+
+Metadata has been collected by using the agent.

--- a/tests/src/org.mockito/mockito-core/4.8.1/build.gradle
+++ b/tests/src/org.mockito/mockito-core/4.8.1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+	id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+	testImplementation "org.mockito:mockito-core:$libraryVersion"
+	testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+	agent {
+		defaultMode = "conditional"
+		modes {
+			conditional {
+				userCodeFilterPath = "user-code-filter.json"
+			}
+		}
+		metadataCopy {
+			mergeWithExisting = true
+			inputTaskNames.add("test")
+			outputDirectories.add("src/test/resources/META-INF/native-image/org.mockito/mockito-core")
+		}
+	}
+}

--- a/tests/src/org.mockito/mockito-core/4.8.1/gradle.properties
+++ b/tests/src/org.mockito/mockito-core/4.8.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version=4.8.1
+metadata.dir=org.mockito/mockito-core/4.8.1

--- a/tests/src/org.mockito/mockito-core/4.8.1/settings.gradle
+++ b/tests/src/org.mockito/mockito-core/4.8.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.mockito.mockito-core_tests'

--- a/tests/src/org.mockito/mockito-core/4.8.1/src/test/java/org_mockito/mockito_core/MockitoTest.java
+++ b/tests/src/org.mockito/mockito-core/4.8.1/src/test/java/org_mockito/mockito_core/MockitoTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mockito.mockito_core;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MockitoTest {
+    @Test
+    void test() {
+        MyService myService = Mockito.mock(MyService.class);
+        Mockito.when(myService.getGreeting()).thenReturn("Hello Mockito");
+        assertThat(myService.getGreeting()).isEqualTo("Hello Mockito");
+    }
+}

--- a/tests/src/org.mockito/mockito-core/4.8.1/src/test/java/org_mockito/mockito_core/MyService.java
+++ b/tests/src/org.mockito/mockito-core/4.8.1/src/test/java/org_mockito/mockito_core/MyService.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mockito.mockito_core;
+
+public interface MyService {
+    String getGreeting();
+}

--- a/tests/src/org.mockito/mockito-core/4.8.1/src/test/resources/META-INF/native-image/test/proxy-config.json
+++ b/tests/src/org.mockito/mockito-core/4.8.1/src/test/resources/META-INF/native-image/test/proxy-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "interfaces": [
+      "org_mockito.mockito_core.MyService"
+    ]
+  }
+]

--- a/tests/src/org.mockito/mockito-core/4.8.1/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/org.mockito/mockito-core/4.8.1/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+org.mockito.internal.creation.proxy.ProxyMockMaker

--- a/tests/src/org.mockito/mockito-core/4.8.1/user-code-filter.json
+++ b/tests/src/org.mockito/mockito-core/4.8.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.mockito.**"
+    }
+  ]
+}


### PR DESCRIPTION
This only works for the 'ProxyMockMaker', which uses JDK proxies to create mocks. This method is only able to mock interfaces.

## What does this PR do?


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
