### PR TITLE
Added metadata for commons-logging:commons-logging:1.2

### DIFF
--- a/metadata/commons-logging/commons-logging/1.2/index.json
+++ b/metadata/commons-logging/commons-logging/1.2/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/commons-logging/commons-logging/1.2/reflect-config.json
+++ b/metadata/commons-logging/commons-logging/1.2/reflect-config.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "org.apache.commons.logging.LogFactory",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.LogFactory"
+    }
+  },
+  {
+    "name": "org.apache.commons.logging.LogFactory",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.impl.LogFactoryImpl"
+    }
+  },
+  {
+    "name": "org.apache.commons.logging.impl.Jdk14Logger",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.impl.LogFactoryImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.logging.impl.LogFactoryImpl",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.LogFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.logging.impl.LogFactoryImpl",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.impl.LogFactoryImpl"
+    }
+  },
+  {
+    "name": "org.apache.commons.logging.impl.SimpleLog",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.impl.LogFactoryImpl"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.logging.impl.WeakHashtable",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.LogFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/commons-logging/commons-logging/index.json
+++ b/metadata/commons-logging/commons-logging/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.2",
+    "module": "commons-logging:commons-logging",
+    "tested-versions": [
+      "1.2"
+    ]
+  }
+]

--- a/metadata/index.json
+++ b/metadata/index.json
@@ -221,7 +221,7 @@
     "directory" : "commons-logging/commons-logging",
     "module" : "commons-logging:commons-logging",
     "allowed-packages" : [
-      "commons-logging"
+      "org.apache.commons.logging"
     ]
   },
   {

--- a/metadata/index.json
+++ b/metadata/index.json
@@ -218,6 +218,13 @@
     ]
   },
   {
+    "directory" : "commons-logging/commons-logging",
+    "module" : "commons-logging:commons-logging",
+    "allowed-packages" : [
+      "commons-logging"
+    ]
+  },
+  {
     "directory": "com.github.ben-manes.caffeine/caffeine",
     "module": "com.github.ben-manes.caffeine:caffeine",
     "allowed-packages": [

--- a/tests/src/commons-logging/commons-logging/1.2/.gitignore
+++ b/tests/src/commons-logging/commons-logging/1.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/commons-logging/commons-logging/1.2/build.gradle
+++ b/tests/src/commons-logging/commons-logging/1.2/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "commons-logging:commons-logging:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/commons-logging/commons-logging/1.2/gradle.properties
+++ b/tests/src/commons-logging/commons-logging/1.2/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.2
+metadata.dir = commons-logging/commons-logging/1.2/

--- a/tests/src/commons-logging/commons-logging/1.2/metadata-extra-filter.json
+++ b/tests/src/commons-logging/commons-logging/1.2/metadata-extra-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.commons.logging.**"}
+  ]
+}

--- a/tests/src/commons-logging/commons-logging/1.2/metadata-user-code-filter.json
+++ b/tests/src/commons-logging/commons-logging/1.2/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.commons.logging.**"}
+  ]
+}

--- a/tests/src/commons-logging/commons-logging/1.2/settings.gradle
+++ b/tests/src/commons-logging/commons-logging/1.2/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'commons-logging.commons-logging_tests'

--- a/tests/src/commons-logging/commons-logging/1.2/src/test/java/commons_logging/commons_logging/CommonsLoggingTest.java
+++ b/tests/src/commons-logging/commons-logging/1.2/src/test/java/commons_logging/commons_logging/CommonsLoggingTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_logging.commons_logging;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.impl.LogFactoryImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsLoggingTest {
+
+    private final PrintStream systemErr = System.err;
+
+    private ByteArrayOutputStream outputStreamCaptor;
+
+    @BeforeEach
+    public void setUp() {
+        outputStreamCaptor = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setErr(systemErr);
+    }
+
+    @Test
+    void testSimpleLog() throws Exception {
+        System.setProperty(LogFactoryImpl.LOG_PROPERTY, "org.apache.commons.logging.impl.SimpleLog");
+        try {
+            LogFactory.getLog("SimpleLogTest").info("info message");
+            assertThat(outputStreamCaptor.toString()).isEqualTo("[INFO] SimpleLogTest - info message\n");
+        } finally {
+            System.clearProperty(LogFactoryImpl.LOG_PROPERTY);
+            resetLogConstructorField();
+        }
+    }
+
+    @Test
+    void testJdk14Logger() throws Exception {
+        System.setProperty(LogFactoryImpl.LOG_PROPERTY, "org.apache.commons.logging.impl.Jdk14Logger");
+        try {
+            LogFactory.getLog("Jdk14LoggerTest").error("error message");
+            assertThat(outputStreamCaptor.toString()).contains("SEVERE: error message");
+        } finally {
+            System.clearProperty(LogFactoryImpl.LOG_PROPERTY);
+            resetLogConstructorField();
+        }
+    }
+
+    private void resetLogConstructorField() throws NoSuchFieldException, IllegalAccessException {
+        Field field = LogFactoryImpl.class.getDeclaredField("logConstructor");
+        field.setAccessible(true);
+        field.set(LogFactory.getFactory(), null);
+    }
+}

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -319,6 +319,17 @@
     ]
   },
   {
+    "test-project-path" : "commons-logging/commons-logging/1.2",
+    "libraries" : [
+      {
+        "name" : "commons-logging:commons-logging",
+        "versions" : [
+          "1.2"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "com.github.ben-manes.caffeine/caffeine/3.1.2",
     "libraries": [
       {


### PR DESCRIPTION
## What does this PR do?
Adds metadata for commons-logging:commons-logging:1.2

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [this](./CONTRIBUTING.md))
- [x] I have properly formatted metadata files (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
