### PR TITLE
Replace greenmail/standalone docker image with the less vulnerable version

### DIFF
--- a/tests/src/com.sun.mail/jakarta.mail/2.0.1/required-docker-images.txt
+++ b/tests/src/com.sun.mail/jakarta.mail/2.0.1/required-docker-images.txt
@@ -1,1 +1,1 @@
-greenmail/standalone:2.0.0
+greenmail/standalone:2.1.0-alpha-1

--- a/tests/src/com.sun.mail/jakarta.mail/2.0.1/src/test/java/com/sun/mail/JakartaMailTest.java
+++ b/tests/src/com.sun.mail/jakarta.mail/2.0.1/src/test/java/com/sun/mail/JakartaMailTest.java
@@ -35,7 +35,7 @@ public class JakartaMailTest {
     static void beforeAll() throws IOException {
         System.out.println("Starting email server ...");
         new ProcessBuilder("docker", "run", "--cidfile", "greenmail.cid", "-p", "3025:3025", "--rm", "-e",
-                "GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose", "greenmail/standalone:2.0.0")
+                "GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose", "greenmail/standalone:2.1.0-alpha-1")
                 .redirectOutput(new File("greenmail-stdout.txt"))
                 .redirectError(new File("greenmail-stderr.txt")).start();
         Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> {

--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -2,7 +2,7 @@ mysql/mysql-server:8.0
 mariadb:10.8
 postgres:15-alpine
 opengauss/opengauss:3.1.0
-greenmail/standalone:2.0.0
+greenmail/standalone:2.1.0-alpha-1
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
 nats:2.9.19


### PR DESCRIPTION
## What does this PR do?
Replaces greenmail docker image that caused [gates failure](https://github.com/oracle/graalvm-reachability-metadata/actions/runs/5409930791/jobs/9830696478#step:4:66), with the newer one with less vulnerabilities.

``` shell
 grype greenmail/standalone:2.1.0-alpha-1
 ✔ Vulnerability DB        [no update available]
New version of grype is available: 0.63.0 (currently running: 0.58.0)
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [188 packages]
 ✔ Scanned image           [66 vulnerabilities]
NAME                   INSTALLED                 FIXED-IN                   TYPE          VULNERABILITY   SEVERITY   
bash                   5.1-6ubuntu1                                         deb           CVE-2022-3715   Low         
coreutils              8.32-4.1ubuntu1                                      deb           CVE-2016-2781   Low         
dbus                   1.12.20-2ubuntu4.1                                   deb           CVE-2023-34969  Low         
dirmngr                2.2.27-3ubuntu2.1                                    deb           CVE-2022-3219   Low         
gpg-agent              2.2.27-3ubuntu2.1                                    deb           CVE-2022-3219   Low         
gpgv                   2.2.27-3ubuntu2.1                                    deb           CVE-2022-3219   Low         
jackson-databind       2.14.1                                               java-archive  CVE-2023-35116  High        
java                   11.0.18+10-LTS                                       binary        CVE-2023-21968  Low         
libc-bin               2.35-0ubuntu3.1                                      deb           CVE-2016-20013  Negligible  
libc6                  2.35-0ubuntu3.1                                      deb           CVE-2016-20013  Negligible  
libcap2                1:2.44-1build3            1:2.44-1ubuntu0.22.04.1    deb           CVE-2023-2602   Low         
libcap2                1:2.44-1build3            1:2.44-1ubuntu0.22.04.1    deb           CVE-2023-2603   Medium      
libfreetype6           2.11.1+dfsg-1ubuntu0.1    2.11.1+dfsg-1ubuntu0.2     deb           CVE-2023-2004   Medium      
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-24593  Low         
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-25180  Low         
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-29499  Medium      
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-32611  Medium      
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-32636  Medium      
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-32643  Medium      
libglib2.0-0           2.72.4-0ubuntu1           2.72.4-0ubuntu2.2          deb           CVE-2023-32665  Medium      
libncurses6            6.3-2                     6.3-2ubuntu0.1             deb           CVE-2022-29458  Negligible  
libncurses6            6.3-2                     6.3-2ubuntu0.1             deb           CVE-2023-29491  Medium      
libncursesw6           6.3-2                     6.3-2ubuntu0.1             deb           CVE-2022-29458  Negligible  
libncursesw6           6.3-2                     6.3-2ubuntu0.1             deb           CVE-2023-29491  Medium      
libpcre3               2:8.39-13ubuntu0.22.04.1                             deb           CVE-2017-11164  Negligible  
libpng16-16            1.6.37-3build5                                       deb           CVE-2022-3857   Low         
libpython3.10-minimal  3.10.6-1~22.04.2                                     deb           CVE-2023-27043  Medium      
libpython3.10-minimal  3.10.6-1~22.04.2          3.10.6-1~22.04.2ubuntu1.1  deb           CVE-2023-24329  Medium      
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.10          deb           CVE-2023-1255   Low         
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.10          deb           CVE-2023-2650   Medium      
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2022-3996   Low         
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0464   Low         
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0465   Low         
libssl3                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0466   Negligible  
libsystemd0            249.11-0ubuntu3.7                                    deb           CVE-2023-31437  Medium      
libsystemd0            249.11-0ubuntu3.7                                    deb           CVE-2023-31438  Medium      
libsystemd0            249.11-0ubuntu3.7                                    deb           CVE-2023-31439  Medium      
libtinfo6              6.3-2                     6.3-2ubuntu0.1             deb           CVE-2022-29458  Negligible  
libtinfo6              6.3-2                     6.3-2ubuntu0.1             deb           CVE-2023-29491  Medium      
libudev1               249.11-0ubuntu3.7                                    deb           CVE-2023-31437  Medium      
libudev1               249.11-0ubuntu3.7                                    deb           CVE-2023-31438  Medium      
libudev1               249.11-0ubuntu3.7                                    deb           CVE-2023-31439  Medium      
libx11-6               2:1.7.5-1                 2:1.7.5-1ubuntu0.2         deb           CVE-2023-3138   Medium      
libx11-data            2:1.7.5-1                 2:1.7.5-1ubuntu0.2         deb           CVE-2023-3138   Medium      
libzstd1               1.4.8+dfsg-3build1                                   deb           CVE-2022-4899   Low         
locales                2.35-0ubuntu3.1                                      deb           CVE-2016-20013  Negligible  
login                  1:4.8.1-2ubuntu2.1                                   deb           CVE-2023-29383  Low         
ncurses-base           6.3-2                     6.3-2ubuntu0.1             deb           CVE-2022-29458  Negligible  
ncurses-base           6.3-2                     6.3-2ubuntu0.1             deb           CVE-2023-29491  Medium      
ncurses-bin            6.3-2                     6.3-2ubuntu0.1             deb           CVE-2022-29458  Negligible  
ncurses-bin            6.3-2                     6.3-2ubuntu0.1             deb           CVE-2023-29491  Medium      
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.10          deb           CVE-2023-1255   Low         
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.10          deb           CVE-2023-2650   Medium      
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2022-3996   Low         
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0464   Low         
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0465   Low         
openssl                3.0.2-0ubuntu1.8          3.0.2-0ubuntu1.9           deb           CVE-2023-0466   Negligible  
passwd                 1:4.8.1-2ubuntu2.1                                   deb           CVE-2023-29383  Low         
perl-base              5.34.0-3ubuntu1.1         5.34.0-3ubuntu1.2          deb           CVE-2023-31484  Medium      
policykit-1            0.105-33                                             deb           CVE-2016-2568   Low         
polkitd                0.105-33                                             deb           CVE-2016-2568   Low         
python3.10-minimal     3.10.6-1~22.04.2                                     deb           CVE-2023-27043  Medium      
python3.10-minimal     3.10.6-1~22.04.2          3.10.6-1~22.04.2ubuntu1.1  deb           CVE-2023-24329  Medium      
systemd                249.11-0ubuntu3.7                                    deb           CVE-2023-31437  Medium      
systemd                249.11-0ubuntu3.7                                    deb           CVE-2023-31438  Medium      
systemd                249.11-0ubuntu3.7                                    deb           CVE-2023-31439  Medium
```
