### PR TITLE
Add `paths(-ignore)` filters to reduce test overhead.

### DIFF
--- a/.github/workflows/checkstyle-skip.yml
+++ b/.github/workflows/checkstyle-skip.yml
@@ -1,0 +1,17 @@
+name: "Check code style"
+
+on:
+  push:
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/checkstyle-skip.yml
+++ b/.github/workflows/checkstyle-skip.yml
@@ -3,11 +3,11 @@ name: "Check code style"
 on:
   push:
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   pull_request:
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 jobs:

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -3,11 +3,11 @@ name: "Check code style"
 on:
   push:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 jobs:

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,6 +1,14 @@
 name: "Check code style"
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
 
 jobs:
   checkstyle:

--- a/.github/workflows/library-and-framework-list-validation-skip.yml
+++ b/.github/workflows/library-and-framework-list-validation-skip.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: "📋 Validate the JSON file"
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/library-and-framework-list-validation-skip.yml
+++ b/.github/workflows/library-and-framework-list-validation-skip.yml
@@ -1,0 +1,15 @@
+name: "Validate library-and-framework-list.json"
+
+on:
+  push:
+    paths-ignore:
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths-ignore:
+      - 'library-and-framework-list*.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/library-and-framework-list-validation.yml
+++ b/.github/workflows/library-and-framework-list-validation.yml
@@ -1,6 +1,12 @@
 name: "Validate library-and-framework-list.json"
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths:
+      - 'library-and-framework-list*.json'
 
 jobs:
   validate-library-and-framework-list-json:

--- a/.github/workflows/scan-docker-images-skip.yml
+++ b/.github/workflows/scan-docker-images-skip.yml
@@ -3,11 +3,11 @@ name: "Scan docker images from the allowed docker images list"
 on:
   push:
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   pull_request:
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 jobs:

--- a/.github/workflows/scan-docker-images-skip.yml
+++ b/.github/workflows/scan-docker-images-skip.yml
@@ -1,0 +1,17 @@
+name: "Scan docker images from the allowed docker images list"
+
+on:
+  push:
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -3,11 +3,11 @@ name: "Scan docker images from the allowed docker images list"
 on:
   push:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 jobs:

--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -1,6 +1,14 @@
 name: "Scan docker images from the allowed docker images list"
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
 
 jobs:
   scan-images:

--- a/.github/workflows/test-all-metadata-skip.yml
+++ b/.github/workflows/test-all-metadata-skip.yml
@@ -1,0 +1,16 @@
+name: "Test all metadata"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-all-metadata-skip.yml
+++ b/.github/workflows/test-all-metadata-skip.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   workflow_dispatch:
 

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
   workflow_dispatch:
 

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-changed-metadata-skip.yml
+++ b/.github/workflows/test-changed-metadata-skip.yml
@@ -1,0 +1,15 @@
+name: "Test changed metadata"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '*.md'
+      - 'library-and-framework-list*.json'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-changed-metadata-skip.yml
+++ b/.github/workflows/test-changed-metadata-skip.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 jobs:

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'library-and-framework-list*.json'
 
 concurrency:

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
+      - 'library-and-framework-list*.json'
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"


### PR DESCRIPTION
## What does this PR do?

This PR adjusts the workflow configs so that they use `paths` and `paths-ignore` to target specific tests. For example, there is no need to test the `library-and-framework-list.json` every time someone changes metadata, and vice versa. Similarly, we don't want to run all tests when changing documentation (markdown files).
