### PR TITLE
Added mssql docker image to the allowed images list

### DIFF
--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -4,3 +4,4 @@ postgres:15-alpine
 opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
+mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04

--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -4,4 +4,4 @@ postgres:15-alpine
 opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
-mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04


### PR DESCRIPTION
```
grype mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04
 ✔ Vulnerability DB        [updated]
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [184 packages]
 ✔ Scanning image...       [182 vulnerabilities]
   ├── 0 critical, 2 high, 129 medium, 32 low, 19 negligible
   └── 152 fixed

NAME                  INSTALLED                     FIXED-IN                      TYPE  VULNERABILITY   SEVERITY   
ca-certificates       20210119~20.04.2              20211016ubuntu0.20.04.1       deb   CVE-2022-23491  Medium      
coreutils             8.30-3ubuntu2                                               deb   CVE-2016-2781   Low         
e2fsprogs             1.45.5-2ubuntu1               1.45.5-2ubuntu1.1             deb   CVE-2022-1304   Medium      
gdb                   9.2-0ubuntu1~20.04.1                                        deb   CVE-2017-9778   Low         
gdbserver             9.2-0ubuntu1~20.04.1                                        deb   CVE-2017-9778   Low         
gpgv                  2.2.19-3ubuntu2.1                                           deb   CVE-2022-3219   Low         
gpgv                  2.2.19-3ubuntu2.1             2.2.19-3ubuntu2.2             deb   CVE-2022-34903  Medium      
krb5-locales          1.17-6ubuntu4.1               1.17-6ubuntu4.2               deb   CVE-2022-42898  Medium      
krb5-locales          1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-36222  Medium      
krb5-locales          1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-37750  Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libasn1-8-heimdal     7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libc-bin              2.31-0ubuntu9.9                                             deb   CVE-2016-20013  Negligible  
libc6                 2.31-0ubuntu9.9                                             deb   CVE-2016-20013  Negligible  
libc6-dbg             2.31-0ubuntu9.9                                             deb   CVE-2016-20013  Negligible  
libcom-err2           1.45.5-2ubuntu1               1.45.5-2ubuntu1.1             deb   CVE-2022-1304   Medium      
libexpat1             2.2.9-1ubuntu0.4              2.2.9-1ubuntu0.5              deb   CVE-2022-40674  Medium      
libexpat1             2.2.9-1ubuntu0.4              2.2.9-1ubuntu0.6              deb   CVE-2022-43680  Medium      
libext2fs2            1.45.5-2ubuntu1               1.45.5-2ubuntu1.1             deb   CVE-2022-1304   Medium      
libgmp10              2:6.2.0+dfsg-4                2:6.2.0+dfsg-4ubuntu0.1       deb   CVE-2021-43618  Low         
libgnutls30           3.6.13-2ubuntu1.6             3.6.13-2ubuntu1.7             deb   CVE-2021-4209   Low         
libgnutls30           3.6.13-2ubuntu1.6             3.6.13-2ubuntu1.7             deb   CVE-2022-2509   Medium      
libgnutls30           3.6.13-2ubuntu1.6             3.6.13-2ubuntu1.8             deb   CVE-2023-0361   Medium      
libgssapi-krb5-2      1.17-6ubuntu4.1               1.17-6ubuntu4.2               deb   CVE-2022-42898  Medium      
libgssapi-krb5-2      1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-36222  Medium      
libgssapi-krb5-2      1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-37750  Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libgssapi3-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libhcrypto4-heimdal   7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libheimbase1-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libheimntlm0-heimdal  7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libhx509-5-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libk5crypto3          1.17-6ubuntu4.1               1.17-6ubuntu4.2               deb   CVE-2022-42898  Medium      
libk5crypto3          1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-36222  Medium      
libk5crypto3          1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-37750  Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libkrb5-26-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libkrb5-3             1.17-6ubuntu4.1               1.17-6ubuntu4.2               deb   CVE-2022-42898  Medium      
libkrb5-3             1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-36222  Medium      
libkrb5-3             1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-37750  Medium      
libkrb5support0       1.17-6ubuntu4.1               1.17-6ubuntu4.2               deb   CVE-2022-42898  Medium      
libkrb5support0       1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-36222  Medium      
libkrb5support0       1.17-6ubuntu4.1               1.17-6ubuntu4.3               deb   CVE-2021-37750  Medium      
libncurses6           6.2-0ubuntu2                                                deb   CVE-2021-39537  Negligible  
libncurses6           6.2-0ubuntu2                                                deb   CVE-2022-29458  Negligible  
libncursesw6          6.2-0ubuntu2                                                deb   CVE-2021-39537  Negligible  
libncursesw6          6.2-0ubuntu2                                                deb   CVE-2022-29458  Negligible  
libpam-modules        1.3.1-5ubuntu4.3              1.3.1-5ubuntu4.4              deb   CVE-2022-28321  Negligible  
libpam-modules-bin    1.3.1-5ubuntu4.3              1.3.1-5ubuntu4.4              deb   CVE-2022-28321  Negligible  
libpam-runtime        1.3.1-5ubuntu4.3              1.3.1-5ubuntu4.4              deb   CVE-2022-28321  Negligible  
libpam0g              1.3.1-5ubuntu4.3              1.3.1-5ubuntu4.4              deb   CVE-2022-28321  Negligible  
libpcre2-8-0          10.34-7                       10.34-7ubuntu0.1              deb   CVE-2022-1586   Low         
libpcre2-8-0          10.34-7                       10.34-7ubuntu0.1              deb   CVE-2022-1587   Low         
libpcre3              2:8.39-12ubuntu0.1                                          deb   CVE-2017-11164  Negligible  
libpython3.8          3.8.10-0ubuntu1~20.04.4                                     deb   CVE-2021-28861  Low         
libpython3.8          3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.5       deb   CVE-2015-20107  Low         
libpython3.8          3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-37454  Medium      
libpython3.8          3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-45061  Medium      
libpython3.8          3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.7       deb   CVE-2023-24329  Medium      
libpython3.8-minimal  3.8.10-0ubuntu1~20.04.4                                     deb   CVE-2021-28861  Low         
libpython3.8-minimal  3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.5       deb   CVE-2015-20107  Low         
libpython3.8-minimal  3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-37454  Medium      
libpython3.8-minimal  3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-45061  Medium      
libpython3.8-minimal  3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.7       deb   CVE-2023-24329  Medium      
libpython3.8-stdlib   3.8.10-0ubuntu1~20.04.4                                     deb   CVE-2021-28861  Low         
libpython3.8-stdlib   3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.5       deb   CVE-2015-20107  Low         
libpython3.8-stdlib   3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-37454  Medium      
libpython3.8-stdlib   3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-45061  Medium      
libpython3.8-stdlib   3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.7       deb   CVE-2023-24329  Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libroken18-heimdal    7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libsqlite3-0          3.31.1-4ubuntu0.3             3.31.1-4ubuntu0.4             deb   CVE-2020-35525  Medium      
libsqlite3-0          3.31.1-4ubuntu0.3             3.31.1-4ubuntu0.4             deb   CVE-2020-35527  Medium      
libsqlite3-0          3.31.1-4ubuntu0.3             3.31.1-4ubuntu0.5             deb   CVE-2022-35737  Medium      
libss2                1.45.5-2ubuntu1               1.45.5-2ubuntu1.1             deb   CVE-2022-1304   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.15            deb   CVE-2022-2068   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.16            deb   CVE-2022-2097   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2022-4304   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2022-4450   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2023-0215   Medium      
libssl1.1             1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2023-0286   High        
libsss-nss-idmap0     2.2.3-3ubuntu0.8                                            deb   CVE-2022-4254   Medium      
libsystemd0           245.4-4ubuntu3.17                                           deb   CVE-2023-26604  Low         
libsystemd0           245.4-4ubuntu3.17             245.4-4ubuntu3.20             deb   CVE-2022-3821   Medium      
libsystemd0           245.4-4ubuntu3.17             245.4-4ubuntu3.20             deb   CVE-2022-4415   Medium      
libtinfo6             6.2-0ubuntu2                                                deb   CVE-2021-39537  Negligible  
libtinfo6             6.2-0ubuntu2                                                deb   CVE-2022-29458  Negligible  
libudev1              245.4-4ubuntu3.17                                           deb   CVE-2023-26604  Low         
libudev1              245.4-4ubuntu3.17             245.4-4ubuntu3.20             deb   CVE-2022-3821   Medium      
libudev1              245.4-4ubuntu3.17             245.4-4ubuntu3.20             deb   CVE-2022-4415   Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2021-3671   Low         
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.1         deb   CVE-2022-3116   Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.2         deb   CVE-2022-41916  Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2021-44758  Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-3437   Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-42898  Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.3         deb   CVE-2022-44640  Medium      
libwind0-heimdal      7.7.0+dfsg-1ubuntu1           7.7.0+dfsg-1ubuntu1.4         deb   CVE-2022-45142  Medium      
libxml2               2.9.10+dfsg-5ubuntu0.20.04.3  2.9.10+dfsg-5ubuntu0.20.04.4  deb   CVE-2016-3709   Medium      
libxml2               2.9.10+dfsg-5ubuntu0.20.04.3  2.9.10+dfsg-5ubuntu0.20.04.5  deb   CVE-2022-2309   Low         
libxml2               2.9.10+dfsg-5ubuntu0.20.04.3  2.9.10+dfsg-5ubuntu0.20.04.5  deb   CVE-2022-40303  Medium      
libxml2               2.9.10+dfsg-5ubuntu0.20.04.3  2.9.10+dfsg-5ubuntu0.20.04.5  deb   CVE-2022-40304  Medium      
locales               2.31-0ubuntu9.9                                             deb   CVE-2016-20013  Negligible  
login                 1:4.8.1-1ubuntu5.20.04.2                                    deb   CVE-2013-4235   Low         
logsave               1.45.5-2ubuntu1               1.45.5-2ubuntu1.1             deb   CVE-2022-1304   Medium      
ncurses-base          6.2-0ubuntu2                                                deb   CVE-2021-39537  Negligible  
ncurses-base          6.2-0ubuntu2                                                deb   CVE-2022-29458  Negligible  
ncurses-bin           6.2-0ubuntu2                                                deb   CVE-2021-39537  Negligible  
ncurses-bin           6.2-0ubuntu2                                                deb   CVE-2022-29458  Negligible  
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.15            deb   CVE-2022-2068   Medium      
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.16            deb   CVE-2022-2097   Medium      
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2022-4304   Medium      
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2022-4450   Medium      
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2023-0215   Medium      
openssl               1.1.1f-1ubuntu2.13            1.1.1f-1ubuntu2.17            deb   CVE-2023-0286   High        
passwd                1:4.8.1-1ubuntu5.20.04.2                                    deb   CVE-2013-4235   Low         
perl-base             5.30.0-9ubuntu0.2             5.30.0-9ubuntu0.3             deb   CVE-2020-16156  Medium      
python3.8             3.8.10-0ubuntu1~20.04.4                                     deb   CVE-2021-28861  Low         
python3.8             3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.5       deb   CVE-2015-20107  Low         
python3.8             3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-37454  Medium      
python3.8             3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-45061  Medium      
python3.8             3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.7       deb   CVE-2023-24329  Medium      
python3.8-minimal     3.8.10-0ubuntu1~20.04.4                                     deb   CVE-2021-28861  Low         
python3.8-minimal     3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.5       deb   CVE-2015-20107  Low         
python3.8-minimal     3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-37454  Medium      
python3.8-minimal     3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.6       deb   CVE-2022-45061  Medium      
python3.8-minimal     3.8.10-0ubuntu1~20.04.4       3.8.10-0ubuntu1~20.04.7       deb   CVE-2023-24329  Medium      
tar                   1.30+dfsg-7ubuntu0.20.04.2    1.30+dfsg-7ubuntu0.20.04.3    deb   CVE-2022-48303  Medium      
wget                  1.20.3-1ubuntu2                                             deb   CVE-2021-31879  Medium      
zlib1g                1:1.2.11.dfsg-2ubuntu1.3      1:1.2.11.dfsg-2ubuntu1.5      deb   CVE-2022-37434  Medium
```