### PR TITLE
Add metadata for Jakarta Servlet API

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -223,7 +223,11 @@
   "module": "io.opentelemetry:opentelemetry-sdk-metrics"
   },
   {
-  "directory": "io.opentelemetry/opentelemetry-sdk-trace",
-  "module": "io.opentelemetry:opentelemetry-sdk-trace"
+    "directory": "io.opentelemetry/opentelemetry-sdk-trace",
+    "module": "io.opentelemetry:opentelemetry-sdk-trace"
+  },
+  {
+    "directory" : "jakarta.servlet/jakarta.servlet-api",
+    "module" : "jakarta.servlet:jakarta.servlet-api"
   }
 ]

--- a/metadata/jakarta.servlet/jakarta.servlet-api/5.0.0/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/5.0.0/index.json
@@ -1,0 +1,3 @@
+[
+  "resource-config.json"
+]

--- a/metadata/jakarta.servlet/jakarta.servlet-api/5.0.0/resource-config.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/5.0.0/resource-config.json
@@ -1,0 +1,23 @@
+
+{
+  "bundles": [
+    {
+      "name": "jakarta.servlet.LocalStrings",
+      "locales": [
+        "und"
+      ],
+      "condition": {
+        "typeReachable": "jakarta.servlet.GenericServlet"
+      }
+    },
+    {
+      "name": "jakarta.servlet.http.LocalStrings",
+      "locales": [
+        "und"
+      ],
+      "condition": {
+        "typeReachable": "jakarta.servlet.http.HttpServlet"
+      }
+    }
+  ]
+}

--- a/metadata/jakarta.servlet/jakarta.servlet-api/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "5.0.0",
+    "module": "jakarta.servlet:jakarta.servlet-api",
+    "tested-versions": [
+      "5.0.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -614,5 +614,16 @@
         ]
       }
     ]
+  },
+  {
+    "test-project-path" : "jakarta.servlet/jakarta.servlet-api/5.0.0",
+    "libraries" : [
+      {
+        "name" : "jakarta.servlet:jakarta.servlet-api",
+        "versions" : [
+          "5.0.0"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/.gitignore
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/build.gradle
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/gradle.properties
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.0.0
+metadata.dir = jakarta.servlet/jakarta.servlet-api/5.0.0/

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/settings.gradle
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.servlet.jakarta.servlet-api_tests'

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import java.io.IOException;
+
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import org.junit.jupiter.api.Test;
+
+
+class JakartaServletTests {
+    @Test
+    void instantiateServlet() {
+        new CustomServlet();
+    }
+
+  @Test
+  void instantiateHttpServlet() {
+    new CustomHttpServlet();
+  }
+
+  static class CustomServlet extends GenericServlet {
+    @Override
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+
+    }
+  }
+
+  static class CustomHttpServlet extends HttpServlet {
+
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds metadata for the Jakarta Servlet API 5.0.0+ dependency.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
