### PR TITLE
Add activemq docker image to the allowed images list

### DIFF
--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -5,3 +5,4 @@ opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
+symptoma/activemq:5.18.0


### PR DESCRIPTION
```
grype symptoma/activemq:5.18.0
 ✔ Vulnerability DB        [no update available]
 ✔ Pulled image            
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [160 packages]
 ✔ Scanning image...       [91 vulnerabilities]
   ├── 6 critical, 31 high, 32 medium, 10 low, 0 negligible (12 unknown)
   └── 36 fixed

NAME                              INSTALLED      FIXED-IN   TYPE          VULNERABILITY        SEVERITY 
activemq-protobuf                 1.1                       java-archive  CVE-2010-0684        Low       
activemq-protobuf                 1.1                       java-archive  CVE-2010-1244        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2011-4905        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2012-5784        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2012-6092        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2012-6551        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2013-1879        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2013-1880        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2013-3060        Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2014-3576        High      
activemq-protobuf                 1.1                       java-archive  CVE-2015-7559        Low       
activemq-protobuf                 1.1                       java-archive  CVE-2016-3088        Critical  
activemq-protobuf                 1.1                       java-archive  CVE-2018-11775       High      
activemq-protobuf                 1.1                       java-archive  CVE-2020-13920       Medium    
activemq-protobuf                 1.1                       java-archive  CVE-2020-13947       Medium    
camel-core                        2.25.4                    java-archive  CVE-2020-11971       High      
camel-core                        2.25.4                    java-archive  CVE-2020-5529        High      
camel-core                        2.25.4         3.2.0      java-archive  GHSA-hfg5-xpvw-c9x4  High      
camel-jms                         2.25.4                    java-archive  CVE-2020-11971       High      
camel-jms                         2.25.4                    java-archive  CVE-2020-5529        High      
camel-spring                      2.25.4                    java-archive  CVE-2020-11971       High      
camel-spring                      2.25.4                    java-archive  CVE-2020-5529        High      
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27533       High      
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27534       High      
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27535       High      
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27536       Critical  
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27537       Medium    
curl                              7.83.1-r6      8.0.1-r0   apk           CVE-2023-27538       Medium    
curl                              7.83.1-r6      8.1.0-r0   apk           CVE-2023-28319       Unknown   
curl                              7.83.1-r6      8.1.0-r0   apk           CVE-2023-28320       Unknown   
curl                              7.83.1-r6      8.1.0-r0   apk           CVE-2023-28321       Unknown   
curl                              7.83.1-r6      8.1.0-r0   apk           CVE-2023-28322       Unknown   
geronimo-annotation_1.3_spec      1.3                       java-archive  CVE-2008-0732        Low       
geronimo-annotation_1.3_spec      1.3                       java-archive  CVE-2011-5034        High      
geronimo-j2ee-connector_1.5_spec  2.0.0                     java-archive  CVE-2007-4548        High      
geronimo-j2ee-connector_1.5_spec  2.0.0                     java-archive  CVE-2007-5797        High      
geronimo-j2ee-connector_1.5_spec  2.0.0                     java-archive  CVE-2008-0732        Low       
geronimo-j2ee-connector_1.5_spec  2.0.0                     java-archive  CVE-2011-5034        High      
geronimo-jta_1.1_spec             1.1.1                     java-archive  CVE-2008-0732        Low       
geronimo-jta_1.1_spec             1.1.1                     java-archive  CVE-2011-5034        High      
java                              17.0.6+10-LTS             binary        CVE-2023-21968       Low       
jettison                          1.5.3          1.5.4      java-archive  GHSA-q6g2-g7f3-rr83  High      
libcrypto1.1                      1.1.1t-r0                 apk           CVE-2023-0466        Medium    
libcrypto1.1                      1.1.1t-r0      1.1.1t-r1  apk           CVE-2023-0464        High      
libcrypto1.1                      1.1.1t-r0      1.1.1t-r2  apk           CVE-2023-0465        Medium    
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27533       High      
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27534       High      
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27535       High      
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27536       Critical  
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27537       Medium    
libcurl                           7.83.1-r6      8.0.1-r0   apk           CVE-2023-27538       Medium    
libcurl                           7.83.1-r6      8.1.0-r0   apk           CVE-2023-28319       Unknown   
libcurl                           7.83.1-r6      8.1.0-r0   apk           CVE-2023-28320       Unknown   
libcurl                           7.83.1-r6      8.1.0-r0   apk           CVE-2023-28321       Unknown   
libcurl                           7.83.1-r6      8.1.0-r0   apk           CVE-2023-28322       Unknown   
libssl1.1                         1.1.1t-r0                 apk           CVE-2023-0466        Medium    
libssl1.1                         1.1.1t-r0      1.1.1t-r1  apk           CVE-2023-0464        High      
libssl1.1                         1.1.1t-r0      1.1.1t-r2  apk           CVE-2023-0465        Medium    
spring-core                       5.3.25                    java-archive  CVE-2016-1000027     Critical  
spring-core                       5.3.25                    java-archive  CVE-2023-20860       High      
spring-core                       5.3.25                    java-archive  CVE-2023-20861       Medium    
spring-core                       5.3.25                    java-archive  CVE-2023-20863       Medium  

```