### PR TITLE
Disable Native Image PR reports.

### DIFF
--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -58,7 +58,6 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
-          native-image-pr-reports: 'true'
       - name: "🧪 Run '${{ matrix.coordinates }}' tests"
         run: |
           ./gradlew test -Pcoordinates=${{ matrix.coordinates }}


### PR DESCRIPTION
## What does this PR do?
Disable PR reports that [can quickly spam PRs](https://github.com/oracle/graalvm-reachability-metadata/pull/173#issuecomment-1382088594) when run across all metadata.