### PR TITLE
Add toolchain to gradle config file

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -17,6 +17,13 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.GRAAL_VM
+    }
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.release = 11
 }


### PR DESCRIPTION
This could probably be improved, but it looks to me like it might be needed to persuade the JDT Language Server (used by Eclipse and VSCode) to build the project cleanly.

In VSCode you have to import one of the test projects into the workspace (probably the same in Eclipse). If you do that before this change the build will fail and you won't be able to use the Java language features in the IDE.

With this change if you run with Java 17, but not the GraalVM edition:

```
$ ./gradlew clean test -Pcoordinates=io.netty:netty-common:4.1.80.Final

> Configure project :
GraalVM Reachability Metadata TCK
---------------------------------

> Task :test-io.netty-netty-common-4.1.80.Final
====================
Testing library: io.netty:netty-common:4.1.80.Final
Command: `/workspaces/graalvm-reachability-metadata/gradlew nativeTest`
Executing test...
-------
Command: [/workspaces/graalvm-reachability-metadata/gradlew, nativeTest]
Starting a Gradle Daemon, 4 busy and 4 incompatible and 6 stopped Daemons could not be reused, use --status for details
> Task :tck-build-logic:extractPluginRequests UP-TO-DATE
> Task :tck-build-logic:generatePluginAdapters UP-TO-DATE
> Task :tck-build-logic:compileJava UP-TO-DATE
> Task :tck-build-logic:compileGroovy UP-TO-DATE
> Task :tck-build-logic:compileGroovyPlugins UP-TO-DATE
> Task :tck-build-logic:pluginDescriptors UP-TO-DATE
> Task :tck-build-logic:processResources UP-TO-DATE
> Task :tck-build-logic:classes UP-TO-DATE
> Task :tck-build-logic:jar UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Error while evaluating property 'javaCompiler' of task ':compileTestJava'
   > Failed to calculate the value of task ':compileTestJava' property 'javaCompiler'.
      > No compatible toolchains found for request filter: {languageVersion=17, vendor=GRAAL_VM, implementation=vendor-specific} (auto-detect true, auto-download true)
...
```

Without this change it just fails with no indication of how to fix it.