### PR TITLE
Adjust docker and grype tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ If you want to extend this list, please create separate pull request to do that.
 That pull request should add a new file in the [`allowed-docker-images` directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
 with the name in the format `Dockerfile-<dockerImageName>` (replace all occurrence of `/` with `_`) .
 The only line that this file needs to contain is `FROM <dockerImageName>`.
-Once open a pull request, please post the result of the following command in your pull request description:
+Once you have opened such a pull request, please post the result of the following command in your pull request description:
 
 ```shell
 grype <dockerImageName>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ In this example this can be done by invoking following command from the reposito
 If your tests use Docker (either with explicit Docker process invocation or through some library method call), all images have to be declared in `required-docker-images` file.
 This file must be placed under `/tests/src/<groupId>/<artifactId>/<versionId>`.
 
-Only Docker images that are listed in [allowed-docker-images directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images) can be executed.
+Only Docker images that are listed in the [`allowed-docker-images` directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images) can be used for testing.
 If you want to extend this list, please create separate pull request to do that.
 That pull request should add a new file in [allowed-docker-images directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
 with the name in the format `Dockerfile-<dockerImageName>` (replace all occurrence of `/` with `_`) .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,23 +239,29 @@ In this example this can be done by invoking following command from the reposito
  
 ### Providing the tests that use docker
  
-If your tests use docker (either with explicit docker process invocation or through some library method call), all images 
-have to be declared in `required-docker-images.txt` file. This file must be placed under `/tests/src/<groupId>/<artifactId>/<versionId>`.
+If your tests use Docker (either with explicit Docker process invocation or through some library method call), all images have to be declared in `required-docker-images` file.
+This file must be placed under `/tests/src/<groupId>/<artifactId>/<versionId>`.
 
-Only docker images that are listed [here](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt)
-can be executed. If you want to extend this list, please create separate pull request to do that, and post the result of the following command on your pull request:
+Only Docker images that are listed in [allowed-docker-images directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images) can be executed.
+If you want to extend this list, please create separate pull request to do that.
+That pull request should add a new file in [allowed-docker-images directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
+with the name in the format `Dockerfile-<dockerImageName>` (replace all occurrence of `/` with `_`) .
+The only line that this file should contain is `FROM <dockerImageName>`.
+Once open a pull request, please post the result of the following command in your pull request description:
 
 ```shell
 grype <dockerImageName>
 ```
 
 Possible scenarios:
-   * If your test uses docker image, and you didn't specify it in the `required-docker-images.txt` file, the test will fail.
-   * If your test uses docker image that is not listed in [allowed docker images list](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt),
+   * If your test uses Docker image, and you didn't specify it in the `required-docker-images.txt` file, the test will fail.
+   * If your test uses Docker image that is not listed in [allowed docker images list](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt),
    the test will fail
    * Only docker images that are in both `required-docker-images.txt` and in the `allowed docker images list`
    can be executed. 
 
+**Note:** For images that comes from Oracle, please consider using them from the official [Oracle Container Registry](https://container-registry.oracle.com).
+See an [example](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-mysql_mysql-server).
 
 ## Tested Libraries and Frameworks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ This file must be placed under `/tests/src/<groupId>/<artifactId>/<versionId>`.
 
 Only Docker images that are listed in the [`allowed-docker-images` directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images) can be used for testing.
 If you want to extend this list, please create separate pull request to do that.
-That pull request should add a new file in [allowed-docker-images directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
+That pull request should add a new file in the [`allowed-docker-images` directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
 with the name in the format `Dockerfile-<dockerImageName>` (replace all occurrence of `/` with `_`) .
 The only line that this file should contain is `FROM <dockerImageName>`.
 Once open a pull request, please post the result of the following command in your pull request description:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,7 @@ Only Docker images that are listed in the [`allowed-docker-images` directory](ht
 If you want to extend this list, please create separate pull request to do that.
 That pull request should add a new file in the [`allowed-docker-images` directory](https://github.com/oracle/graalvm-reachability-metadata/blob/master/tests/tck-build-logic/src/main/resources/allowed-docker-images)
 with the name in the format `Dockerfile-<dockerImageName>` (replace all occurrence of `/` with `_`) .
-The only line that this file should contain is `FROM <dockerImageName>`.
+The only line that this file needs to contain is `FROM <dockerImageName>`.
 Once open a pull request, please post the result of the following command in your pull request description:
 
 ```shell

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -31,7 +31,6 @@ public class DockerUtils {
             allowedImages.addAll(images);
         }
 
-        System.out.println(allowedImages);
         return allowedImages;
     }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -1,15 +1,38 @@
 package org.graalvm.internal.tck;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DockerUtils {
 
     public static Set<String> getAllowedImages() throws IOException {
-        return new HashSet<>(Files.readAllLines(Paths.get("./tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt")));
+        String dockerfileDirectory = Paths.get("./tests/tck-build-logic/src/main/resources/allowed-docker-images").toString();
+        File[] dockerFiles = new File(dockerfileDirectory).listFiles();
+        if (dockerFiles == null) {
+            throw new RuntimeException("Cannot find allowed-docker-images directory content");
+        }
+
+        final String FROM = "FROM";
+        Set<String> allowedImages = new HashSet<>();
+        for (File dockerFile : dockerFiles) {
+            List<String> images = Files.readAllLines(dockerFile.toPath())
+                    .stream()
+                    .filter(line -> line.startsWith(FROM))
+                    .map(line -> line.substring(FROM.length()).trim())
+                    .toList();
+
+            allowedImages.addAll(images);
+        }
+
+        System.out.println(allowedImages);
+        return allowedImages;
     }
 
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -30,7 +30,7 @@ public class DockerUtils {
                     .map(line -> line.substring(FROM.length()).trim())
                     .toList();
             if (images.size() != 1) {
-                throw new RuntimeException("Dockerfile: " + dockerFile.getName() + " must contain only one FROM line, got '" + images.size() + "' (" + images+ "). Please read our documentation: "
+                throw new RuntimeException("Dockerfile: " + dockerFile.getName() + " must contain only one FROM line, got '" + images.size() + "' (" + images + "). Please read our documentation: "
                 + new URI("https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#providing-the-tests-that-use-docker"));
             }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -2,6 +2,8 @@ package org.graalvm.internal.tck;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -12,7 +14,7 @@ import java.util.stream.Collectors;
 
 public class DockerUtils {
 
-    public static Set<String> getAllowedImages() throws IOException {
+    public static Set<String> getAllowedImages() throws IOException, URISyntaxException {
         String dockerfileDirectory = Paths.get("./tests/tck-build-logic/src/main/resources/allowed-docker-images").toString();
         File[] dockerFiles = new File(dockerfileDirectory).listFiles();
         if (dockerFiles == null) {
@@ -27,6 +29,10 @@ public class DockerUtils {
                     .filter(line -> line.startsWith(FROM))
                     .map(line -> line.substring(FROM.length()).trim())
                     .toList();
+            if (images.size() != 1) {
+                throw new RuntimeException("Dockerfile: " + dockerFile.getName() + " must contain only one FROM line, got '" + images.size() + "' (" + images+ "). Please read our documentation: "
+                + new URI("https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#providing-the-tests-that-use-docker"));
+            }
 
             allowedImages.addAll(images);
         }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -34,7 +34,7 @@ public class DockerUtils {
                 + new URI("https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#providing-the-tests-that-use-docker"));
             }
 
-            allowedImages.addAll(images);
+            allowedImages.add(images.get(0));
         }
 
         return allowedImages;

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
@@ -8,6 +8,7 @@ import org.gradle.process.ExecResult;
 
 import javax.inject.Inject;
 import java.io.*;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Predicate;
 
@@ -21,7 +22,7 @@ public abstract class GrypeTask extends DefaultTask {
     private final String jqMatcher = " | jq -c '.matches | .[] | .vulnerability | select(.severity | (contains(\"High\") or contains(\"Critical\")))'";
 
     @TaskAction
-    void run() throws IllegalStateException, IOException {
+    void run() throws IllegalStateException, IOException, URISyntaxException {
         List<String> vulnerableImages = new ArrayList<>();
         Set<String> allowedImages = getAllowedImages();
         boolean shouldFail = false;

--- a/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
+++ b/tests/tck-build-logic/src/main/resources/AllowedDockerImages.txt
@@ -1,9 +1,0 @@
-container-registry.oracle.com/mysql/community-server:8.1
-mariadb:10.8
-postgres:15-alpine
-opengauss/opengauss:3.1.0
-greenmail/standalone:2.1.0-alpha-1
-nginx:1-alpine-slim
-mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04
-nats:2.9.19
-eclipse-mosquitto:2.0.15


### PR DESCRIPTION
## What does this PR do?
This is a follow-up PR of [this PR](https://github.com/oracle/graalvm-reachability-metadata/pull/351). It removes usage of `AllowedDockerImages.txt` and introduces a new way we are collecting allowed docker images list.

## Checklist before merging
n/a