### PR TITLE
Remove MBean-related reflection entries from undertow-core

### DIFF
--- a/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/reflect-config.json
@@ -45,18 +45,6 @@
     "condition": {
       "typeReachable": "io.undertow.Undertow"
     },
-    "name": "[Ljavax.management.ObjectName;"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "[Ljavax.management.openmbean.CompositeData;"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
     "name": "[S"
   },
   {
@@ -64,76 +52,6 @@
       "typeReachable": "io.undertow.Undertow"
     },
     "name": "[Z"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.GarbageCollectorMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.GcInfo",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.HotSpotDiagnosticMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.ThreadMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.UnixOperatingSystemMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.VMOption",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.internal.HotSpotDiagnostic",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.internal.HotSpotThreadImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "com.sun.management.internal.OperatingSystemImpl",
-    "queryAllPublicConstructors": true
   },
   {
     "condition": {
@@ -449,55 +367,6 @@
     "condition": {
       "typeReachable": "io.undertow.Undertow"
     },
-    "name": "javax.management.MBeanOperationInfo",
-    "queryAllPublicMethods": true,
-    "queriedMethods": [
-      {
-        "name": "getSignature",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "javax.management.MBeanServerBuilder",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "javax.management.ObjectName"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "javax.management.openmbean.CompositeData"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "javax.management.openmbean.TabularData"
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
     "name": "jdk.management.jfr.ConfigurationInfo",
     "queryAllPublicMethods": true
   },
@@ -691,62 +560,6 @@
       "typeReachable": "io.undertow.Undertow"
     },
     "name": "org.xnio.nio.NioXnioWorker$NioWorkerMetrics",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.ClassLoadingImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.CompilationImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.ManagementFactoryHelper$1",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.MemoryImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.MemoryManagerImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.MemoryPoolImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "io.undertow.Undertow"
-    },
-    "name": "sun.management.RuntimeImpl",
     "queryAllPublicConstructors": true
   },
   {


### PR DESCRIPTION
## What does this PR do?

Similar to the problem with Hibernate that #113 fixed, Undertow's metadata contains entries for various MBean-related classes. This metadata causes a call to
`ManagementFactory.getPlatformMBeanServer()` to [fail with a `javax.management.openmbean.OpenDataException`](https://github.com/spring-projects/spring-boot/issues/33677). It would appear that the metadata is sufficient for the bootstrapping of the MBean server to take a different code path to normal and this path fails. This PR removes the offending metadata which fixes `ManagementFactory.getPlatformMBeanServer()` and has no adverse effects on the existing tests for hibernate-core.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

No new tests have been added but the existing tests are unaffected by the changes.
