### PR TITLE
Fix compatibility with Hibernate 6.2.2

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.2.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.2.0.Final/reflect-config.json
@@ -882,5 +882,15 @@
   {
     "condition":{"typeReachable":"org.hibernate.dialect.PgJdbcHelper"},
     "name":"org.postgresql.util.PGobject"
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.dialect.DialectLogging"},
+    "name":"org.hibernate.dialect.DialectLogging_$logger",
+    "methods":[{"name":"<init>","parameterTypes":["org.jboss.logging.Logger"] }]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.metamodel.mapping.MappingModelCreationLogging"},
+    "name":"org.hibernate.metamodel.mapping.MappingModelCreationLogging_$logger",
+    "methods":[{"name":"<init>","parameterTypes":["org.jboss.logging.Logger"] }]
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/index.json
+++ b/metadata/org.hibernate.orm/hibernate-core/index.json
@@ -4,7 +4,8 @@
     "metadata-version": "6.2.0.Final",
     "module": "org.hibernate.orm:hibernate-core",
     "tested-versions": [
-      "6.2.0.Final"
+      "6.2.0.Final",
+      "6.2.2.Final"
     ]
   },
   {


### PR DESCRIPTION
This commit adds additional reflection entries for logger that are required due to https://hibernate.atlassian.net/browse/HHH-16507 and https://hibernate.atlassian.net/browse/HHH-16441 to fix compatibility with Hibernate 6.2.2.

I chose to not create a dedicated new version for maintanablity reasons and because those hints are triggered by `typeReachable` condition that allow to support both 6.2.0 and 6.2.2.