### PR TITLE
Add support for `org.apache.curator:curator-client:5.4.0` and `org.apache.curator:curator-framework:5.4.0`

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -225,6 +225,27 @@
     ]
   },
   {
+    "directory": "org.apache.curator/curator-client",
+    "module": "org.apache.curator:curator-client",
+    "requires": [
+      "org.mockito:mockito-core"
+    ],
+    "allowed-packages": [
+      "org.apache.curator"
+    ]
+  },
+  {
+    "directory": "org.apache.curator/curator-framework",
+    "module": "org.apache.curator:curator-framework",
+    "requires": [
+      "org.apache.curator:curator-client",
+      "org.mockito:mockito-core"
+    ],
+    "allowed-packages": [
+      "org.apache.curator.framework"
+    ]
+  },
+  {
     "directory": "org.jetbrains.kotlin/kotlin-reflect",
     "module": "org.jetbrains.kotlin:kotlin-reflect",
     "allowed-packages": [

--- a/metadata/org.apache.curator/curator-client/5.4.0/index.json
+++ b/metadata/org.apache.curator/curator-client/5.4.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.apache.curator/curator-client/5.4.0/reflect-config.json
+++ b/metadata/org.apache.curator/curator-client/5.4.0/reflect-config.json
@@ -1,0 +1,79 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.retry.RetryForever"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.retry.RetryForever"
+    },
+    "name": "java.lang.StackWalker",
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": [
+          "java.util.Set",
+          "int"
+        ]
+      },
+      {
+        "name": "walk",
+        "parameterTypes": [
+          "java.util.function.Function"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.retry.RetryForever"
+    },
+    "name": "java.lang.StackWalker$Option"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.retry.RetryForever"
+    },
+    "name": "java.lang.StackWalker$StackFrame",
+    "methods": [
+      {
+        "name": "getClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFileName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLineNumber",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMethodName",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.utils.DefaultZookeeperFactory"
+    },
+    "name": "org.apache.zookeeper.ClientCnxnSocketNIO",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.zookeeper.client.ZKClientConfig"
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.curator/curator-client/index.json
+++ b/metadata/org.apache.curator/curator-client/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "5.4.0",
+    "module": "org.apache.curator:curator-client",
+    "tested-versions": [
+      "5.4.0"
+    ]
+  }
+]

