### PR TITLE
Disable jetty test

### DIFF
--- a/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
@@ -13,8 +13,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JettyClientTest {
+
+    private static final boolean DISABLE_TEST = true;
     @Test
     void test() throws Exception {
+        if (DISABLE_TEST) {
+            return;
+        }
         HttpClient client = new HttpClient();
         client.start();
         try {

--- a/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JettyClientTest {
 
+    // This test communicates with external service so it should be disabled until it is refactored
     private static final boolean DISABLE_TEST = true;
     @Test
     void test() throws Exception {

--- a/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JettyClientTest {
 
-    // This test communicates with external service so it should be disabled until it is refactored
+    // This test communicates with external service so it should be disabled until it is refactored. See related issue: https://github.com/oracle/graalvm-reachability-metadata/issues/259
     private static final boolean DISABLE_TEST = true;
     @Test
     void test() throws Exception {


### PR DESCRIPTION
## What does this PR do?

Disables JettyClientTest. This test communicates with some external service so it should be disabled until it is refactored.