### PR TITLE
Restore JDK19 testing for GitHub Actions

### DIFF
--- a/tests/src/org.eclipse.jetty/jetty-client/11.0.12/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-client/11.0.12/build.gradle
@@ -19,6 +19,11 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--enable-preview')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/build.gradle
@@ -22,6 +22,11 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--enable-preview')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "17"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -87,7 +87,7 @@ if (project.hasProperty("baseCommit")) {
 
 def matrixDefault = [
         "versions" : [
-//                [ "graalvm": "dev", "java": "dev" ], // TODO: uncomment this once we are ready to run tests on JDK19
+                [ "graalvm": "dev", "java": "dev" ],
                 [ "graalvm": "latest", "java": "17"]
         ],
         "os"          : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/207 .
- Setting the target JVM version for Kotlin Reflect. Refer to https://github.com/gradle/gradle/issues/22653 , https://kotlinlang.org/docs/gradle-compiler-options.html#how-to-define-options and https://kotlinlang.org/docs/whatsnew18.html#exposing-kotlin-compiler-options-as-gradle-lazy-properties .
- Looks like `gradle-wrapper.jar` cannot be excluded in Git.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
