### PR TITLE
Upgrade Spring version in Thymeleaf Spring tests

### DIFF
--- a/tests/src/org.thymeleaf/thymeleaf-spring6/3.1.0.M2/build.gradle
+++ b/tests/src/org.thymeleaf/thymeleaf-spring6/3.1.0.M2/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")
     testImplementation("org.slf4j:slf4j-simple:1.7.36")
     testImplementation("org.thymeleaf:thymeleaf-spring6:$libraryVersion")
-    testImplementation("org.springframework:spring-web:6.0.0-M6")
-    testImplementation("org.springframework:spring-webflux:6.0.0-M6")
-    testImplementation("org.springframework:spring-context:6.0.0-M6")
+    testImplementation("org.springframework:spring-web:6.0.0")
+    testImplementation("org.springframework:spring-webflux:6.0.0")
+    testImplementation("org.springframework:spring-context:6.0.0")
     testImplementation('org.assertj:assertj-core:3.22.0')
 }
 


### PR DESCRIPTION
Spring 6.0 milestones versions were using internal GraalVM
for its `ConstantReadableJavaField`, which has been replaced by
`PreComputeFieldFeature` in the RC phase.

This commit upgrades the Spring version being used in the Thymeleaf
Spring tests to avoid referencing internal GraalVM APIs.

Fixes gh-230
