### PR TITLE
Move kotlin.internal.jdk8.JDK8PlatformImplementations to kotlin-stdlib.

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -106,6 +106,10 @@
     "module": "com.github.ben-manes.caffeine:caffeine"
   },
   {
+    "directory": "org.jetbrains.kotlin/kotlin-stdlib",
+    "module": "org.jetbrains.kotlin:kotlin-stdlib"
+  },
+  {
     "directory": "org.jetbrains.kotlin/kotlin-reflect",
     "module": "org.jetbrains.kotlin:kotlin-reflect"
   },

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/1.7.10/reflect-config.json
@@ -89,17 +89,5 @@
     },
     "name": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter",
     "allPublicFields": true
-  },
-  {
-    "condition": {
-      "typeReachable": "kotlin.internal.jdk8.JDK8PlatformImplementations"
-    },
-    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ]
   }
 ]

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/reflect-config.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "condition": {
+      "typeReachable": "kotlin.internal.jdk8.JDK8PlatformImplementations"
+    },
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.7.10",
+    "module": "org.jetbrains.kotlin:kotlin-stdlib",
+    "tested-versions": [
+      "1.7.10"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -264,6 +264,17 @@
     ]
   },
   {
+    "test-project-path": "org.jetbrains.kotlin/kotlin-stdlib/1.7.10",
+    "libraries": [
+      {
+        "name": "org.jetbrains.kotlin:kotlin-stdlib",
+        "versions": [
+          "1.7.10"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.jetbrains.kotlin/kotlin-reflect/1.7.10",
     "libraries": [
       {

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/src/test/kotlin/kotlinreflect/KotlinReflectTests.kt
@@ -1,13 +1,7 @@
 package kotlinreflect
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.random.Random
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
@@ -45,22 +39,6 @@ class KotlinReflectTests {
         assertThat(annotatedProperty.annotations).hasSize(1)
         assertThat(annotatedProperty.annotations[0]).isInstanceOf(TestAnnotation::class.java)
         assertThat((annotatedProperty.annotations[0] as TestAnnotation).value).isEqualTo("annotation-on-field")
-    }
-    @Test
-    fun testCoroutine() {
-        val updated = AtomicBoolean(false)
-        assertThat(updated.get()).isFalse
-        CoroutineScope(Dispatchers.Default).launch {
-            delay(500)
-            updated.set(true)
-        }
-        Thread.sleep(1000)
-        assertThat(updated.get()).isTrue
-    }
-    @Test
-    fun testKotlinRandom() {
-        val randomValue = Random.nextInt(0, 10)
-        assertThat(randomValue).isBetween(0, 10)
     }
 }
 

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -12,8 +12,11 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4"
+
+    implementation 'org.jetbrains.kotlin:kotlin-test-junit:1.7.10'
+
 }
 
 compileTestKotlin {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/gradle.properties
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.7.10
+metadata.dir = org.jetbrains.kotlin/kotlin-stdlib/1.7.10

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/settings.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'kotlin-stdlib-tests'

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/src/test/kotlin/kotlinstdlib/KotlinStdlibTests.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/src/test/kotlin/kotlinstdlib/KotlinStdlibTests.kt
@@ -1,0 +1,33 @@
+package kotlinstdlib
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.Test
+
+
+class KotlinStdlibTests {
+  @Test
+  fun testCoroutine() {
+    val updated = AtomicBoolean(false)
+    assertFalse(updated.get())
+    CoroutineScope(Dispatchers.Default).launch {
+      delay(500)
+      updated.set(true)
+    }
+    Thread.sleep(1000)
+    assertTrue(updated.get())
+  }
+
+  @Test
+  fun testKotlinRandom() {
+    val randomValue = Random.nextInt(0, 10)
+    assertTrue { randomValue in 0 until 10 }
+  }
+}
+


### PR DESCRIPTION
## What does this PR do?
Adds metadata for `kotlin.internal.jdk8.JDK8PlatformImplementations` when using `kotlin-stdlib`.

## Checklist before merging
- [X] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [X] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
