### PR TITLE
Allow Testcontainers to create DockerConfigFile from json using Jackson

### DIFF
--- a/metadata/org.testcontainers/testcontainers/1.17.6/reflect-config.json
+++ b/metadata/org.testcontainers/testcontainers/1.17.6/reflect-config.json
@@ -1971,6 +1971,15 @@
     "condition": {
       "typeReachable": "org.testcontainers.DockerClientFactory"
     },
+    "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.testcontainers.DockerClientFactory"
+    },
     "name": "com.github.dockerjava.api.model.NetworkSettings",
     "allDeclaredFields": true,
     "allDeclaredConstructors": true


### PR DESCRIPTION
## What does this PR do?

When using Testcontainers in a native image and a `~/.docker/config.json` file is present, a failure occurs:

```
Failures (1):
  JUnit Jupiter:TcdemoApplicationTests
    ClassSource [className = 'com.example.tcdemo.TcdemoApplicationTests', filePosition = null]
    => java.util.ServiceConfigurationError: org.testcontainers.dockerclient.DockerClientProviderStrategy: Provider org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy could not be instantiated
       java.base@17.0.5/java.util.ServiceLoader.fail(ServiceLoader.java:586)
       java.base@17.0.5/java.util.ServiceLoader$ProviderImpl.newInstance(ServiceLoader.java:813)
       java.base@17.0.5/java.util.ServiceLoader$ProviderImpl.get(ServiceLoader.java:729)
       java.base@17.0.5/java.util.ServiceLoader$3.next(ServiceLoader.java:1403)
       java.base@17.0.5/java.lang.Iterable.forEach(Iterable.java:74)
       [...]
       Suppressed: java.util.ServiceConfigurationError: org.testcontainers.dockerclient.DockerClientProviderStrategy: Provider org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy could not be instantiated
         java.base@17.0.5/java.util.ServiceLoader.fail(ServiceLoader.java:586)
         java.base@17.0.5/java.util.ServiceLoader$ProviderImpl.newInstance(ServiceLoader.java:813)
         java.base@17.0.5/java.util.ServiceLoader$ProviderImpl.get(ServiceLoader.java:729)
         java.base@17.0.5/java.util.ServiceLoader$3.next(ServiceLoader.java:1403)
         java.base@17.0.5/java.lang.Iterable.forEach(Iterable.java:74)
         [...]
       Caused by: com.github.dockerjava.api.exception.DockerClientException: Failed to parse docker configuration file
         org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder.readDockerConfig(DefaultDockerClientConfig.java:472)
         org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder.build(DefaultDockerClientConfig.java:457)
         org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy.<init>(EnvironmentAndSystemPropertyClientProviderStrategy.java:57)
         org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy.<init>(EnvironmentAndSystemPropertyClientProviderStrategy.java:34)
         java.base@17.0.5/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
         [...]
       Caused by: java.io.IOException: Failed to parse docker config.json
         org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile.loadCurrentConfig(DockerConfigFile.java:179)
         org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile.loadConfig(DockerConfigFile.java:146)
         org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder.readDockerConfig(DefaultDockerClientConfig.java:470)
         [...]
       Caused by: org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile: no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)
 at [Source: /Users/awilkinson/.docker/config.json; line: 2, column: 2]
         org.testcontainers.shaded.com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:1456)
         org.testcontainers.shaded.com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1012)
         org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1206)
         org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:314)
         org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:148)
         [...]
```

This PR adds the necessary reflection config to allow the shaded Docker Java code to create a `DockerConfigFile` instance from json using Jackson.

## Checklist before merging
- [x] I have properly formatted metadata files (see [CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [ ] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

I haven't yet updated the tests as I have been unable to reproduce the problem using them. Locally editing `TestcontainersTest` to set `IS_DISABLED` to `true` isn't sufficient. I suspect this may be due to the way in which the tests are launched by the TCK? Perhaps `user.home` is set to a custom location or some alternative configuration is provided which means that `~/.docker/config.json` is never read?

@mhalbritter I think you made the original Testcontainers contribution. Does any of the above sound familiar to you?