### PR TITLE
Remove MBean-related reflection entries from hibernate-validator

### DIFF
--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reflect-config.json
@@ -81,12 +81,6 @@
     "condition": {
       "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
     },
-    "name": "[Ljavax.management.openmbean.CompositeData;"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
     "name": "[S"
   },
   {
@@ -130,76 +124,6 @@
         "parameterTypes": []
       }
     ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.GarbageCollectorMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.GcInfo",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.HotSpotDiagnosticMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.ThreadMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.UnixOperatingSystemMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.VMOption",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.internal.GarbageCollectorExtImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.internal.HotSpotDiagnostic",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.internal.HotSpotThreadImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "com.sun.management.internal.OperatingSystemImpl",
-    "queryAllPublicConstructors": true
   },
   {
     "condition": {
@@ -810,129 +734,6 @@
   },
   {
     "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.BufferPoolMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.ClassLoadingMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.CompilationMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.LockInfo",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.ManagementPermission",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.MemoryMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.MemoryManagerMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.MemoryPoolMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.MemoryUsage",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.MonitorInfo",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.PlatformLoggingMXBean",
-    "queryAllPublicMethods": true,
-    "queriedMethods": [
-      {
-        "name": "getLoggerLevel",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "getLoggerNames",
-        "parameterTypes": []
-      },
-      {
-        "name": "getParentLoggerName",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      },
-      {
-        "name": "setLoggerLevel",
-        "parameterTypes": [
-          "java.lang.String",
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.RuntimeMXBean",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "java.lang.management.ThreadInfo",
-    "queryAllPublicMethods": true
-  },
-  {
-    "condition": {
       "typeReachable": "org.hibernate.validator.internal.util.logging.Log_$logger"
     },
     "name": "java.lang.reflect.Method"
@@ -1034,55 +835,6 @@
       "typeReachable": "org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager"
     },
     "name": "javafx.beans.value.ObservableValue"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.MBeanOperationInfo",
-    "queryAllPublicMethods": true,
-    "queriedMethods": [
-      {
-        "name": "getSignature",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.MBeanServerBuilder",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.ObjectName"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.openmbean.CompositeData"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "javax.management.openmbean.TabularData"
   },
   {
     "condition": {
@@ -1298,62 +1050,6 @@
       "typeReachable": "org.hibernate.validator.internal.metadata.core.ConstraintHelper"
     },
     "name": "org.joda.time.ReadableInstant"
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.ClassLoadingImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.CompilationImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.ManagementFactoryHelper$1",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.MemoryImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.MemoryManagerImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.MemoryPoolImpl",
-    "queryAllPublicConstructors": true
-  },
-  {
-    "condition": {
-      "typeReachable": "org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount"
-    },
-    "name": "sun.management.RuntimeImpl",
-    "queryAllPublicConstructors": true
   },
   {
     "condition": {


### PR DESCRIPTION
## What does this PR do?

Similar to the problem with Hibernate that #113 fixed, Hibernate Validator's metadata contains entries for various MBean-related classes. This metadata causes a call to
`ManagementFactory.getPlatformMBeanServer()` to fail with a `javax.management.openmbean.OpenDataException`. It would appear that the metadata is sufficient for the bootstrapping of the MBean server to take a different code path to normal and this path fails. This PR removes the offending metadata which fixes `ManagementFactory.getPlatformMBeanServer()` and has no adverse effects on the existing tests for hibernate-validator.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

No new tests have been added but the existing tests are unaffected by the changes.