--- a/metadata/org.apache.curator/curator-framework/5.4.0/index.json
+++ b/metadata/org.apache.curator/curator-framework/5.4.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.apache.curator/curator-framework/5.4.0/reflect-config.json
+++ b/metadata/org.apache.curator/curator-framework/5.4.0/reflect-config.json
@@ -1,0 +1,174 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.schema.SchemaSetLoader"
+    },
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceWatcher"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceWatcher"
+    },
+    "name": "java.lang.StackWalker",
+    "methods": [
+      {
+        "name": "getInstance",
+        "parameterTypes": [
+          "java.util.Set",
+          "int"
+        ]
+      },
+      {
+        "name": "walk",
+        "parameterTypes": [
+          "java.util.function.Function"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceWatcher"
+    },
+    "name": "java.lang.StackWalker$Option"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceWatcher"
+    },
+    "name": "java.lang.StackWalker$StackFrame",
+    "methods": [
+      {
+        "name": "getClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFileName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLineNumber",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMethodName",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.CuratorFrameworkImpl"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.ProtectedMode"
+    },
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceFacadeCache"
+    },
+    "name": "org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture",
+    "fields": [
+      {
+        "name": "listeners"
+      },
+      {
+        "name": "value"
+      },
+      {
+        "name": "waiters"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceFacadeCache"
+    },
+    "name": "org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$Waiter",
+    "fields": [
+      {
+        "name": "next"
+      },
+      {
+        "name": "thread"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.EnsembleTracker"
+    },
+    "name": "org.apache.zookeeper.AddWatchMode"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.EnsembleTracker"
+    },
+    "name": "org.apache.zookeeper.server.quorum.MultipleAddresses",
+    "methods": [
+      {
+        "name": "getReachableOrOne",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.EnsembleTracker"
+    },
+    "name": "org.apache.zookeeper.server.quorum.QuorumPeer$QuorumServer",
+    "fields": [
+      {
+        "name": "addr"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.NamespaceFacadeCache"
+    },
+    "name": "sun.misc.Unsafe",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.ProtectedMode"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.curator/curator-framework/index.json
+++ b/metadata/org.apache.curator/curator-framework/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "5.4.0",
+    "module": "org.apache.curator:curator-framework",
+    "tested-versions": [
+      "5.4.0"
+    ]
+  }
+]

--- a/metadata/org.mockito/mockito-core/4.8.1/reflect-config.json
+++ b/metadata/org.mockito/mockito-core/4.8.1/reflect-config.json
@@ -197,5 +197,12 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.invocation.TypeSafeMatching"
+    },
+    "name": "org.mockito.internal.matchers.Equals",
+    "queryAllPublicMethods": true
   }
 ]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -330,6 +330,28 @@
     ]
   },
   {
+    "test-project-path": "org.apache.curator/curator-client/5.4.0",
+    "libraries": [
+      {
+        "name": "org.apache.curator:curator-client",
+        "versions": [
+          "5.4.0"
+        ]
+      }
+    ]
+  },
+  {
+    "test-project-path": "org.apache.curator/curator-framework/5.4.0",
+    "libraries": [
+      {
+        "name": "org.apache.curator:curator-framework",
+        "versions": [
+          "5.4.0"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.jetbrains.kotlin/kotlin-reflect/1.7.10",
     "libraries": [
       {

--- a/tests/src/org.apache.curator/curator-client/5.4.0/.gitignore
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.curator/curator-client/5.4.0/build.gradle
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/build.gradle
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.curator:curator-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.apache.curator:curator-test:$libraryVersion"
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.apache.zookeeper:zookeeper:3.8.1'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--initialize-at-build-time=org.junit.platform.engine.TestTag')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.apache.curator/curator-client")
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/gradle.properties
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.4.0
+metadata.dir = org.apache.curator/curator-client/5.4.0/

--- a/tests/src/org.apache.curator/curator-client/5.4.0/settings.gradle
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.curator.curator-client_tests'

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org/apache/curator/TestEnsurePath.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org/apache/curator/TestEnsurePath.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator;
+
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.utils.EnsurePath;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("deprecation")
+public class TestEnsurePath {
+    @Test
+    @Disabled("https://github.com/mockito/mockito/issues/2435")
+    public void testBasic() throws Exception {
+        ZooKeeper client = mock(ZooKeeper.class, Mockito.RETURNS_MOCKS);
+        CuratorZookeeperClient curator = mock(CuratorZookeeperClient.class);
+        RetryPolicy retryPolicy = new RetryOneTime(1);
+        RetryLoop retryLoop = new RetryLoopImpl(retryPolicy, null);
+        when(curator.getZooKeeper()).thenReturn(client);
+        when(curator.getRetryPolicy()).thenReturn(retryPolicy);
+        when(curator.newRetryLoop()).thenReturn(retryLoop);
+        Stat fakeStat = mock(Stat.class);
+        when(client.exists(Mockito.any(), anyBoolean())).thenReturn(fakeStat);
+        EnsurePath ensurePath = new EnsurePath("/one/two/three");
+        ensurePath.ensure(curator);
+        verify(client, times(3)).exists(Mockito.any(), anyBoolean());
+        ensurePath.ensure(curator);
+        verifyNoMoreInteractions(client);
+        ensurePath.ensure(curator);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    @Disabled("https://github.com/mockito/mockito/issues/2435")
+    public void testSimultaneous() throws Exception {
+        ZooKeeper client = mock(ZooKeeper.class, Mockito.RETURNS_MOCKS);
+        RetryPolicy retryPolicy = new RetryOneTime(1);
+        RetryLoop retryLoop = new RetryLoopImpl(retryPolicy, null);
+        final CuratorZookeeperClient curator = mock(CuratorZookeeperClient.class);
+        when(curator.getZooKeeper()).thenReturn(client);
+        when(curator.getRetryPolicy()).thenReturn(retryPolicy);
+        when(curator.newRetryLoop()).thenReturn(retryLoop);
+        final Stat fakeStat = mock(Stat.class);
+        final CountDownLatch startedLatch = new CountDownLatch(2);
+        final CountDownLatch finishedLatch = new CountDownLatch(2);
+        final Semaphore semaphore = new Semaphore(0);
+        when(client.exists(Mockito.any(), anyBoolean())).thenAnswer((Answer<Stat>) invocation -> {
+            semaphore.acquire();
+            return fakeStat;
+        });
+        final EnsurePath ensurePath = new EnsurePath("/one/two/three");
+        ExecutorService service = Executors.newCachedThreadPool();
+        IntStream.range(0, 2).mapToObj(i -> (Callable<Void>) () -> {
+            startedLatch.countDown();
+            ensurePath.ensure(curator);
+            finishedLatch.countDown();
+            return null;
+        }).forEach(service::submit);
+        assertTrue(startedLatch.await(10, TimeUnit.SECONDS));
+        semaphore.release(3);
+        assertTrue(finishedLatch.await(10, TimeUnit.SECONDS));
+        verify(client, times(3)).exists(Mockito.any(), anyBoolean());
+        ensurePath.ensure(curator);
+        verifyNoMoreInteractions(client);
+        ensurePath.ensure(curator);
+        verifyNoMoreInteractions(client);
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.utils;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("resource")
+public class TestCloseableExecutorService {
+    private static final int QTY = 10;
+    private volatile ExecutorService executorService;
+
+    @BeforeEach
+    public void setup() {
+        executorService = Executors.newFixedThreadPool(QTY * 2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void testBasicRunnable() {
+        try {
+            CloseableExecutorService service = new CloseableExecutorService(executorService);
+            CountDownLatch startLatch = new CountDownLatch(QTY);
+            CountDownLatch latch = new CountDownLatch(QTY);
+            IntStream.range(0, QTY).forEach(i -> submitRunnable(service, startLatch, latch));
+            assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+            service.close();
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testBasicCallable() throws InterruptedException {
+        CloseableExecutorService service = new CloseableExecutorService(executorService);
+        final CountDownLatch startLatch = new CountDownLatch(QTY);
+        final CountDownLatch latch = new CountDownLatch(QTY);
+        IntStream.range(0, QTY).mapToObj(i -> (Callable<Void>) () -> {
+            try {
+                startLatch.countDown();
+                Thread.currentThread().join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                latch.countDown();
+            }
+            return null;
+        }).forEach(service::submit);
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        service.close();
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testListeningRunnable() throws InterruptedException {
+        CloseableExecutorService service = new CloseableExecutorService(executorService);
+        List<Future<?>> futures;
+        final CountDownLatch startLatch = new CountDownLatch(QTY);
+        futures = IntStream.range(0, QTY).mapToObj(i -> service.submit(() -> {
+                    try {
+                        startLatch.countDown();
+                        Thread.currentThread().join();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+        )).collect(Collectors.toList());
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        futures.forEach(future -> future.cancel(true));
+        assertEquals(service.size(), 0);
+    }
+
+    @Test
+    public void testListeningCallable() throws InterruptedException {
+        CloseableExecutorService service = new CloseableExecutorService(executorService);
+        final CountDownLatch startLatch = new CountDownLatch(QTY);
+        List<Future<?>> futures = IntStream.range(0, QTY).mapToObj(i -> service.submit((Callable<Void>) () -> {
+                    try {
+                        startLatch.countDown();
+                        Thread.currentThread().join();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return null;
+                }
+        )).collect(Collectors.toList());
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        futures.forEach(future -> future.cancel(true));
+        assertEquals(service.size(), 0);
+    }
+
+    @Test
+    public void testPartialRunnable() throws InterruptedException {
+        final CountDownLatch outsideLatch = new CountDownLatch(1);
+        executorService.submit(() -> {
+                    try {
+                        Thread.currentThread().join();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        outsideLatch.countDown();
+                    }
+                }
+        );
+        CloseableExecutorService service = new CloseableExecutorService(executorService);
+        CountDownLatch startLatch = new CountDownLatch(QTY);
+        CountDownLatch latch = new CountDownLatch(QTY);
+        IntStream.range(0, QTY).forEach(i -> submitRunnable(service, startLatch, latch));
+        Awaitility.await().until(() -> service.size() >= QTY);
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        service.close();
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        assertEquals(outsideLatch.getCount(), 1);
+    }
+
+    private void submitRunnable(CloseableExecutorService service, final CountDownLatch startLatch, final CountDownLatch latch) {
+        service.submit(() -> {
+                    try {
+                        startLatch.countDown();
+                        Thread.sleep(100000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+        );
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/BasicTests.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/BasicTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.RetryLoop;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BasicTests extends BaseClassForTests {
+    @Test
+    @Disabled("https://github.com/mockito/mockito/issues/2435")
+    public void testFactory() throws Exception {
+        final ZooKeeper mockZookeeper = Mockito.mock(ZooKeeper.class);
+        ZookeeperFactory zookeeperFactory = (connectString, sessionTimeout, watcher, canBeReadOnly) -> mockZookeeper;
+        CuratorZookeeperClient client = new CuratorZookeeperClient(zookeeperFactory, new FixedEnsembleProvider(server.getConnectString()),
+                10000, 10000, null, new RetryOneTime(1), false);
+        client.start();
+        assertEquals(client.getZooKeeper(), mockZookeeper);
+    }
+
+    @Test
+    public void testExpiredSession() throws Exception {
+        final Timing timing = new Timing();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Watcher watcher = event -> {
+            if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                latch.countDown();
+            }
+        };
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                timing.session(), timing.connection(), watcher, new RetryOneTime(2));
+        try (client) {
+            client.start();
+            final AtomicBoolean firstTime = new AtomicBoolean(true);
+            RetryLoop.callWithRetry(client, () -> {
+                        if (firstTime.compareAndSet(true, false)) {
+                            try {
+                                client.getZooKeeper().create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                            } catch (KeeperException.NodeExistsException ignore) {
+                            }
+                            client.getZooKeeper().getTestable().injectSessionExpiration();
+                            assertTrue(timing.awaitLatch(latch));
+                        }
+                        ZooKeeper zooKeeper = client.getZooKeeper();
+                        client.blockUntilConnectedOrTimedOut();
+                        assertNotNull(zooKeeper.exists("/foo", false));
+                        return null;
+                    }
+            );
+        }
+    }
+
+    @Test
+    public void testReconnect() throws Exception {
+        CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                10000, 10000, null, new RetryOneTime(1));
+        try (client) {
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            byte[] writtenData = {1, 2, 3};
+            client.getZooKeeper().create("/test", writtenData, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            Thread.sleep(1000);
+            server.stop();
+            Thread.sleep(1000);
+            server.restart();
+            assertTrue(client.blockUntilConnectedOrTimedOut());
+            byte[] readData = client.getZooKeeper().getData("/test", false, null);
+            assertArrayEquals(readData, writtenData);
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000,
+                10000, null, new RetryOneTime(1));
+        try (client) {
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            String path = client.getZooKeeper().create("/test", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertEquals(path, "/test");
+        }
+    }
+
+    @Test
+    public void testBackgroundConnect() throws Exception {
+        final int connectionTimeoutMs = 4000;
+        try (CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000,
+                connectionTimeoutMs, null, new RetryOneTime(1))) {
+            assertFalse(client.isConnected());
+            client.start();
+            Awaitility.await()
+                    .atMost(Duration.ofMillis(connectionTimeoutMs))
+                    .untilAsserted(() -> Assertions.assertTrue(client.isConnected()));
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestIs37.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestIs37.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestIs37 extends CuratorTestBase {
+    @Test
+    @Tag(zk37Group)
+    public void testIsZk37() throws Exception {
+        assertNotNull(Class.forName("org.apache.zookeeper.proto.WhoAmIResponse"));
+    }
+
+    @Override
+    protected void createServer() {
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestRetryLoop.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestRetryLoop.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.RetryLoop;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.RetrySleeper;
+import org.apache.curator.SessionFailedRetryPolicy;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TestRetryLoop extends BaseClassForTests {
+    @Test
+    public void testExponentialBackoffRetryLimit() {
+        RetrySleeper sleeper = (time, unit) -> assertTrue(unit.toMillis(time) <= 100);
+        ExponentialBackoffRetry retry = new ExponentialBackoffRetry(1, Integer.MAX_VALUE, 100);
+        IntStream.iterate(0, i -> i >= 0, i -> i + 1).forEach(i -> retry.allowRetry(i, 0, sleeper));
+    }
+
+    @Test
+    public void testRetryLoopWithFailure() throws Exception {
+        CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 5000, 5000,
+                null, new RetryOneTime(1));
+        try (client) {
+            client.start();
+            int loopCount = 0;
+            RetryLoop retryLoop = client.newRetryLoop();
+            outer:
+            while (retryLoop.shouldContinue()) {
+                ++loopCount;
+                switch (loopCount) {
+                    case 1 -> server.stop();
+                    case 2 -> server.restart();
+                    case 3, 4 -> {
+                    }
+                    default -> {
+                        fail();
+                        break outer;
+                    }
+                }
+                try {
+                    client.blockUntilConnectedOrTimedOut();
+                    client.getZooKeeper().create("/test", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    retryLoop.markComplete();
+                } catch (Exception e) {
+                    retryLoop.takeException(e);
+                }
+            }
+            assertThat(loopCount).isGreaterThanOrEqualTo(2);
+        }
+    }
+
+    @Test
+    public void testRetryLoop() throws Exception {
+        CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
+        try (client) {
+            client.start();
+            int loopCount = 0;
+            RetryLoop retryLoop = client.newRetryLoop();
+            while (retryLoop.shouldContinue()) {
+                if (++loopCount > 2) {
+                    fail();
+                    break;
+                }
+                try {
+                    client.getZooKeeper().create("/test", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    retryLoop.markComplete();
+                } catch (Exception e) {
+                    retryLoop.takeException(e);
+                }
+            }
+            assertTrue(loopCount > 0);
+        }
+    }
+
+    @Test
+    public void testRetryForever() throws Exception {
+        int retryIntervalMs = 1;
+        RetrySleeper sleeper = mock(RetrySleeper.class);
+        RetryForever retryForever = new RetryForever(retryIntervalMs);
+        for (int i = 0; i < 10; i++) {
+            boolean allowed = retryForever.allowRetry(i, 0, sleeper);
+            assertTrue(allowed);
+            verify(sleeper, times(i + 1)).sleepFor(retryIntervalMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Test
+    public void testRetryForeverWithSessionFailed() throws Exception {
+        final Timing timing = new Timing();
+        final RetryPolicy retryPolicy = new SessionFailedRetryPolicy(new RetryForever(1000));
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                timing.session(), timing.connection(), null, retryPolicy);
+        try (client) {
+            client.start();
+            int loopCount = 0;
+            final RetryLoop retryLoop = client.newRetryLoop();
+            while (retryLoop.shouldContinue()) {
+                if (++loopCount > 1) {
+                    break;
+                }
+                try {
+                    client.getZooKeeper().getTestable().injectSessionExpiration();
+                    client.getZooKeeper().create("/test", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    retryLoop.markComplete();
+                } catch (Exception e) {
+                    retryLoop.takeException(e);
+                }
+            }
+            fail("Should failed with SessionExpiredException.");
+        } catch (Exception e) {
+            if (e instanceof KeeperException) {
+                int rc = ((KeeperException) e).code().intValue();
+                assertEquals(rc, KeeperException.Code.SESSIONEXPIRED.intValue());
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestSessionFailRetryLoop.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/TestSessionFailRetryLoop.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.RetryLoop;
+import org.apache.curator.SessionFailRetryLoop;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestSessionFailRetryLoop extends BaseClassForTests {
+    @Test
+    public void testRetry() throws Exception {
+        Timing timing = new Timing();
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                timing.session(), timing.connection(), null, new ExponentialBackoffRetry(100, 3));
+        SessionFailRetryLoop retryLoop = client.newSessionFailRetryLoop(SessionFailRetryLoop.Mode.RETRY);
+        try (retryLoop) {
+            retryLoop.start();
+            client.start();
+            final AtomicBoolean secondWasDone = new AtomicBoolean(false);
+            final AtomicBoolean firstTime = new AtomicBoolean(true);
+            while (retryLoop.shouldContinue()) {
+                try {
+                    RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                                if (firstTime.compareAndSet(true, false)) {
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    client.getZooKeeper().getTestable().injectSessionExpiration();
+                                    client.getZooKeeper();
+                                    client.blockUntilConnectedOrTimedOut();
+                                }
+                                assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                return null;
+                            }
+                    );
+                    RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                                assertFalse(firstTime.get());
+                                assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                secondWasDone.set(true);
+                                return null;
+                            }
+                    );
+                } catch (Exception e) {
+                    retryLoop.takeException(e);
+                }
+            }
+            assertTrue(secondWasDone.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRetryStatic() throws Exception {
+        Timing timing = new Timing();
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), timing.session(), timing.connection(), null, new ExponentialBackoffRetry(100, 3));
+        SessionFailRetryLoop retryLoop = client.newSessionFailRetryLoop(SessionFailRetryLoop.Mode.RETRY);
+        try (retryLoop) {
+            retryLoop.start();
+            client.start();
+            final AtomicBoolean secondWasDone = new AtomicBoolean(false);
+            final AtomicBoolean firstTime = new AtomicBoolean(true);
+            SessionFailRetryLoop.callWithRetry(client, SessionFailRetryLoop.Mode.RETRY, () -> {
+                        RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                                    if (firstTime.compareAndSet(true, false)) {
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        client.getZooKeeper().getTestable().injectSessionExpiration();
+                                        client.getZooKeeper();
+                                        client.blockUntilConnectedOrTimedOut();
+                                    }
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    return null;
+                                }
+                        );
+                        RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                            assertFalse(firstTime.get());
+                            assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                            secondWasDone.set(true);
+                            return null;
+                        });
+                        return null;
+                    }
+            );
+            assertTrue(secondWasDone.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        final Timing timing = new Timing();
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                timing.session(), timing.connection(), null, new ExponentialBackoffRetry(100, 3));
+        SessionFailRetryLoop retryLoop = client.newSessionFailRetryLoop(SessionFailRetryLoop.Mode.FAIL);
+        try (retryLoop) {
+            retryLoop.start();
+            client.start();
+            try {
+                while (retryLoop.shouldContinue()) {
+                    try {
+                        RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                            assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                            client.getZooKeeper().getTestable().injectSessionExpiration();
+                            timing.sleepABit();
+                            client.getZooKeeper();
+                            client.blockUntilConnectedOrTimedOut();
+                            assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                            return null;
+                        });
+                    } catch (Exception e) {
+                        retryLoop.takeException(e);
+                    }
+                }
+                fail();
+            } catch (SessionFailRetryLoop.SessionFailedException ignored) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasicStatic() throws Exception {
+        Timing timing = new Timing();
+        final CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(),
+                timing.session(), timing.connection(), null, new ExponentialBackoffRetry(100, 3));
+        SessionFailRetryLoop retryLoop = client.newSessionFailRetryLoop(SessionFailRetryLoop.Mode.FAIL);
+        try (retryLoop) {
+            retryLoop.start();
+            client.start();
+            try {
+                SessionFailRetryLoop.callWithRetry(client, SessionFailRetryLoop.Mode.FAIL, () -> {
+                            RetryLoop.callWithRetry(client, (Callable<Void>) () -> {
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        client.getZooKeeper().getTestable().injectSessionExpiration();
+                                        client.getZooKeeper();
+                                        client.blockUntilConnectedOrTimedOut();
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        return null;
+                                    }
+                            );
+                            return null;
+                        }
+                );
+            } catch (SessionFailRetryLoop.SessionFailedException ignored) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/utils/TestCloseableScheduledExecutorService.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/utils/TestCloseableScheduledExecutorService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client.utils;
+
+import org.apache.curator.utils.CloseableScheduledExecutorService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("resource")
+public class TestCloseableScheduledExecutorService {
+    private static final int QTY = 10;
+    private static final int DELAY_MS = 100;
+
+    private volatile ScheduledExecutorService executorService;
+
+    @BeforeEach
+    public void setup() {
+        executorService = Executors.newScheduledThreadPool(QTY * 2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void testCloseableScheduleWithFixedDelay() throws InterruptedException {
+        CloseableScheduledExecutorService service = new CloseableScheduledExecutorService(executorService);
+        final CountDownLatch latch = new CountDownLatch(QTY);
+        service.scheduleWithFixedDelay(latch::countDown, DELAY_MS, DELAY_MS, TimeUnit.MILLISECONDS);
+        assertTrue(latch.await((QTY * 2) * DELAY_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testCloseableScheduleWithFixedDelayAndAdditionalTasks() throws InterruptedException {
+        final AtomicInteger outerCounter = new AtomicInteger(0);
+        Runnable command = outerCounter::incrementAndGet;
+        executorService.scheduleWithFixedDelay(command, DELAY_MS, DELAY_MS, TimeUnit.MILLISECONDS);
+        CloseableScheduledExecutorService service = new CloseableScheduledExecutorService(executorService);
+        final AtomicInteger innerCounter = new AtomicInteger(0);
+        service.scheduleWithFixedDelay(innerCounter::incrementAndGet, DELAY_MS, DELAY_MS, TimeUnit.MILLISECONDS);
+        Thread.sleep(DELAY_MS * 4);
+        service.close();
+        Thread.sleep(DELAY_MS * 2);
+        int innerValue = innerCounter.get();
+        assertTrue(innerValue > 0);
+        int value = outerCounter.get();
+        Thread.sleep(DELAY_MS * 2);
+        int newValue = outerCounter.get();
+        assertTrue(newValue > value);
+        assertEquals(innerValue, innerCounter.get());
+        value = newValue;
+        Thread.sleep(DELAY_MS * 2);
+        newValue = outerCounter.get();
+        assertTrue(newValue > value);
+        assertEquals(innerValue, innerCounter.get());
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/utils/TestZKPaths.java
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/java/org_apache_curator/curator_client/utils/TestZKPaths.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client.utils;
+
+import org.apache.curator.utils.ZKPaths;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestZKPaths {
+    @Test
+    public void testMakePath() {
+        assertEquals(ZKPaths.makePath(null, "/"), "/");
+        assertEquals(ZKPaths.makePath("", null), "/");
+        assertEquals(ZKPaths.makePath("/", null), "/");
+        assertEquals(ZKPaths.makePath(null, null), "/");
+        assertEquals(ZKPaths.makePath("/", "/"), "/");
+        assertEquals(ZKPaths.makePath("", "/"), "/");
+        assertEquals(ZKPaths.makePath("/", ""), "/");
+        assertEquals(ZKPaths.makePath("", ""), "/");
+        assertEquals(ZKPaths.makePath("foo", ""), "/foo");
+        assertEquals(ZKPaths.makePath("foo", "/"), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", ""), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", "/"), "/foo");
+        assertEquals(ZKPaths.makePath("foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("", "bar"), "/bar");
+        assertEquals(ZKPaths.makePath("/", "bar"), "/bar");
+        assertEquals(ZKPaths.makePath("", "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath("/", "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath("foo", "bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", "/bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "/bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "bar/"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo/", "/bar/"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", "bar", "baz"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("foo", "bar", "baz", "qux"), "/foo/bar/baz/qux");
+        assertEquals(ZKPaths.makePath("/foo", "/bar", "/baz"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("/foo/", "/bar/", "/baz/"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("foo", null, ""), "/foo");
+        assertEquals(ZKPaths.makePath("foo", "bar", ""), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", null, "baz"), "/foo/baz");
+    }
+
+    @Test
+    public void testSplit() {
+        assertEquals(ZKPaths.split("/"), Collections.emptyList());
+        assertEquals(ZKPaths.split("/test"), Collections.singletonList("test"));
+        assertEquals(ZKPaths.split("/test/one"), Arrays.asList("test", "one"));
+        assertEquals(ZKPaths.split("/test/one/two"), Arrays.asList("test", "one", "two"));
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/curator-client-test-metadata/proxy-config.json
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/curator-client-test-metadata/proxy-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.mockito.internal.creation.proxy.ProxyMockMaker"
+    },
+    "interfaces": [
+      "org.apache.curator.RetrySleeper"
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/jni-config.json
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/jni-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.Arrays",
+    "methods": [
+      {
+        "name": "asList",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/reflect-config.json
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/reflect-config.json
@@ -1,0 +1,385 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Boolean",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Byte",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Character",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Deprecated",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Double",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Float",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Integer",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Long",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Short",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.StackTraceElement",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.String"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ClientCnxn$SendThread"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ClientCnxnSocketNIO"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.persistence.FileTxnLog$FileTxnIterator"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.math.BigDecimal"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.math.BigInteger"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.Date"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.PropertyPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.logging.LogManager",
+    "methods": [
+      {
+        "name": "getLoggingMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.logging.LoggingMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ZooKeeper"
+    },
+    "name": "org.apache.zookeeper.ClientCnxnSocketNIO",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.zookeeper.client.ZKClientConfig"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"
+    },
+    "name": "org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.quorum.QuorumPeerConfig"
+    },
+    "name": "org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.ConnectionBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.ConnectionMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.DataTreeBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.DataTreeMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.NIOServerCnxnFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.ZooKeeperServerBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.ZooKeeperServerMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.watch.WatchManagerFactory"
+    },
+    "name": "org.apache.zookeeper.server.watch.WatchManager",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "sun.security.provider.ConfigFile",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.auth.DigestAuthenticationProvider"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+org.mockito.internal.creation.proxy.ProxyMockMaker

--- a/tests/src/org.apache.curator/curator-client/5.4.0/user-code-filter.json
+++ b/tests/src/org.apache.curator/curator-client/5.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.curator.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/.gitignore
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/build.gradle
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/build.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.curator:curator-framework:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.apache.curator:curator-test:$libraryVersion"
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.apache.zookeeper:zookeeper:3.8.1'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--initialize-at-build-time=org.junit.platform.engine.TestTag')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.apache.curator/curator-framework")
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/gradle.properties
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.4.0
+metadata.dir = org.apache.curator/curator-framework/5.4.0/

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/settings.gradle
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.curator.curator-framework_tests'

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.WatchersDebug;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
+
+import java.util.concurrent.Callable;
+
+@SuppressWarnings("ConstantValue")
+public final class TestCleanState {
+    private static final boolean IS_ENABLED = Boolean.getBoolean("PROPERTY_VALIDATE_NO_REMAINING_WATCHERS");
+
+    public static void closeAndTestClean(CuratorFramework client) {
+        if ((client == null) || !IS_ENABLED) {
+            return;
+        }
+        try {
+            Timing2 timing = new Timing2();
+            CuratorFrameworkImpl internalClient = (CuratorFrameworkImpl) client;
+            EnsembleTracker ensembleTracker = internalClient.getEnsembleTracker();
+            if (ensembleTracker != null) {
+                Awaitility.await()
+                        .until(() -> !ensembleTracker.hasOutstanding());
+                ensembleTracker.close();
+            }
+            ZooKeeper zooKeeper = internalClient.getZooKeeper();
+            if (zooKeeper != null) {
+                final int maxLoops = 3;
+                for (int i = 0; i < maxLoops; ++i) {
+                    if (i > 0) {
+                        timing.multiple(.5).sleepABit();
+                    }
+                    boolean isLast = (i + 1) == maxLoops;
+                    if (WatchersDebug.getChildWatches(zooKeeper).size() != 0) {
+                        if (isLast) {
+                            throw new AssertionError("One or more child watchers are still registered: " + WatchersDebug.getChildWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    if (WatchersDebug.getExistWatches(zooKeeper).size() != 0) {
+                        if (isLast) {
+                            throw new AssertionError("One or more exists watchers are still registered: " + WatchersDebug.getExistWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    if (WatchersDebug.getDataWatches(zooKeeper).size() != 0) {
+                        if (isLast) {
+                            throw new AssertionError("One or more data watchers are still registered: " + WatchersDebug.getDataWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    break;
+                }
+            }
+        } catch (IllegalStateException ignore) {
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    public static void test(CuratorFramework client, Callable<Void> proc) throws Exception {
+        boolean succeeded = false;
+        try {
+            proc.call();
+            succeeded = true;
+        } finally {
+            if (succeeded) {
+                closeAndTestClean(client);
+            } else {
+                CloseableUtils.closeQuietly(client);
+            }
+        }
+    }
+
+    private TestCleanState() {
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CreateBuilderMain;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"FieldMayBeFinal", "deprecation", "unused", "OptionalGetWithoutIsPresent"})
+public class TestCreate extends BaseClassForTests {
+    private static final List<ACL> READ_CREATE = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+    private static final List<ACL> READ_CREATE_WRITE = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ | ZooDefs.Perms.WRITE, ANYONE_ID_UNSAFE));
+
+    private static ACLProvider testACLProvider = new ACLProvider() {
+        @Override
+        public List<ACL> getDefaultAcl() {
+            return ZooDefs.Ids.OPEN_ACL_UNSAFE;
+        }
+
+        @Override
+        public List<ACL> getAclForPath(String path) {
+            return switch (path) {
+                case "/bar" -> READ_CREATE;
+                case "/bar/foo" -> READ_CREATE_WRITE;
+                default -> null;
+            };
+        }
+    };
+
+    private CuratorFramework createClient(ACLProvider aclProvider) {
+        return CuratorFrameworkFactory.builder().
+                aclProvider(aclProvider).
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+    }
+
+    @Test
+    public void testCreateWithParentsWithAcl() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            String path = "/bar/foo";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            client.create().creatingParentsIfNeeded().withACL(acl).forPath(path);
+            List<ACL> actualBarFoo = client.getACL().forPath(path);
+            assertEquals(actualBarFoo, acl);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateWithParentsWithAclApplyToParents() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            String path = "/bar/foo";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            client.create().creatingParentsIfNeeded().withACL(acl, true).forPath(path);
+            List<ACL> actualBarFoo = client.getACL().forPath(path);
+            assertEquals(actualBarFoo, acl);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, acl);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateWithParentsWithAclInBackground() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            String path = "/bar/foo";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            client.create().creatingParentsIfNeeded().withACL(acl).inBackground(callback).forPath(path);
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            List<ACL> actualBarFoo = client.getACL().forPath(path);
+            assertEquals(actualBarFoo, acl);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateWithParentsWithAclApplyToParentsInBackground() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            String path = "/bar/foo";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            client.create().creatingParentsIfNeeded().withACL(acl, true).inBackground(callback).forPath(path);
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            List<ACL> actualBarFoo = client.getACL().forPath(path);
+            assertEquals(actualBarFoo, acl);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, acl);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateWithParentsWithoutAcl() throws Exception {
+        CuratorFramework client = createClient(testACLProvider);
+        try {
+            client.start();
+            String path = "/bar/foo/boo";
+            client.create().creatingParentsIfNeeded().forPath(path);
+            List<ACL> actualBarFooBoo = client.getACL().forPath("/bar/foo/boo");
+            assertEquals(actualBarFooBoo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            List<ACL> actualBarFoo = client.getACL().forPath("/bar/foo");
+            assertEquals(actualBarFoo, READ_CREATE_WRITE);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, READ_CREATE);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateWithParentsWithoutAclInBackground() throws Exception {
+        CuratorFramework client = createClient(testACLProvider);
+        try {
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            final String path = "/bar/foo/boo";
+            client.create().creatingParentsIfNeeded().inBackground(callback).forPath(path);
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            List<ACL> actualBarFooBoo = client.getACL().forPath(path);
+            assertEquals(actualBarFooBoo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            List<ACL> actualBarFoo = client.getACL().forPath("/bar/foo");
+            assertEquals(actualBarFoo, READ_CREATE_WRITE);
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, READ_CREATE);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private void check(CuratorFramework client, CreateBuilderMain builder, String path, byte[] data, boolean expectedSuccess) throws Exception {
+        int expectedCode = (expectedSuccess) ? KeeperException.Code.OK.intValue() : KeeperException.Code.NODEEXISTS.intValue();
+        try {
+            builder.forPath(path, data);
+            assertEquals(expectedCode, KeeperException.Code.OK.intValue());
+            Stat stat = new Stat();
+            byte[] actualData = client.getData().storingStatIn(stat).forPath(path);
+            assertTrue(IdempotentUtils.matches(0, data, stat.getVersion(), actualData));
+        } catch (KeeperException e) {
+            assertEquals(expectedCode, e.getCode());
+        }
+    }
+
+    private void checkBackground(CuratorFramework client, CreateBuilderMain builder, String path, byte[] data, boolean expectedSuccess) throws Exception {
+        int expectedCode = (expectedSuccess) ? KeeperException.Code.OK.intValue() : KeeperException.Code.NODEEXISTS.intValue();
+        AtomicInteger actualCode = new AtomicInteger(-1);
+        CountDownLatch latch = new CountDownLatch(1);
+        BackgroundCallback callback = (client1, event) -> {
+            actualCode.set(event.getResultCode());
+            latch.countDown();
+        };
+        builder.inBackground(callback).forPath(path, data);
+        assertTrue(latch.await(5000, TimeUnit.MILLISECONDS), "Callback not invoked");
+        assertEquals(expectedCode, actualCode.get());
+        if (expectedCode == KeeperException.Code.OK.intValue()) {
+            Stat stat = new Stat();
+            byte[] actualData = client.getData().storingStatIn(stat).forPath(path);
+            assertTrue(IdempotentUtils.matches(0, data, stat.getVersion(), actualData));
+        }
+    }
+
+    private CreateBuilderMain clBefore(CreateBuilderMain builder) {
+        ((CreateBuilderImpl) builder).failBeforeNextCreateForTesting = true;
+        return builder;
+    }
+
+    private CreateBuilderMain clAfter(CreateBuilderMain builder) {
+        ((CreateBuilderImpl) builder).failNextCreateForTesting = true;
+        return builder;
+    }
+
+    private CreateBuilderMain clCheck(CreateBuilderMain builder) {
+        ((CreateBuilderImpl) builder).failNextIdempotentCheckForTesting = true;
+        return builder;
+    }
+
+    @Test
+    public void testBackgroundFaultInjectionHang() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            Stat stat = new Stat();
+            String path = "/create";
+            byte[] data = new byte[]{1, 2};
+            CreateBuilderMain create = client.create();
+            check(client, create, path, data, true);
+            checkBackground(client, clAfter(client.create()), path, data, false);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testIdempotentCreate() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            Stat stat = new Stat();
+            String path = "/idpcreate";
+            String pathBack = "/idpcreateback";
+            byte[] data1 = new byte[]{1, 2, 3};
+            byte[] data2 = new byte[]{4, 5, 6};
+            check(client, client.create().idempotent(), path, data1, true);
+            checkBackground(client, client.create().idempotent(), pathBack, data1, true);
+            check(client, client.create().idempotent(), path, data1, true);
+            checkBackground(client, client.create().idempotent(), pathBack, data1, true);
+            check(client, client.create().idempotent(), path, data2, false);
+            checkBackground(client, client.create().idempotent(), pathBack, data2, false);
+            client.setData().forPath(path, data2);
+            client.setData().forPath(pathBack, data2);
+            check(client, client.create().idempotent(), path, data1, false);
+            checkBackground(client, client.create().idempotent(), pathBack, data1, false);
+            check(client, client.create().idempotent(), path, data2, false);
+            checkBackground(client, client.create().idempotent(), pathBack, data2, false);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testIdempotentCreateConnectionLoss() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            String path1 = "/idpcreate1";
+            String path2 = "/idpcreate2";
+            String path3 = "/create3";
+            String path4 = "/create4";
+            byte[] data = new byte[]{1, 2, 3};
+            byte[] data2 = new byte[]{1, 2, 3, 4};
+            check(client, clBefore(client.create().idempotent()), path1, data, true);
+            checkBackground(client, clBefore(client.create().idempotent()), path1 + "back", data, true);
+            check(client, clAfter(client.create().idempotent()), path2, data, true);
+            checkBackground(client, clAfter(client.create().idempotent()), path2 + "back", data, true);
+            check(client, clBefore(client.create().idempotent()), path1, data, true);
+            checkBackground(client, clBefore(client.create().idempotent()), path1 + "back", data, true);
+            check(client, clAfter(client.create().idempotent()), path2, data, true);
+            checkBackground(client, clAfter(client.create().idempotent()), path2 + "back", data, true);
+            check(client, clCheck(client.create().idempotent()), path2, data, true);
+            checkBackground(client, clCheck(client.create().idempotent()), path2 + "back", data, true);
+            check(client, clBefore(client.create().idempotent()), path1, data2, false);
+            checkBackground(client, clBefore(client.create().idempotent()), path1 + "back", data2, false);
+            check(client, clAfter(client.create().idempotent()), path2, data2, false);
+            checkBackground(client, clAfter(client.create().idempotent()), path2 + "back", data2, false);
+            check(client, clCheck(client.create().idempotent()), path2, data2, false);
+            checkBackground(client, clCheck(client.create().idempotent()), path2 + "back", data2, false);
+            check(client, clBefore(client.create()), path3, data, true);
+            checkBackground(client, clBefore(client.create()), path3 + "back", data, true);
+            check(client, clAfter(client.create()), path4, data, false);
+            checkBackground(client, clAfter(client.create()), path4 + "back", data, false);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateProtectedUtils() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build()) {
+            client.start();
+            client.blockUntilConnected();
+            client.create().forPath("/parent");
+            assertEquals(client.getChildren().forPath("/parent").size(), 0);
+            client.create().withProtection().withMode(CreateMode.EPHEMERAL).forPath("/parent/test");
+            final List<String> children = client.getChildren().forPath("/parent");
+            assertEquals(1, children.size());
+            final String testZNodeName = children.get(0);
+            assertEquals(testZNodeName.length(), ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH + "test".length());
+            assertTrue(testZNodeName.startsWith(ProtectedUtils.PROTECTED_PREFIX));
+            assertEquals(testZNodeName.charAt(ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH - 1), ProtectedUtils.PROTECTED_SEPARATOR);
+            assertTrue(ProtectedUtils.isProtectedZNode(testZNodeName));
+            assertEquals(ProtectedUtils.normalize(testZNodeName), "test");
+            assertFalse(ProtectedUtils.isProtectedZNode("parent"));
+            assertEquals(ProtectedUtils.normalize("parent"), "parent");
+        }
+    }
+
+    @Test
+    public void testProtectedUtils() {
+        String name = "_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
+        assertTrue(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), "yo");
+        assertEquals(ProtectedUtils.extractProtectedId(name).get(), "53345f98-9423-4e0c-a7b5-9f819e3ec2e1");
+        name = "c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        name = "_c_53345f98-hola-4e0c-a7b5-9f819e3ec2e1-yo";
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        name = "_c_53345f98-hola-4e0c-a7b5-9f819e3ec2e1+yo";
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        name = "_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
+        assertEquals(name, ProtectedUtils.toProtectedZNode("yo", "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"));
+        assertEquals("yo", ProtectedUtils.toProtectedZNode("yo", null));
+        String path = ZKPaths.makePath("hola", "yo");
+        assertEquals(ProtectedUtils.toProtectedZNodePath(path, "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"), ZKPaths.makePath("hola", name));
+        assertEquals(ProtectedUtils.toProtectedZNodePath(path, null), path);
+        path = ZKPaths.makePath("hola", name);
+        assertEquals(ProtectedUtils.normalizePath(path), "/hola/yo");
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestDelete.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestDelete.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.BackgroundPathable;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.DeleteBuilderMain;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.zookeeper.KeeperException.Code.BADVERSION;
+import static org.apache.zookeeper.KeeperException.Code.NONODE;
+import static org.apache.zookeeper.KeeperException.Code.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"deprecation", "FieldMayBeFinal"})
+public class TestDelete extends BaseClassForTests {
+
+    private static byte[] createData = new byte[]{5, 6, 7, 8};
+
+    private CuratorFramework createClient() {
+        return CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/test";
+            check(client, client.delete(), path, NONODE.intValue());
+            client.create().forPath(path, createData);
+            check(client, client.delete(), path, OK.intValue());
+            client.create().forPath(path, createData);
+            check(client, client.delete().withVersion(1), path, BADVERSION.intValue());
+            check(client, client.delete().withVersion(0), path, OK.intValue());
+            client.create().forPath(path, createData);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackground() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/test";
+            checkBackground(client, client.delete(), path, NONODE.intValue());
+            client.create().forPath(path, createData);
+            checkBackground(client, client.delete(), path, OK.intValue());
+            client.create().forPath(path, createData);
+            checkBackground(client, client.delete().withVersion(1), path, BADVERSION.intValue());
+            checkBackground(client, client.delete().withVersion(0), path, OK.intValue());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private void checkBackground(CuratorFramework client, BackgroundPathable<Void> builder, String path, int expectedCode) throws Exception {
+        AtomicInteger actualCode = new AtomicInteger(-1);
+        CountDownLatch latch = new CountDownLatch(1);
+        BackgroundCallback callback = (client1, event) -> {
+            actualCode.set(event.getResultCode());
+            latch.countDown();
+        };
+        builder.inBackground(callback).forPath(path);
+        assertTrue(latch.await(5000, TimeUnit.MILLISECONDS), "Callback not invoked");
+        assertEquals(expectedCode, actualCode.get());
+        if (expectedCode == OK.intValue()) {
+            assertNull(client.checkExists().forPath(path));
+        }
+    }
+
+    private void check(CuratorFramework client, BackgroundPathable<Void> builder, String path, int expectedCode) throws Exception {
+        try {
+            builder.forPath(path);
+            assertEquals(expectedCode, OK.intValue());
+            assertNull(client.checkExists().forPath(path));
+        } catch (KeeperException e) {
+            assertEquals(expectedCode, e.getCode());
+        }
+    }
+
+    @Test
+    public void testIdempotentDelete() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/idpset";
+            String pathBack = "/idpsetback";
+            check(client, client.delete().idempotent().withVersion(0), path, OK.intValue());
+            checkBackground(client, client.delete().idempotent().withVersion(0), pathBack, OK.intValue());
+            check(client, client.delete().idempotent(), path, OK.intValue());
+            checkBackground(client, client.delete().idempotent(), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, client.delete().idempotent(), path, OK.intValue());
+            checkBackground(client, client.delete().idempotent(), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, client.delete().idempotent().withVersion(0), path, OK.intValue());
+            checkBackground(client, client.delete().idempotent().withVersion(0), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.setData().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            client.setData().forPath(pathBack, createData);
+            check(client, client.delete().idempotent().withVersion(0), path, BADVERSION.intValue());
+            checkBackground(client, client.delete().idempotent().withVersion(0), pathBack, BADVERSION.intValue());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private DeleteBuilderMain clBefore(DeleteBuilderMain builder) {
+        ((DeleteBuilderImpl) builder).failBeforeNextDeleteForTesting = true;
+        return builder;
+    }
+
+    private DeleteBuilderMain clAfter(DeleteBuilderMain builder) {
+        ((DeleteBuilderImpl) builder).failNextDeleteForTesting = true;
+        return builder;
+    }
+
+    @Test
+    public void testIdempotentDeleteConnectionLoss() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/delete";
+            String pathBack = "/deleteBack";
+            String pathNormal = "/deleteNormal";
+            String pathNormalBack = "/deleteNormalBack";
+            check(client, clBefore(client.delete().idempotent()).withVersion(0), path, OK.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()).withVersion(0), pathBack, OK.intValue());
+            check(client, clBefore(client.delete().idempotent()), path, OK.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()), pathBack, OK.intValue());
+            check(client, clAfter(client.delete().idempotent()).withVersion(0), path, OK.intValue());
+            checkBackground(client, clAfter(client.delete().idempotent()).withVersion(0), pathBack, OK.intValue());
+            check(client, clBefore(client.delete().idempotent()), path, OK.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clBefore(client.delete().idempotent()), path, OK.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clBefore(client.delete().idempotent()).withVersion(0), path, OK.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()).withVersion(0), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clAfter(client.delete().idempotent()), path, OK.intValue());
+            checkBackground(client, clAfter(client.delete().idempotent()), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clAfter(client.delete().idempotent()).withVersion(0), path, OK.intValue());
+            checkBackground(client, clAfter(client.delete().idempotent()).withVersion(0), pathBack, OK.intValue());
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clBefore(client.delete().idempotent()).withVersion(2), path, BADVERSION.intValue());
+            checkBackground(client, clBefore(client.delete().idempotent()).withVersion(2), pathBack, BADVERSION.intValue());
+            check(client, clAfter(client.delete().idempotent()).withVersion(2), path, BADVERSION.intValue());
+            checkBackground(client, clAfter(client.delete().idempotent()).withVersion(2), pathBack, BADVERSION.intValue());
+            client.create().forPath(pathNormal, createData);
+            client.create().forPath(pathNormalBack, createData);
+            check(client, clBefore(client.delete()).withVersion(0), pathNormal, OK.intValue());
+            checkBackground(client, clBefore(client.delete()).withVersion(0), pathNormalBack, OK.intValue());
+            client.create().forPath(pathNormal, createData);
+            client.create().forPath(pathNormalBack, createData);
+            check(client, clBefore(client.delete()), pathNormal, OK.intValue());
+            checkBackground(client, clBefore(client.delete()), pathNormalBack, OK.intValue());
+            client.create().forPath(pathNormal, createData);
+            client.create().forPath(pathNormalBack, createData);
+            check(client, clAfter(client.delete()).withVersion(0), pathNormal, NONODE.intValue());
+            checkBackground(client, clAfter(client.delete()).withVersion(0), pathNormalBack, NONODE.intValue());
+            client.create().forPath(pathNormal, createData);
+            client.create().forPath(pathNormalBack, createData);
+            check(client, clAfter(client.delete()), pathNormal, NONODE.intValue());
+            checkBackground(client, clAfter(client.delete()), pathNormalBack, NONODE.intValue());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testQuietDelete() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.delete().quietly().forPath("/foo/bar");
+            final BlockingQueue<Integer> rc = new LinkedBlockingQueue<>();
+            BackgroundCallback backgroundCallback = (client1, event) -> rc.add(event.getResultCode());
+            client.delete().quietly().inBackground(backgroundCallback).forPath("/foo/bar/hey");
+            Integer code = rc.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
+            assertNotNull(code);
+            assertEquals(code.intValue(), OK.intValue());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundDelete() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.getCuratorListenable().addListener((client1, event) -> {
+                        if (event.getType() == CuratorEventType.DELETE) {
+                            assertEquals(event.getPath(), "/head");
+                            ((CountDownLatch) event.getContext()).countDown();
+                        }
+                    }
+            );
+            client.create().forPath("/head");
+            assertNotNull(client.checkExists().forPath("/head"));
+            CountDownLatch latch = new CountDownLatch(1);
+            client.delete().inBackground(latch).forPath("/head");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertNull(client.checkExists().forPath("/head"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundDeleteWithChildren() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.getCuratorListenable().addListener((client1, event) -> {
+                        if (event.getType() == CuratorEventType.DELETE) {
+                            assertEquals(event.getPath(), "/one/two");
+                            ((CountDownLatch) event.getContext()).countDown();
+                        }
+                    }
+            );
+            client.create().creatingParentsIfNeeded().forPath("/one/two/three/four");
+            assertNotNull(client.checkExists().forPath("/one/two/three/four"));
+            CountDownLatch latch = new CountDownLatch(1);
+            client.delete().deletingChildrenIfNeeded().inBackground(latch).forPath("/one/two");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertNull(client.checkExists().forPath("/one/two"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.create().forPath("/head");
+            assertNotNull(client.checkExists().forPath("/head"));
+            client.delete().forPath("/head");
+            assertNull(client.checkExists().forPath("/head"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testDeleteWithChildren() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        client.start();
+        try {
+            client.create().creatingParentsIfNeeded().forPath("/one/two/three/four/five/six", "foo".getBytes());
+            client.delete().deletingChildrenIfNeeded().forPath("/one/two/three/four/five");
+            assertNull(client.checkExists().forPath("/one/two/three/four/five"));
+            client.delete().deletingChildrenIfNeeded().forPath("/one/two");
+            assertNull(client.checkExists().forPath("/one/two"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testDeleteGuaranteedWithChildren() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        client.start();
+        try {
+            client.create().creatingParentsIfNeeded().forPath("/one/two/three/four/five/six", "foo".getBytes());
+            client.delete().guaranteed().deletingChildrenIfNeeded().forPath("/one/two/three/four/five");
+            assertNull(client.checkExists().forPath("/one/two/three/four/five"));
+            client.delete().guaranteed().deletingChildrenIfNeeded().forPath("/one/two");
+            assertNull(client.checkExists().forPath("/one/two"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestFailedDeleteManager extends BaseClassForTests {
+    @Test
+    public void testLostSession() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new ExponentialBackoffRetry(100, 3));
+        try {
+            client.start();
+            client.create().forPath("/test-me");
+            final CountDownLatch latch = new CountDownLatch(1);
+            final Semaphore semaphore = new Semaphore(0);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if ((newState == ConnectionState.LOST) || (newState == ConnectionState.SUSPENDED)) {
+                    semaphore.release();
+                } else if (newState == ConnectionState.RECONNECTED) {
+                    latch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            server.stop();
+            assertTrue(timing.acquireSemaphore(semaphore));
+            try {
+                client.delete().guaranteed().forPath("/test-me");
+                fail();
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException ignored) {
+            }
+            assertTrue(timing.acquireSemaphore(semaphore));
+            timing.sleepABit();
+            server.restart();
+            assertTrue(timing.awaitLatch(latch));
+            timing.sleepABit();
+            assertNull(client.checkExists().forPath("/test-me"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithNamespaceAndLostSession() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString())
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .retryPolicy(new ExponentialBackoffRetry(100, 3))
+                .namespace("aisa")
+                .build();
+        try {
+            client.start();
+            client.create().forPath("/test-me");
+            final CountDownLatch latch = new CountDownLatch(1);
+            final Semaphore semaphore = new Semaphore(0);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if ((newState == ConnectionState.LOST) || (newState == ConnectionState.SUSPENDED)) {
+                    semaphore.release();
+                } else if (newState == ConnectionState.RECONNECTED) {
+                    latch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            server.stop();
+            assertTrue(timing.acquireSemaphore(semaphore));
+            try {
+                client.delete().guaranteed().forPath("/test-me");
+                fail();
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException ignored) {
+            }
+            assertTrue(timing.acquireSemaphore(semaphore));
+            timing.sleepABit();
+            server.restart();
+            assertTrue(timing.awaitLatch(latch));
+            timing.sleepABit();
+            assertNull(client.checkExists().forPath("/test-me"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithNamespaceAndLostSessionAlt() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString())
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .retryPolicy(new ExponentialBackoffRetry(100, 3))
+                .build();
+        try {
+            client.start();
+            CuratorFramework namespaceClient = client.usingNamespace("foo");
+            namespaceClient.create().forPath("/test-me");
+            final CountDownLatch latch = new CountDownLatch(1);
+            final Semaphore semaphore = new Semaphore(0);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if ((newState == ConnectionState.LOST) || (newState == ConnectionState.SUSPENDED)) {
+                    semaphore.release();
+                } else if (newState == ConnectionState.RECONNECTED) {
+                    latch.countDown();
+                }
+            };
+            namespaceClient.getConnectionStateListenable().addListener(listener);
+            server.stop();
+            assertTrue(timing.acquireSemaphore(semaphore));
+            try {
+                namespaceClient.delete().guaranteed().forPath("/test-me");
+                fail();
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException ignored) {
+            }
+            assertTrue(timing.acquireSemaphore(semaphore));
+            timing.sleepABit();
+            server.restart();
+            assertTrue(timing.awaitLatch(latch));
+            timing.sleepABit();
+            assertNull(namespaceClient.checkExists().forPath("/test-me"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        final String path = "/one/two/three";
+        Timing timing = new Timing();
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).connectionTimeoutMs(timing.connection()).sessionTimeoutMs(timing.session());
+        CuratorFrameworkImpl client = new CuratorFrameworkImpl(builder);
+        client.start();
+        try {
+            client.create().creatingParentsIfNeeded().forPath(path);
+            assertNotNull(client.checkExists().forPath(path));
+            server.stop();
+            try {
+                client.delete().forPath(path);
+                fail();
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException ignored) {
+            }
+            server.restart();
+            assertNotNull(client.checkExists().forPath(path));
+            server.stop();
+            try {
+                client.delete().guaranteed().forPath(path);
+                fail();
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException ignored) {
+            }
+            server.restart();
+            final int tries = 5;
+            for (int i = 0; i < tries; ++i) {
+                if (client.checkExists().forPath(path) != null) {
+                    timing.sleepABit();
+                }
+            }
+            assertNull(client.checkExists().forPath(path));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testGuaranteedDeleteOnNonExistentNodeInForeground() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        final AtomicBoolean pathAdded = new AtomicBoolean(false);
+        ((CuratorFrameworkImpl) client).getFailedDeleteManager().debugListener = path -> pathAdded.set(true);
+        try {
+            client.delete().guaranteed().forPath("/nonexistent");
+            fail();
+        } catch (NoNodeException e) {
+            assertFalse(pathAdded.get());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void testGuaranteedDeleteOnNonExistentNodeInBackground() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        final AtomicBoolean pathAdded = new AtomicBoolean(false);
+        ((CuratorFrameworkImpl) client).getFailedDeleteManager().debugListener = path -> pathAdded.set(true);
+        final CountDownLatch backgroundLatch = new CountDownLatch(1);
+        BackgroundCallback background = (client1, event) -> backgroundLatch.countDown();
+        try {
+            client.delete().guaranteed().inBackground(background).forPath("/nonexistent");
+            backgroundLatch.await();
+            assertFalse(pathAdded.get());
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("unused")
+public class TestFrameworkBackground extends BaseClassForTests {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Test
+    public void testErrorListener() throws Exception {
+        final AtomicBoolean aclProviderCalled = new AtomicBoolean(false);
+        ACLProvider badAclProvider = new ACLProvider() {
+            @Override
+            public List<ACL> getDefaultAcl() {
+                if (aclProviderCalled.getAndSet(true)) {
+                    throw new UnsupportedOperationException();
+                } else {
+                    return new ArrayList<>();
+                }
+            }
+
+            @Override
+            public List<ACL> getAclForPath(String path) {
+                if (aclProviderCalled.getAndSet(true)) {
+                    throw new UnsupportedOperationException();
+                } else {
+                    return new ArrayList<>();
+                }
+            }
+        };
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .aclProvider(badAclProvider)
+                .build();
+        try {
+            client.start();
+            final CountDownLatch errorLatch = new CountDownLatch(1);
+            UnhandledErrorListener listener = (message, e) -> {
+                if (e instanceof UnsupportedOperationException) {
+                    errorLatch.countDown();
+                }
+            };
+            client.create().inBackground().withUnhandledErrorListener(listener).forPath("/foo");
+            assertTrue(new Timing().awaitLatch(errorLatch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testListenerConnectedAtStart() throws Exception {
+        server.stop();
+        Timing timing = new Timing(2);
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryNTimes(0, 0));
+        try {
+            client.start();
+            final CountDownLatch connectedLatch = new CountDownLatch(1);
+            final AtomicBoolean firstListenerAction = new AtomicBoolean(true);
+            final AtomicReference<ConnectionState> firstListenerState = new AtomicReference<>();
+            ConnectionStateListener listener = (client1, newState) -> {
+                if (firstListenerAction.compareAndSet(true, false)) {
+                    firstListenerState.set(newState);
+                    System.out.println("First listener state is " + newState);
+                }
+                if (newState == ConnectionState.CONNECTED) {
+                    connectedLatch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            client.create().inBackground().forPath("/foo");
+            server.restart();
+            assertTrue(timing.awaitLatch(connectedLatch));
+            assertFalse(firstListenerAction.get());
+            ConnectionState firstconnectionState = firstListenerState.get();
+            assertEquals(firstconnectionState, ConnectionState.CONNECTED, "First listener state MUST BE CONNECTED but is " + firstconnectionState);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRetries() throws Exception {
+        final int sleep = 1000;
+        final int timesFirst = 5;
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryNTimes(timesFirst, sleep));
+        try {
+            client.start();
+            client.getZookeeperClient().blockUntilConnectedOrTimedOut();
+            final CountDownLatch latch = new CountDownLatch(timesFirst);
+            final List<Long> times = Lists.newArrayList();
+            final AtomicLong start = new AtomicLong(System.currentTimeMillis());
+            ((CuratorFrameworkImpl) client).debugListener = data -> {
+                if (data.getOperation().getClass().getName().contains("CreateBuilderImpl")) {
+                    long now = System.currentTimeMillis();
+                    times.add(now - start.get());
+                    start.set(now);
+                    latch.countDown();
+                }
+            };
+            server.stop();
+            client.create().inBackground().forPath("/one");
+            latch.await();
+            for (long elapsed : times.subList(1, times.size())) {
+                assertTrue(elapsed >= sleep, elapsed + ": " + times);
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            final BlockingQueue<String> paths = Queues.newLinkedBlockingQueue();
+            BackgroundCallback callback = (client1, event) -> paths.add(event.getPath());
+            client.create().inBackground(callback).forPath("/one");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one");
+            client.create().inBackground(callback).forPath("/one/two");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two");
+            client.create().inBackground(callback).forPath("/one/two/three");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two/three");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCuratorCallbackOnError() throws Exception {
+        Timing timing = new Timing();
+        try (CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .retryPolicy(new RetryOneTime(1000)).build()) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            client.start();
+            BackgroundCallback curatorCallback = (client1, event) -> {
+                if (event.getResultCode() == Code.CONNECTIONLOSS.intValue()) {
+                    latch.countDown();
+                }
+            };
+            server.stop();
+            client.getChildren().inBackground(curatorCallback).forPath("/");
+            assertTrue(timing.awaitLatch(latch), "Callback has not been called by curator !");
+        }
+    }
+
+    @Test
+    public void testShutdown() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory
+                .builder()
+                .connectString(server.getConnectString())
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection()).retryPolicy(new RetryOneTime(1))
+                .maxCloseWaitMs(timing.forWaiting().milliseconds())
+                .build();
+        try {
+            final AtomicBoolean hadIllegalStateException = new AtomicBoolean(false);
+            ((CuratorFrameworkImpl) client).debugUnhandledErrorListener = (message, e) -> {
+                if (e instanceof IllegalStateException) {
+                    hadIllegalStateException.set(true);
+                }
+            };
+            client.start();
+            final CountDownLatch operationReadyLatch = new CountDownLatch(1);
+            ((CuratorFrameworkImpl) client).debugListener = data -> {
+                try {
+                    operationReadyLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            };
+            client.create().inBackground().forPath("/hey");
+            timing.sleepABit();
+            client.close();
+            operationReadyLatch.countDown();
+            timing.sleepABit();
+            assertFalse(hadIllegalStateException.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
@@ -1,0 +1,597 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import com.google.common.collect.Queues;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.RetrySleeper;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.ErrorListenerPathAndBytesable;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings({"ResultOfMethodCallIgnored", "DataFlowIssue", "resource"})
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
+public class TestFrameworkEdges extends BaseClassForTests {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final Timing2 timing = new Timing2();
+
+    @BeforeAll
+    public static void setUpClass() {
+        System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    }
+
+    @Test
+    @DisplayName("test case for CURATOR-525")
+    public void testValidateConnectionEventRaces() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 2000, 1000, new RetryOneTime(1))) {
+            CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
+            client.start();
+            client.getChildren().forPath("/");
+            client.create().forPath("/foo");
+            BlockingQueue<ConnectionState> stateQueue = new LinkedBlockingQueue<>();
+            client.getConnectionStateListenable().addListener((__, newState) -> stateQueue.add(newState));
+            server.stop();
+            assertEquals(timing.takeFromQueue(stateQueue), ConnectionState.SUSPENDED);
+            assertEquals(timing.takeFromQueue(stateQueue), ConnectionState.LOST);
+            clientImpl.debugCheckBackgroundRetryReadyLatch = new CountDownLatch(1);
+            clientImpl.debugCheckBackgroundRetryLatch = new CountDownLatch(1);
+            client.delete().guaranteed().inBackground().forPath("/foo");
+            timing.awaitLatch(clientImpl.debugCheckBackgroundRetryReadyLatch);
+            server.restart();
+            assertEquals(timing.takeFromQueue(stateQueue), ConnectionState.RECONNECTED);
+            clientImpl.injectedCode = KeeperException.Code.SESSIONEXPIRED;
+            clientImpl.debugCheckBackgroundRetryLatch.countDown();
+            assertEquals(timing.takeFromQueue(stateQueue), ConnectionState.LOST);
+            assertEquals(timing.takeFromQueue(stateQueue), ConnectionState.RECONNECTED);
+        }
+    }
+
+    @Test
+    public void testInjectSessionExpiration() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            CountDownLatch expiredLatch = new CountDownLatch(1);
+            Watcher watcher = event -> {
+                if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                    expiredLatch.countDown();
+                }
+            };
+            client.checkExists().usingWatcher(watcher).forPath("/foobar");
+            client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
+            assertTrue(timing.awaitLatch(expiredLatch));
+        }
+    }
+
+    @Test
+    public void testProtectionWithKilledSession() throws Exception {
+        server.stop();
+        try (TestingCluster cluster = createAndStartCluster(3)) {
+            InstanceSpec instanceSpec0 = cluster.getServers().get(0).getInstanceSpec();
+            CountDownLatch serverStoppedLatch = new CountDownLatch(1);
+            RetryPolicy retryPolicy = new RetryForever(100) {
+                @Override
+                public boolean allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper) {
+                    if (serverStoppedLatch.getCount() > 0) {
+                        try {
+                            cluster.killServer(instanceSpec0);
+                        } catch (Exception ignored) {
+                        }
+                        serverStoppedLatch.countDown();
+                    }
+                    return super.allowRetry(retryCount, elapsedTimeMs, sleeper);
+                }
+            };
+            try (CuratorFramework client = CuratorFrameworkFactory.newClient(instanceSpec0.getConnectString(), timing.session(), timing.connection(), retryPolicy)) {
+                BlockingQueue<String> createdNode = new LinkedBlockingQueue<>();
+                BackgroundCallback callback = (__, event) -> {
+                    if (event.getType() == CuratorEventType.CREATE) {
+                        createdNode.offer(event.getPath());
+                    }
+                };
+                client.start();
+                client.create().forPath("/test");
+                ErrorListenerPathAndBytesable<String> builder = client.create().withProtection().withMode(CreateMode.EPHEMERAL).inBackground(callback);
+                ((CreateBuilderImpl) builder).failNextCreateForTesting = true;
+                builder.forPath("/test/hey");
+                assertTrue(timing.awaitLatch(serverStoppedLatch));
+                timing.forSessionSleep().sleep();
+                cluster.restartServer(instanceSpec0);
+                String path = timing.takeFromQueue(createdNode);
+                List<String> children = client.getChildren().forPath("/test");
+                assertEquals(Collections.singletonList(ZKPaths.getNodeFromPath(path)), children);
+            }
+        }
+    }
+
+    @Test
+    public void testBackgroundLatencyUnSleep() throws Exception {
+        server.stop();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            ((CuratorFrameworkImpl) client).sleepAndQueueOperationSeconds = Integer.MAX_VALUE;
+            final CountDownLatch latch = new CountDownLatch(3);
+            BackgroundCallback callback = (client1, event) -> {
+                if ((event.getType() == CuratorEventType.CREATE) && (event.getResultCode() == KeeperException.Code.OK.intValue())) {
+                    latch.countDown();
+                }
+            };
+            client.create().inBackground(callback).forPath("/test");
+            client.create().inBackground(callback).forPath("/test/one");
+            client.create().inBackground(callback).forPath("/test/two");
+            server.restart();
+            assertTrue(timing.awaitLatch(latch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateContainersForBadConnect() throws Exception {
+        final int serverPort = server.getPort();
+        server.close();
+
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 1000, 1000, new RetryNTimes(10, timing.forSleepingABit().milliseconds()));
+        try {
+            new Thread(() -> {
+                try {
+                    Thread.sleep(3000);
+                    server = new TestingServer(serverPort, true);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }).start();
+            client.start();
+            client.createContainers("/this/does/not/exist");
+            assertNotNull(client.checkExists().forPath("/this/does/not/exist"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testQuickClose() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryNTimes(0, 0));
+        try {
+            client.start();
+            client.close();
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testProtectedCreateNodeDeletion() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryNTimes(0, 0));
+        try {
+            client.start();
+            for (int i = 0; i < 2; ++i) {
+                CuratorFramework localClient = (i == 0) ? client : client.usingNamespace("nm");
+                localClient.create().forPath("/parent");
+                assertEquals(localClient.getChildren().forPath("/parent").size(), 0);
+                CreateBuilderImpl createBuilder = (CreateBuilderImpl) localClient.create();
+                createBuilder.failNextCreateForTesting = true;
+                FindAndDeleteProtectedNodeInBackground.debugInsertError.set(true);
+                try {
+                    createBuilder.withProtection().forPath("/parent/test");
+                    fail("failNextCreateForTesting should have caused a ConnectionLossException");
+                } catch (KeeperException.ConnectionLossException ignored) {
+                }
+                timing.sleepABit();
+                List<String> children = localClient.getChildren().forPath("/parent");
+                assertEquals(children.size(), 0, children.toString());
+                localClient.delete().forPath("/parent");
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testPathsFromProtectingInBackground() throws Exception {
+        for (CreateMode mode : CreateMode.values()) {
+            internalTestPathsFromProtectingInBackground(mode);
+        }
+    }
+
+    private void internalTestPathsFromProtectingInBackground(CreateMode mode) throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().creatingParentsIfNeeded().forPath("/a/b/c");
+            final BlockingQueue<String> paths = new ArrayBlockingQueue<>(2);
+            BackgroundCallback callback = (client1, event) -> {
+                paths.put(event.getName());
+                paths.put(event.getPath());
+            };
+            final String testPath = "/a/b/c/test-";
+            long ttl = timing.forWaiting().milliseconds() * 1000L;
+            CreateBuilder firstCreateBuilder = client.create();
+            if (mode.isTTL()) {
+                firstCreateBuilder.withTtl(ttl);
+            }
+            firstCreateBuilder.withMode(mode).inBackground(callback).forPath(testPath);
+            String name1 = timing.takeFromQueue(paths);
+            String path1 = timing.takeFromQueue(paths);
+            client.close();
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryOneTime(1));
+            client.start();
+            CreateBuilderImpl createBuilder = (CreateBuilderImpl) client.create();
+            createBuilder.withProtection();
+            if (mode.isTTL()) {
+                createBuilder.withTtl(ttl);
+            }
+            client.create().forPath(createBuilder.adjustPath(testPath));
+            createBuilder.debugForceFindProtectedNode = true;
+            createBuilder.withMode(mode).inBackground(callback).forPath(testPath);
+            String name2 = timing.takeFromQueue(paths);
+            String path2 = timing.takeFromQueue(paths);
+            assertEquals(ZKPaths.getPathAndNode(name1).getPath(), ZKPaths.getPathAndNode(testPath).getPath());
+            assertEquals(ZKPaths.getPathAndNode(name2).getPath(), ZKPaths.getPathAndNode(testPath).getPath());
+            assertEquals(ZKPaths.getPathAndNode(path1).getPath(), ZKPaths.getPathAndNode(testPath).getPath());
+            assertEquals(ZKPaths.getPathAndNode(path2).getPath(), ZKPaths.getPathAndNode(testPath).getPath());
+            client.delete().deletingChildrenIfNeeded().forPath("/a/b/c");
+            client.delete().forPath("/a/b");
+            client.delete().forPath("/a");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void connectionLossWithBackgroundTest() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryOneTime(1));
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            client.start();
+            client.getZookeeperClient().blockUntilConnectedOrTimedOut();
+            server.close();
+            client.getChildren().inBackground((client1, event) -> latch.countDown()).forPath("/");
+            assertTrue(timing.awaitLatch(latch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testReconnectAfterLoss() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            final CountDownLatch lostLatch = new CountDownLatch(1);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if (newState == ConnectionState.LOST) {
+                    lostLatch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            client.checkExists().forPath("/");
+            server.stop();
+            assertTrue(timing.awaitLatch(lostLatch));
+            try {
+                client.checkExists().forPath("/");
+                fail();
+            } catch (KeeperException.ConnectionLossException ignored) {
+            }
+            server.restart();
+            client.checkExists().forPath("/");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testGetAclNoStat() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            try {
+                client.getACL().forPath("/");
+            } catch (NullPointerException e) {
+                fail();
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testMissedResponseOnBackgroundESCreate() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            CreateBuilderImpl createBuilder = (CreateBuilderImpl) client.create();
+            createBuilder.failNextCreateForTesting = true;
+
+            final BlockingQueue<String> queue = Queues.newArrayBlockingQueue(1);
+            BackgroundCallback callback = (client1, event) -> queue.put(event.getPath());
+            createBuilder.withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).inBackground(callback).forPath("/");
+            String ourPath = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertTrue(ourPath.startsWith(ZKPaths.makePath("/", ProtectedUtils.PROTECTED_PREFIX)));
+            assertFalse(createBuilder.failNextCreateForTesting);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testMissedResponseOnESCreate() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            CreateBuilderImpl createBuilder = (CreateBuilderImpl) client.create();
+            createBuilder.failNextCreateForTesting = true;
+            String ourPath = createBuilder.withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/");
+            assertTrue(ourPath.startsWith(ZKPaths.makePath("/", ProtectedUtils.PROTECTED_PREFIX)));
+            assertFalse(createBuilder.failNextCreateForTesting);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSessionKilled() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.create().forPath("/sessionTest");
+            CountDownLatch sessionDiedLatch = new CountDownLatch(1);
+            Watcher watcher = event -> {
+                if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                    sessionDiedLatch.countDown();
+                }
+            };
+            client.checkExists().usingWatcher(watcher).forPath("/sessionTest");
+            client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
+            assertTrue(timing.awaitLatch(sessionDiedLatch));
+            assertNotNull(client.checkExists().forPath("/sessionTest"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNestedCalls() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.getCuratorListenable().addListener((client1, event) -> {
+                if (event.getType() == CuratorEventType.EXISTS) {
+                    Stat stat = client1.checkExists().forPath("/yo/yo/yo");
+                    assertNull(stat);
+
+                    client1.create().inBackground(event.getContext()).forPath("/what");
+                } else if (event.getType() == CuratorEventType.CREATE) {
+                    ((CountDownLatch) event.getContext()).countDown();
+                }
+            });
+            CountDownLatch latch = new CountDownLatch(1);
+            client.checkExists().inBackground(latch).forPath("/hey");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundFailure() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        client.start();
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            client.getConnectionStateListenable().addListener((client1, newState) -> {
+                if (newState == ConnectionState.LOST) {
+                    latch.countDown();
+                }
+            });
+            client.checkExists().forPath("/hey");
+            client.checkExists().inBackground().forPath("/hey");
+            server.stop();
+            client.checkExists().inBackground().forPath("/hey");
+            assertTrue(timing.awaitLatch(latch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testFailure() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 100, 100, new RetryOneTime(1));
+        client.start();
+        try {
+            client.checkExists().forPath("/hey");
+            client.checkExists().inBackground().forPath("/hey");
+            server.stop();
+            client.checkExists().forPath("/hey");
+            fail();
+        } catch (KeeperException.SessionExpiredException | KeeperException.ConnectionLossException ignored) {
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRetry() throws Exception {
+        final int maxRetries = 3;
+        final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(10));
+        client.start();
+        try {
+            final AtomicInteger retries = new AtomicInteger(0);
+            final Semaphore semaphore = new Semaphore(0);
+            RetryPolicy policy = (retryCount, elapsedTimeMs, sleeper) -> {
+                semaphore.release();
+                if (retries.incrementAndGet() == maxRetries) {
+                    try {
+                        server.restart();
+                    } catch (Exception e) {
+                        throw new Error(e);
+                    }
+                }
+                try {
+                    sleeper.sleepFor(100, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return true;
+            };
+            client.getZookeeperClient().setRetryPolicy(policy);
+            server.stop();
+            client.checkExists().forPath("/hey");
+            assertTrue(semaphore.tryAcquire(maxRetries, timing.forWaiting().seconds(), TimeUnit.SECONDS), "Remaining leases: " + semaphore.availablePermits());
+            client.getZookeeperClient().setRetryPolicy(new RetryOneTime(100));
+            client.checkExists().forPath("/hey");
+            client.getZookeeperClient().setRetryPolicy(policy);
+            semaphore.drainPermits();
+            retries.set(0);
+            server.stop();
+            client.checkExists().inBackground().forPath("/hey");
+            assertTrue(semaphore.tryAcquire(maxRetries, timing.forWaiting().seconds(), TimeUnit.SECONDS), "Remaining leases: " + semaphore.availablePermits());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNotStarted() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.getData();
+            fail();
+        } catch (Exception ignored) {
+        } catch (Throwable e) {
+            fail("", e);
+        }
+    }
+
+    @Test
+    public void testStopped() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.getData();
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+        try {
+            client.getData();
+            fail();
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    public void testDeleteChildrenConcurrently() throws Exception {
+        final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        CuratorFramework client2 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            client.start();
+            client2.start();
+            int childCount = 500;
+            for (int i = 0; i < childCount; i++) {
+                client.create().creatingParentsIfNeeded().forPath("/parent/child" + i);
+            }
+            final CountDownLatch latch = new CountDownLatch(1);
+            executorService.submit(() -> {
+                try {
+                    client.delete().deletingChildrenIfNeeded().forPath("/parent");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    if (e instanceof KeeperException.NoNodeException) {
+                        fail("client delete failed, shouldn't throw NoNodeException", e);
+                    } else {
+                        fail("unexpected exception", e);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+            boolean threadDeleted = false;
+            Random random = new Random();
+            for (int i = 0; i < childCount; i++) {
+                String child = "/parent/child" + random.nextInt(childCount);
+                try {
+                    if (!threadDeleted) {
+                        Stat stat = client2.checkExists().forPath(child);
+                        if (stat == null) {
+                            threadDeleted = true;
+                            log.info("client has deleted the child {}", child);
+                        }
+                    } else {
+                        try {
+                            client2.delete().forPath(child);
+                            log.info("client2 deleted the child {} successfully", child);
+                            break;
+                        } catch (KeeperException.NoNodeException ignore) {
+                        } catch (Exception e) {
+                            fail("unexpected exception", e);
+                        }
+                    }
+                } catch (Exception e) {
+                    fail("unexpected exception", e);
+                }
+            }
+            assertTrue(timing.awaitLatch(latch));
+            assertNull(client2.checkExists().forPath("/parent"));
+        } finally {
+            try {
+                executorService.shutdownNow();
+                executorService.awaitTermination(timing.milliseconds(), TimeUnit.MILLISECONDS);
+            } finally {
+                CloseableUtils.closeQuietly(client);
+                CloseableUtils.closeQuietly(client2);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException.NoAuthException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings("resource")
+public class TestNamespaceFacade extends BaseClassForTests {
+    @Test
+    public void testInvalid() {
+        try {
+            CuratorFrameworkFactory.builder().namespace("/snafu").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testGetNamespace() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        CuratorFramework client2 = CuratorFrameworkFactory.builder().namespace("snafu").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
+        try {
+            client.start();
+            CuratorFramework fooClient = client.usingNamespace("foo");
+            CuratorFramework barClient = client.usingNamespace("bar");
+            assertEquals(client.getNamespace(), "");
+            assertEquals(client2.getNamespace(), "snafu");
+            assertEquals(fooClient.getNamespace(), "foo");
+            assertEquals(barClient.getNamespace(), "bar");
+        } finally {
+            CloseableUtils.closeQuietly(client2);
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSimultaneous() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorFramework fooClient = client.usingNamespace("foo");
+            CuratorFramework barClient = client.usingNamespace("bar");
+            fooClient.create().forPath("/one");
+            barClient.create().forPath("/one");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/foo/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/bar/one", false));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCache() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            assertSame(client.usingNamespace("foo"), client.usingNamespace("foo"));
+            assertNotSame(client.usingNamespace("foo"), client.usingNamespace("bar"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/one");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
+            client.usingNamespace("space").create().forPath("/one");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/space", false));
+            client.usingNamespace("name").create().forPath("/one");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name/one", false));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRootAccess() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/one");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
+            assertNotNull(client.checkExists().forPath("/"));
+            try {
+                client.checkExists().forPath("");
+                fail("IllegalArgumentException expected");
+            } catch (IllegalArgumentException expected) {
+            }
+            assertNotNull(client.usingNamespace("one").checkExists().forPath("/"));
+            try {
+                client.usingNamespace("one").checkExists().forPath("");
+                fail("IllegalArgumentException expected");
+            } catch (IllegalArgumentException expected) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+
+    @Test
+    public void testIsStarted() {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        CuratorFramework namespaced = client.usingNamespace(null);
+        assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to start.");
+        client.close();
+        assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to close.");
+    }
+
+    @Test
+    public void testACL() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        client.getZookeeperClient().blockUntilConnectedOrTimedOut();
+        client.create().creatingParentsIfNeeded().forPath("/parent/child", "A string".getBytes());
+        CuratorFramework client2 = client.usingNamespace("parent");
+        assertNotNull(client2.getData().forPath("/child"));
+        client.setACL().withACL(Collections.singletonList(new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.ANYONE_ID_UNSAFE))).forPath("/parent/child");
+        try {
+            List<ACL> acls = client2.getACL().forPath("/child");
+            assertNotNull(acls);
+            assertEquals(acls.size(), 1);
+            assertEquals(acls.get(0).getId(), ZooDefs.Ids.ANYONE_ID_UNSAFE);
+            assertEquals(acls.get(0).getPerms(), ZooDefs.Perms.WRITE);
+            client2.setACL().withACL(Collections.singletonList(
+                            new ACL(ZooDefs.Perms.DELETE, ZooDefs.Ids.ANYONE_ID_UNSAFE))).
+                    forPath("/child");
+            fail("Expected auth exception was not thrown");
+        } catch (NoAuthException ignored) {
+        }
+    }
+
+    @Test
+    public void testUnfixForEmptyNamespace() {
+        CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
+        CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
+        assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
+        CloseableUtils.closeQuietly(client);
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestSetData.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestSetData.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.BackgroundPathAndBytesable;
+import org.apache.curator.framework.api.SetDataBuilder;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.zookeeper.KeeperException.Code.BADVERSION;
+import static org.apache.zookeeper.KeeperException.Code.NONODE;
+import static org.apache.zookeeper.KeeperException.Code.OK;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"FieldMayBeFinal", "deprecation", "unused"})
+public class TestSetData extends BaseClassForTests {
+    private static byte[] createData = new byte[]{5, 6, 7, 8};
+
+    private CuratorFramework createClient() {
+        return CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            Stat stat = new Stat();
+            String path = "/test";
+            byte[] data = new byte[]{1};
+            byte[] data2 = new byte[]{1, 2};
+            check(client, client.setData(), path, data, NONODE.intValue(), -1);
+            client.create().forPath(path, createData);
+            check(client, client.setData(), path, data, OK.intValue(), 1);
+            check(client, client.setData().withVersion(1), path, data2, OK.intValue(), 2);
+            check(client, client.setData().withVersion(1), path, data, BADVERSION.intValue(), 2);
+            assertArrayEquals(data2, client.getData().forPath(path));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackground() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            Stat stat = new Stat();
+            String path = "/test";
+            byte[] data = new byte[]{1};
+            byte[] data2 = new byte[]{1, 2};
+            checkBackground(client, client.setData(), path, data, NONODE.intValue(), -1);
+            client.create().forPath(path, createData);
+            checkBackground(client, client.setData(), path, data, OK.intValue(), 1);
+            checkBackground(client, client.setData().withVersion(1), path, data2, OK.intValue(), 2);
+            checkBackground(client, client.setData().withVersion(1), path, data, BADVERSION.intValue(), 3);
+            assertArrayEquals(data2, client.getData().forPath(path));
+
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private void check(CuratorFramework client, BackgroundPathAndBytesable<Stat> builder, String path, byte[] data, int expectedCode, int expectedVersionAfter) throws Exception {
+        try {
+            builder.forPath(path, data);
+            assertEquals(expectedCode, OK.intValue());
+            Stat stat = new Stat();
+            byte[] actualData = client.getData().storingStatIn(stat).forPath(path);
+            assertTrue(IdempotentUtils.matches(expectedVersionAfter, data, stat.getVersion(), actualData));
+        } catch (KeeperException e) {
+            assertEquals(expectedCode, e.getCode());
+        }
+    }
+
+    private void checkBackground(CuratorFramework client, BackgroundPathAndBytesable<Stat> builder, String path, byte[] data, int expectedCode, int expectedVersionAfter) throws Exception {
+        AtomicInteger actualCode = new AtomicInteger(-1);
+        CountDownLatch latch = new CountDownLatch(1);
+        BackgroundCallback callback = (client1, event) -> {
+            actualCode.set(event.getResultCode());
+            latch.countDown();
+        };
+        builder.inBackground(callback).forPath(path, data);
+        assertTrue(latch.await(5000, TimeUnit.MILLISECONDS), "Callback not invoked");
+        assertEquals(expectedCode, actualCode.get());
+        if (expectedCode == OK.intValue()) {
+            Stat stat = new Stat();
+            byte[] actualData = client.getData().storingStatIn(stat).forPath(path);
+            assertTrue(IdempotentUtils.matches(expectedVersionAfter, data, stat.getVersion(), actualData));
+        }
+    }
+
+    @Test
+    public void testIdempotentSet() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            Stat stat = new Stat();
+            String path = "/idpset";
+            String pathBack = "/idpsetback";
+            byte[] data1 = new byte[]{1, 2, 3};
+            byte[] data2 = new byte[]{4, 5, 6};
+            byte[] data3 = new byte[]{7, 8, 9};
+            check(client, client.setData().idempotent(), path, data1, NONODE.intValue(), -1);
+            checkBackground(client, client.setData().idempotent(), pathBack, data1, NONODE.intValue(), -1);
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, client.setData().idempotent(), path, data1, OK.intValue(), 1);
+            checkBackground(client, client.setData().idempotent(), pathBack, data1, OK.intValue(), 1);
+            check(client, client.setData().idempotent().withVersion(1), path, data2, OK.intValue(), 2);
+            checkBackground(client, client.setData().idempotent().withVersion(1), pathBack, data2, OK.intValue(), 2);
+            check(client, client.setData().idempotent().withVersion(1), path, data2, OK.intValue(), 2);
+            checkBackground(client, client.setData().idempotent().withVersion(1), pathBack, data2, OK.intValue(), 2);
+            check(client, client.setData().idempotent().withVersion(1), path, data3, BADVERSION.intValue(), 1);
+            checkBackground(client, client.setData().idempotent().withVersion(1), pathBack, data3, BADVERSION.intValue(), 1);
+            check(client, client.setData().idempotent().withVersion(0), path, data2, BADVERSION.intValue(), 2);
+            checkBackground(client, client.setData().idempotent().withVersion(0), pathBack, data2, BADVERSION.intValue(), 2);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private SetDataBuilder clBefore(SetDataBuilder builder) {
+        ((SetDataBuilderImpl) builder).failBeforeNextSetForTesting = true;
+        return builder;
+    }
+
+    private SetDataBuilder clAfter(SetDataBuilder builder) {
+        ((SetDataBuilderImpl) builder).failNextSetForTesting = true;
+        return builder;
+    }
+
+    private SetDataBuilder clCheck(SetDataBuilder builder) {
+        ((SetDataBuilderImpl) builder).failNextIdempotentCheckForTesting = true;
+        return builder;
+    }
+
+    @Test
+    public void testIdempotentSetConnectionLoss() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String idpPath = "/idpset";
+            String idpPathBack = "/idpsetback";
+            String path = "/set";
+            String pathBack = "/setBack";
+            byte[] data = new byte[]{1};
+            byte[] data2 = new byte[]{1, 2};
+            byte[] data3 = new byte[]{1, 2, 3};
+            byte[] data4 = new byte[]{1, 2, 3, 4};
+            check(client, clBefore(client.setData().idempotent()), idpPath, data, NONODE.intValue(), -1);
+            checkBackground(client, clBefore(client.setData().idempotent()), idpPathBack, data, NONODE.intValue(), -1);
+            check(client, clAfter(client.setData().idempotent()), idpPath, data, NONODE.intValue(), -1);
+            checkBackground(client, clAfter(client.setData().idempotent()), idpPathBack, data, NONODE.intValue(), -1);
+            check(client, clCheck(client.setData().idempotent()), idpPath, data, NONODE.intValue(), -1);
+            checkBackground(client, clCheck(client.setData().idempotent()), idpPathBack, data, NONODE.intValue(), -1);
+            client.create().forPath(idpPath, createData);
+            client.create().forPath(idpPathBack, createData);
+            check(client, clBefore(client.setData().idempotent()).withVersion(0), idpPath, data, OK.intValue(), 1);
+            checkBackground(client, clBefore(client.setData().idempotent()).withVersion(0), idpPathBack, data, OK.intValue(), 1);
+            check(client, clAfter(client.setData().idempotent()).withVersion(1), idpPath, data2, OK.intValue(), 2);
+            checkBackground(client, clAfter(client.setData().idempotent()).withVersion(1), idpPathBack, data2, OK.intValue(), 2);
+            check(client, clBefore(client.setData().idempotent()), idpPath, data3, OK.intValue(), 3);
+            checkBackground(client, clBefore(client.setData().idempotent()), idpPathBack, data3, OK.intValue(), 3);
+            check(client, clAfter(client.setData().idempotent()), idpPath, data4, OK.intValue(), 5);
+            checkBackground(client, clAfter(client.setData().idempotent()), idpPathBack, data4, OK.intValue(), 5);
+            check(client, clBefore(client.setData().idempotent()).withVersion(4), idpPath, data4, OK.intValue(), 5);
+            checkBackground(client, clBefore(client.setData().idempotent()).withVersion(4), idpPathBack, data4, OK.intValue(), 5);
+            check(client, clAfter(client.setData().idempotent()).withVersion(4), idpPath, data4, OK.intValue(), 5);
+            checkBackground(client, clAfter(client.setData().idempotent()).withVersion(4), idpPathBack, data4, OK.intValue(), 5);
+            check(client, clCheck(client.setData().idempotent()).withVersion(4), idpPath, data4, OK.intValue(), 5);
+            checkBackground(client, clCheck(client.setData().idempotent()).withVersion(4), idpPathBack, data4, OK.intValue(), 5);
+            check(client, clBefore(client.setData().idempotent()).withVersion(0), idpPath, data4, BADVERSION.intValue(), -1);
+            checkBackground(client, clBefore(client.setData().idempotent()).withVersion(0), idpPathBack, data4, BADVERSION.intValue(), -1);
+            check(client, clAfter(client.setData().idempotent()).withVersion(0), idpPath, data4, BADVERSION.intValue(), -1);
+            checkBackground(client, clAfter(client.setData().idempotent()).withVersion(0), idpPathBack, data4, BADVERSION.intValue(), -1);
+            check(client, clCheck(client.setData().idempotent()).withVersion(0), idpPath, data4, BADVERSION.intValue(), -1);
+            checkBackground(client, clCheck(client.setData().idempotent()).withVersion(0), idpPathBack, data4, BADVERSION.intValue(), -1);
+            check(client, clBefore(client.setData().idempotent()).withVersion(4), idpPath, data, BADVERSION.intValue(), -1);
+            checkBackground(client, clBefore(client.setData().idempotent()).withVersion(4), idpPathBack, data, BADVERSION.intValue(), -1);
+            check(client, clAfter(client.setData().idempotent()).withVersion(4), idpPath, data, BADVERSION.intValue(), -1);
+            checkBackground(client, clAfter(client.setData().idempotent()).withVersion(4), idpPathBack, data, BADVERSION.intValue(), -1);
+            check(client, clCheck(client.setData().idempotent()).withVersion(4), idpPath, data, BADVERSION.intValue(), -1);
+            checkBackground(client, clCheck(client.setData().idempotent()).withVersion(4), idpPathBack, data, BADVERSION.intValue(), -1);
+            client.create().forPath(path, createData);
+            client.create().forPath(pathBack, createData);
+            check(client, clBefore(client.setData()).withVersion(0), path, data, OK.intValue(), 1);
+            checkBackground(client, clBefore(client.setData()).withVersion(0), pathBack, data, OK.intValue(), 1);
+            check(client, clAfter(client.setData()).withVersion(1), path, data2, BADVERSION.intValue(), -1);
+            checkBackground(client, clAfter(client.setData()).withVersion(1), pathBack, data2, BADVERSION.intValue(), -1);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.CuratorTempFramework;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestTempFramework extends BaseClassForTests {
+    @Test
+    public void testBasic() throws Exception {
+        CuratorTempFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp();
+        try {
+            client.inTransaction().create().forPath("/foo", "data".getBytes()).and().commit();
+            byte[] bytes = client.getData().forPath("/foo");
+            assertArrayEquals(bytes, "data".getBytes());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testInactivity() throws Exception {
+        final CuratorTempFrameworkImpl client = (CuratorTempFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp(1, TimeUnit.SECONDS);
+        try {
+            ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
+            Runnable command = client::updateLastAccess;
+            service.scheduleAtFixedRate(command, 10, 10, TimeUnit.MILLISECONDS);
+            client.inTransaction().create().forPath("/foo", "data".getBytes()).and().commit();
+            service.shutdownNow();
+            Thread.sleep(2000);
+            assertNull(client.getCleanup());
+            assertNull(client.getClient());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import com.google.common.collect.Sets;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+public class TestWatcherIdentity extends BaseClassForTests {
+    private static final String PATH = "/foo";
+    private static final int TIMEOUT_MS = 100000;
+
+    private static class CountZKWatcher implements Watcher {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public void process(WatchedEvent event) {
+            count.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void testSameWatcherPerZKDocs() throws Exception {
+        CountZKWatcher actualWatcher = new CountZKWatcher();
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(),
+                timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/test");
+            client.checkExists().usingWatcher(actualWatcher).forPath("/test");
+            client.getData().usingWatcher(actualWatcher).forPath("/test");
+            client.setData().forPath("/test", "foo".getBytes());
+            client.delete().forPath("/test");
+            Awaitility.await().untilAsserted(() -> assertEquals(1, actualWatcher.count.getAndSet(0)));
+            client.create().forPath("/test");
+            client.checkExists().usingWatcher(actualWatcher).forPath("/test");
+            client.delete().forPath("/test");
+            Awaitility.await()
+                    .untilAsserted(() -> assertEquals(1, actualWatcher.count.get()));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSameCuratorWatcherPerZKDocs() throws Exception {
+        CuratorWatcher actualWatcher = mock(CuratorWatcher.class);
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(),
+                timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/test");
+            client.checkExists().usingWatcher(actualWatcher).forPath("/test");
+            client.getData().usingWatcher(actualWatcher).forPath("/test");
+            client.setData().forPath("/test", "foo".getBytes());
+            client.delete().forPath("/test");
+            Mockito.verify(actualWatcher, Mockito.timeout(TIMEOUT_MS).times(1)).process(any(WatchedEvent.class));
+            client.create().forPath("/test");
+            client.checkExists().usingWatcher(actualWatcher).forPath("/test");
+            client.delete().forPath("/test");
+            Mockito.verify(actualWatcher, Mockito.timeout(TIMEOUT_MS).times(2)).process(any(WatchedEvent.class));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSetAddition() {
+        Watcher watcher = event -> {
+        };
+        NamespaceWatcher namespaceWatcher1 = new NamespaceWatcher(null, watcher, "/foo");
+        NamespaceWatcher namespaceWatcher2 = new NamespaceWatcher(null, watcher, "/foo");
+        assertEquals(namespaceWatcher1, namespaceWatcher2);
+        assertNotEquals(namespaceWatcher1, watcher);
+        assertNotEquals(watcher, namespaceWatcher1);
+        Set<Watcher> set = Sets.newHashSet();
+        set.add(namespaceWatcher1);
+        set.add(namespaceWatcher2);
+        assertEquals(set.size(), 1);
+    }
+
+    @Test
+    public void testCuratorWatcher() throws Exception {
+        Timing timing = new Timing();
+        CuratorWatcher watcher = mock(CuratorWatcher.class);
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(),
+                timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath(PATH);
+            client.getData().usingWatcher(watcher).forPath(PATH);
+            client.getData().usingWatcher(watcher).forPath(PATH);
+            client.setData().forPath(PATH, new byte[]{});
+            Mockito.verify(watcher, Mockito.timeout(TIMEOUT_MS).times(1)).process(any(WatchedEvent.class));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testZKWatcher() throws Exception {
+        Timing timing = new Timing();
+        CountZKWatcher watcher = new CountZKWatcher();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(),
+                timing.connection(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath(PATH);
+            client.getData().usingWatcher(watcher).forPath(PATH);
+            client.getData().usingWatcher(watcher).forPath(PATH);
+            client.setData().forPath(PATH, new byte[]{});
+            Awaitility.await()
+                    .untilAsserted(() -> assertEquals(1, watcher.count.get()));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.WatcherRemoveCuratorFramework;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.WatchersDebug;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestWatcherRemovalManager extends CuratorTestBase {
+    @Test
+    public void testSameWatcherDifferentPaths1Triggered() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            final CountDownLatch latch = new CountDownLatch(1);
+            Watcher watcher = event -> latch.countDown();
+            removerClient.checkExists().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.checkExists().usingWatcher(watcher).forPath("/d/e/f");
+            removerClient.create().creatingParentsIfNeeded().forPath("/d/e/f");
+            Timing timing = new Timing();
+            assertTrue(timing.awaitLatch(latch));
+            timing.sleepABit();
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testSameWatcherDifferentPaths() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher watcher = event -> {
+            };
+            removerClient.checkExists().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.checkExists().usingWatcher(watcher).forPath("/d/e/f");
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 2);
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testSameWatcherDifferentKinds1Triggered() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            final CountDownLatch latch = new CountDownLatch(1);
+            Watcher watcher = event -> latch.countDown();
+            removerClient.create().creatingParentsIfNeeded().forPath("/a/b/c");
+            removerClient.checkExists().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.getData().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.setData().forPath("/a/b/c", "new".getBytes());
+            Timing timing = new Timing();
+            assertTrue(timing.awaitLatch(latch));
+            timing.sleepABit();
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testSameWatcherDifferentKinds() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher watcher = event -> {
+            };
+            removerClient.create().creatingParentsIfNeeded().forPath("/a/b/c");
+            removerClient.checkExists().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.getData().usingWatcher(watcher).forPath("/a/b/c");
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testWithRetry() throws Exception {
+        server.stop();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher w = event -> {
+            };
+            try {
+                removerClient.checkExists().usingWatcher(w).forPath("/one/two/three");
+                fail("Should have thrown ConnectionLossException");
+            } catch (KeeperException.ConnectionLossException expected) {
+            }
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testWithRetryInBackground() throws Exception {
+        server.stop();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher w = event -> {
+            };
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            removerClient.checkExists().usingWatcher(w).inBackground(callback).forPath("/one/two/three");
+            assertTrue(new Timing().awaitLatch(latch));
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testMissingNode() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher w = event -> {
+            };
+            try {
+                removerClient.getData().usingWatcher(w).forPath("/one/two/three");
+                fail("Should have thrown NoNodeException");
+            } catch (KeeperException.NoNodeException expected) {
+            }
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testMissingNodeInBackground() throws Exception {
+        final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        Callable<Void> proc = () -> {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher w = event -> {
+            };
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            removerClient.getData().usingWatcher(w).inBackground(callback).forPath("/one/two/three");
+            assertTrue(new Timing().awaitLatch(latch));
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+            removerClient.removeWatchers();
+            return null;
+        };
+        TestCleanState.test(client, proc);
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            internalTryBasic(client);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testBasicNamespace1() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            internalTryBasic(client.usingNamespace("foo"));
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testBasicNamespace2() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .namespace("hey")
+                .build();
+        try {
+            client.start();
+            internalTryBasic(client);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testBasicNamespace3() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .namespace("hey")
+                .build();
+        try {
+            client.start();
+            internalTryBasic(client.usingNamespace("lakjsf"));
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testSameWatcher() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/test");
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            Watcher watcher = event -> {
+            };
+            removerClient.getData().usingWatcher(watcher).forPath("/test");
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            removerClient.getData().usingWatcher(watcher).forPath("/test");
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            removerClient.removeWatchers();
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testTriggered() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            final CountDownLatch latch = new CountDownLatch(1);
+            Watcher watcher = event -> {
+                if (event.getType() == Watcher.Event.EventType.NodeCreated) {
+                    latch.countDown();
+                }
+            };
+            removerClient.checkExists().usingWatcher(watcher).forPath("/yo");
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            removerClient.create().forPath("/yo");
+            assertTrue(new Timing().awaitLatch(latch));
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    @Test
+    public void testResetFromWatcher() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            final WatcherRemovalFacade removerClient = (WatcherRemovalFacade) client.newWatcherRemoveCuratorFramework();
+            final CountDownLatch createdLatch = new CountDownLatch(1);
+            final CountDownLatch deletedLatch = new CountDownLatch(1);
+            Watcher watcher = new Watcher() {
+                @Override
+                public void process(WatchedEvent event) {
+                    if (event.getType() == Event.EventType.NodeCreated) {
+                        try {
+                            removerClient.checkExists().usingWatcher(this).forPath("/yo");
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        createdLatch.countDown();
+                    } else if (event.getType() == Event.EventType.NodeDeleted) {
+                        deletedLatch.countDown();
+                    }
+                }
+            };
+            removerClient.checkExists().usingWatcher(watcher).forPath("/yo");
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            removerClient.create().forPath("/yo");
+            assertTrue(timing.awaitLatch(createdLatch));
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            removerClient.delete().forPath("/yo");
+            assertTrue(timing.awaitLatch(deletedLatch));
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
+        } finally {
+            TestCleanState.closeAndTestClean(client);
+        }
+    }
+
+    private void internalTryBasic(CuratorFramework client) throws Exception {
+        WatcherRemoveCuratorFramework removerClient = client.newWatcherRemoveCuratorFramework();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Watcher watcher = event -> {
+            if (event.getType() == Watcher.Event.EventType.DataWatchRemoved) {
+                latch.countDown();
+            }
+        };
+        removerClient.checkExists().usingWatcher(watcher).forPath("/hey");
+        List<String> existWatches = WatchersDebug.getExistWatches(client.getZookeeperClient().getZooKeeper());
+        assertEquals(existWatches.size(), 1);
+        removerClient.removeWatchers();
+        assertTrue(new Timing().awaitLatch(latch));
+        existWatches = WatchersDebug.getExistWatches(client.getZookeeperClient().getZooKeeper());
+        assertEquals(existWatches.size(), 0);
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.Watcher.Event.EventType;
+import org.apache.zookeeper.Watcher.WatcherType;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings({"deprecation", "SameParameterValue"})
+public class TestWatchesBuilder extends CuratorTestBase {
+    private AtomicReference<ConnectionState> registerConnectionStateListener(CuratorFramework client) {
+        final AtomicReference<ConnectionState> state = new AtomicReference<>();
+        client.getConnectionStateListenable().addListener((client1, newState) -> {
+            state.set(newState);
+            synchronized (state) {
+                state.notify();
+            }
+        });
+
+        return state;
+    }
+
+    private boolean blockUntilDesiredConnectionState(AtomicReference<ConnectionState> stateRef, Timing timing, final ConnectionState desiredState) {
+        if (stateRef.get() == desiredState) {
+            return true;
+        }
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized (stateRef) {
+            if (stateRef.get() == desiredState) {
+                return true;
+            }
+
+            try {
+                stateRef.wait(timing.milliseconds());
+                return stateRef.get() == desiredState;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    @Test
+    public void testRemoveCuratorDefaultWatcher() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+
+            final String path = "/";
+            client.getCuratorListenable().addListener((client1, event) -> {
+                if (event.getType() == CuratorEventType.WATCHED && event.getWatchedEvent().getType() == EventType.DataWatchRemoved) {
+                    removedLatch.countDown();
+                }
+            });
+            client.checkExists().watched().forPath(path);
+            client.watches().removeAll().forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveCuratorWatch() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            final String path = "/";
+            CuratorWatcher watcher = event -> {
+                if (event.getPath().equals(path) && event.getType() == EventType.DataWatchRemoved) {
+                    removedLatch.countDown();
+                }
+            };
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            client.watches().remove(watcher).forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveWatch() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            final String path = "/";
+            Watcher watcher = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            client.watches().remove(watcher).forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveWatchInBackgroundWithCallback() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final CountDownLatch removedLatch = new CountDownLatch(2);
+            final String path = "/";
+            Watcher watcher = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            BackgroundCallback callback = (client1, event) -> {
+                if (event.getType() == CuratorEventType.REMOVE_WATCHES && event.getPath().equals(path)) {
+                    removedLatch.countDown();
+                }
+            };
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            client.watches().remove(watcher).ofType(WatcherType.Any).inBackground(callback).forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveWatchInBackgroundWithNoCallback() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final String path = "/";
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            Watcher watcher = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            client.watches().remove(watcher).inBackground().forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveAllWatches() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final String path = "/";
+            final CountDownLatch removedLatch = new CountDownLatch(2);
+            Watcher watcher1 = new CountDownWatcher(path, removedLatch, EventType.ChildWatchRemoved);
+            Watcher watcher2 = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.getChildren().usingWatcher(watcher1).forPath(path);
+            client.checkExists().usingWatcher(watcher2).forPath(path);
+            client.watches().removeAll().forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveAllDataWatches() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final String path = "/";
+            final AtomicBoolean removedFlag = new AtomicBoolean(false);
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            Watcher watcher1 = new BooleanWatcher(path, removedFlag, EventType.ChildWatchRemoved);
+            Watcher watcher2 = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.getChildren().usingWatcher(watcher1).forPath(path);
+            client.checkExists().usingWatcher(watcher2).forPath(path);
+            client.watches().removeAll().ofType(WatcherType.Data).forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertFalse(removedFlag.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveAllChildWatches() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final String path = "/";
+            final AtomicBoolean removedFlag = new AtomicBoolean(false);
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            Watcher watcher1 = new BooleanWatcher(path, removedFlag, EventType.DataWatchRemoved);
+            Watcher watcher2 = new CountDownWatcher(path, removedLatch, EventType.ChildWatchRemoved);
+            client.checkExists().usingWatcher(watcher1).forPath(path);
+            client.getChildren().usingWatcher(watcher2).forPath(path);
+            client.watches().removeAll().ofType(WatcherType.Children).forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertFalse(removedFlag.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveLocalWatch() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            AtomicReference<ConnectionState> stateRef = registerConnectionStateListener(client);
+            final String path = "/";
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            Watcher watcher = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            server.stop();
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            client.watches().removeAll().locally().forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveLocalWatchInBackground() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            AtomicReference<ConnectionState> stateRef = registerConnectionStateListener(client);
+            final String path = "/";
+            final CountDownLatch removedLatch = new CountDownLatch(1);
+            Watcher watcher = new CountDownWatcher(path, removedLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            server.stop();
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            client.watches().removeAll().locally().inBackground().forPath(path);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveUnregisteredWatcher() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final String path = "/";
+            Watcher watcher = event -> {
+            };
+            try {
+                client.watches().remove(watcher).forPath(path);
+                fail("Expected KeeperException.NoWatcherException");
+            } catch (KeeperException.NoWatcherException expected) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testRemoveUnregisteredWatcherQuietly() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            final AtomicBoolean watcherRemoved = new AtomicBoolean(false);
+            final String path = "/";
+            Watcher watcher = new BooleanWatcher(path, watcherRemoved, EventType.DataWatchRemoved);
+            client.watches().remove(watcher).quietly().forPath(path);
+            timing.sleepABit();
+            assertFalse(watcherRemoved.get());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testGuaranteedRemoveWatch() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            AtomicReference<ConnectionState> stateRef = registerConnectionStateListener(client);
+            String path = "/";
+            CountDownLatch removeLatch = new CountDownLatch(1);
+            Watcher watcher = new CountDownWatcher(path, removeLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            server.stop();
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            try {
+                client.watches().remove(watcher).guaranteed().forPath(path);
+                fail();
+            } catch (KeeperException.ConnectionLossException ignored) {
+            }
+            server.restart();
+            timing.awaitLatch(removeLatch);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testGuaranteedRemoveWatchInBackground() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new ExponentialBackoffRetry(100, 3));
+        try {
+            client.start();
+            AtomicReference<ConnectionState> stateRef = registerConnectionStateListener(client);
+            final CountDownLatch guaranteeAddedLatch = new CountDownLatch(1);
+            ((CuratorFrameworkImpl) client).getFailedRemoveWatcherManager().debugListener = detail -> guaranteeAddedLatch.countDown();
+            String path = "/";
+            CountDownLatch removeLatch = new CountDownLatch(1);
+            Watcher watcher = new CountDownWatcher(path, removeLatch, EventType.DataWatchRemoved);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+            server.stop();
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            client.watches().remove(watcher).guaranteed().inBackground().forPath(path);
+            timing.awaitLatch(guaranteeAddedLatch);
+            server.restart();
+            timing.awaitLatch(removeLatch);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testPersistentWatch() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            client.blockUntilConnected();
+            CountDownLatch latch = new CountDownLatch(3);
+            Watcher watcher = event -> latch.countDown();
+            client.watchers().add().withMode(AddWatchMode.PERSISTENT).usingWatcher(watcher).forPath("/test/foo");
+            client.create().creatingParentsIfNeeded().forPath("/test/foo");
+            client.setData().forPath("/test/foo", "hey".getBytes());
+            client.delete().forPath("/test/foo");
+            assertTrue(timing.awaitLatch(latch));
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testPersistentWatchInBackground() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            client.blockUntilConnected();
+            CountDownLatch backgroundLatch = new CountDownLatch(1);
+            BackgroundCallback backgroundCallback = (__, ___) -> backgroundLatch.countDown();
+            CountDownLatch latch = new CountDownLatch(3);
+            Watcher watcher = event -> latch.countDown();
+            client.watchers().add().withMode(AddWatchMode.PERSISTENT).inBackground(backgroundCallback).usingWatcher(watcher).forPath("/test/foo");
+            client.create().creatingParentsIfNeeded().forPath("/test/foo");
+            client.setData().forPath("/test/foo", "hey".getBytes());
+            client.delete().forPath("/test/foo");
+            assertTrue(timing.awaitLatch(backgroundLatch));
+            assertTrue(timing.awaitLatch(latch));
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testPersistentRecursiveWatch() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            client.blockUntilConnected();
+            CountDownLatch latch = new CountDownLatch(5);
+            Watcher watcher = event -> latch.countDown();
+            client.watchers().add().withMode(AddWatchMode.PERSISTENT_RECURSIVE).usingWatcher(watcher).forPath("/test");
+            client.create().forPath("/test");
+            client.create().forPath("/test/a");
+            client.create().forPath("/test/a/b");
+            client.create().forPath("/test/a/b/c");
+            client.create().forPath("/test/a/b/c/d");
+            assertTrue(timing.awaitLatch(latch));
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testPersistentRecursiveWatchInBackground() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            client.blockUntilConnected();
+            CountDownLatch backgroundLatch = new CountDownLatch(1);
+            BackgroundCallback backgroundCallback = (__, ___) -> backgroundLatch.countDown();
+            CountDownLatch latch = new CountDownLatch(5);
+            Watcher watcher = event -> latch.countDown();
+            client.watchers().add().withMode(AddWatchMode.PERSISTENT_RECURSIVE).inBackground(backgroundCallback).usingWatcher(watcher).forPath("/test");
+            client.create().forPath("/test");
+            client.create().forPath("/test/a");
+            client.create().forPath("/test/a/b");
+            client.create().forPath("/test/a/b/c");
+            client.create().forPath("/test/a/b/c/d");
+            assertTrue(timing.awaitLatch(backgroundLatch));
+            assertTrue(timing.awaitLatch(latch));
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testPersistentRecursiveDefaultWatch() throws Exception {
+        CountDownLatch latch = new CountDownLatch(6);
+        ZookeeperFactory zookeeperFactory = (connectString, sessionTimeout, watcher, canBeReadOnly) -> {
+            Watcher actualWatcher = event -> {
+                watcher.process(event);
+                latch.countDown();
+            };
+            return new ZooKeeper(connectString, sessionTimeout, actualWatcher);
+        };
+        try (CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).zookeeperFactory(zookeeperFactory).build()) {
+            client.start();
+            client.blockUntilConnected();
+            client.watchers().add().withMode(AddWatchMode.PERSISTENT_RECURSIVE).forPath("/test");
+            client.create().forPath("/test");
+            client.create().forPath("/test/a");
+            client.create().forPath("/test/a/b");
+            client.create().forPath("/test/a/b/c");
+            client.create().forPath("/test/a/b/c/d");
+            assertTrue(timing.awaitLatch(latch));
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private static class CountDownWatcher implements Watcher {
+        private String path;
+        private EventType eventType;
+        private CountDownLatch removeLatch;
+
+        CountDownWatcher(String path, CountDownLatch removeLatch, EventType eventType) {
+            this.path = path;
+            this.eventType = eventType;
+            this.removeLatch = removeLatch;
+        }
+
+        @Override
+        public void process(WatchedEvent event) {
+            if (event.getPath() == null || event.getType() == null) {
+                return;
+            }
+
+            if (event.getPath().equals(path) && event.getType() == eventType) {
+                removeLatch.countDown();
+            }
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private static class BooleanWatcher implements Watcher {
+        private String path;
+        private EventType eventType;
+        private AtomicBoolean removedFlag;
+
+        BooleanWatcher(String path, AtomicBoolean removedFlag, EventType eventType) {
+            this.path = path;
+            this.eventType = eventType;
+            this.removedFlag = removedFlag;
+        }
+
+        @Override
+        public void process(WatchedEvent event) {
+            if (event.getPath() == null || event.getType() == null) {
+                return;
+            }
+
+            if (event.getPath().equals(path) && event.getType() == eventType) {
+                removedFlag.set(true);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/state/TestCircuitBreaker.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org/apache/curator/framework/state/TestCircuitBreaker.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.curator.framework.state;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.retry.RetryUntilElapsed;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"FieldMayBeFinal", "NullableProblems"})
+public class TestCircuitBreaker {
+    private static Duration[] lastDelay = new Duration[]{Duration.ZERO};
+    private static ScheduledThreadPoolExecutor service = new ScheduledThreadPoolExecutor(1) {
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            lastDelay[0] = Duration.of(unit.toNanos(delay), ChronoUnit.NANOS);
+            command.run();
+            return null;
+        }
+    };
+
+    @AfterAll
+    public static void tearDown() {
+        service.shutdownNow();
+    }
+
+    @Test
+    public void testBasic() {
+        final int retryQty = 1;
+        final Duration delay = Duration.ofSeconds(10);
+        CircuitBreaker circuitBreaker = CircuitBreaker.build(new RetryNTimes(retryQty, (int) delay.toMillis()), service);
+        AtomicInteger counter = new AtomicInteger(0);
+        assertTrue(circuitBreaker.tryToOpen(counter::incrementAndGet));
+        assertEquals(lastDelay[0], delay);
+        assertFalse(circuitBreaker.tryToOpen(counter::incrementAndGet));
+        assertEquals(circuitBreaker.getRetryCount(), 1);
+        assertEquals(counter.get(), 1);
+        assertFalse(circuitBreaker.tryToRetry(counter::incrementAndGet));
+        assertEquals(circuitBreaker.getRetryCount(), 1);
+        assertEquals(counter.get(), 1);
+        assertTrue(circuitBreaker.close());
+        assertEquals(circuitBreaker.getRetryCount(), 0);
+        assertFalse(circuitBreaker.close());
+    }
+
+    @Test
+    public void testVariousOpenRetryFails() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.build(new RetryForever(1), service);
+        assertFalse(circuitBreaker.tryToRetry(() -> {
+        }));
+        assertTrue(circuitBreaker.tryToOpen(() -> {
+        }));
+        assertFalse(circuitBreaker.tryToOpen(() -> {
+        }));
+        assertTrue(circuitBreaker.close());
+        assertFalse(circuitBreaker.close());
+    }
+
+    @Test
+    public void testWithRetryUntilElapsed() {
+        RetryPolicy retryPolicy = new RetryUntilElapsed(10000, 10000);
+        CircuitBreaker circuitBreaker = CircuitBreaker.build(retryPolicy, service);
+        assertTrue(circuitBreaker.tryToOpen(() -> {
+        }));
+        assertEquals(lastDelay[0], Duration.ofMillis(10000));
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/ensemble/TestEnsembleProvider.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/ensemble/TestEnsembleProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.ensemble;
+
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestEnsembleProvider extends BaseClassForTests {
+    private final Timing timing = new Timing();
+
+    @Test
+    public void testBasic() {
+        Semaphore counter = new Semaphore(0);
+        final CuratorFramework client = newClient(counter);
+        try {
+            client.start();
+            assertTrue(timing.acquireSemaphore(counter));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testAfterSessionExpiration() throws Exception {
+        TestingServer oldServer = server;
+        Semaphore counter = new Semaphore(0);
+        final CuratorFramework client = newClient(counter);
+        try {
+            final CountDownLatch connectedLatch = new CountDownLatch(1);
+            final CountDownLatch lostLatch = new CountDownLatch(1);
+            final CountDownLatch reconnectedLatch = new CountDownLatch(1);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if (newState == ConnectionState.CONNECTED) {
+                    connectedLatch.countDown();
+                }
+                if (newState == ConnectionState.LOST) {
+                    lostLatch.countDown();
+                }
+                if (newState == ConnectionState.RECONNECTED) {
+                    reconnectedLatch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            client.start();
+            assertTrue(timing.awaitLatch(connectedLatch));
+            server.stop();
+            assertTrue(timing.awaitLatch(lostLatch));
+            counter.drainPermits();
+            IntStream.range(0, 5).forEach(i -> assertTrue(timing.acquireSemaphore(counter), "Failed when i is: " + i));
+            server = new TestingServer();
+            assertTrue(timing.awaitLatch(reconnectedLatch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+            CloseableUtils.closeQuietly(oldServer);
+        }
+    }
+
+    private CuratorFramework newClient(Semaphore counter) {
+        return CuratorFrameworkFactory.builder()
+                .ensembleProvider(new CountingEnsembleProvider(counter))
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .retryPolicy(new RetryOneTime(1))
+                .build();
+    }
+
+    private class CountingEnsembleProvider implements EnsembleProvider {
+        private final Semaphore getConnectionStringCounter;
+
+        CountingEnsembleProvider(Semaphore getConnectionStringCounter) {
+            this.getConnectionStringCounter = getConnectionStringCounter;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public String getConnectionString() {
+            getConnectionStringCounter.release();
+            return server.getConnectString();
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void setConnectionString(String connectionString) {
+        }
+
+        @Override
+        public boolean updateServerListEnabled() {
+            return false;
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestBlockUntilConnected.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestBlockUntilConnected.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings("NonAtomicOperationOnVolatileField")
+public class TestBlockUntilConnected extends BaseClassForTests {
+    @Test
+    public void testBlockUntilConnectedCurrentlyConnected() {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        try {
+            final CountDownLatch connectedLatch = new CountDownLatch(1);
+            client.getConnectionStateListenable().addListener((client1, newState) -> {
+                if (newState.isConnected()) {
+                    connectedLatch.countDown();
+                }
+            });
+            client.start();
+            assertTrue(timing.awaitLatch(connectedLatch), "Timed out awaiting latch");
+            assertTrue(client.blockUntilConnected(1, TimeUnit.SECONDS), "Not connected");
+        } catch (InterruptedException e) {
+            fail("Unexpected interruption");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBlockUntilConnectedCurrentlyNeverConnected() {
+        CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        try {
+            client.start();
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
+        } catch (InterruptedException e) {
+            fail("Unexpected interruption");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBlockUntilConnectedCurrentlyAwaitingReconnect() {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                sessionTimeoutMs(timing.session()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        final CountDownLatch lostLatch = new CountDownLatch(1);
+        client.getConnectionStateListenable().addListener((client1, newState) -> {
+            if (newState == ConnectionState.LOST) {
+                lostLatch.countDown();
+            }
+        });
+        try {
+            client.start();
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Failed to connect");
+            CloseableUtils.closeQuietly(server);
+            assertTrue(timing.awaitLatch(lostLatch), "Failed to reach LOST state");
+            server = new TestingServer(server.getPort(), server.getTempDirectory());
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
+        } catch (Exception e) {
+            fail("Unexpected exception " + e);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBlockUntilConnectedConnectTimeout() {
+        CloseableUtils.closeQuietly(server);
+        CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        try {
+            client.start();
+            assertFalse(client.blockUntilConnected(5, TimeUnit.SECONDS), "Connected");
+        } catch (InterruptedException e) {
+            fail("Unexpected interruption");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBlockUntilConnectedInterrupt() {
+        CloseableUtils.closeQuietly(server);
+        final CuratorFramework client = CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        try {
+            client.start();
+            final Thread threadToInterrupt = Thread.currentThread();
+            Timer timer = new Timer();
+            timer.schedule(new TimerTask() {
+
+                @Override
+                public void run() {
+                    threadToInterrupt.interrupt();
+                }
+            }, 3000);
+            client.blockUntilConnected(5, TimeUnit.SECONDS);
+            fail("Expected interruption did not occur");
+        } catch (InterruptedException ignored) {
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBlockUntilConnectedTightLoop() throws InterruptedException {
+        CuratorFramework client;
+        for (int i = 0; i < 50; i++) {
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(100));
+            try {
+                client.start();
+                client.blockUntilConnected();
+
+                assertTrue(client.getZookeeperClient().isConnected(), "Not connected after blocking for connection #" + i);
+            } finally {
+                client.close();
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompression.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompression.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CompressionProvider;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class TestCompression extends BaseClassForTests {
+    @Test
+    public void testCompressionProvider() throws Exception {
+        final byte[] data = "here's a string".getBytes();
+        final AtomicInteger compressCounter = new AtomicInteger();
+        final AtomicInteger decompressCounter = new AtomicInteger();
+        CompressionProvider compressionProvider = new CompressionProvider() {
+            @Override
+            public byte[] compress(String path, byte[] data) {
+                compressCounter.incrementAndGet();
+                byte[] bytes = new byte[data.length * 2];
+                System.arraycopy(data, 0, bytes, 0, data.length);
+                System.arraycopy(data, 0, bytes, data.length, data.length);
+                return bytes;
+            }
+
+            @Override
+            public byte[] decompress(String path, byte[] compressedData) {
+                decompressCounter.incrementAndGet();
+                byte[] bytes = new byte[compressedData.length / 2];
+                System.arraycopy(compressedData, 0, bytes, 0, bytes.length);
+                return bytes;
+            }
+        };
+        CuratorFramework client = CuratorFrameworkFactory.builder().
+                compressionProvider(compressionProvider).
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+        try {
+            client.start();
+            client.create().compressed().creatingParentsIfNeeded().forPath("/a/b/c", data);
+            assertNotEquals(data, client.getData().forPath("/a/b/c"));
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+        assertEquals(compressCounter.get(), 1);
+        assertEquals(decompressCounter.get(), 1);
+    }
+
+    @Test
+    public void testSetData() throws Exception {
+        final byte[] data = "here's a string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().creatingParentsIfNeeded().forPath("/a/b/c", data);
+            assertArrayEquals(data, client.getData().forPath("/a/b/c"));
+            client.setData().compressed().forPath("/a/b/c", data);
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        final byte[] data = "here's a string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().compressed().creatingParentsIfNeeded().forPath("/a/b/c", data);
+            assertNotEquals(data, client.getData().forPath("/a/b/c"));
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompressionInTransactionNew.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompressionInTransactionNew.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestCompressionInTransactionNew extends BaseClassForTests {
+    @Test
+    public void testSetData() throws Exception {
+        final String path = "/a";
+        final byte[] data = "here's a string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp op = client.transactionOp().create().forPath(path, data);
+            client.transaction().forOperations(op);
+            assertArrayEquals(data, client.getData().forPath(path));
+            op = client.transactionOp().setData().compressed().forPath(path, data);
+            client.transaction().forOperations(op);
+            assertArrayEquals(data, client.getData().decompressed().forPath(path));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSetCompressedAndUncompressed() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp op1 = client.transactionOp().create().compressed().forPath(path1);
+            CuratorOp op2 = client.transactionOp().create().forPath(path2);
+            client.transaction().forOperations(op1, op2);
+            assertNotNull(client.checkExists().forPath(path1));
+            assertNotNull(client.checkExists().forPath(path2));
+            op1 = client.transactionOp().setData().compressed().forPath(path1, data1);
+            op2 = client.transactionOp().setData().forPath(path2, data2);
+            client.transaction().forOperations(op1, op2);
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertArrayEquals(data2, client.getData().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/a/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp op1 = client.transactionOp().create().compressed().forPath(path1, data1);
+            CuratorOp op2 = client.transactionOp().create().compressed().forPath(path2, data2);
+            client.transaction().forOperations(op1, op2);
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data2, client.getData().forPath(path2));
+            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateCompressedAndUncompressed() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp op1 = client.transactionOp().create().compressed().forPath(path1, data1);
+            CuratorOp op2 = client.transactionOp().create().forPath(path2, data2);
+            client.transaction().forOperations(op1, op2);
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertArrayEquals(data2, client.getData().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompressionInTransactionOld.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCompressionInTransactionOld.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("deprecation")
+public class TestCompressionInTransactionOld extends BaseClassForTests {
+    @Test
+    public void testSetData() throws Exception {
+        final String path = "/a";
+        final byte[] data = "here's a string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.inTransaction().create().forPath(path, data).and().commit();
+            assertArrayEquals(data, client.getData().forPath(path));
+            client.inTransaction().setData().compressed().forPath(path, data).and().commit();
+            assertArrayEquals(data, client.getData().decompressed().forPath(path));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSetCompressedAndUncompressed() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.inTransaction().create().compressed().forPath(path1).and().create().forPath(path2).and().commit();
+            assertNotNull(client.checkExists().forPath(path1));
+            assertNotNull(client.checkExists().forPath(path2));
+            client.inTransaction().setData().compressed().forPath(path1, data1).and().setData().forPath(path2, data2).and().commit();
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertArrayEquals(data2, client.getData().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/a/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.inTransaction().create().compressed().forPath(path1, data1).and().create().compressed().forPath(path2, data2).and().commit();
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data2, client.getData().forPath(path2));
+            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateCompressedAndUncompressed() throws Exception {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        final byte[] data1 = "here's a string".getBytes();
+        final byte[] data2 = "here's another string".getBytes();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.inTransaction().create().compressed().forPath(path1, data1).and().create().forPath(path2, data2).and().commit();
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
+            assertArrayEquals(data2, client.getData().forPath(path2));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCreateReturningStat.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestCreateReturningStat.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestCreateReturningStat extends CuratorTestBase {
+    private CuratorFramework createClient() {
+        return CuratorFrameworkFactory.builder().
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+    }
+
+    private void compare(CuratorFramework client, String path,
+                         Stat expected) throws Exception {
+        Stat queriedStat = client.checkExists().forPath(path);
+        assertEquals(queriedStat, expected);
+    }
+
+    @Test
+    public void testOrSetDataStoringStatIn() throws Exception {
+        try (CuratorFramework client = createClient()) {
+            client.start();
+            client.getZookeeperClient().blockUntilConnectedOrTimedOut();
+            final String path = "/test";
+            final Stat versionZeroStat = new Stat();
+            client.create().orSetData().storingStatIn(versionZeroStat).forPath(path);
+            assertEquals(0, versionZeroStat.getVersion());
+            final Stat versionOneStat = new Stat();
+            client.create().orSetData().storingStatIn(versionOneStat).forPath(path);
+            assertEquals(versionZeroStat.getAversion(), versionOneStat.getAversion());
+            assertEquals(versionZeroStat.getCtime(), versionOneStat.getCtime());
+            assertEquals(versionZeroStat.getCversion(), versionOneStat.getCversion());
+            assertEquals(versionZeroStat.getCzxid(), versionOneStat.getCzxid());
+            assertEquals(versionZeroStat.getDataLength(), versionOneStat.getDataLength());
+            assertEquals(versionZeroStat.getEphemeralOwner(), versionOneStat.getEphemeralOwner());
+            assertTrue(versionZeroStat.getMtime() <= versionOneStat.getMtime());
+            assertNotEquals(versionZeroStat.getMzxid(), versionOneStat.getMzxid());
+            assertEquals(versionZeroStat.getNumChildren(), versionOneStat.getNumChildren());
+            assertEquals(versionZeroStat.getPzxid(), versionOneStat.getPzxid());
+            assertEquals(1, versionOneStat.getVersion());
+        }
+    }
+
+    @Test
+    public void testCreateReturningStat() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla";
+            Stat stat = new Stat();
+            client.create().storingStatIn(stat).forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateReturningStatIncludingParents() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla/bla";
+            Stat stat = new Stat();
+            client.create().creatingParentsIfNeeded().storingStatIn(stat).forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateReturningStatIncludingParentsReverse() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla/bla";
+            Stat stat = new Stat();
+            client.create().storingStatIn(stat).creatingParentsIfNeeded().forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateReturningStatCompressed() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla";
+            Stat stat = new Stat();
+            client.create().compressed().storingStatIn(stat).forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateReturningStatWithProtected() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla";
+            Stat stat = new Stat();
+            path = client.create().withProtection().storingStatIn(stat).forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateReturningStatInBackground() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/bla";
+            Stat stat = new Stat();
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AtomicReference<Stat> statRef = new AtomicReference<>();
+            BackgroundCallback callback = (client1, event) -> {
+                if (event.getType() == CuratorEventType.CREATE) {
+                    statRef.set(event.getStat());
+                    latch.countDown();
+                }
+            };
+            client.create().storingStatIn(stat).inBackground(callback).forPath(path);
+            if (!timing.awaitLatch(latch)) {
+                fail("Timed out awaing latch");
+            }
+            compare(client, path, statRef.get());
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testIdempotentCreateReturningStat() throws Exception {
+        CuratorFramework client = createClient();
+        try {
+            client.start();
+            String path = "/testidp";
+            client.create().forPath(path);
+            Stat stat = new Stat();
+            client.create().idempotent().storingStatIn(stat).forPath(path);
+            compare(client, path, stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestEnabledSessionExpiredState.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestEnabledSessionExpiredState.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestEnabledSessionExpiredState extends BaseClassForTests {
+    private final Timing2 timing = new Timing2();
+    private CuratorFramework client;
+    private BlockingQueue<ConnectionState> states;
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .connectionTimeoutMs(timing.connection())
+                .sessionTimeoutMs(timing.session())
+                .retryPolicy(new RetryOneTime(1))
+                .build();
+        client.start();
+        states = Queues.newLinkedBlockingQueue();
+        ConnectionStateListener listener = (client, newState) -> states.add(newState);
+        client.getConnectionStateListenable().addListener(listener);
+    }
+
+    @AfterEach
+    @Override
+    public void teardown() throws Exception {
+        try {
+            CloseableUtils.closeQuietly(client);
+        } finally {
+            super.teardown();
+        }
+    }
+
+    @Test
+    public void testResetCausesLost() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        client.checkExists().forPath("/");
+        client.getZookeeperClient().reset();
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+    }
+
+    @Test
+    public void testInjectedWatchedEvent() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        final CountDownLatch latch = new CountDownLatch(1);
+        Watcher watcher = event -> {
+            if (event.getType() == Watcher.Event.EventType.None) {
+                if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                    latch.countDown();
+                }
+            }
+        };
+        client.checkExists().usingWatcher(watcher).forPath("/");
+        server.stop();
+        assertTrue(timing.forSessionSleep().awaitLatch(latch));
+    }
+
+    @Test
+    public void testKillSession() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+    }
+
+    @Test
+    public void testReconnectWithoutExpiration() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        server.stop();
+        try {
+            client.checkExists().forPath("/");
+        } catch (KeeperException.ConnectionLossException ignore) {
+        }
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        server.restart();
+        client.checkExists().forPath("/");
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+    }
+
+    @Test
+    public void testSessionExpirationFromTimeout() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        server.stop();
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+    }
+
+    @Test
+    public void testSessionExpirationFromTimeoutWithRestart() throws Exception {
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        server.stop();
+        timing.forSessionSleep().sleep();
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        server.restart();
+        client.checkExists().forPath("/");
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+        assertNull(states.poll(timing.multiple(.5).milliseconds(), TimeUnit.MILLISECONDS));
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestEnsureContainers.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestEnsureContainers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.EnsureContainers;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestEnsureContainers extends BaseClassForTests {
+    @Test
+    public void testBasic() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
+            ensureContainers.ensure();
+            assertNotNull(client.checkExists().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSingleExecution() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
+            ensureContainers.ensure();
+            assertNotNull(client.checkExists().forPath("/one/two/three"));
+            client.delete().forPath("/one/two/three");
+            ensureContainers.ensure();
+            assertNull(client.checkExists().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestExistsBuilder.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestExistsBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.imps.DefaultACLProvider;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestExistsBuilder extends BaseClassForTests {
+    @Test
+    public void testExistsWithParentsWithAclApplyToParents() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            String path = "/bar/foo/test";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            assertNull(client.checkExists().creatingParentsIfNeeded().withACL(acl).forPath(path));
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, acl);
+            List<ACL> actualBarFoo = client.getACL().forPath("/bar/foo");
+            assertEquals(actualBarFoo, acl);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testExistsWithParentsWithAclApplyToParentsInBackground() throws Exception {
+        CuratorFramework client = createClient(new DefaultACLProvider());
+        try {
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            String path = "/bar/foo/test";
+            List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            client.checkExists().creatingParentsIfNeeded().withACL(acl).inBackground(callback).forPath(path);
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            List<ACL> actualBar = client.getACL().forPath("/bar");
+            assertEquals(actualBar, acl);
+            List<ACL> actualBarFoo = client.getACL().forPath("/bar/foo");
+            assertEquals(actualBarFoo, acl);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private CuratorFramework createClient(ACLProvider aclProvider) {
+        return CuratorFrameworkFactory.builder().
+                aclProvider(aclProvider).
+                connectString(server.getConnectString()).
+                retryPolicy(new RetryOneTime(1)).
+                build();
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestFramework.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestFramework.java
@@ -1,0 +1,813 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import com.google.common.collect.Lists;
+import org.apache.curator.framework.AuthInfo;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.EnsurePath;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings({"deprecation", "unused", "BooleanMethodIsAlwaysInverted", "JUnit3StyleTestMethodInJUnit4Class"})
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
+public class TestFramework extends BaseClassForTests {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        System.setProperty("znode.container.checkIntervalMs", "1000");
+        super.setup();
+    }
+
+    @AfterEach
+    @Override
+    public void teardown() throws Exception {
+        System.clearProperty("znode.container.checkIntervalMs");
+        super.teardown();
+    }
+
+    public void testWaitForShutdownTimeoutMs() throws Exception {
+        final BlockingQueue<Integer> timeoutQueue = new ArrayBlockingQueue<>(1);
+        ZookeeperFactory zookeeperFactory = new ZookeeperFactory() {
+            @Override
+            public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws IOException {
+                return new ZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly) {
+                    @Override
+                    public boolean close(int waitForShutdownTimeoutMs) throws InterruptedException {
+                        timeoutQueue.add(waitForShutdownTimeoutMs);
+                        return super.close(waitForShutdownTimeoutMs);
+                    }
+                };
+            }
+        };
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .zookeeperFactory(zookeeperFactory)
+                .waitForShutdownTimeoutMs(10064)
+                .build();
+        try {
+            client.start();
+            client.checkExists().forPath("/foo");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+        Integer polledValue = timeoutQueue.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
+        assertNotNull(polledValue);
+        assertEquals(10064, polledValue.intValue());
+    }
+
+    @Test
+    public void testSessionLossWithLongTimeout() throws Exception {
+        final Timing timing = new Timing();
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.forWaiting().milliseconds(),
+                timing.connection(), new RetryOneTime(1))) {
+            final CountDownLatch connectedLatch = new CountDownLatch(1);
+            final CountDownLatch lostLatch = new CountDownLatch(1);
+            final CountDownLatch restartedLatch = new CountDownLatch(1);
+            client.getConnectionStateListenable().addListener((client1, newState) -> {
+                if (newState == ConnectionState.CONNECTED) {
+                    connectedLatch.countDown();
+                } else if (newState == ConnectionState.LOST) {
+                    lostLatch.countDown();
+                } else if (newState == ConnectionState.RECONNECTED) {
+                    restartedLatch.countDown();
+                }
+            });
+            client.start();
+            assertTrue(timing.awaitLatch(connectedLatch));
+            server.stop();
+            timing.sleepABit();
+            assertTrue(timing.awaitLatch(lostLatch));
+            server.restart();
+            assertTrue(timing.awaitLatch(restartedLatch));
+        }
+    }
+
+    @Test
+    public void testConnectionState() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        try {
+            final BlockingQueue<ConnectionState> queue = new LinkedBlockingQueue<>();
+            ConnectionStateListener listener = (client1, newState) -> queue.add(newState);
+            client.getConnectionStateListenable().addListener(listener);
+            client.start();
+            assertEquals(queue.poll(timing.multiple(4).seconds(), TimeUnit.SECONDS), ConnectionState.CONNECTED);
+            server.stop();
+            assertEquals(queue.poll(timing.multiple(4).seconds(), TimeUnit.SECONDS), ConnectionState.SUSPENDED);
+            assertEquals(queue.poll(timing.multiple(4).seconds(), TimeUnit.SECONDS), ConnectionState.LOST);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateOrSetData() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            String name = client.create().forPath("/hey", "there".getBytes());
+            assertEquals(name, "/hey");
+            name = client.create().orSetData().forPath("/hey", "other".getBytes());
+            assertEquals(name, "/hey");
+            assertArrayEquals(client.getData().forPath("/hey"), "other".getBytes());
+            name = client.create().orSetData().creatingParentsIfNeeded().forPath("/a/b/c", "there".getBytes());
+            assertEquals(name, "/a/b/c");
+            name = client.create().orSetData().creatingParentsIfNeeded().forPath("/a/b/c", "what".getBytes());
+            assertEquals(name, "/a/b/c");
+            assertArrayEquals(client.getData().forPath("/a/b/c"), "what".getBytes());
+            final BlockingQueue<CuratorEvent> queue = new LinkedBlockingQueue<>();
+            BackgroundCallback backgroundCallback = (client1, event) -> queue.add(event);
+            client.create().orSetData().inBackground(backgroundCallback).forPath("/a/b/c", "another".getBytes());
+            CuratorEvent event = queue.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
+            assertNotNull(event);
+            assertEquals(event.getResultCode(), KeeperException.Code.OK.intValue());
+            assertEquals(event.getType(), CuratorEventType.CREATE);
+            assertEquals(event.getPath(), "/a/b/c");
+            assertEquals(event.getName(), "/a/b/c");
+            CuratorEvent unexpectedEvent = queue.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
+            assertNull(unexpectedEvent);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNamespaceWithWatcher() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).namespace("aisa").retryPolicy(new RetryOneTime(1)).build();
+        client.start();
+        try {
+            final BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+            Watcher watcher = event -> {
+                try {
+                    queue.put(event.getPath());
+                } catch (InterruptedException e) {
+                    throw new Error(e);
+                }
+            };
+            client.create().forPath("/base");
+            client.getChildren().usingWatcher(watcher).forPath("/base");
+            client.create().forPath("/base/child");
+
+            String path = new Timing2().takeFromQueue(queue);
+            assertEquals(path, "/base");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNamespaceInBackground() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).namespace("aisa").retryPolicy(new RetryOneTime(1)).build();
+        client.start();
+        try {
+            final BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+            CuratorListener listener = (client1, event) -> {
+                if (event.getType() == CuratorEventType.EXISTS) {
+                    queue.put(event.getPath());
+                }
+            };
+            client.getCuratorListenable().addListener(listener);
+            client.create().forPath("/base");
+            client.checkExists().inBackground().forPath("/base");
+            String path = queue.poll(10, TimeUnit.SECONDS);
+            assertEquals(path, "/base");
+            client.getCuratorListenable().removeListener(listener);
+            BackgroundCallback callback = (client12, event) -> queue.put(event.getPath());
+            client.getChildren().inBackground(callback).forPath("/base");
+            path = queue.poll(10, TimeUnit.SECONDS);
+            assertEquals(path, "/base");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateACLSingleAuth() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder
+                .connectString(server.getConnectString())
+                .authorization("digest", "me1:pass1".getBytes())
+                .retryPolicy(new RetryOneTime(1))
+                .build();
+        client.start();
+        try {
+            ACL acl = new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.AUTH_IDS);
+            List<ACL> aclList = Lists.newArrayList(acl);
+            client.create().withACL(aclList).forPath("/test", "test".getBytes());
+            client.close();
+            client = builder
+                    .connectString(server.getConnectString())
+                    .authorization("digest", "me1:pass1".getBytes())
+                    .retryPolicy(new RetryOneTime(1))
+                    .build();
+            client.start();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+            } catch (KeeperException.NoAuthException e) {
+                fail("Auth failed");
+            }
+            client.close();
+            client = builder
+                    .connectString(server.getConnectString())
+                    .authorization("digest", "something:else".getBytes())
+                    .retryPolicy(new RetryOneTime(1))
+                    .build();
+            client.start();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+                fail("Should have failed with auth exception");
+            } catch (KeeperException.NoAuthException ignored) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testACLDeprecatedApis() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1));
+        assertNull(builder.getAuthScheme());
+        assertNull(builder.getAuthValue());
+        builder = builder.authorization("digest", "me1:pass1".getBytes());
+        assertEquals(builder.getAuthScheme(), "digest");
+        assertArrayEquals(builder.getAuthValue(), "me1:pass1".getBytes());
+    }
+
+    @Test
+    public void testCreateACLMultipleAuths() throws Exception {
+        List<AuthInfo> authInfos = new ArrayList<>();
+        authInfos.add(new AuthInfo("digest", "me1:pass1".getBytes()));
+        authInfos.add(new AuthInfo("digest", "me2:pass2".getBytes()));
+
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder
+                .connectString(server.getConnectString())
+                .authorization(authInfos)
+                .retryPolicy(new RetryOneTime(1))
+                .build();
+        client.start();
+        try {
+            ACL acl = new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.AUTH_IDS);
+            List<ACL> aclList = Lists.newArrayList(acl);
+            client.create().withACL(aclList).forPath("/test", "test".getBytes());
+            client.close();
+            client = builder
+                    .connectString(server.getConnectString())
+                    .authorization("digest", "me1:pass1".getBytes())
+                    .retryPolicy(new RetryOneTime(1))
+                    .build();
+            client.start();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+            } catch (KeeperException.NoAuthException e) {
+                fail("Auth failed");
+            }
+            client.close();
+            client = builder
+                    .connectString(server.getConnectString())
+                    .authorization("digest", "me2:pass2".getBytes())
+                    .retryPolicy(new RetryOneTime(1))
+                    .build();
+            client.start();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+            } catch (KeeperException.NoAuthException e) {
+                fail("Auth failed");
+            }
+            client.close();
+            client = builder
+                    .connectString(server.getConnectString())
+                    .authorization("digest", "something:else".getBytes())
+                    .retryPolicy(new RetryOneTime(1))
+                    .build();
+            client.start();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+                fail("Should have failed with auth exception");
+            } catch (KeeperException.NoAuthException ignored) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateACLWithReset() throws Exception {
+        Timing timing = new Timing();
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder
+                .connectString(server.getConnectString())
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .authorization("digest", "me:pass".getBytes())
+                .retryPolicy(new RetryOneTime(1))
+                .build();
+        client.start();
+        try {
+            final CountDownLatch lostLatch = new CountDownLatch(1);
+            ConnectionStateListener listener = (client1, newState) -> {
+                if (newState == ConnectionState.LOST) {
+                    lostLatch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            ACL acl = new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.AUTH_IDS);
+            List<ACL> aclList = Lists.newArrayList(acl);
+            client.create().withACL(aclList).forPath("/test", "test".getBytes());
+            server.stop();
+            assertTrue(timing.awaitLatch(lostLatch));
+            try {
+                client.checkExists().forPath("/");
+                fail("Connection should be down");
+            } catch (KeeperException.ConnectionLossException ignored) {
+            }
+            server.restart();
+            try {
+                client.setData().forPath("/test", "test".getBytes());
+            } catch (KeeperException.NoAuthException e) {
+                fail("Auth failed");
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateParents() throws Exception {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        client.start();
+        try {
+            client.create().creatingParentsIfNeeded().forPath("/one/two/three", "foo".getBytes());
+            byte[] data = client.getData().forPath("/one/two/three");
+            assertArrayEquals(data, "foo".getBytes());
+            client.create().creatingParentsIfNeeded().forPath("/one/two/another", "bar".getBytes());
+            data = client.getData().forPath("/one/two/another");
+            assertArrayEquals(data, "bar".getBytes());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testOverrideCreateParentContainers() throws Exception {
+        if (!checkForContainers()) {
+            return;
+        }
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .dontUseContainerParents()
+                .build();
+        try {
+            client.start();
+            client.create().creatingParentContainersIfNeeded().forPath("/one/two/three", "foo".getBytes());
+            byte[] data = client.getData().forPath("/one/two/three");
+            assertArrayEquals(data, "foo".getBytes());
+            client.delete().forPath("/one/two/three");
+            new Timing().sleepABit();
+            assertNotNull(client.checkExists().forPath("/one/two"));
+            new Timing().sleepABit();
+            assertNotNull(client.checkExists().forPath("/one"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateParentContainers() throws Exception {
+        if (!checkForContainers()) {
+            return;
+        }
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            client.create().creatingParentContainersIfNeeded().forPath("/one/two/three", "foo".getBytes());
+            byte[] data = client.getData().forPath("/one/two/three");
+            assertArrayEquals(data, "foo".getBytes());
+            client.delete().forPath("/one/two/three");
+            new Timing().sleepABit();
+            assertNull(client.checkExists().forPath("/one/two"));
+            new Timing().sleepABit();
+            assertNull(client.checkExists().forPath("/one"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private boolean checkForContainers() {
+        if (ZKPaths.getContainerCreateMode() == CreateMode.PERSISTENT) {
+            System.out.println("Not using CreateMode.CONTAINER enabled version of ZooKeeper");
+            return false;
+        }
+        return true;
+    }
+
+    @Test
+    public void testCreatingParentsTheSame() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            assertNull(client.checkExists().forPath("/one/two"));
+            client.create().creatingParentContainersIfNeeded().forPath("/one/two/three");
+            assertNotNull(client.checkExists().forPath("/one/two"));
+            client.delete().deletingChildrenIfNeeded().forPath("/one");
+            assertNull(client.checkExists().forPath("/one"));
+            assertNull(client.checkExists().forPath("/one/two"));
+            client.checkExists().creatingParentContainersIfNeeded().forPath("/one/two/three");
+            assertNotNull(client.checkExists().forPath("/one/two"));
+            assertNull(client.checkExists().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testExistsCreatingParents() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            assertNull(client.checkExists().forPath("/one/two"));
+            client.checkExists().creatingParentContainersIfNeeded().forPath("/one/two/three");
+            assertNotNull(client.checkExists().forPath("/one/two"));
+            assertNull(client.checkExists().forPath("/one/two/three"));
+            assertNull(client.checkExists().creatingParentContainersIfNeeded().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testExistsCreatingParentsInBackground() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            assertNull(client.checkExists().forPath("/one/two"));
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            client.checkExists().creatingParentContainersIfNeeded().inBackground(callback).forPath("/one/two/three");
+            assertTrue(new Timing().awaitLatch(latch));
+            assertNotNull(client.checkExists().forPath("/one/two"));
+            assertNull(client.checkExists().forPath("/one/two/three"));
+            assertNull(client.checkExists().creatingParentContainersIfNeeded().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testEnsurePathWithNamespace() throws Exception {
+        final String namespace = "jz";
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace(namespace).build();
+        client.start();
+        try {
+            EnsurePath ensurePath = new EnsurePath("/pity/the/fool");
+            ensurePath.ensure(client.getZookeeperClient());
+            assertNull(client.getZookeeperClient().getZooKeeper().exists("/jz/pity/the/fool", false));
+            ensurePath = client.newNamespaceAwareEnsurePath("/pity/the/fool");
+            ensurePath.ensure(client.getZookeeperClient());
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/jz/pity/the/fool", false));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateContainersWithNamespace() throws Exception {
+        final String namespace = "container1";
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace(namespace).build();
+        try {
+            client.start();
+            String path = "/path1/path2";
+            client.createContainers(path);
+            assertNotNull(client.checkExists().forPath(path));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/" + namespace + path, false));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+
+    @Test
+    public void testCreateContainersUsingNamespace() throws Exception {
+        final String namespace = "container2";
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
+        try {
+            client.start();
+            CuratorFramework nsClient = client.usingNamespace(namespace);
+            String path = "/path1/path2";
+            nsClient.createContainers(path);
+            assertNotNull(nsClient.checkExists().forPath(path));
+            assertNotNull(nsClient.getZookeeperClient().getZooKeeper().exists("/" + namespace + path, false));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNamespace() throws Exception {
+        final String namespace = "TestNamespace";
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        CuratorFramework client = builder.connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace(namespace).build();
+        client.start();
+        try {
+            String actualPath = client.create().forPath("/test");
+            assertEquals(actualPath, "/test");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/" + namespace + "/test", false));
+            assertNull(client.getZookeeperClient().getZooKeeper().exists("/test", false));
+            actualPath = client.usingNamespace(null).create().forPath("/non");
+            assertEquals(actualPath, "/non");
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/non", false));
+            client.create().forPath("/test/child", "hey".getBytes());
+            byte[] bytes = client.getData().forPath("/test/child");
+            assertArrayEquals(bytes, "hey".getBytes());
+            bytes = client.usingNamespace(null).getData().forPath("/" + namespace + "/test/child");
+            assertArrayEquals(bytes, "hey".getBytes());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCustomCallback() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> {
+                if (event.getType() == CuratorEventType.CREATE) {
+                    if (event.getPath().equals("/head")) {
+                        latch.countDown();
+                    }
+                }
+            };
+            client.create().inBackground(callback).forPath("/head");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSync() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.getCuratorListenable().addListener((client1, event) -> {
+                        if (event.getType() == CuratorEventType.SYNC) {
+                            assertEquals(event.getPath(), "/head");
+                            ((CountDownLatch) event.getContext()).countDown();
+                        }
+                    }
+            );
+            client.create().forPath("/head");
+            assertNotNull(client.checkExists().forPath("/head"));
+            CountDownLatch latch = new CountDownLatch(1);
+            client.sync("/head", latch);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSyncNew() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.create().forPath("/head");
+            assertNotNull(client.checkExists().forPath("/head"));
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> {
+                if (event.getType() == CuratorEventType.SYNC) {
+                    latch.countDown();
+                }
+            };
+            client.sync().inBackground(callback).forPath("/head");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testGetSequentialChildren() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.create().forPath("/head");
+            for (int i = 0; i < 10; ++i) {
+                client.create().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/head/child");
+            }
+            List<String> children = client.getChildren().forPath("/head");
+            assertEquals(children.size(), 10);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundGetDataWithWatch() throws Exception {
+        final byte[] data1 = {1, 2, 3};
+        final byte[] data2 = {4, 5, 6, 7};
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            final CountDownLatch watchedLatch = new CountDownLatch(1);
+            client.getCuratorListenable().addListener((client1, event) -> {
+                        if (event.getType() == CuratorEventType.GET_DATA) {
+                            assertEquals(event.getPath(), "/test");
+                            assertArrayEquals(event.getData(), data1);
+                            ((CountDownLatch) event.getContext()).countDown();
+                        } else if (event.getType() == CuratorEventType.WATCHED) {
+                            if (event.getWatchedEvent().getType() == Watcher.Event.EventType.NodeDataChanged) {
+                                assertEquals(event.getPath(), "/test");
+                                watchedLatch.countDown();
+                            }
+                        }
+                    }
+            );
+            client.create().forPath("/test", data1);
+            CountDownLatch backgroundLatch = new CountDownLatch(1);
+            client.getData().watched().inBackground(backgroundLatch).forPath("/test");
+            assertTrue(backgroundLatch.await(10, TimeUnit.SECONDS));
+            client.setData().forPath("/test", data2);
+            assertTrue(watchedLatch.await(10, TimeUnit.SECONDS));
+            byte[] checkData = client.getData().forPath("/test");
+            assertArrayEquals(checkData, data2);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundCreate() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.getCuratorListenable().addListener((client1, event) -> {
+                        if (event.getType() == CuratorEventType.CREATE) {
+                            assertEquals(event.getPath(), "/test");
+                            ((CountDownLatch) event.getContext()).countDown();
+                        }
+                    }
+            );
+            CountDownLatch latch = new CountDownLatch(1);
+            client.create().inBackground(latch).forPath("/test", new byte[]{1, 2, 3});
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCreateModes() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            byte[] writtenBytes = {1, 2, 3};
+            client.create().forPath("/test", writtenBytes);
+            client.close();
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client.start();
+            byte[] readBytes = client.getData().forPath("/test");
+            assertArrayEquals(writtenBytes, readBytes);
+            client.create().withMode(CreateMode.EPHEMERAL).forPath("/ghost", writtenBytes);
+            client.close();
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client.start();
+            readBytes = client.getData().forPath("/test");
+            assertArrayEquals(writtenBytes, readBytes);
+            Stat stat = client.checkExists().forPath("/ghost");
+            assertNull(stat);
+            String realPath = client.create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/pseq", writtenBytes);
+            assertNotSame(realPath, "/pseq");
+            client.close();
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client.start();
+            readBytes = client.getData().forPath(realPath);
+            assertArrayEquals(writtenBytes, readBytes);
+            realPath = client.create().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/eseq", writtenBytes);
+            assertNotSame(realPath, "/eseq");
+            client.close();
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client.start();
+            stat = client.checkExists().forPath(realPath);
+            assertNull(stat);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testConfigurableZookeeper() throws Exception {
+        CuratorFramework client = null;
+        try {
+            ZKClientConfig zkClientConfig = new ZKClientConfig();
+            String zookeeperRequestTimeout = "30000";
+            zkClientConfig.setProperty(ZKClientConfig.ZOOKEEPER_REQUEST_TIMEOUT, zookeeperRequestTimeout);
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), 30000, 30000, new RetryOneTime(1), zkClientConfig);
+            client.start();
+            byte[] writtenBytes = {1, 2, 3};
+            client.create().forPath("/test", writtenBytes);
+            byte[] readBytes = client.getData().forPath("/test");
+            assertArrayEquals(writtenBytes, readBytes);
+            assertEquals(zookeeperRequestTimeout, client.getZookeeperClient().getZooKeeper().getClientConfig().getProperty(ZKClientConfig.ZOOKEEPER_REQUEST_TIMEOUT));
+        } catch (NoSuchMethodError e) {
+            log.debug("NoSuchMethodError: ", e);
+            log.info("Got NoSuchMethodError, meaning probably this cannot be used with ZooKeeper version < 3.6.1");
+        } finally {
+            try {
+                CloseableUtils.closeQuietly(client);
+            } catch (NoSuchMethodError e) {
+                log.debug("close: NoSuchMethodError: ", e);
+                log.info("close: Got NoSuchMethodError, meaning probably this cannot be used with ZooKeeper version < 3.6.1");
+            }
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            String path = client.create().withMode(CreateMode.PERSISTENT).forPath("/test", new byte[]{1, 2, 3});
+            assertEquals(path, "/test");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSequentialWithTrailingSeparator() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        client.start();
+        try {
+            client.create().forPath("/test");
+            String path = client.create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test/");
+            assertTrue(path.startsWith("/test/"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestGzipCompressionProvider.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestGzipCompressionProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.imps.GzipCompressionProvider;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings("unused")
+public class TestGzipCompressionProvider {
+    @Test
+    public void testDecompressCorrupt() {
+        GzipCompressionProvider provider = new GzipCompressionProvider();
+        try {
+            provider.decompress(null, new byte[100]);
+            fail("Expected IOException");
+        } catch (IOException ignore) {
+        }
+        byte[] compressedData = provider.compress(null, new byte[0]);
+        for (int i = 0; i < compressedData.length; i++) {
+            try {
+                provider.decompress(null, Arrays.copyOf(compressedData, i));
+            } catch (IOException ignore) {
+            }
+            for (int change = 1; change < 256; change++) {
+                byte b = compressedData[i];
+                compressedData[i] = (byte) (b + change);
+                try {
+                    provider.decompress(null, compressedData);
+                } catch (IOException ignore) {
+                }
+                compressedData[i] = b;
+            }
+        }
+    }
+
+    private static byte[] jdkCompress(byte[] data) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (GZIPOutputStream out = new GZIPOutputStream(bytes)) {
+            out.write(data);
+            out.finish();
+        }
+        return bytes.toByteArray();
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestMultiClient.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestMultiClient.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMultiClient extends BaseClassForTests {
+    @Test
+    public void testNotify() throws Exception {
+        CuratorFramework client1 = null;
+        CuratorFramework client2 = null;
+        try {
+            client1 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client2 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            client1.start();
+            client2.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            client1.getCuratorListenable().addListener((client, event) -> {
+                        if (event.getType() == CuratorEventType.WATCHED) {
+                            if (event.getWatchedEvent().getType() == Watcher.Event.EventType.NodeDataChanged) {
+                                if (event.getPath().equals("/test")) {
+                                    latch.countDown();
+                                }
+                            }
+                        }
+                    }
+            );
+            client1.create().forPath("/test", new byte[]{1, 2, 3});
+            client1.checkExists().watched().forPath("/test");
+            client2.getCuratorListenable().addListener((client, event) -> {
+                        if (event.getType() == CuratorEventType.SYNC) {
+                            client.setData().forPath("/test", new byte[]{10, 20});
+                        }
+                    }
+            );
+            client2.sync().forPath("/test");
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client1);
+            CloseableUtils.closeQuietly(client2);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestNeverConnected.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestNeverConnected.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestNeverConnected {
+    @Test
+    public void testNeverConnected() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient("localhost:1111", 100, 100, new RetryOneTime(1));
+        try {
+            final BlockingQueue<ConnectionState> queue = Queues.newLinkedBlockingQueue();
+            ConnectionStateListener listener = (client1, state) -> queue.add(state);
+            client.getConnectionStateListenable().addListener(listener);
+            client.start();
+            client.create().inBackground().forPath("/");
+            ConnectionState polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.SUSPENDED);
+            polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.LOST);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestReadOnly.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestReadOnly.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestReadOnly extends BaseClassForTests {
+    @BeforeEach
+    public void setup() {
+        System.setProperty("readonlymode.enabled", "true");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setProperty("readonlymode.enabled", "false");
+    }
+
+    @Test
+    public void testReadOnly() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = null;
+        TestingCluster cluster = createAndStartCluster(2);
+        try {
+            client = CuratorFrameworkFactory.builder().connectString(cluster.getConnectString()).canBeReadOnly(true).connectionTimeoutMs(timing.connection()).sessionTimeoutMs(timing.session()).retryPolicy(new ExponentialBackoffRetry(100, 3)).build();
+            client.start();
+            client.create().forPath("/test");
+            final CountDownLatch readOnlyLatch = new CountDownLatch(1);
+            final CountDownLatch reconnectedLatch = new CountDownLatch(1);
+            ConnectionStateListener listener = (client1, newState) -> {
+                switch (newState) {
+                    case READ_ONLY -> readOnlyLatch.countDown();
+                    case RECONNECTED -> reconnectedLatch.countDown();
+                }
+            };
+            client.getConnectionStateListenable().addListener(listener);
+            InstanceSpec ourInstance = cluster.findConnectionInstance(client.getZookeeperClient().getZooKeeper());
+            Iterator<InstanceSpec> iterator = cluster.getInstances().iterator();
+            InstanceSpec killInstance = iterator.next();
+            if (killInstance.equals(ourInstance)) {
+                killInstance = iterator.next();
+            }
+            cluster.killServer(killInstance);
+            assertEquals(reconnectedLatch.getCount(), 1);
+            assertTrue(timing.awaitLatch(readOnlyLatch));
+            assertEquals(reconnectedLatch.getCount(), 1);
+            cluster.restartServer(killInstance);
+            assertTrue(timing.awaitLatch(reconnectedLatch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+            CloseableUtils.closeQuietly(cluster);
+        }
+    }
+
+    @Override
+    protected void createServer() {
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestReconfiguration.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestReconfiguration.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.EnsembleTracker;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.server.quorum.QuorumPeer;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.apache.zookeeper.server.quorum.flexible.QuorumMaj;
+import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings({"SameParameterValue", "unused"})
+public class TestReconfiguration extends CuratorTestBase {
+    private final Timing2 timing = new Timing2();
+    private TestingCluster cluster;
+    private EnsembleProvider ensembleProvider;
+    private static final String superUserPasswordDigest = "curator-test:zghsj3JfJqK7DbWf0RQ1BgbJH9w=";
+    private static final String superUserPassword = "curator-test";
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        QuorumPeerConfig.setReconfigEnabled(true);
+        System.setProperty("zookeeper.DigestAuthenticationProvider.superDigest", superUserPasswordDigest);
+        CloseableUtils.closeQuietly(server);
+        cluster = createAndStartCluster(3);
+    }
+
+    @AfterEach
+    @Override
+    public void teardown() throws Exception {
+        CloseableUtils.closeQuietly(cluster);
+        ensembleProvider = null;
+        System.clearProperty("zookeeper.DigestAuthenticationProvider.superDigest");
+        super.teardown();
+    }
+
+    @Test
+    public void testBasicGetConfig() throws Exception {
+        try (CuratorFramework client = newClient()) {
+            client.start();
+            byte[] configData = client.getConfig().forEnsemble();
+            QuorumVerifier quorumVerifier = toQuorumVerifier(configData);
+            System.out.println(quorumVerifier);
+            assertConfig(quorumVerifier, cluster.getInstances());
+            Assertions.assertEquals(EnsembleTracker.configToConnectionString(quorumVerifier), ensembleProvider.getConnectionString());
+        }
+    }
+
+    @Test
+    public void testConfigToConnectionStringIPv4Normal() throws Exception {
+        String config = "server.1=10.1.2.3:2888:3888:participant;10.2.3.4:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("10.2.3.4:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringIPv6Normal() throws Exception {
+        String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[2001:db8:85a3:0:0:8a2e:370:7334]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringIPv4NoClientAddr() throws Exception {
+        String config = "server.1=10.1.2.3:2888:3888:participant;2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringIPv4WildcardClientAddr() throws Exception {
+        String config = "server.1=10.1.2.3:2888:3888:participant;0.0.0.0:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringNoClientAddrOrPort() throws Exception {
+        String config = "server.1=10.1.2.3:2888:3888:participant";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("", configString);
+    }
+
+    @Test
+    public void testHostname() throws Exception {
+        String config = "server.1=localhost:2888:3888:participant;localhost:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("localhost:2181", configString);
+    }
+
+    @Test
+    public void testIPv6Wildcard1() throws Exception {
+        String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;[::]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
+    }
+
+    @Test
+    public void testIPv6Wildcard2() throws Exception {
+        String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[::0]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("1010:1:2:3:4:5:6:7:2181", configString);
+    }
+
+    @Test
+    public void testMixedIPv1() throws Exception {
+        String config = "server.1=10.1.2.3:2888:3888:participant;[::]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testMixedIPv2() throws Exception {
+        String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;127.0.0.1:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("127.0.0.1:2181", configString);
+    }
+
+    @Override
+    protected void createServer() {
+    }
+
+    private CuratorFramework newClient() {
+        return newClient(cluster.getConnectString(), true);
+    }
+
+    private CuratorFramework newClient(String connectionString) {
+        return newClient(connectionString, true);
+    }
+
+    private CuratorFramework newClient(String connectionString, boolean withEnsembleProvider) {
+        final AtomicReference<String> connectString = new AtomicReference<>(connectionString);
+        ensembleProvider = new EnsembleProvider() {
+            @Override
+            public void start() {
+            }
+
+            @Override
+            public boolean updateServerListEnabled() {
+                return false;
+            }
+
+            @Override
+            public String getConnectionString() {
+                return connectString.get();
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public void setConnectionString(String connectionString) {
+                connectString.set(connectionString);
+            }
+        };
+        return CuratorFrameworkFactory.builder()
+                .ensembleProvider(ensembleProvider)
+                .ensembleTracker(withEnsembleProvider)
+                .sessionTimeoutMs(timing.session())
+                .connectionTimeoutMs(timing.connection())
+                .authorization("digest", superUserPassword.getBytes())
+                .retryPolicy(new ExponentialBackoffRetry(timing.forSleepingABit().milliseconds(), 3))
+                .build();
+    }
+
+    private CountDownLatch setChangeWaiter(CuratorFramework client) throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        Watcher watcher = event -> {
+            if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+                latch.countDown();
+            }
+        };
+        client.getConfig().usingWatcher(watcher).forEnsemble();
+        return latch;
+    }
+
+    private void assertConfig(QuorumVerifier config, Collection<InstanceSpec> instances) {
+        instances.forEach(instance -> {
+            QuorumPeer.QuorumServer quorumServer = config.getAllMembers().get((long) instance.getServerId());
+            assertNotNull(quorumServer, String.format("Looking for %s - found %s", instance.getServerId(), config.getAllMembers()));
+            assertEquals(quorumServer.clientAddr.getPort(), instance.getPort());
+        });
+    }
+
+    private List<String> toReconfigSpec(Collection<InstanceSpec> instances) {
+        String localhost = new InetSocketAddress((InetAddress) null, 0).getAddress().getHostAddress();
+        return instances.stream()
+                .map(instance -> "server." + instance.getServerId() + "=" +
+                        localhost + ":" + instance.getElectionPort() + ":" + instance.getQuorumPort() + ";" + instance.getPort())
+                .collect(Collectors.toList());
+    }
+
+    private static QuorumVerifier toQuorumVerifier(byte[] bytes) throws Exception {
+        assertNotNull(bytes);
+        Properties properties = new Properties();
+        properties.load(new ByteArrayInputStream(bytes));
+        return new QuorumMaj(properties);
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTransactionsNew.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTransactionsNew.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.framework.api.transaction.OperationType;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class TestTransactionsNew extends BaseClassForTests {
+    @Test
+    public void testErrors() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/bar");
+            CuratorOp createOp2 = client.transactionOp().create().forPath("/z/blue");
+            final BlockingQueue<CuratorEvent> callbackQueue = new LinkedBlockingQueue<>();
+            BackgroundCallback callback = (client1, event) -> callbackQueue.add(event);
+            client.transaction().inBackground(callback).forOperations(createOp1, createOp2);
+            CuratorEvent event = callbackQueue.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
+            assertNotNull(event);
+            assertNotNull(event.getOpResults());
+            assertEquals(event.getOpResults().size(), 2);
+            assertEquals(event.getOpResults().get(0).getError(), KeeperException.Code.OK.intValue());
+            assertEquals(event.getOpResults().get(1).getError(), KeeperException.Code.NONODE.intValue());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testCheckVersion() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/foo");
+            Stat stat = client.setData().forPath("/foo", "new".getBytes());
+            CuratorOp statOp = client.transactionOp().check().withVersion(stat.getVersion() + 1).forPath("/foo");
+            CuratorOp createOp = client.transactionOp().create().forPath("/bar");
+            try {
+                client.transaction().forOperations(statOp, createOp);
+                fail();
+            } catch (KeeperException.BadVersionException ignored) {
+            }
+            assertNull(client.checkExists().forPath("/bar"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithNamespace() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo", "one".getBytes());
+            CuratorOp createOp2 = client.transactionOp().create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "one".getBytes());
+            CuratorOp setDataOp = client.transactionOp().setData().forPath("/foo", "two".getBytes());
+            CuratorOp createOp3 = client.transactionOp().create().forPath("/foo/bar");
+            CuratorOp deleteOp = client.transactionOp().delete().forPath("/foo/bar");
+            Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2, setDataOp, createOp3, deleteOp);
+            assertNotNull(client.checkExists().forPath("/foo"));
+            assertNotNull(client.usingNamespace(null).checkExists().forPath("/galt/foo"));
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertNull(client.checkExists().forPath("/foo/bar"));
+            CuratorTransactionResult ephemeralResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-")::apply).findFirst().get();
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo");
+            CuratorOp createOp2 = client.transactionOp().create().forPath("/foo/bar", "snafu".getBytes());
+            Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2);
+            assertNotNull(client.checkExists().forPath("/foo/bar"));
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            CuratorTransactionResult fooResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo")::apply).findFirst().get();
+            CuratorTransactionResult fooBarResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar")::apply).findFirst().get();
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackground() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo");
+            CuratorOp createOp2 = client.transactionOp().create().forPath("/foo/bar", "snafu".getBytes());
+            final BlockingQueue<List<CuratorTransactionResult>> queue = Queues.newLinkedBlockingQueue();
+            BackgroundCallback callback = (client1, event) -> queue.add(event.getOpResults());
+            client.transaction().inBackground(callback).forOperations(createOp1, createOp2);
+            Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
+            assertNotNull(results);
+            assertNotNull(client.checkExists().forPath("/foo/bar"));
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            CuratorTransactionResult fooResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo")::apply).findFirst().get();
+            CuratorTransactionResult fooBarResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar")::apply).findFirst().get();
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundWithNamespace() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo", "one".getBytes());
+            CuratorOp createOp2 = client.transactionOp().create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "one".getBytes());
+            CuratorOp setDataOp = client.transactionOp().setData().forPath("/foo", "two".getBytes());
+            CuratorOp createOp3 = client.transactionOp().create().forPath("/foo/bar");
+            CuratorOp deleteOp = client.transactionOp().delete().forPath("/foo/bar");
+            final BlockingQueue<List<CuratorTransactionResult>> queue = Queues.newLinkedBlockingQueue();
+            BackgroundCallback callback = (client1, event) -> queue.add(event.getOpResults());
+            client.transaction().inBackground(callback).forOperations(createOp1, createOp2, setDataOp, createOp3, deleteOp);
+            Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
+            assertNotNull(results);
+            assertNotNull(client.checkExists().forPath("/foo"));
+            assertNotNull(client.usingNamespace(null).checkExists().forPath("/galt/foo"));
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertNull(client.checkExists().forPath("/foo/bar"));
+            CuratorTransactionResult ephemeralResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-")::apply).findFirst().get();
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTransactionsOld.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTransactionsOld.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.framework.api.transaction.OperationType;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SuppressWarnings({"deprecation", "OptionalGetWithoutIsPresent"})
+public class TestTransactionsOld extends BaseClassForTests {
+    @Test
+    public void testCheckVersion() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            client.create().forPath("/foo");
+            Stat stat = client.setData().forPath("/foo", "new".getBytes());
+            try {
+                client.inTransaction()
+                        .check().withVersion(stat.getVersion() + 1).forPath("/foo")
+                        .and()
+                        .create().forPath("/bar")
+                        .and()
+                        .commit();
+                fail();
+            } catch (KeeperException.BadVersionException ignored) {
+            }
+            assertNull(client.checkExists().forPath("/bar"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithNamespace() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try {
+            client.start();
+            Collection<CuratorTransactionResult> results = client.inTransaction()
+                    .create().forPath("/foo", "one".getBytes())
+                    .and()
+                    .create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "one".getBytes())
+                    .and()
+                    .setData().forPath("/foo", "two".getBytes())
+                    .and()
+                    .create().forPath("/foo/bar")
+                    .and()
+                    .delete().forPath("/foo/bar")
+                    .and()
+                    .commit();
+            assertNotNull(client.checkExists().forPath("/foo"));
+            assertNotNull(client.usingNamespace(null).checkExists().forPath("/galt/foo"));
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertNull(client.checkExists().forPath("/foo/bar"));
+            CuratorTransactionResult ephemeralResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-")::apply).findFirst().get();
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithCompression() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try (client) {
+            client.start();
+            Collection<CuratorTransactionResult> results =
+                    client.inTransaction()
+                            .create().compressed().forPath("/foo", "one".getBytes())
+                            .and()
+                            .create().compressed().withACL(ZooDefs.Ids.READ_ACL_UNSAFE).forPath("/bar", "two".getBytes())
+                            .and()
+                            .create().compressed().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "three".getBytes())
+                            .and()
+                            .create().compressed().withMode(CreateMode.PERSISTENT).withACL(ZooDefs.Ids.READ_ACL_UNSAFE).forPath("/baz", "four".getBytes())
+                            .and()
+                            .setData().compressed().withVersion(0).forPath("/foo", "five".getBytes())
+                            .and()
+                            .commit();
+            assertNotNull(client.checkExists().forPath("/foo"));
+            assertArrayEquals(client.getData().decompressed().forPath("/foo"), "five".getBytes());
+            assertNotNull(client.checkExists().forPath("/bar"));
+            assertArrayEquals(client.getData().decompressed().forPath("/bar"), "two".getBytes());
+            assertEquals(client.getACL().forPath("/bar"), ZooDefs.Ids.READ_ACL_UNSAFE);
+            CuratorTransactionResult ephemeralResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-")::apply).findFirst().get();
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+            assertNotNull(client.checkExists().forPath("/baz"));
+            assertArrayEquals(client.getData().decompressed().forPath("/baz"), "four".getBytes());
+            assertEquals(client.getACL().forPath("/baz"), ZooDefs.Ids.READ_ACL_UNSAFE);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+            Collection<CuratorTransactionResult> results =
+                    client.inTransaction()
+                            .create().forPath("/foo")
+                            .and()
+                            .create().forPath("/foo/bar", "snafu".getBytes())
+                            .and()
+                            .commit();
+
+            assertNotNull(client.checkExists().forPath("/foo/bar"));
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            CuratorTransactionResult fooResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo")::apply).findFirst().get();
+            CuratorTransactionResult fooBarResult = results.stream()
+                    .filter(CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar")::apply).findFirst().get();
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTtlNodes.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestTtlNodes.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestTtlNodes extends CuratorTestBase {
+    @BeforeAll
+    public static void setUpClass() {
+        System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    }
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        System.setProperty("znode.container.checkIntervalMs", "1");
+        super.setup();
+    }
+
+    @AfterEach
+    @Override
+    public void teardown() throws Exception {
+        super.teardown();
+        System.clearProperty("znode.container.checkIntervalMs");
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            client.create().withTtl(10).creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_WITH_TTL).forPath("/a/b/c");
+            Thread.sleep(20);
+            assertNull(client.checkExists().forPath("/a/b/c"));
+        }
+    }
+
+    @Test
+    public void testBasicInBackground() throws Exception {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(1);
+            BackgroundCallback callback = (client1, event) -> latch.countDown();
+            client.create().withTtl(10).creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_WITH_TTL).inBackground(callback).forPath("/a/b/c");
+            assertTrue(new Timing().awaitLatch(latch));
+            Thread.sleep(20);
+            assertNull(client.checkExists().forPath("/a/b/c"));
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestWithCluster.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/imps/TestWithCluster.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.Timing;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestWithCluster extends CuratorTestBase {
+    @Test
+    public void testSplitBrain() throws Exception {
+        Timing timing = new Timing();
+        CuratorFramework client = null;
+        TestingCluster cluster = createAndStartCluster(3);
+        try {
+            for (InstanceSpec instanceSpec : cluster.getInstances()) {
+                client = CuratorFrameworkFactory.newClient(instanceSpec.getConnectString(), new RetryOneTime(1));
+                client.start();
+                client.checkExists().forPath("/");
+                client.close();
+                client = null;
+            }
+            client = CuratorFrameworkFactory.newClient(cluster.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+            client.start();
+            final CountDownLatch latch = new CountDownLatch(2);
+            client.getConnectionStateListenable().addListener((client1, newState) -> {
+                        if ((newState == ConnectionState.SUSPENDED) || (newState == ConnectionState.LOST)) {
+                            latch.countDown();
+                        }
+                    }
+            );
+            client.checkExists().forPath("/");
+            for (InstanceSpec instanceSpec : cluster.getInstances()) {
+                if (!instanceSpec.equals(cluster.findConnectionInstance(client.getZookeeperClient().getZooKeeper()))) {
+                    assertTrue(cluster.killServer(instanceSpec));
+                }
+            }
+            assertTrue(timing.awaitLatch(latch));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+            CloseableUtils.closeQuietly(cluster);
+        }
+    }
+
+    @Override
+    protected void createServer() {
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/schema/TestSchema.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/schema/TestSchema.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Charsets;
+import com.google.common.collect.Maps;
+import com.google.common.io.Resources;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.schema.Schema;
+import org.apache.curator.framework.schema.SchemaSet;
+import org.apache.curator.framework.schema.SchemaSetLoader;
+import org.apache.curator.framework.schema.SchemaValidator;
+import org.apache.curator.framework.schema.SchemaViolation;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestSchema extends BaseClassForTests {
+    @Test
+    public void testBasics() throws Exception {
+        SchemaSet schemaSet = loadSchemaSet("schema1.json", null);
+        Schema schema = schemaSet.getNamedSchema("test");
+        assertNotNull(schema);
+        Map<String, String> expectedMetadata = Maps.newHashMap();
+        expectedMetadata.put("one", "1");
+        expectedMetadata.put("two", "2");
+        assertEquals(schema.getMetadata(), expectedMetadata);
+        CuratorFramework client = newClient(schemaSet);
+        try {
+            client.start();
+            try {
+                String rawPath = schema.getRawPath();
+                assertEquals(rawPath, "/a/b/c");
+                client.create().creatingParentsIfNeeded().forPath(rawPath);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/a/b/c");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSchemaValidator() throws Exception {
+        final SchemaValidator schemaValidator = (schema, path, data, acl) -> data.length > 0;
+        SchemaSetLoader.SchemaValidatorMapper schemaValidatorMapper = name -> schemaValidator;
+        SchemaSet schemaSet = loadSchemaSet("schema3.json", schemaValidatorMapper);
+        CuratorFramework client = newClient(schemaSet);
+        try {
+            client.start();
+            try {
+                client.create().forPath("/test", new byte[0]);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.create().forPath("/test", "good".getBytes());
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testMulti() throws Exception {
+        SchemaSet schemaSet = loadSchemaSet("schema2.json", null);
+        CuratorFramework client = newClient(schemaSet);
+        try {
+            client.start();
+            try {
+                client.create().creatingParentsIfNeeded().forPath("/a/b/c");
+                fail("Should've violated schema: test");
+            } catch (SchemaViolation ignored) {
+            }
+            try {
+                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/a/b/c/d/e");
+                fail("Should've violated schema: test2");
+            } catch (SchemaViolation ignored) {
+            }
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testTransaction() throws Exception {
+        final SchemaValidator schemaValidator = (schema, path, data, acl) -> data.length > 0;
+        SchemaSetLoader.SchemaValidatorMapper schemaValidatorMapper = name -> schemaValidator;
+        SchemaSet schemaSet = loadSchemaSet("schema4.json", schemaValidatorMapper);
+        CuratorFramework client = newClient(schemaSet);
+        try {
+            client.start();
+            CuratorOp createAPersistent = client.transactionOp().create().forPath("/a");
+            CuratorOp createAEphemeral = client.transactionOp().create().withMode(CreateMode.EPHEMERAL).forPath("/a");
+            CuratorOp deleteA = client.transactionOp().delete().forPath("/a");
+            CuratorOp createBEmptyData = client.transactionOp().create().forPath("/b", new byte[0]);
+            CuratorOp createBWithData = client.transactionOp().create().forPath("/b", new byte[10]);
+            CuratorOp setBEmptyData = client.transactionOp().setData().forPath("/b", new byte[0]);
+            CuratorOp setBWithData = client.transactionOp().setData().forPath("/b", new byte[10]);
+            try {
+                client.transaction().forOperations(createAPersistent, createAEphemeral);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.transaction().forOperations(createAEphemeral);
+            try {
+                client.transaction().forOperations(deleteA);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            try {
+                client.transaction().forOperations(createBEmptyData);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.transaction().forOperations(createBWithData);
+            try {
+                client.transaction().forOperations(setBEmptyData);
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.transaction().forOperations(setBWithData);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testYaml() throws Exception {
+        String yaml = Resources.toString(Resources.getResource("schema.yaml"), Charsets.UTF_8);
+        JsonNode root = new ObjectMapper(new YAMLFactory()).readTree(yaml);
+        List<Schema> schemas = new SchemaSetLoader(root, null).getSchemas();
+        assertEquals(schemas.size(), 2);
+        assertEquals(schemas.get(0).getName(), "test");
+        assertEquals(schemas.get(0).getMetadata().size(), 0);
+        assertEquals(schemas.get(1).getName(), "test2");
+        assertEquals(schemas.get(1).getMetadata().size(), 2);
+        assertEquals(schemas.get(1).getMetadata().get("two"), "2");
+    }
+
+    @Test
+    public void testOrdering() throws Exception {
+        SchemaSet schemaSet = loadSchemaSet("schema5.json", null);
+        CuratorFramework client = newClient(schemaSet);
+        try {
+            client.start();
+            try {
+                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/exact/match");
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            try {
+                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/exact/foo/bar");
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            try {
+                client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/exact/other/bar");
+                fail("Should've violated schema");
+            } catch (SchemaViolation ignored) {
+            }
+            client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/exact/match");
+            client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/exact/other/thing");
+            client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/exact/foo/bar");
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    private CuratorFramework newClient(SchemaSet schemaSet) {
+        return CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .retryPolicy(new RetryOneTime(1))
+                .schemaSet(schemaSet)
+                .build();
+    }
+
+    private SchemaSet loadSchemaSet(String name, SchemaSetLoader.SchemaValidatorMapper schemaValidatorMapper) throws IOException {
+        String json = Resources.toString(Resources.getResource(name), Charsets.UTF_8);
+        return new SchemaSetLoader(json, schemaValidatorMapper).toSchemaSet(true);
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/state/TestCircuitBreakingConnectionStateListener.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/state/TestCircuitBreakingConnectionStateListener.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.state;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.RetrySleeper;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.CircuitBreakingConnectionStateListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.compatibility.Timing2;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+public class TestCircuitBreakingConnectionStateListener {
+    private final CuratorFramework dummyClient = CuratorFrameworkFactory.newClient("foo", new RetryOneTime(1));
+    private final Timing2 timing = new Timing2();
+    private final Timing2 retryTiming = timing.multiple(.25);
+    private volatile ScheduledThreadPoolExecutor service;
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static class RecordingListener implements ConnectionStateListener {
+        final BlockingQueue<ConnectionState> stateChanges = new LinkedBlockingQueue<>();
+
+        @Override
+        public void stateChanged(CuratorFramework client, ConnectionState newState) {
+            stateChanges.offer(newState);
+        }
+    }
+
+    private class TestRetryPolicy extends RetryForever {
+        volatile boolean isRetrying = true;
+
+        TestRetryPolicy() {
+            super(retryTiming.milliseconds());
+        }
+
+        @Override
+        public boolean allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper) {
+            return isRetrying && super.allowRetry(retryCount, elapsedTimeMs, sleeper);
+        }
+    }
+
+    @BeforeEach
+    public void setup() {
+        service = new ScheduledThreadPoolExecutor(1);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        service.shutdownNow();
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        RecordingListener recordingListener = new RecordingListener();
+        TestRetryPolicy retryPolicy = new TestRetryPolicy();
+        CircuitBreakingConnectionStateListener listener = new CircuitBreakingConnectionStateListener(dummyClient, recordingListener, retryPolicy, service);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        synchronized (listener) {
+            listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+            listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+            listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+            listener.stateChanged(dummyClient, ConnectionState.LOST);
+            listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        }
+        retryTiming.multiple(2).sleep();
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        retryPolicy.isRetrying = false;
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.SUSPENDED);
+    }
+
+    @Test
+    public void testResetsAfterReconnect() throws Exception {
+        RecordingListener recordingListener = new RecordingListener();
+        TestRetryPolicy retryPolicy = new TestRetryPolicy();
+        CircuitBreakingConnectionStateListener listener = new CircuitBreakingConnectionStateListener(dummyClient, recordingListener, retryPolicy, service);
+        synchronized (listener) {
+            listener.stateChanged(dummyClient, ConnectionState.LOST);
+            listener.stateChanged(dummyClient, ConnectionState.LOST);
+        }
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.RECONNECTED);
+    }
+
+    @Test
+    public void testRetryNever() throws Exception {
+        RecordingListener recordingListener = new RecordingListener();
+        RetryPolicy retryNever = (retryCount, elapsedTimeMs, sleeper) -> false;
+        CircuitBreakingConnectionStateListener listener = new CircuitBreakingConnectionStateListener(dummyClient, recordingListener, retryNever, service);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        assertFalse(listener.isOpen());
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        assertFalse(listener.isOpen());
+    }
+
+    @Test
+    public void testRetryOnce() throws Exception {
+        RecordingListener recordingListener = new RecordingListener();
+        RetryPolicy retryOnce = new RetryOneTime(retryTiming.milliseconds());
+        CircuitBreakingConnectionStateListener listener = new CircuitBreakingConnectionStateListener(dummyClient, recordingListener, retryOnce, service);
+        synchronized (listener) {
+            listener.stateChanged(dummyClient, ConnectionState.LOST);
+            listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+            assertTrue(listener.isOpen());
+        }
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.SUSPENDED);
+        assertFalse(listener.isOpen());
+    }
+
+    @Test
+    public void testSuspendedToLostRatcheting() throws Exception {
+        RecordingListener recordingListener = new RecordingListener();
+        RetryPolicy retryInfinite = new RetryForever(Integer.MAX_VALUE);
+        CircuitBreakingConnectionStateListener listener = new CircuitBreakingConnectionStateListener(dummyClient, recordingListener, retryInfinite, service);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        assertFalse(listener.isOpen());
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        assertTrue(listener.isOpen());
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        assertTrue(listener.isOpen());
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        assertEquals(timing.takeFromQueue(recordingListener.stateChanges), ConnectionState.LOST);
+        assertTrue(listener.isOpen());
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        assertTrue(listener.isOpen());
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        listener.stateChanged(dummyClient, ConnectionState.RECONNECTED);
+        listener.stateChanged(dummyClient, ConnectionState.READ_ONLY);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        listener.stateChanged(dummyClient, ConnectionState.SUSPENDED);
+        listener.stateChanged(dummyClient, ConnectionState.LOST);
+        assertTrue(recordingListener.stateChanges.isEmpty());
+        assertTrue(listener.isOpen());
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/state/TestConnectionStateManager.java
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/java/org_apache_curator/curator_framework/state/TestConnectionStateManager.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework.state;
+
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.framework.state.SessionConnectionStateErrorPolicy;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.curator.test.compatibility.Timing2;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestConnectionStateManager extends BaseClassForTests {
+    @Test
+    @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
+    public void testSessionConnectionStateErrorPolicyWithExpirationPercent30() throws Exception {
+        Timing2 timing = new Timing2();
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .connectionTimeoutMs(1000)
+                .sessionTimeoutMs(timing.session())
+                .retryPolicy(new RetryOneTime(1))
+                .connectionStateErrorPolicy(new SessionConnectionStateErrorPolicy())
+                .simulatedSessionExpirationPercent(30)
+                .build();
+        final int lostStateExpectedMs = (timing.session() / 3) + timing.forSleepingABit().milliseconds();
+        try {
+            CountDownLatch connectedLatch = new CountDownLatch(1);
+            CountDownLatch lostLatch = new CountDownLatch(1);
+            ConnectionStateListener stateListener = (client1, newState) -> {
+                if (newState == ConnectionState.CONNECTED) {
+                    connectedLatch.countDown();
+                }
+                if (newState == ConnectionState.LOST) {
+                    lostLatch.countDown();
+                }
+            };
+            timing.sleepABit();
+            client.getConnectionStateListenable().addListener(stateListener);
+            client.start();
+            assertTrue(timing.awaitLatch(connectedLatch));
+            server.close();
+            assertTrue(lostLatch.await(lostStateExpectedMs, TimeUnit.MILLISECONDS));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    @Tag(CuratorTestBase.zk36Group)
+    public void testConnectionStateRecoversFromUnexpectedExpiredConnection() throws Exception {
+        Timing2 timing = new Timing2();
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(server.getConnectString())
+                .connectionTimeoutMs(1_000)
+                .sessionTimeoutMs(250)
+                .retryPolicy(new RetryOneTime(1))
+                .connectionStateErrorPolicy(new SessionConnectionStateErrorPolicy())
+                .build();
+        final BlockingQueue<ConnectionState> queue = Queues.newLinkedBlockingQueue();
+        ConnectionStateListener listener = (client1, state) -> queue.add(state);
+        client.getConnectionStateListenable().addListener(listener);
+        client.start();
+        try {
+            ConnectionState polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.CONNECTED);
+            client.getZookeeperClient().getZooKeeper().getTestable().queueEvent(new WatchedEvent(
+                    Watcher.Event.EventType.None, Watcher.Event.KeeperState.Disconnected, null));
+            polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.SUSPENDED);
+            assertThrows(RuntimeException.class, () -> client.getZookeeperClient()
+                    .getZooKeeper().getTestable().queueEvent(new WatchedEvent(
+                            Watcher.Event.EventType.None, Watcher.Event.KeeperState.Expired, null) {
+                        @Override
+                        public String getPath() {
+                            throw new RuntimeException("Path doesn't exist!");
+                        }
+                    }));
+            polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.LOST);
+            polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
+            assertEquals(polled, ConnectionState.RECONNECTED);
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/curator-framework-test-metadata/proxy-config.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/curator-framework-test-metadata/proxy-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestWatcherIdentity"
+    },
+    "interfaces": [
+      "org.apache.curator.framework.api.CuratorWatcher"
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/curator-framework-test-metadata/reflect-config.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/curator-framework-test-metadata/reflect-config.json
@@ -1,0 +1,80 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestWatcherIdentity"
+    },
+    "name": "java.lang.StackWalker",
+    "methods": [
+      {
+        "name": "walk",
+        "parameterTypes": [
+          "java.util.function.Function"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestWatcherIdentity"
+    },
+    "name": "java.lang.StackWalker$StackFrame",
+    "methods": [
+      {
+        "name": "getClassName",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestFailedDeleteManager"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestFrameworkEdges"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestFrameworkEdges$1"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.curator.framework.imps.TestWatcherIdentity"
+    },
+    "name": "java.lang.reflect.InvocationHandler",
+    "methods": [
+      {
+        "name": "invokeDefault",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.reflect.Method",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/jni-config.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/jni-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.Arrays",
+    "methods": [
+      {
+        "name": "asList",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/reflect-config.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.8.1/reflect-config.json
@@ -1,0 +1,385 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Boolean",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Byte",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Character",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Deprecated",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Double",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Float",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Integer",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Long",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Short",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.StackTraceElement",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.String"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ClientCnxn$SendThread"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ClientCnxnSocketNIO"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.persistence.FileTxnLog$FileTxnIterator"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "getSuppressed",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.math.BigDecimal"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.math.BigInteger"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.Date"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.PropertyPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.logging.LogManager",
+    "methods": [
+      {
+        "name": "getLoggingMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.jmx.MBeanRegistry"
+    },
+    "name": "java.util.logging.LoggingMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ZooKeeper"
+    },
+    "name": "org.apache.zookeeper.ClientCnxnSocketNIO",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.zookeeper.client.ZKClientConfig"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"
+    },
+    "name": "org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.quorum.QuorumPeerConfig"
+    },
+    "name": "org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.ConnectionBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.ConnectionMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.DataTreeBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.DataTreeMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "org.apache.zookeeper.server.NIOServerCnxnFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.ZooKeeperServerBean",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ZooKeeperServer"
+    },
+    "name": "org.apache.zookeeper.server.ZooKeeperServerMXBean",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.watch.WatchManagerFactory"
+    },
+    "name": "org.apache.zookeeper.server.watch.WatchManager",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.ServerCnxnFactory"
+    },
+    "name": "sun.security.provider.ConfigFile",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.auth.DigestAuthenticationProvider"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+org.mockito.internal.creation.proxy.ProxyMockMaker

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema.yaml
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema.yaml
@@ -1,0 +1,15 @@
+
+- name: test
+  path: /a/b/c
+  documentation: This is a schema
+  ephemeral: must
+  sequential: cannot
+
+- name: test2
+  path: /a/.*
+  isRegex: true
+  ephemeral: cannot
+  canBeDeleted: false
+  metadata:
+    one: 1
+    two: 2

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema1.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema1.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "test",
+    "path": "/a/b/c",
+    "documentation": "This is a schema",
+    "ephemeral": "must",
+    "sequential": "cannot",
+    "metadata": {
+      "one": 1,
+      "two": "2"
+    }
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema2.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema2.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "test",
+    "path": "/a/b/c",
+    "documentation": "This is a schema",
+    "ephemeral": "must",
+    "sequential": "cannot"
+  },
+
+  {
+    "name": "test2",
+    "path": "/a/.*",
+    "isRegex": true,
+    "ephemeral": "cannot",
+    "canBeDeleted": false
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema3.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema3.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "test",
+    "path": "/test",
+    "schemaValidator": "test"
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema4.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema4.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "testa",
+    "path": "/a",
+    "ephemeral": "must",
+    "canBeDeleted": false
+  },
+
+  {
+    "name": "testb",
+    "path": "/b",
+    "schemaValidator": "test"
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema5.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/src/test/resources/schema5.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "1",
+    "path": "/exact/match",
+    "isRegex": false,
+    "ephemeral": "cannot",
+    "sequential": "must"
+  },
+
+  {
+    "name": "2",
+    "path": "/exact/other/.*",
+    "isRegex": true,
+    "ephemeral": "must",
+    "sequential": "can"
+  },
+
+  {
+    "name": "3",
+    "path": "/exact/.*",
+    "isRegex": true,
+    "ephemeral": "can",
+    "sequential": "cannot"
+  }
+]

--- a/tests/src/org.apache.curator/curator-framework/5.4.0/user-code-filter.json
+++ b/tests/src/org.apache.curator/curator-framework/5.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.curator.framework.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- For https://github.com/oracle/graalvm-reachability-metadata/issues/163 .
- Add support for `org.apache.curator:curator-client:5.4.0`.
- Add support for `org.apache.curator:curator-framework:5.4.0`.


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
