### PR TITLE
Add Neo4j-Java-Driver to `library-and-framework-list.json`.

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -809,5 +809,21 @@
         "test_level": "fully-tested"
       }
     ]
+  },
+  {
+    "artifact": "org.neo4j.driver:neo4j-java-driver",
+    "description": "Official Java Driver for Neo4j",
+    "details": [
+      {
+        "minimum_version": "4.4.6",
+        "metadata_locations": [
+          "https://github.com/neo4j/neo4j-java-driver/tree/5.0/driver/src/main/resources/META-INF/native-image/org.neo4j.driver/neo4j-java-driver"
+        ],
+        "tests_locations": [
+          "https://github.com/neo4j-drivers/neo4j-java-driver-native-smoke-tests"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## What does this PR do?

This adds the Neo4j-Java-Driver to the list of tested libraries and frameworks.
We use the linked repository in CI, testing all currently maintained versions of the driver.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
