### PR TITLE
Added kotlin.internal.jdk8.JDK8PlatformImplementations constructor.

### DIFF
--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
@@ -89,5 +89,17 @@
     },
     "name": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter",
     "allPublicFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.internal.jdk8.JDK8PlatformImplementations"
+    },
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -13,6 +13,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4"
+
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
@@ -3,16 +3,7 @@ package kotlinreflect
 import kotlinx.coroutines.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
-import java.io.FileOutputStream
-import java.io.FileWriter
-import java.time.Instant
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.concurrent.thread
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
@@ -54,23 +45,12 @@ class KotlinReflectTests {
     @Test
     fun testCoroutine() {
         val updated = AtomicBoolean(false)
-        CoroutineScope(Dispatchers.IO).launch {
-            val writer = FileWriter(File.createTempFile("tmp-couroutine", ".txt"))
-            writer.use {
-                val start = "start:" + Instant.now()
-                writer.append(start)
-                println(start)
-                delay(500)
-                updated.set(true)
-                val end = "end:" + Instant.now()
-                writer.append(end)
-                println(end)
-            }
+        CoroutineScope(Dispatchers.Default).launch {
+        delay(500)
+        updated.set(true)
         }
-        println("sleep:" + Instant.now())
         Thread.sleep(1000)
-        println("awake:" + Instant.now())
-        assertThat(updated.get()).isTrue
+        assertThat(updated.get()).isTrue    
     }
 }
 

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
@@ -1,7 +1,18 @@
 package kotlinreflect
 
+import kotlinx.coroutines.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FileWriter
+import java.time.Instant
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
@@ -39,6 +50,27 @@ class KotlinReflectTests {
         assertThat(annotatedProperty.annotations).hasSize(1)
         assertThat(annotatedProperty.annotations[0]).isInstanceOf(TestAnnotation::class.java)
         assertThat((annotatedProperty.annotations[0] as TestAnnotation).value).isEqualTo("annotation-on-field")
+    }
+    @Test
+    fun testCoroutine() {
+        val updated = AtomicBoolean(false)
+        CoroutineScope(Dispatchers.IO).launch {
+            val writer = FileWriter(File.createTempFile("tmp-couroutine", ".txt"))
+            writer.use {
+                val start = "start:" + Instant.now()
+                writer.append(start)
+                println(start)
+                delay(500)
+                updated.set(true)
+                val end = "end:" + Instant.now()
+                writer.append(end)
+                println(end)
+            }
+        }
+        println("sleep:" + Instant.now())
+        Thread.sleep(1000)
+        println("awake:" + Instant.now())
+        assertThat(updated.get()).isTrue
     }
 }
 


### PR DESCRIPTION
## What does this PR do?
Adds support for kotlin.internal.jdk8.JDK8PlatformImplementations constructor.


## Checklist before merging
- [X] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [X] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

I encountered this with a Spring Boot native application that used async coroutines that perform IO.
This section by itself in `resources/META-INF/native-image/reflect-config.json` did solve the problem
