### PR TITLE
Let the user override the default toolchain

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -19,8 +19,12 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
-        vendor = JvmVendorSpec.GRAAL_VM
+        languageVersion = providers.environmentVariable("TCK_JAVA_VERSION")
+                .orElse(JavaVersion.current().majorVersion)
+                .map(JavaLanguageVersion::of)
+        vendor = providers.environmentVariable("TCK_JAVA_VENDOR")
+                .map(JvmVendorSpec::matching)
+                .orElse(JvmVendorSpec.GRAAL_VM)
     }
 }
 
@@ -88,5 +92,16 @@ graalvmNative {
             buildArgs.add('-H:+StrictConfiguration') // Necessary in order to test metadata properly
             verbose = true
         }
+    }
+    binaries.all {
+        def toolchainService = project.extensions.findByType(JavaToolchainService)
+        javaLauncher.set(toolchainService.launcherFor {
+            languageVersion = providers.environmentVariable("TCK_JAVA_VERSION")
+                    .orElse(JavaVersion.current().majorVersion)
+                    .map(JavaLanguageVersion::of)
+            vendor = providers.environmentVariable("TCK_JAVA_VENDOR")
+                    .map(JvmVendorSpec::matching)
+                    .orElse(JvmVendorSpec.GRAAL_VM)
+        })
     }
 }


### PR DESCRIPTION
## What does this PR do?

This commit lets the user set a couple of environement variables to tweak which JDK will be used to compile the tests and build the native binaries:

- TCK_JAVA_VERSION should be set to the language version, eg. 20
- TCK_JAVA_VENDOR should be set to the vendor, e.g Oracle

