### PR TITLE
Added eclipse-mosquitto:2.0.15 to the list of allowed docker images

### DIFF
--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -6,3 +6,4 @@ greenmail/standalone:2.1.0-alpha-1
 nginx:1-alpine-slim
 mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
 nats:2.9.19
+eclipse-mosquitto:2.0.15


### PR DESCRIPTION
```
grype eclipse-mosquitto:2.0.15
 ✔ Vulnerability DB        [updated]
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [22 packages]
 ✔ Scanning image...       [0 vulnerabilities]
   ├── 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── 0 fixed
```
