### PR TITLE
Narrow the search in getAllowedPackages function

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -130,7 +130,10 @@
   },
   {
     "directory" : "org.apache.tomcat/tomcat-jdbc",
-    "module" : "org.apache.tomcat:tomcat-jdbc"
+    "module" : "org.apache.tomcat:tomcat-jdbc",
+    "allowed-packages": [
+      "org.apache.tomcat.jdbc"
+    ]
   },
   {
     "directory": "com.google.protobuf/protobuf-java-util",

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ConfigFilesChecker.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ConfigFilesChecker.java
@@ -388,7 +388,7 @@ public abstract class ConfigFilesChecker extends DefaultTask {
         for (var entry : entries) {
             if (entry.get("module").toString().startsWith(groupId + ":" + artifactId)) {
                 if (entry.get("allowed-packages") == null) {
-                    throw new IllegalStateException("Missing allowed-packages property for " + groupId);
+                    throw new IllegalStateException("Missing allowed-packages property for " + groupId + ":" + artifactId);
                 }
 
                 return (List<String>) entry.get("allowed-packages");

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ConfigFilesChecker.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ConfigFilesChecker.java
@@ -381,11 +381,12 @@ public abstract class ConfigFilesChecker extends DefaultTask {
     private List<String> getAllowedPackages() {
         File indexFile = getIndexFile().get().getAsFile();
         String groupId = coordinates.group();
+        String artifactId = coordinates.artifact();
 
         List<Map<String, Object>> entries = getConfigEntries(indexFile);
 
         for (var entry : entries) {
-            if (entry.get("module").toString().startsWith(groupId)) {
+            if (entry.get("module").toString().startsWith(groupId + ":" + artifactId)) {
                 if (entry.get("allowed-packages") == null) {
                     throw new IllegalStateException("Missing allowed-packages property for " + groupId);
                 }


### PR DESCRIPTION
## What does this PR do?
Currently we are looking for `allowedPackages` field in `metdata/index.json` by searching for the `groupId` in the module name of the corresponding library. It turns out that this approach misses corner case when two libraries have the same `groupId` but different `artifactId` (Example: `org.eclipse.paho:org.eclipse.paho.client.mqttv3` and `org.eclipse.paho:org.eclipse.paho.mqttv5.client`). This PR narrows the search by looking for both `groupId` and `artifactId` in the module name.