### PR TITLE
Add null check in diffCordinates function

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
@@ -155,16 +155,15 @@ public abstract class TckExtension {
             // If tck was changed we should retest everything, just to be safe.
             return getMatchingCoordinates("");
         }
-
         // First get all available coordinates, then filter them by if their corresponding metadata / tests directories
         // contain changed files.
         return getMatchingCoordinates("").stream().filter(c -> {
             Path metadataDir = getMetadataDir(c);
-            if (changed.get("metadata").stream().anyMatch(f -> f.startsWith(metadataDir))) {
+            if (changed.get("metadata") != null && changed.get("metadata").stream().anyMatch(f -> f.startsWith(metadataDir))) {
                 return true;
             }
             Path testDir = getTestDir(c);
-            if (changed.get("test").stream().anyMatch(f -> f.startsWith(testDir))) {
+            if (changed.get("test") != null && changed.get("test").stream().anyMatch(f -> f.startsWith(testDir))) {
                 return true;
             }
             return false;


### PR DESCRIPTION
## What does this PR do?

As reported in [this](https://github.com/oracle/graalvm-reachability-metadata/actions/runs/3911262846/jobs/6685813930) gate there is an attempt to create a stream over the element which is null(we don't have null check for element we are trying to get from map). @melix please check if the fix can break something else in your logic here, since you are more familiar with this part of the code.