### PR TITLE
Add metadata for graphql-java-extended-validation

### DIFF
--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1/index.json
@@ -1,0 +1,5 @@
+[
+  "proxy-config.json",
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1/proxy-config.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1/proxy-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "interfaces": [
+      "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+    ]
+  }
+]

--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1/reflect-config.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "graphql.schema.DataFetchingEnvironmentImpl",
+    "methods": [
+      {
+        "name": "getLocale",
+        "parameterTypes": []
+      }
+    ],
+    "condition": {
+      "typeReachable": "graphql.GraphQL"
+    }
+  }
+]

--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1/resource-config.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "bundles": [
+    {
+      "name": "graphql.validation.ValidationMessages"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "19.1",
+    "module": "com.graphql-java:graphql-java-extended-validation",
+    "tested-versions": [
+      "19.1"
+    ]
+  }
+]

--- a/metadata/index.json
+++ b/metadata/index.json
@@ -44,7 +44,10 @@
   },
   {
     "directory": "org.hibernate.validator/hibernate-validator",
-    "module": "org.hibernate.validator:hibernate-validator"
+    "module": "org.hibernate.validator:hibernate-validator",
+    "requires": [
+      "org.jboss.logging:jboss-logging"
+    ]
   },
   {
     "directory": "org.apache.tomcat.embed/tomcat-embed-core",
@@ -177,6 +180,14 @@
   {
     "directory": "io.jsonwebtoken/jjwt-gson",
     "module": "io.jsonwebtoken:jjwt-gson"
+  },
+  {
+    "directory": "com.graphql-java/graphql-java-extended-validation",
+    "module": "com.graphql-java:graphql-java-extended-validation",
+    "requires": [
+      "com.graphql-java:graphql-java",
+      "org.hibernate.validator:hibernate-validator"
+    ]
   },
   {
     "directory": "net.java.dev.jna/jna",

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
+    implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
+    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+	binaries {
+		test {
+			buildArgs.add('--no-fallback')
+			buildArgs.add('-H:IncludeLocales=fr')
+		}
+	}
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.1
+metadata.dir = com.graphql-java/graphql-java-extended-validation/19.1/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-extended-validation-tests'

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/java/graphql/GraphQlValidationTests.java
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/java/graphql/GraphQlValidationTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.schemawiring.ValidationSchemaWiring;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlValidationTests {
+
+
+  @Test
+  void validationErrorQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ hired(application: {name: \"p\"}) }");
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name size must be between 3 and 100");
+  }
+
+  @Test
+  void validationErrorQueryInFrench() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(ExecutionInput.newExecutionInput("{ hired(application: {name: \"p\"}) }").locale(Locale.FRENCH).build());
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name la taille doit etre comprise entre 3 et 100");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlValidationTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+    ValidationRules validationRules = ValidationRules.newValidationRules()
+        .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
+        .build();
+    ValidationSchemaWiring schemaWiring = new ValidationSchemaWiring(validationRules);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+    runtimeWiringBuilder.directiveWiring(schemaWiring);
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/validation.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/graphql/validation.graphqls
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/graphql/validation.graphqls
@@ -1,0 +1,10 @@
+type Query {
+    hired (application : Application!) : Boolean
+}
+
+directive @Size(min : Int = 0, max : Int = 2147483647, message : String = "graphql.validation.Size.message")
+on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+input Application {
+    name : String @Size(min : 3, max : 100)
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/graphql/validation/ValidationMessages_fr.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/src/test/resources/graphql/validation/ValidationMessages_fr.properties
@@ -1,0 +1,1 @@
+graphql.validation.Size.message={path} la taille doit etre comprise entre {min} et {max}

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -484,6 +484,17 @@
     ]
   },
   {
+    "test-project-path": "com.graphql-java/graphql-java-extended-validation/19.1",
+    "libraries": [
+      {
+        "name": "com.graphql-java:graphql-java-extended-validation",
+        "versions": [
+          "19.1"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "net.java.dev.jna/jna/5.8.0",
     "libraries": [
       {


### PR DESCRIPTION
## What does this PR do?

This PR builds on the existing graphql-java metadata and adds the relevant content for the graphql-java-extended-validation artifact.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) 
document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
