### PR TITLE
Core Helidon Libraries

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -48,5 +48,88 @@
         "test_level": "community-tested"
       }
     ]
+  },
+  {
+    "artifact": "io.helidon.config:helidon-config",
+    "description": "Helidon Configuration.",
+    "details": [
+      {
+        "minimum_version": "1.0.0",
+        "metadata_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/config/config/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config"
+        ],
+        "tests_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/se-1"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "io.helidon.webserver:helidon-webserver",
+    "description": "Helidon Reactive WebServer. Requires Helidon native image feature.",
+    "details": [
+      {
+        "minimum_version": "1.0.0",
+        "maximal_version": "4.0",
+        "metadata_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/webserver/webserver/src/main/resources/META-INF/helidon/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/se-1"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "io.helidon.webclient:helidon-webclient",
+    "description": "Helidon Reactive WebClient.",
+    "details": [
+      {
+        "minimum_version": "1.0.0",
+        "maximal_version": "4.0",
+        "metadata_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/webclient/webclient/src/main/resources/META-INF/native-image/io.helidon.webclient/helidon-webclient"
+        ],
+        "tests_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/se-1"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "io.helidon.microprofile.bundles:helidon-microprofile",
+    "description": "Helidon MicroProfile Bundle. Requires Helidon native image features.",
+    "details": [
+      {
+        "minimum_version": "2.0.0",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-1",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-2",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-3"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "io.helidon.microprofile.bundles:helidon-microprofile-core",
+    "description": "Helidon MicroProfile Core Bundle. Requires Helidon native image features.",
+    "details": [
+      {
+        "minimum_version": "2.0.0",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-1",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-2",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-3"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
   }
 ]

--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -74,7 +74,8 @@
         "maximal_version": "4.0",
         "metadata_locations": [
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver",
-          "https://github.com/helidon-io/helidon/tree/helidon-3.x/webserver/webserver/src/main/resources/META-INF/helidon/native-image"
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/webserver/webserver/src/main/resources/META-INF/helidon/native-image",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/integrations/graal/native-image-extension"
         ],
         "tests_locations": [
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/se-1"
@@ -106,7 +107,10 @@
     "details": [
       {
         "minimum_version": "2.0.0",
-        "metadata_locations": [],
+        "metadata_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/microprofile",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/integrations/graal/mp-native-image-extension"
+        ],
         "tests_locations": [
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-1",
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-2",
@@ -122,7 +126,10 @@
     "details": [
       {
         "minimum_version": "2.0.0",
-        "metadata_locations": [],
+        "metadata_locations": [
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/microprofile",
+          "https://github.com/helidon-io/helidon/tree/helidon-3.x/integrations/graal/mp-native-image-extension"
+        ],
         "tests_locations": [
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-1",
           "https://github.com/helidon-io/helidon/tree/helidon-3.x/tests/integration/native-image/mp-2",


### PR DESCRIPTION
Add a few of Helidon libraries that support native image.

## Checklist before merging
- [ ] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document) - I cannot run `./gradlew check` as it fails on 
```
graalvm-reachability-metadata/tests/src/ch.qos.logback/logback-classic/1.2.11"): error=2, No such file or directory
```
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests)) - tests are part of Helidon project
