### PR TITLE
Fix "requires" clauses being ignored

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -49,13 +49,6 @@ String metadataPath = Objects.requireNonNullElse(
 		providers.gradleProperty('metadata.dir').get()
 )
 
-File metadataFile
-if (!metadataPath.startsWith("/")) {
-	metadataFile = file(tck.metadataRoot).toPath().resolve(metadataPath).toFile()
-} else {
-    metadataFile = file(metadataPath)
-}
-
 String libraryVersion = System.getenv("GVM_TCK_LV") ?: providers.gradleProperty('library.version').get()
 
 String libraryGAV = System.getenv("GVM_TCK_LC") ?: providers.gradleProperty('library.coordinates').getOrElse(null)
@@ -79,9 +72,12 @@ tasks.named('test') {
 }
 
 graalvmNative {
+    metadataRepository {
+        enabled = true
+        uri(tck.metadataRoot.get().asFile)
+    }
     binaries {
         test {
-            configurationFileDirectories.from(metadataFile)
             if (override) {
                 excludeConfig.put(libraryGAV, [".*"])
             }


### PR DESCRIPTION
This commit fixes the metadata repository not being used in the TCK. Before, it was assumed that each test was working in isolation, but in practice, #211 showed that it is not the case.

So instead of the TCK figuring out by itself which metadata config to include, and completely ignoring the "requires" clauses, we will now simply configure the tests to use the metadata from the current state of the repository. It makes things easier, at the cost of possible side effects: it is possible that the metadata from a transitive dependency is actually what makes a build pass.

However this drawback should be covered by regular code reviews, as it is unexpected that metadata for a transitive "talks" about the current module under test.

Fixes #211

## What does this PR do?


## Checklist before merging
- [ ] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
