### PR TITLE
Add reflection config for ConcurrentHistogram(AbstractHistogram)

### DIFF
--- a/metadata/org.hdrhistogram/HdrHistogram/2.1.12/reflect-config.json
+++ b/metadata/org.hdrhistogram/HdrHistogram/2.1.12/reflect-config.json
@@ -50,6 +50,20 @@
   },
   {
     "condition": {
+      "typeReachable": "org.HdrHistogram.ConcurrentHistogram"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.HdrHistogram.AbstractHistogram"
+        ]
+      }
+    ],
+    "name": "org.HdrHistogram.ConcurrentHistogram"
+  },
+  {
+    "condition": {
       "typeReachable": "org.HdrHistogram.DoubleHistogram"
     },
     "methods": [

--- a/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/src/test/java/hdrhistogram/HdrHistogramTest.java
+++ b/tests/src/org.hdrhistogram/HdrHistogram/2.1.12/src/test/java/hdrhistogram/HdrHistogramTest.java
@@ -13,6 +13,7 @@ import org.HdrHistogram.AtomicHistogram;
 import org.HdrHistogram.ConcurrentDoubleHistogram;
 import org.HdrHistogram.ConcurrentHistogram;
 import org.HdrHistogram.DoubleHistogram;
+import org.HdrHistogram.DoubleRecorder;
 import org.HdrHistogram.EncodableHistogram;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.IntCountsHistogram;
@@ -44,6 +45,11 @@ class HdrHistogramTest {
         encodeDecode(new ShortCountsHistogram(0), ShortCountsHistogram::decodeFromCompressedByteBuffer);
         encodeDecode(new SynchronizedDoubleHistogram(0), SynchronizedDoubleHistogram::decodeFromCompressedByteBuffer);
         encodeDecode(new SynchronizedHistogram(0), SynchronizedHistogram::decodeFromCompressedByteBuffer);
+    }
+
+    @Test
+    void testReflectionWithConcurrentHistogramConstructorWithAbstractHistogram() throws Exception {
+        new DoubleRecorder(0).getIntervalHistogramInto(new DoubleHistogram(0));
     }
 
     private void encodeDecode(EncodableHistogram histogram, Decoder decoder) throws DataFormatException {


### PR DESCRIPTION
## What does this PR do?

This PR adds reflection config for the `ConcurrentHistogram(AbstractHistogram)` constructor.

Closes gh-234

## Checklist before merging
- [ ] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
