### PR TITLE
Add support for `javax.cache:cache-api:1.1.1`

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -103,6 +103,10 @@
     "module": "org.flywaydb:flyway-core"
   },
   {
+    "directory": "javax.cache/cache-api",
+    "module": "javax.cache:cache-api"
+  },
+  {
     "directory": "com.sun.mail/jakarta.mail",
     "module": "com.sun.mail:jakarta.mail"
   },

--- a/metadata/javax.cache/cache-api/1.1.1/index.json
+++ b/metadata/javax.cache/cache-api/1.1.1/index.json
@@ -1,0 +1,4 @@
+[
+  "resource-config.json",
+  "serialization-config.json"
+]

--- a/metadata/javax.cache/cache-api/1.1.1/resource-config.json
+++ b/metadata/javax.cache/cache-api/1.1.1/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "javax.cache.Caching$CachingProviderRegistry$1"
+        },
+        "pattern": "\\QMETA-INF/services/javax.cache.spi.CachingProvider\\E"
+      }
+    ]
+  },
+  "bundles": []
+}

--- a/metadata/javax.cache/cache-api/1.1.1/serialization-config.json
+++ b/metadata/javax.cache/cache-api/1.1.1/serialization-config.json
@@ -1,0 +1,48 @@
+{
+  "lambdaCapturingTypes": [],
+  "proxies": [],
+  "types": [
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "javax.cache.configuration.FactoryBuilder$SingletonFactory"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "javax.cache.expiry.AccessedExpiryPolicy"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "javax.cache.expiry.Duration"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "javax.cache.expiry.EternalExpiryPolicy"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "java.lang.Number"
+    },
+    {
+      "condition": {
+        "typeReachable": "java.lang.Object"
+      },
+      "name": "java.lang.Integer"
+    }
+  ]
+}

