### PR TITLE
Upgrade Native Build Tools and update to GraalVM for JDK 17.

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: 'latest'
           java-version: '17'
+          distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: ./gradlew checkstyle

--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -13,8 +13,9 @@ jobs:
           fetch-depth: 0
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.1'
           java-version: '17'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🔎 Check docker images"
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -24,8 +24,8 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: 'latest'
           java-version: '17'
+          distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🕸️ Populate matrix"
         id: set-matrix
@@ -34,7 +34,7 @@ jobs:
 
   test-all-metadata:
     if: github.repository == 'oracle/graalvm-reachability-metadata'
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.versions.graalvm }} ${{ matrix.versions.java }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.versions.java }} @ ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: get-all-metadata
@@ -47,9 +47,8 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: ${{ matrix.versions.graalvm }}
           java-version: ${{ matrix.versions.java }}
-          components: 'native-image'
+          distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
       - name: "Pull allowed docker images"

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -34,7 +34,7 @@ jobs:
 
   test-all-metadata:
     if: github.repository == 'oracle/graalvm-reachability-metadata'
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.versions.java }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: get-all-metadata
@@ -47,7 +47,7 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: ${{ matrix.versions.java }}
+          java-version: ${{ matrix.version }}
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -26,8 +26,8 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: 'latest'
           java-version: '17'
+          distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "🕸️ Populate matrix"
         id: set-matrix
@@ -35,7 +35,7 @@ jobs:
           ./gradlew generateMatrixDiffCoordinates -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.event.pull_request.head.sha }}
 
   test-changed-metadata:
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM ${{ matrix.versions.graalvm }} ${{ matrix.versions.java }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.versions.java }} @ ${{ matrix.os }})"
     if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -50,9 +50,8 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          version: ${{ matrix.versions.graalvm }}
           java-version: ${{ matrix.versions.java }}
-          components: 'native-image'
+          distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
       - name: "Pull allowed docker images"

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -35,7 +35,7 @@ jobs:
           ./gradlew generateMatrixDiffCoordinates -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.event.pull_request.head.sha }}
 
   test-changed-metadata:
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.versions.java }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -50,7 +50,7 @@ jobs:
       - name: "🔧 Prepare environment"
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: ${{ matrix.versions.java }}
+          java-version: ${{ matrix.version }}
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Project versions
-nativeBuildTools = "0.9.20"
+nativeBuildTools = "0.9.23"
 
 # External dependencies
 junitPlatform = "1.9.2"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -90,10 +90,8 @@ if (project.hasProperty("baseCommit")) {
 }
 
 def matrixDefault = [
-        "versions" : [
-            [ "java": "17" ]
-        ],
-        "os"       : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"
+        "version": ["17"],
+        "os"     : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"
 ]
 
 final String METADATA_GROUP = "Metadata"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -91,10 +91,9 @@ if (project.hasProperty("baseCommit")) {
 
 def matrixDefault = [
         "versions" : [
-                [ "graalvm": "dev",    "java": "17" ],
-                [ "graalvm": "latest", "java": "17" ]
+            [ "java": "17" ]
         ],
-        "os"          : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"
+        "os"       : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"
 ]
 
 final String METADATA_GROUP = "Metadata"

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -24,7 +24,7 @@ java {
                 .map(JavaLanguageVersion::of)
         vendor = providers.environmentVariable("TCK_JAVA_VENDOR")
                 .map(JvmVendorSpec::matching)
-                .orElse(JvmVendorSpec.GRAAL_VM)
+                .orElse(JvmVendorSpec.matching(""))
     }
 }
 
@@ -101,7 +101,7 @@ graalvmNative {
                     .map(JavaLanguageVersion::of)
             vendor = providers.environmentVariable("TCK_JAVA_VENDOR")
                     .map(JvmVendorSpec::matching)
-                    .orElse(JvmVendorSpec.GRAAL_VM)
+                    .orElse(JvmVendorSpec.matching(""))
         })
     }
 }


### PR DESCRIPTION
## What does this PR do?
This PR upgrade the NBT to `0.9.23` and updates all uses of the `setup-graalvm` action to use the new GraalVM for JDK 17 release.

## Checklist before merging
n/a
