### PR TITLE
Add missing constructor hint required by hibernate PostgreSQLDialect.

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.1.1.Final/reflect-config.json
@@ -11728,7 +11728,13 @@
       "typeReachable": "org.postgresql.Driver"
     },
     "name": "org.postgresql.util.PGobject",
-    "queryAllDeclaredMethods": true
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "condition": {

--- a/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.1.1.Final/src/test/java/org/hibernate/orm/HibernateOrmTest.java
@@ -28,6 +28,7 @@ import org.hibernate.annotations.GeneratorType;
 import org.hibernate.annotations.TenantId;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.ValueGenerationType;
+import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
 import org.hibernate.boot.registry.selector.internal.StrategySelectorImpl;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
@@ -48,6 +49,7 @@ import org.hibernate.tuple.AttributeBinder;
 import org.hibernate.tuple.GenerationTiming;
 import org.hibernate.tuple.TenantIdGeneration;
 import org.hibernate.tuple.ValueGenerator;
+import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.jupiter.api.Test;
 
 public class HibernateOrmTest {
@@ -173,6 +175,21 @@ public class HibernateOrmTest {
         dialectFactory.injectServices(new StubServiceRegistryImplementor());
 
         assertNotNull(dialectFactory.buildDialect(Collections.singletonMap(AvailableSettings.DIALECT, "org.hibernate.dialect.PostgreSQLDialect"), () -> StubDialectResolutionInfo.INSTANCE));
+    }
+
+    @Test
+    void initPostgresqlDialect() {
+
+        TypeContributions contributions = new TypeContributions() {
+            TypeConfiguration configuration = new TypeConfiguration();
+            @Override
+            public TypeConfiguration getTypeConfiguration() {
+                return configuration;
+            }
+        };
+
+        ServiceRegistry registry = new StubServiceRegistryImplementor();
+        new org.hibernate.dialect.PostgreSQLDialect().contributeTypes(contributions, registry);
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the `PostgreSQLDialect` contributes types to the hibernate configuration that require reflective access to the `org.postgresql.util.PGobject` constructor which caused:

```
java.lang.NoSuchMethodException: org.postgresql.util.PGobject.<init>()
        at java.base@17.0.5/java.lang.Class.getConstructor0(DynamicHub.java:3585)
        at java.base@17.0.5/java.lang.Class.getConstructor(DynamicHub.java:2271)
        at org.hibernate.dialect.PostgreSQLPGObjectJdbcType.<clinit>(PostgreSQLPGObjectJdbcType.java:50)
        at org.hibernate.dialect.PostgreSQLDialect.registerColumnTypes(PostgreSQLDialect.java:231)
        at org.hibernate.dialect.Dialect.contributeTypes(Dialect.java:1341)
        at org.hibernate.dialect.PostgreSQLDialect.contributeTypes(PostgreSQLDialect.java:1229)
        at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.handleTypes(MetadataBuildingProcess.java:386)
        at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.complete(MetadataBuildingProcess.java:143)
        at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.metadata(EntityManagerFactoryBuilderImpl.java:1350)
        at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1421)
```

Closes: #131

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
