### PR TITLE
Add zookeeper docker image to the allowed images list

### DIFF
--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -5,3 +5,4 @@ opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
+zookeeper:3.8.1


### PR DESCRIPTION
## What does this PR do?
- For https://github.com/oracle/graalvm-reachability-metadata/pull/208 and https://github.com/oracle/graalvm-reachability-metadata/issues/206.
- Add zookeeper docker image to the allowed images list.
```shell
grype zookeeper:3.8.1
 ✔ Vulnerability DB        [updated]
 ✔ Pulled image            
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [185 packages]
 ✔ Scanning image...       [37 vulnerabilities]
   ├── 0 critical, 0 high, 3 medium, 25 low, 9 negligible
   └── 10 fixed
NAME            INSTALLED                 FIXED-IN            TYPE  VULNERABILITY   SEVERITY   
bash            5.1-6ubuntu1                                  deb   CVE-2022-3715   Low         
coreutils       8.32-4.1ubuntu1                               deb   CVE-2016-2781   Low         
curl            7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27533  Low         
curl            7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27534  Low         
curl            7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27535  Medium      
curl            7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27536  Low         
curl            7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27538  Low         
dirmngr         2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gnupg           2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gnupg-l10n      2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gnupg-utils     2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpg             2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpg-agent       2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpg-wks-client  2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpg-wks-server  2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpgconf         2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpgsm           2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
gpgv            2.2.27-3ubuntu2.1                             deb   CVE-2022-3219   Low         
libc-bin        2.35-0ubuntu3.1                               deb   CVE-2016-20013  Negligible  
libc6           2.35-0ubuntu3.1                               deb   CVE-2016-20013  Negligible  
libcurl4        7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27533  Low         
libcurl4        7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27534  Low         
libcurl4        7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27535  Medium      
libcurl4        7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27536  Low         
libcurl4        7.81.0-1ubuntu1.8         7.81.0-1ubuntu1.10  deb   CVE-2023-27538  Low         
libncurses6     6.3-2                                         deb   CVE-2022-29458  Negligible  
libncursesw6    6.3-2                                         deb   CVE-2022-29458  Negligible  
libpcre3        2:8.39-13ubuntu0.22.04.1                      deb   CVE-2017-11164  Negligible  
libpng16-16     1.6.37-3build5                                deb   CVE-2022-3857   Low         
libsqlite3-0    3.37.2-2ubuntu0.1                             deb   CVE-2022-46908  Low         
libssl3         3.0.2-0ubuntu1.8                              deb   CVE-2022-3996   Low         
libtinfo6       6.3-2                                         deb   CVE-2022-29458  Negligible  
locales         2.35-0ubuntu3.1                               deb   CVE-2016-20013  Negligible  
ncurses-base    6.3-2                                         deb   CVE-2022-29458  Negligible  
ncurses-bin     6.3-2                                         deb   CVE-2022-29458  Negligible  
openssl         3.0.2-0ubuntu1.8                              deb   CVE-2022-3996   Low         
wget            1.21.2-2ubuntu1                               deb   CVE-2021-31879  Medium 
```


## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
