### PR TITLE
Increase the timeout period of CI to solve the unit test timeout problem of some libraries

### DIFF
--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -34,7 +34,7 @@ jobs:
   test-all-metadata:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.versions.graalvm }} ${{ matrix.versions.java }} @ ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 80
     needs: get-all-metadata
     strategy:
       fail-fast: false

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -37,7 +37,7 @@ jobs:
     name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.versions.graalvm }} ${{ matrix.versions.java }} @ ${{ matrix.os }})"
     if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 80
     needs: get-changed-metadata
 
     strategy:


### PR DESCRIPTION
## What does this PR do?

- For https://github.com/oracle/graalvm-reachability-metadata/issues/163#issuecomment-1418723038 .
- Increase the timeout period of CI to solve the unit test timeout problem of some libraries.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
