### PR TITLE
Added kotlin.internal.jdk8.JDK8PlatformImplementations constructor.

### DIFF
--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
@@ -89,5 +89,17 @@
     },
     "name": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter",
     "allPublicFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "kotlin.internal.jdk8.JDK8PlatformImplementations"
+    },
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -13,6 +13,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4"
+
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
@@ -1,7 +1,13 @@
 package kotlinreflect
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
@@ -39,6 +45,22 @@ class KotlinReflectTests {
         assertThat(annotatedProperty.annotations).hasSize(1)
         assertThat(annotatedProperty.annotations[0]).isInstanceOf(TestAnnotation::class.java)
         assertThat((annotatedProperty.annotations[0] as TestAnnotation).value).isEqualTo("annotation-on-field")
+    }
+    @Test
+    fun testCoroutine() {
+        val updated = AtomicBoolean(false)
+        assertThat(updated.get()).isFalse
+        CoroutineScope(Dispatchers.Default).launch {
+            delay(500)
+            updated.set(true)
+        }
+        Thread.sleep(1000)
+        assertThat(updated.get()).isTrue
+    }
+    @Test
+    fun testKotlinRandom() {
+        val randomValue = Random.nextInt(0, 10)
+        assertThat(randomValue).isBetween(0, 10)
     }
 }
 


### PR DESCRIPTION
## What does this PR do?
Adds `kotlin.internal.jdk8.JDK8PlatformImplementations constructor` to `reflect-config.json`.

It is required when using coroutines.

## Checklist before merging
- [X] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [X] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
