### PR TITLE
Added metadata for org.apache.httpcomponents:httpclient:4.5.14

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -114,6 +114,13 @@
     ]
   },
   {
+    "directory" : "org.apache.httpcomponents/httpclient",
+    "module" : "org.apache.httpcomponents:httpclient",
+    "allowed-packages" : [
+      "org.apache.http"
+    ]
+  },
+  {
     "directory": "org.apache.tomcat.embed/tomcat-embed-core",
     "module": "org.apache.tomcat.embed:tomcat-embed-core",
     "allowed-packages": [

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/index.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/index.json
@@ -1,0 +1,5 @@
+[
+  "reflect-config.json",
+  "resource-config.json",
+  "serialization-config.json"
+]

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/reflect-config.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "org.apache.http.impl.auth.BasicScheme",
+    "condition": {
+      "typeReachable": "org.apache.http.impl.client.BasicAuthCache"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/resource-config.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/resource-config.json
@@ -1,0 +1,20 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qmozilla/public-suffix-list.txt\\E",
+        "condition": {
+          "typeReachable": "java.lang.Class"
+        }
+      },
+      {
+        "pattern": "\\Qorg/apache/http/client/version.properties\\E",
+        "condition": {
+          "typeReachable": "org.apache.http.util.VersionInfo"
+        }
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/resource-config.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/resource-config.json
@@ -4,7 +4,7 @@
       {
         "pattern": "\\Qmozilla/public-suffix-list.txt\\E",
         "condition": {
-          "typeReachable": "java.lang.Class"
+          "typeReachable": "org.apache.http.conn.util.PublicSuffixMatcherLoader"
         }
       },
       {

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/serialization-config.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/serialization-config.json
@@ -3,13 +3,22 @@
   ],
   "types": [
     {
-      "name": "org.apache.http.impl.auth.BasicScheme"
+      "name": "org.apache.http.impl.auth.BasicScheme",
+      "condition": {
+        "typeReachable": "org.apache.http.impl.client.BasicAuthCache"
+      }
     },
     {
-      "name": "org.apache.http.impl.auth.RFC2617Scheme"
+      "name": "org.apache.http.impl.auth.RFC2617Scheme",
+      "condition": {
+        "typeReachable": "org.apache.http.impl.client.BasicAuthCache"
+      }
     },
     {
-      "name": "java.util.HashMap"
+      "name": "java.util.HashMap",
+      "condition": {
+        "typeReachable": "org.apache.http.impl.client.BasicAuthCache"
+      }
     }
   ]
 }

--- a/metadata/org.apache.httpcomponents/httpclient/4.5.14/serialization-config.json
+++ b/metadata/org.apache.httpcomponents/httpclient/4.5.14/serialization-config.json
@@ -1,0 +1,15 @@
+{
+  "lambdaCapturingTypes": [
+  ],
+  "types": [
+    {
+      "name": "org.apache.http.impl.auth.BasicScheme"
+    },
+    {
+      "name": "org.apache.http.impl.auth.RFC2617Scheme"
+    },
+    {
+      "name": "java.util.HashMap"
+    }
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpclient/index.json
+++ b/metadata/org.apache.httpcomponents/httpclient/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "4.5.14",
+    "module": "org.apache.httpcomponents:httpclient",
+    "tested-versions": [
+      "4.5.14"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -143,6 +143,17 @@
     ]
   },
   {
+    "test-project-path" : "org.apache.httpcomponents/httpclient/4.5.14",
+    "libraries" : [
+      {
+        "name" : "org.apache.httpcomponents:httpclient",
+        "versions" : [
+          "4.5.14"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.apache.tomcat.embed/tomcat-embed-core/10.0.20",
     "libraries": [
       {

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/.gitignore
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/.gitignore
@@ -1,0 +1,6 @@
+gradlew.bat
+gradlew
+gradle/
+build/
+nginx-stderr.txt
+nginx-stdout.txt

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/build.gradle
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.httpcomponents:httpclient:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 4.5.14
+metadata.dir = org.apache.httpcomponents/httpclient/4.5.14/

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/required-docker-images.txt
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/required-docker-images.txt
@@ -1,0 +1,1 @@
+nginx:1-alpine-slim

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/settings.gradle
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.httpcomponents.httpclient_tests'

--- a/tests/src/org.apache.httpcomponents/httpclient/4.5.14/src/test/java/org_apache_httpcomponents/httpclient/HttpClientTest.java
+++ b/tests/src/org.apache.httpcomponents/httpclient/4.5.14/src/test/java/org_apache_httpcomponents/httpclient/HttpClientTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpclient;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientTest {
+
+    private static int port;
+
+    private static Process process;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Finding available port ...");
+        port = findAvailablePort();
+        System.out.println("Found port: " + port);
+
+        System.out.println("Starting nginx ...");
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "-p", port + ":80", "nginx:1-alpine-slim")
+                .redirectOutput(new File("nginx-stdout.txt"))
+                .redirectError(new File("nginx-stderr.txt"))
+                .start();
+
+        // Wait until connection can be established
+        waitUntilContainerStarted(60);
+
+        System.out.println("nginx started");
+    }
+
+    private static int findAvailablePort() throws IOException {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            assertThat(serverSocket).isNotNull();
+            int localPort = serverSocket.getLocalPort();
+            assertThat(localPort).isGreaterThan(0);
+            return localPort;
+        }
+    }
+
+    private static void waitUntilContainerStarted(int startupTimeoutSeconds) {
+        System.out.println("Waiting for nginx container to become available");
+
+        Exception lastConnectionException = null;
+
+        long end = System.currentTimeMillis() + startupTimeoutSeconds * 1000L;
+        while (System.currentTimeMillis() < end) {
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                // continue
+            }
+            try (Socket socket = new Socket()) {
+                socket.setSoTimeout(100);
+                socket.connect(new InetSocketAddress("localhost", port), 100);
+                if (!check(socket)) {
+                    continue;
+                }
+                return;
+            } catch (Exception e) {
+                lastConnectionException = e;
+            }
+        }
+        throw new IllegalStateException("nginx container cannot be accessed on localhost:" + port, lastConnectionException);
+    }
+
+    private static boolean check(Socket socket) throws IOException {
+        try {
+            // -1 indicates the socket has been closed immediately
+            // Other responses or a timeout are considered as success
+            if (socket.getInputStream().read() == -1) {
+                return false;
+            }
+        } catch (SocketTimeoutException ex) {
+        }
+        return true;
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (process != null && process.isAlive()) {
+            System.out.println("Shutting down nginx");
+            process.destroy();
+        }
+    }
+
+    @Test
+    void testBasicSchemeDeserialization() throws Exception {
+        AuthCache authCache = new BasicAuthCache();
+        authCache.put(new HttpHost("localhost", port, "http"), new BasicScheme());
+
+        HttpClientContext context = HttpClientContext.create();
+        context.setAuthCache(authCache);
+
+        HttpGet httpGet = new HttpGet("http://localhost:%d/".formatted(port));
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            try (CloseableHttpResponse response = httpclient.execute(httpGet, context)) {
+                assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Adds metadata for org.apache.httpcomponents:httpclient:4.5.14

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [this](./CONTRIBUTING.md))
- [x] I have properly formatted metadata files (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
