### PR TITLE
Add metadata for Jboss Servlet API 4.0

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -248,5 +248,9 @@
   {
     "directory" : "org.mariadb/r2dbc-mariadb",
     "module" : "org.mariadb:r2dbc-mariadb"
+  },
+  {
+    "directory" : "org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec",
+    "module" : "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec"
   }
 ]

--- a/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
+++ b/metadata/io.undertow/undertow-core/2.2.19.Final/resource-config.json
@@ -1,18 +1,4 @@
 {
-  "bundles": [
-    {
-      "name": "javax.servlet.LocalStrings",
-      "locales": [
-        "und"
-      ]
-    },
-    {
-      "name": "javax.servlet.http.LocalStrings",
-      "locales": [
-        "und"
-      ]
-    }
-  ],
   "resources": {
     "includes": [
       {

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/index.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/index.json
@@ -1,0 +1,3 @@
+[
+  "resource-config.json"
+]

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/resource-config.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/resource-config.json
@@ -1,0 +1,22 @@
+{
+  "bundles": [
+    {
+      "name": "javax.servlet.LocalStrings",
+      "locales": [
+        "und"
+      ],
+      "condition": {
+        "typeReachable": "javax.servlet.GenericServlet"
+      }
+    },
+    {
+      "name": "javax.servlet.http.LocalStrings",
+      "locales": [
+        "und"
+      ],
+      "condition": {
+        "typeReachable": "javax.servlet.http.HttpServlet"
+      }
+    }
+  ]
+}

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "2.0.0.Final",
+    "module": "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+    "tested-versions": [
+      "2.0.0.Final"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -658,5 +658,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path": "org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final",
+    "libraries": [
+      {
+        "name": "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+        "versions": [
+          "2.0.0.Final"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/.gitignore
+++ b/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/build.gradle
+++ b/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}

--- a/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/gradle.properties
+++ b/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 2.0.0.Final
+metadata.dir = org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/

--- a/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/settings.gradle
+++ b/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec_tests'

--- a/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/src/test/java/jboss/servletspec/JbossServletSpecTests.java
+++ b/tests/src/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/src/test/java/jboss/servletspec/JbossServletSpecTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jboss.servletspec;
+
+import java.io.IOException;
+
+import javax.servlet.GenericServlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+
+class JbossServletSpecTests {
+    @Test
+    void instantiateServlet() {
+    new CustomServlet();
+    }
+
+  static class CustomServlet extends GenericServlet {
+    @Override
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This adds reachability metadata for the
`org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec:2.0.0.Final` dependency and removes the duplicate metadata from the undertow one. As of undertow 2.3, undertow is using the Jakarta servlet spec.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
