### PR TITLE
Change docker image to the official one from oracle repository

### DIFF
--- a/tests/src/com.mysql/mysql-connector-j/8.0.31/required-docker-images.txt
+++ b/tests/src/com.mysql/mysql-connector-j/8.0.31/required-docker-images.txt
@@ -1,1 +1,1 @@
-mysql/mysql-server:8.0
+container-registry.oracle.com/mysql/community-server:8.1

--- a/tests/src/com.mysql/mysql-connector-j/8.0.31/src/test/java/mysql/MySQLTests.java
+++ b/tests/src/com.mysql/mysql-connector-j/8.0.31/src/test/java/mysql/MySQLTests.java
@@ -51,7 +51,7 @@ public class MySQLTests {
         System.out.println("Starting MySQL ...");
         process = new ProcessBuilder(
                 "docker", "run", "--rm", "-p", "3306:3306", "-e", "MYSQL_DATABASE=" + DATABASE, "-e", "MYSQL_USER=" + USERNAME,
-                "-e", "MYSQL_PASSWORD=" + PASSWORD, "mysql/mysql-server:8.0").redirectOutput(new File("mysql-stdout.txt"))
+                "-e", "MYSQL_PASSWORD=" + PASSWORD, "container-registry.oracle.com/mysql/community-server:8.1").redirectOutput(new File("mysql-stdout.txt"))
                 .redirectError(new File("mysql-stderr.txt")).start();
 
         // Wait until connection can be established

--- a/tests/src/mysql/mysql-connector-java/8.0.29/required-docker-images.txt
+++ b/tests/src/mysql/mysql-connector-java/8.0.29/required-docker-images.txt
@@ -1,1 +1,1 @@
-mysql/mysql-server:8.0
+container-registry.oracle.com/mysql/community-server:8.1

--- a/tests/src/mysql/mysql-connector-java/8.0.29/src/test/java/mysql/MySQLTests.java
+++ b/tests/src/mysql/mysql-connector-java/8.0.29/src/test/java/mysql/MySQLTests.java
@@ -51,7 +51,7 @@ public class MySQLTests {
         System.out.println("Starting MySQL ...");
         process = new ProcessBuilder(
                 "docker", "run", "--rm", "-p", "3306:3306", "-e", "MYSQL_DATABASE=" + DATABASE, "-e", "MYSQL_USER=" + USERNAME,
-                "-e", "MYSQL_PASSWORD=" + PASSWORD, "mysql/mysql-server:8.0").redirectOutput(new File("mysql-stdout.txt"))
+                "-e", "MYSQL_PASSWORD=" + PASSWORD, "container-registry.oracle.com/mysql/community-server:8.1").redirectOutput(new File("mysql-stdout.txt"))
                 .redirectError(new File("mysql-stderr.txt")).start();
 
         // Wait until connection can be established

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/required-docker-images.txt
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/required-docker-images.txt
@@ -1,1 +1,1 @@
-mysql/mysql-server:8.0
+container-registry.oracle.com/mysql/community-server:8.1

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/HibernateReactiveCoreTest.java
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/HibernateReactiveCoreTest.java
@@ -56,7 +56,7 @@ class HibernateReactiveCoreTest {
         logger.info("Starting MySQL ...");
         process = new ProcessBuilder(
                 "docker", "run", "--rm", "-p", "3306:3306", "-e", "MYSQL_DATABASE=" + DATABASE, "-e", "MYSQL_USER=" + USERNAME,
-                "-e", "MYSQL_PASSWORD=" + PASSWORD, "mysql/mysql-server:8.0").inheritIO().start();
+                "-e", "MYSQL_PASSWORD=" + PASSWORD, "container-registry.oracle.com/mysql/community-server:8.1").inheritIO().start();
 
         waitUntil(() -> {
             openConnection().close();

--- a/tests/src/samples/docker/image-pull/required-docker-images.txt
+++ b/tests/src/samples/docker/image-pull/required-docker-images.txt
@@ -1,1 +1,1 @@
-mysql/mysql-server:8.0
+container-registry.oracle.com/mysql/community-server:8.1

--- a/tests/src/samples/docker/image-pull/src/test/java/image/pull/DockerImagePullTests.java
+++ b/tests/src/samples/docker/image-pull/src/test/java/image/pull/DockerImagePullTests.java
@@ -32,7 +32,7 @@ class DockerImagePullTests {
 
     @Test
     void pullAllowedImage() throws Exception {
-        runImage("mysql/mysql-server:8.0", true);
+        runImage("container-registry.oracle.com/mysql/community-server:8.1", true);
     }
 
     @Test

--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -1,4 +1,4 @@
-mysql/mysql-server:8.0
+container-registry.oracle.com/mysql/community-server:8.1
 mariadb:10.8
 postgres:15-alpine
 opengauss/opengauss:3.1.0


### PR DESCRIPTION
## What does this PR do?
Change docker image to the official one from [oracle repository](https://container-registry.oracle.com/ords/f?p=113:10::::::)

```
grype container-registry.oracle.com/mysql/community-server:8.1
 ✔ Vulnerability DB        [no update available]
New version of grype is available: 0.64.2 (currently running: 0.58.0)
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [135 packages]
 ✔ Scanned image           [11 vulnerabilities]
NAME          INSTALLED       FIXED-IN                  TYPE    VULNERABILITY        SEVERITY 
certifi       2022.12.7       2022.12.07                python  GHSA-43fp-rhv2-5gv8  Medium    
cryptography  39.0.2          41.0.0                    python  GHSA-5cpq-8wj7-hf2v  Low       
cryptography  39.0.2          41.0.2                    python  GHSA-cf7p-gm2m-833m  Medium    
gnutls        3.6.16-6.el8_7  10:3.6.16-4.0.1.el8_fips  rpm     ELSA-2022-9221       Medium    
libgcrypt     1.8.5-7.el8_6   10:1.8.5-6.el8_fips       rpm     ELSA-2022-9263       Medium    
libgcrypt     1.8.5-7.el8_6   10:1.8.5-7.el8_6_fips     rpm     ELSA-2022-9564       High      
pip           20.2.4                                    python  CVE-2018-20225       High      
pip           20.2.4                                    python  CVE-2021-3572        Medium    
pip           20.2.4          21.1                      python  GHSA-5xp3-jfq3-5q8x  Medium    
setuptools    50.3.2                                    python  CVE-2022-40897       Medium    
setuptools    50.3.2          65.5.1                    python  GHSA-r9hx-vwmv-q579  High 
```