--- a/metadata/javax.cache/cache-api/index.json
+++ b/metadata/javax.cache/cache-api/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.1.1",
+    "module": "javax.cache:cache-api",
+    "tested-versions": [
+      "1.1.1"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -253,6 +253,17 @@
     ]
   },
   {
+    "test-project-path": "javax.cache/cache-api/1.1.1",
+    "libraries": [
+      {
+        "name": "javax.cache:cache-api",
+        "versions": [
+          "1.1.1"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "com.sun.mail/jakarta.mail/2.0.1",
     "libraries": [
       {

--- a/tests/src/javax.cache/cache-api/1.1.1/.gitignore
+++ b/tests/src/javax.cache/cache-api/1.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/javax.cache/cache-api/1.1.1/build.gradle
+++ b/tests/src/javax.cache/cache-api/1.1.1/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "javax.cache:cache-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.jsr107.ri:cache-ri-impl:$libraryVersion"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/javax.cache/cache-api")
+        }
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/gradle.properties
+++ b/tests/src/javax.cache/cache-api/1.1.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.1.1
+metadata.dir = javax.cache/cache-api/1.1.1/

--- a/tests/src/javax.cache/cache-api/1.1.1/settings.gradle
+++ b/tests/src/javax.cache/cache-api/1.1.1/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'javax.cache.cache-api_tests'

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/CacheTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/CacheTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.AccessedExpiryPolicy;
+
+import static javax.cache.expiry.Duration.ONE_HOUR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class CacheTest {
+    @Test
+    public void simpleCache() {
+        CacheManager manager = Caching.getCachingProvider().getCacheManager();
+        Configuration<Integer, String> configuration = new MutableConfiguration<Integer, String>().setTypes(Integer.class, String.class);
+        assertThat(manager.getCache("simpleCache22")).isNull();
+        Cache<Integer, String> simpleCache = manager.createCache("simpleCache22", configuration);
+        simpleCache.put(2, "value");
+        assertThat(simpleCache.get(2)).isEqualTo("value");
+    }
+
+    @Test
+    public void simpleAPITypeEnforcement() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<String, Integer>()
+                .setStoreByValue(true).setTypes(String.class, Integer.class)
+                .setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        cacheManager.createCache("simpleCache", config);
+        Cache<String, Integer> cache = Caching.getCache("simpleCache", String.class, Integer.class);
+        cache.put("key", 1);
+        assertEquals(1, cache.get("key"));
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+
+    @Test
+    public void simpleAPITypeEnforcementUsingCaching() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<>();
+        config.setTypes(String.class, Integer.class).setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        cacheManager.createCache("simpleCache2", config);
+        Cache<String, Integer> cache = Caching.getCache("simpleCache2", String.class, Integer.class);
+        cache.put("key", 1);
+        assertEquals(1, cache.get("key"));
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+
+    @Test
+    public void simpleAPIWithGenericsAndNoTypeEnforcement() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<>();
+        config.setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        cacheManager.createCache("sampleCache3", config);
+        Cache<String, Integer> cache = cacheManager.getCache("sampleCache3");
+        cache.put("key", 1);
+        assertThat(cache.get("key")).isEqualTo(1);
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+
+
+    @Test
+    public void simpleAPINoGenericsAndNoTypeEnforcement() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        String cacheName = "sampleCache";
+        MutableConfiguration<Object, Object> config = new MutableConfiguration<>()
+                .setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        cacheManager.createCache(cacheName, config);
+        Cache<Object, Object> cache = cacheManager.getCache(cacheName);
+        cache.put("key", 1);
+        cache.put(1, "key");
+        assertEquals(1, (Integer) cache.get("key"));
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+
+    @Test
+    public void simpleAPITypeEnforcementObject() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<Object, Object> config = new MutableConfiguration<>()
+                .setTypes(Object.class, Object.class).setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        cacheManager.createCache("simpleCache4", config);
+        Cache<Object, Object> cache = Caching.getCache("simpleCache4", Object.class, Object.class);
+        cache.put("key", 1);
+        assertEquals(1, cache.get("key"));
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/CompletionListenerTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/CompletionListenerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.AccessedExpiryPolicy;
+import javax.cache.integration.CompletionListenerFuture;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+
+import static javax.cache.expiry.Duration.ONE_HOUR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompletionListenerTest {
+    @Test
+    public void testCompletionListener() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<String, Integer>()
+                .setTypes(String.class, Integer.class).setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        Cache<String, Integer> cache = cacheManager.createCache("simpleCache3", config);
+        HashSet<String> keys = new HashSet<>();
+        keys.add("23432lkj");
+        keys.add("4fsdldkj");
+        CompletionListenerFuture future = new CompletionListenerFuture();
+        cache.loadAll(keys, true, future);
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (ExecutionException e) {
+            e.getCause();
+        }
+        assertThat(future.isDone()).isEqualTo(true);
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/EntryProcessorTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/EntryProcessorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.MutableEntry;
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EntryProcessorTest {
+    @Test
+    public void incrementValue() {
+        CacheManager manager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> configuration = new MutableConfiguration<String, Integer>().setTypes(String.class, Integer.class);
+        Cache<String, Integer> cache = manager.createCache("example", configuration);
+        String key = "counter";
+        cache.put(key, 1);
+        assertThat(cache.invoke(key, new IncrementProcessor<>())).isEqualTo(1);
+        assertThat(cache.get(key)).isEqualTo(2);
+    }
+
+    public static class IncrementProcessor<K> implements EntryProcessor<K, Integer, Integer>, Serializable {
+        public static final long serialVersionUID = 201306211238L;
+
+        @Override
+        public Integer process(MutableEntry<K, Integer> entry, Object... arguments) {
+            if (entry.exists()) {
+                Integer current = entry.getValue();
+                entry.setValue(current + 1);
+                return current;
+            } else {
+                entry.setValue(0);
+                return -1;
+            }
+        }
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/StatisticsTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/StatisticsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.AccessedExpiryPolicy;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import java.util.ArrayList;
+import java.util.stream.IntStream;
+
+import static javax.cache.expiry.Duration.ONE_HOUR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StatisticsTest {
+    private enum CacheStatistics {
+        CacheHits, CacheHitPercentage,
+        CacheMisses, CacheMissPercentage,
+        CacheGets, CachePuts, CacheRemovals, CacheEvictions,
+        AverageGetTime, AveragePutTime, AverageRemoveTime
+    }
+
+    @Test
+    public void accessStatistics() throws MalformedObjectNameException, AttributeNotFoundException, MBeanException, ReflectionException,
+            InstanceNotFoundException {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<String, Integer>()
+                .setTypes(String.class, Integer.class).setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR)).setStatisticsEnabled(true);
+        Cache<String, Integer> cache = cacheManager.createCache("simpleCacheWithStatistics", config);
+        long cacheHits = 5;
+        long cacheMisses = 3;
+        long cacheGets = cacheHits + cacheMisses;
+        long cacheRemovals = 3;
+        long cachePuts = cacheRemovals + 1;
+        long cacheEvictions = 0;
+        float cacheHitPercentage = (float) cacheHits / cacheGets * 100.0f;
+        float cacheMissPercentage = (float) cacheMisses / cacheGets * 100.0f;
+        cache.put("valid-key", 1);
+        IntStream.iterate(0, i -> i < cacheHits, i -> i + 1).mapToObj(i -> "valid-key").forEach(cache::get);
+        IntStream.iterate(0, i -> i < cacheMisses, i -> i + 1).mapToObj(i -> "invalid-key").forEach(cache::get);
+        IntStream.iterate(0, i -> i < cacheRemovals, i -> i + 1).forEach(i -> cache.put("key" + i, i));
+        IntStream.iterate(0, i -> i < cacheRemovals, i -> i + 1).mapToObj(i -> "key" + i).forEach(cache::remove);
+        ArrayList<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
+        ObjectName objectName = new ObjectName("javax.cache:type=CacheStatistics"
+                + ",CacheManager=" + (cache.getCacheManager().getURI().toString())
+                + ",Cache=" + cache.getName());
+        assertEquals(cacheHits, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheHits.toString()));
+        assertEquals(cacheHitPercentage, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheHitPercentage.toString()));
+        assertEquals(cacheMisses, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheMisses.toString()));
+        assertEquals(cacheMissPercentage, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheMissPercentage.toString()));
+        assertEquals(cacheGets, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheGets.toString()));
+        assertEquals(cachePuts, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CachePuts.toString()));
+        assertEquals(cacheRemovals, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheRemovals.toString()));
+        assertEquals(cacheEvictions, mBeanServers.get(0).getAttribute(objectName, CacheStatistics.CacheEvictions.toString()));
+        assertTrue((float) mBeanServers.get(0).getAttribute(objectName, CacheStatistics.AverageGetTime.toString()) > 0.0f);
+        assertTrue((float) mBeanServers.get(0).getAttribute(objectName, CacheStatistics.AveragePutTime.toString()) > 0.0f);
+        assertTrue((float) mBeanServers.get(0).getAttribute(objectName, CacheStatistics.AverageRemoveTime.toString()) > 0.0f);
+        for (CacheStatistics cacheStatistic : CacheStatistics.values()) {
+            assertThat(mBeanServers.get(0).getAttribute(objectName, cacheStatistic.toString())).isNotNull();
+        }
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/TypeSafetyTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/TypeSafetyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeSafetyTest {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void runtimeTypeEnforcement() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<String, Integer>().setTypes(String.class, Integer.class);
+        Cache<String, Integer> simpleCache = cacheManager.createCache("simpleCache5", config);
+        simpleCache.put("key1", 3);
+        assertThat(simpleCache.get("key1")).isEqualTo(3);
+        try {
+            ((Cache) simpleCache).put(123, "String");
+        } catch (ClassCastException ignored) {
+        }
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/AbstractEntryProcessor.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/AbstractEntryProcessor.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core.stepbystep;
+
+import javax.cache.processor.EntryProcessor;
+import java.io.Serializable;
+
+public abstract class AbstractEntryProcessor<K, V, T> implements EntryProcessor<K, V, T>, Serializable {
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/MyCacheEntryListener.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/MyCacheEntryListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core.stepbystep;
+
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.event.CacheEntryUpdatedListener;
+
+public class MyCacheEntryListener implements CacheEntryCreatedListener<String, String>,
+        CacheEntryUpdatedListener<String, String> {
+    @Override
+    public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+            throws CacheEntryListenerException {
+        for (CacheEntryEvent<? extends String, ? extends String> entryEvent : cacheEntryEvents) {
+            System.out.println("Created: " + entryEvent.getKey() + " with value: " + entryEvent.getValue());
+        }
+    }
+
+    @Override
+    public void onUpdated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+            throws CacheEntryListenerException {
+        for (CacheEntryEvent<? extends String, ? extends String> entryEvent : cacheEntryEvents) {
+            System.out.println("Updated: " + entryEvent.getKey() + " with value: " + entryEvent.getValue());
+        }
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/SimpleTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/SimpleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core.stepbystep;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.MutableEntry;
+import javax.cache.spi.CachingProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleTest {
+    @Test
+    void testSimple() {
+        CachingProvider provider = Caching.getCachingProvider();
+        CacheManager manager = provider.getCacheManager();
+        MutableConfiguration<String, String> configuration = new MutableConfiguration<String, String>()
+                .setStoreByValue(false).setTypes(String.class, String.class);
+        Cache<String, String> cache = manager.createCache("my-cache", configuration);
+        CacheEntryListenerConfiguration<String, String> listenerConfiguration = new MutableCacheEntryListenerConfiguration<>(
+                FactoryBuilder.factoryOf(MyCacheEntryListener.class),
+                null, false, true
+        );
+        cache.registerCacheEntryListener(listenerConfiguration);
+        cache.put("message", "hello");
+        cache.put("message", "g'day");
+        cache.put("message", "bonjour");
+        String result = cache.invoke("message", new AbstractEntryProcessor<>() {
+            @Override
+            public String process(MutableEntry<String, String> entry,
+                                  Object... arguments) throws EntryProcessorException {
+                return entry.exists() ? entry.getValue().toUpperCase() : null;
+            }
+        });
+        assertThat(result).isEqualTo("BONJOUR");
+        assertThat(cache.get("message")).isEqualTo("bonjour");
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/StepTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/core/stepbystep/StepTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.core.stepbystep;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.spi.CachingProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StepTest {
+
+    @Test
+    void testStep1() {
+        assertThat(Caching.getCachingProvider().getCacheManager()).isNotNull();
+    }
+
+    @Test
+    void testStep2() {
+        CacheManager manager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, String> configuration = new MutableConfiguration<String, String>()
+                .setStoreByValue(true).setTypes(String.class, String.class);
+        Cache<String, String> cache = manager.createCache("greetings2", configuration);
+        cache.put("AU", "gudday mate");
+        cache.put("US", "hello");
+        cache.put("FR", "bonjour");
+        assertThat(cache.get("AU")).isEqualTo("gudday mate");
+    }
+
+    @Test
+    void testStep3() {
+        CachingProvider provider = Caching.getCachingProvider();
+        CacheManager manager = provider.getCacheManager();
+        MutableConfiguration<String, String> configuration = new MutableConfiguration<String, String>()
+                .setStoreByValue(true).setTypes(String.class, String.class);
+        Cache<String, String> cache = manager.createCache("greetings3", configuration);
+        cache.put("AU", "gudday mate");
+        cache.put("US", "hello");
+        cache.put("FR", "bonjour");
+        cache.invoke("AU", (entry, arguments) -> {
+            if (entry.exists()) {
+                String currentValue = entry.getValue();
+                entry.setValue(currentValue.toUpperCase());
+                return currentValue;
+            } else {
+                return null;
+            }
+        });
+        assertThat(cache.get("AU")).isEqualTo("GUDDAY MATE");
+    }
+
+    @Test
+    void testStep4() {
+        CachingProvider provider = Caching.getCachingProvider();
+        CacheManager manager = provider.getCacheManager();
+        MutableConfiguration<String, String> configuration = new MutableConfiguration<String, String>()
+                .setStoreByValue(true).setTypes(String.class, String.class);
+        Cache<String, String> cache = manager.createCache("greetings4", configuration);
+        CacheEntryListenerConfiguration<String, String> listenerConfiguration = new MutableCacheEntryListenerConfiguration<>(
+                FactoryBuilder.factoryOf(MyCacheEntryListener.class), null, false, true
+        );
+        cache.registerCacheEntryListener(listenerConfiguration);
+        cache.put("AU", "gudday mate");
+        cache.put("US", "hello");
+        cache.put("FR", "bonjour");
+        cache.invoke("AU", (EntryProcessor<String, String, String>) (entry, arguments) -> {
+            if (entry.exists()) {
+                entry.setValue(entry.getValue().toUpperCase());
+            }
+            return null;
+        });
+        assertThat(cache.get("AU")).isEqualTo("GUDDAY MATE");
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/optional/CacheTest.java
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/java/javax_cache/cache_api/optional/CacheTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_cache.cache_api.optional;
+
+import org.junit.jupiter.api.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.AccessedExpiryPolicy;
+
+import static javax.cache.expiry.Duration.ONE_HOUR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class CacheTest {
+    @Test
+    public void simpleAPITypeEnforcement() {
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        MutableConfiguration<String, Integer> config = new MutableConfiguration<>();
+        config.setStoreByValue(false).setTypes(String.class, Integer.class).setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR))
+                .setStatisticsEnabled(true);
+        cacheManager.createCache("simpleOptionalCache", config);
+        Cache<String, Integer> cache = Caching.getCache("simpleOptionalCache", String.class, Integer.class);
+        cache.put("key", 1);
+        assertEquals(1, cache.get("key"));
+        cache.remove("key");
+        assertNull(cache.get("key"));
+    }
+}

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/cache-api-test-metadata/reflect-config.json
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/cache-api-test-metadata/reflect-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "condition": {
+      "typeReachable": "javax.cache.configuration.FactoryBuilder$ClassFactory"
+    },
+    "name": "javax_cache.cache_api.core.stepbystep.MyCacheEntryListener",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "javax.cache.configuration.FactoryBuilder$ClassFactory"
+    },
+    "name": "javax_cache.cache_api.core.stepbystep.SimpleTest$MyCacheEntryListener",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/org.jsr107.ri/cache-ri-impl/jni-config.json
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/org.jsr107.ri/cache-ri-impl/jni-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.util.Arrays",
+    "methods": [
+      {
+        "name": "asList",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/org.jsr107.ri/cache-ri-impl/reflect-config.json
+++ b/tests/src/javax.cache/cache-api/1.1.1/src/test/resources/META-INF/native-image/org.jsr107.ri/cache-ri-impl/reflect-config.json
@@ -1,0 +1,299 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Boolean",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Byte",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Character",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Deprecated",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Double",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Float",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.RISerializingInternalConverter$CustomizedClassLoaderObjectInputStream"
+    },
+    "name": "java.lang.Integer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Integer",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Long",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.RISerializingInternalConverter$CustomizedClassLoaderObjectInputStream"
+    },
+    "name": "java.lang.Number"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Short",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.StackTraceElement",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.String"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.math.BigDecimal"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.math.BigInteger"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.util.Date"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.util.PropertyPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.util.logging.LogManager",
+    "methods": [
+      {
+        "name": "getLoggingMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "java.util.logging.LoggingMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "javax.cache.management.CacheStatisticsMXBean",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "getAverageGetTime",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAveragePutTime",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAverageRemoveTime",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheEvictions",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheGets",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheHitPercentage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheHits",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheMissPercentage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheMisses",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCachePuts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCacheRemovals",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jsr107.ri.management.MBeanServerRegistrationUtility"
+    },
+    "name": "org.jsr107.ri.management.RICacheStatisticsMXBean",
+    "queryAllPublicConstructors": true
+  }
+]

--- a/tests/src/javax.cache/cache-api/1.1.1/user-code-filter.json
+++ b/tests/src/javax.cache/cache-api/1.1.1/user-code-filter.json
@@ -1,0 +1,6 @@
+{
+  "rules": [
+    {"excludeClasses": "**"},
+    {"includeClasses": "javax.cache.**"}
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/136 .
- For https://github.com/oracle/graalvm-reachability-metadata/pull/169 and https://github.com/oracle/graalvm-reachability-metadata/pull/124 .


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
