### PR TITLE
Add OCI Java SDK to the list of libraries supporting native image

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -1,23 +1,5 @@
 [
   {
-    "artifact": "com.oracle.oci.sdk:oci-java-sdk",
-    "description": "Oracle Cloud Infrastructure Java SDK",
-    "details": [
-      {
-        "minimum_version": "3.0.0",
-        "metadata_locations": [
-          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm/",
-          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm-jersey3/"
-        ],
-        "tests_locations": [
-          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-addon/src/test/java/com/oracle/bmc/graalvm",
-          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-jersey3-addon/src/test/java/com/oracle/bmc/graalvm"
-        ],
-        "test_level": "fully-tested"
-      }
-    ]
-  },
-  {
     "artifact": "com.datastax.oss:java-driver-core",
     "description": "DataStax Java Driver for Apache Cassandra",
     "details": [
@@ -61,6 +43,24 @@
         ],
         "tests_locations": [
           "https://www.oracle.com/a/otn/docs/what-is-in-db21c-for-java-developers.pdf"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
+    "artifact": "com.oracle.oci.sdk:oci-java-sdk",
+    "description": "Oracle Cloud Infrastructure Java SDK",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "metadata_locations": [
+          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm/",
+          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm-jersey3/"
+        ],
+        "tests_locations": [
+          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-addon/src/test/java/com/oracle/bmc/graalvm",
+          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-jersey3-addon/src/test/java/com/oracle/bmc/graalvm"
         ],
         "test_level": "fully-tested"
       }

--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -1,5 +1,23 @@
 [
   {
+    "artifact": "com.oracle.oci.sdk:oci-java-sdk",
+    "description": "Oracle Cloud Infrastructure Java SDK",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "metadata_locations": [
+          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm/",
+          "https://repo1.maven.org/maven2/com/oracle/oci/sdk/oci-java-sdk-addons-graalvm-jersey3/"
+        ],
+        "tests_locations": [
+          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-addon/src/test/java/com/oracle/bmc/graalvm",
+          "https://github.com/oracle/oci-java-sdk/tree/master/bmc-addons/bmc-graalvm-jersey3-addon/src/test/java/com/oracle/bmc/graalvm"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "com.datastax.oss:java-driver-core",
     "description": "DataStax Java Driver for Apache Cassandra",
     "details": [


### PR DESCRIPTION
## What does this PR do?
Adds OCI Java SDK to the list of libraries supporting native image

## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [this](./CONTRIBUTING.md))
- [ ] I have properly formatted metadata files (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [this](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
