### PR TITLE
Set number of allowed high vulnerabilities to previous state

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
@@ -54,7 +54,7 @@ public abstract class GrypeTask extends DefaultTask {
                     vulnerableImages.add("Image: " + image + " contains " + numberOfCritical + " critical, and " + numberOfHigh + " high vulnerabilities");
                 }
 
-                if (numberOfHigh > 5 || numberOfCritical > 0) {
+                if (numberOfHigh > 4 || numberOfCritical > 0) {
                     shouldFail = true;
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Follow up [this PR](https://github.com/oracle/graalvm-reachability-metadata/pull/329). It reverts changes from [this PR](https://github.com/oracle/graalvm-reachability-metadata/pull/337) which was quick fix
