### PR TITLE
Add testcontainers/ryuk docker image to the allowed images list

### DIFF
--- a/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-testcontainers_ryuk
+++ b/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-testcontainers_ryuk
@@ -1,0 +1,1 @@
+FROM testcontainers/ryuk:0.5.1


### PR DESCRIPTION
## What does this PR do?

- For https://github.com/oracle/graalvm-reachability-metadata/pull/170 and https://github.com/oracle/graalvm-reachability-metadata/issues/164.
- Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/250.
- Add testcontainers/ryuk docker image to the allowed images list.
```shell
$ grype testcontainers/ryuk:0.5.1
✔ Vulnerability DB        [updated]
 ✔ Parsed image            
 ✔ Cataloged packages      [27 packages]
 ✔ Scanning image...       [4 vulnerabilities]
   ├── 0 critical, 2 high, 2 medium, 0 low, 0 negligible
   └── 2 fixed
NAME          INSTALLED  FIXED-IN   TYPE  VULNERABILITY  SEVERITY 
libcrypto1.1  1.1.1t-r2             apk   CVE-2023-0466  Medium    
libcrypto1.1  1.1.1t-r2  1.1.1u-r0  apk   CVE-2023-2650  High      
libssl1.1     1.1.1t-r2             apk   CVE-2023-0466  Medium    
libssl1.1     1.1.1t-r2  1.1.1u-r0  apk   CVE-2023-2650  High
```

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
