### PR TITLE
add nacos docker images

### DIFF
--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -5,4 +5,4 @@ opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
-nacos/nacos-server:v2.1.0
+nacos/nacos-server:v2.2.0

--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -5,3 +5,4 @@ opengauss/opengauss:3.1.0
 greenmail/standalone:2.0.0
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
+nacos/nacos-server:v2.1.0


### PR DESCRIPTION
## What does this PR do?
- For https://github.com/oracle/graalvm-reachability-metadata/issues/260 and https://github.com/oracle/graalvm-reachability-metadata/pull/327
- Add testcontainers/ryuk docker image to the allowed images list.

```
$ grype docker:nacos/nacos-server:v2.2.0
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [459 packages]
 ✔ Scanning image...       [1263 vulnerabilities]
   ├── 9 critical, 31 high, 458 medium, 758 low, 0 negligible (7 unknown)
   └── 60 fixed
NAME                         INSTALLED                 FIXED-IN                  TYPE          VULNERABILITY        SEVERITY
audit-libs                   2.8.5-4.el7               (won't fix)               rpm           CVE-2015-5186        Medium
avahi-libs                   0.6.31-20.el7             (won't fix)               rpm           CVE-2021-3468        Medium
avahi-libs                   0.6.31-20.el7             (won't fix)               rpm           CVE-2023-1981        Medium
bash                         4.2.46-35.el7_9           (won't fix)               rpm           CVE-2012-6711        Medium
bash                         4.2.46-35.el7_9           (won't fix)               rpm           CVE-2019-18276       Low
bind-license                 32:9.11.4-26.P2.el7_9.10                            rpm           CVE-2023-2828        High
bind-license                 32:9.11.4-26.P2.el7_9.10  (won't fix)               rpm           CVE-2013-5661        Low
bind-license                 32:9.11.4-26.P2.el7_9.10  (won't fix)               rpm           CVE-2016-6170        Low
bind-license                 32:9.11.4-26.P2.el7_9.10  (won't fix)               rpm           CVE-2022-3094        Medium
bind-license                 32:9.11.4-26.P2.el7_9.10  32:9.11.4-26.P2.el7_9.13  rpm           CVE-2021-25220       Medium
bind-license                 32:9.11.4-26.P2.el7_9.10  32:9.11.4-26.P2.el7_9.13  rpm           CVE-2022-2795        Medium
binutils                     2.27-44.base.el7_9.1                                rpm           CVE-2014-9939        Low
binutils                     2.27-44.base.el7_9.1                                rpm           CVE-2019-17450       Low
binutils                     2.27-44.base.el7_9.1      (won't fix)               rpm           CVE-2015-8538        Low
binutils                     2.27-44.base.el7_9.1      (won't fix)               rpm           CVE-2016-2226        Low
binutils                     2.27-44.base.el7_9.1      (won't fix)               rpm           CVE-2016-4487        Low
binutils                     2.27-44.base.el7_9.1      (won't fix)               rpm           CVE-2016-4488        Low
…………
```