### PR TITLE
Add reflection for default Relay types in GraphQL Java

### DIFF
--- a/metadata/com.graphql-java/graphql-java/19.2/reflect-config.json
+++ b/metadata/com.graphql-java/graphql-java/19.2/reflect-config.json
@@ -1,5 +1,33 @@
 [
   {
+    "name": "graphql.relay.DefaultConnection",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "graphql.relay.Connection"
+    }
+  },
+  {
+    "name": "graphql.relay.DefaultEdge",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "graphql.relay.Connection"
+    }
+  },
+  {
+    "name": "graphql.relay.DefaultPageInfo",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "graphql.relay.Connection"
+    }
+  },
+  {
+    "name": "graphql.relay.DefaultConnectionCursor",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "graphql.relay.Connection"
+    }
+  },
+  {
     "name": "graphql.schema.GraphQLArgument",
     "allPublicMethods": true,
     "condition": {

--- a/tests/src/com.graphql-java/graphql-java/19.2/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/19.2/src/test/java/graphql/starwars/Human.java
@@ -15,12 +15,12 @@ public class Human implements Character {
 
   @Override
   public Long getId() {
-    return null;
+    return 42L;
   }
 
   @Override
   public String getName() {
-    return null;
+    return "GraalVM";
   }
 
   @Override

--- a/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "name": "graphql.starwars.Human",
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/graphql/starwars.graphqls
@@ -11,6 +11,7 @@ type QueryType {
     hero(episode: Episode): Character!
     human(id : String) : Human
     droid(id: ID!): Droid
+    humans: HumanConnection
 }
 
 enum Episode {
@@ -23,7 +24,7 @@ type Human implements Character {
     id: ID!
     name: String!
     friends: [Character]
-    appearsIn: [Episode]!
+    appearsIn: [Episode]
     homePlanet: String
 }
 
@@ -42,4 +43,21 @@ interface Character {
 
 input NewCharacter {
     name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
 }


### PR DESCRIPTION
GraphQL Java ships interfaces for the Relay spec, as well as default
implementations for those types: Connection, Edge, PageInfo,
ConnectionCursor.

This commits adds reflection metadata for default implementations since
they are likely to be used when the GraphQL schema leverages the
interfaces provided by GraphQL Java.


## Checklist before merging
- [x] I have properly formatted metadata files (see 
[CONTRIBUTING](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) document)
- [x] I have added thorough tests. (see [this](/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
