### PR TITLE
Add `timeout-minutes` to all build jobs.

### DIFF
--- a/.github/workflows/library-and-framework-list-validation.yml
+++ b/.github/workflows/library-and-framework-list-validation.yml
@@ -6,6 +6,7 @@ jobs:
   validate-library-and-framework-list-json:
     name: "📋 Checks if the json file is written according to the existing schema"
     runs-on: "ubuntu-20.04"
+    timeout-minutes: 5
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -18,6 +18,7 @@ jobs:
   get-all-metadata:
     name: "📋 Get list of all supported libraries"
     runs-on: "ubuntu-20.04"
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -37,6 +38,7 @@ jobs:
   test-all-metadata:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.version }} ${{ matrix.java-version }} @ ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     needs: get-all-metadata
     strategy:
       fail-fast: false

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -17,6 +17,7 @@ jobs:
   get-changed-metadata:
     name: "📋 Get a list of all changed libraries"
     runs-on: "ubuntu-20.04"
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       none-found: ${{ steps.set-matrix.outputs.none-found }}
@@ -40,6 +41,7 @@ jobs:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.version }} ${{ matrix.java-version }} @ ${{ matrix.os }})"
     if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     needs: get-changed-metadata
 
     strategy:


### PR DESCRIPTION
## What does this PR do?
This PR adds reasonable timeouts (5m and 20min) to all build jobs to cancel stale builds as early as possible (the default timeout is 6h, which is way too much). [Here's an example build job](https://github.com/oracle/graalvm-reachability-metadata/actions/runs/3621925163) that failed after 6 hours.

Related to https://github.com/oracle/graalvm-reachability-metadata/pull/122#issuecomment-1338515655.

## Checklist before merging
n/a
