### PR TITLE
Correct type reachable condition in Quartz resource config

### DIFF
--- a/metadata/org.quartz-scheduler/quartz/2.3.2/resource-config.json
+++ b/metadata/org.quartz-scheduler/quartz/2.3.2/resource-config.json
@@ -4,7 +4,7 @@
       {
         "pattern": "\\Qorg/quartz/impl/jdbcjobstore/tables_\\E.*\\Q.sql\\E",
         "condition": {
-          "typeReachable": "org.quartz.SimpleJob"
+          "typeReachable": "org.quartz.impl.StdSchedulerFactory"
         }
       },
       {

--- a/tests/src/org.quartz-scheduler/quartz/2.3.2/src/test/java/quartz/QuartzTest.java
+++ b/tests/src/org.quartz-scheduler/quartz/2.3.2/src/test/java/quartz/QuartzTest.java
@@ -4,12 +4,19 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package org.quartz;
+package quartz;
 
 import java.io.InputStream;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.simpl.SimpleThreadPool;
 

--- a/tests/src/org.quartz-scheduler/quartz/2.3.2/src/test/java/quartz/SimpleJob.java
+++ b/tests/src/org.quartz-scheduler/quartz/2.3.2/src/test/java/quartz/SimpleJob.java
@@ -4,7 +4,10 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package org.quartz;
+package quartz;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
 
 public class SimpleJob implements Job {
 


### PR DESCRIPTION
fe74d0e8 added a type reachable condition for Quartz's SQL resource files but the type that was used (org.quartz.SimpleJob) isn't part of Quartz and only exists in the tests for the Quartz metadata.

## What does this PR do?

Updates the tests to reveal the problem by moving their classes out of the org.quartz namespace and updates the metadata to use a type in the condition that's part of Quartz.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
