### PR TITLE
Added metadata for org.apache.kafka:kafka-clients:3.5.1

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -121,6 +121,13 @@
     ]
   },
   {
+    "directory" : "org.apache.kafka/kafka-clients",
+    "module" : "org.apache.kafka:kafka-clients",
+    "allowed-packages" : [
+      "org.apache.kafka"
+    ]
+  },
+  {
     "directory": "org.apache.tomcat.embed/tomcat-embed-core",
     "module": "org.apache.tomcat.embed:tomcat-embed-core",
     "allowed-packages": [

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/index.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
@@ -84,6 +84,62 @@
     ]
   },
   {
+    "name": "org.apache.kafka.common.security.authenticator.AbstractLogin$DefaultLoginCallbackHandler",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.LoginManager"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.authenticator.DefaultLogin",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.LoginManager"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.authenticator.SaslClientCallbackHandler",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.network.SaslChannelBuilder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.plain.PlainLoginModule",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.AbstractLogin"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.apache.kafka.common.serialization.BooleanDeserializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.consumer.RangeAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.metrics.JmxReporter",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.Utils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.IntegerDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.IntegerSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.StringDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.StringSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.utils.AppInfoParser$AppInfo",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.AppInfoParser"
+    }
+  },
+  {
+    "name": "org.apache.kafka.common.utils.AppInfoParser$AppInfoMBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.AppInfoParser"
+    }
+  }
+]

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
@@ -238,6 +238,34 @@
     ]
   },
   {
+    "name": "org.apache.kafka.common.serialization.ListDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ListSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.apache.kafka.common.serialization.LongDeserializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
@@ -255,6 +283,188 @@
     "name": "org.apache.kafka.common.serialization.LongSerializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListDeserializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ByteArraySerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ByteBufferSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BytesSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$DoubleSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$FloatSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$LongSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ShortSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$StringSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$UUIDSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$VoidSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
     },
     "methods": [
       {

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
@@ -42,6 +42,174 @@
     ]
   },
   {
+    "name": "org.apache.kafka.common.serialization.BooleanDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BooleanSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteArraySerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteBufferDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteBufferSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BytesDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BytesSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.DoubleDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.DoubleSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.FloatDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.FloatSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.apache.kafka.common.serialization.IntegerDeserializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
@@ -70,6 +238,62 @@
     ]
   },
   {
+    "name": "org.apache.kafka.common.serialization.LongDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.LongSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ShortDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ShortSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.apache.kafka.common.serialization.StringDeserializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
@@ -85,6 +309,62 @@
   },
   {
     "name": "org.apache.kafka.common.serialization.StringSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.UUIDDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.UUIDSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.VoidDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.VoidSerializer",
     "condition": {
       "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
     },

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
@@ -28,6 +28,48 @@
     ]
   },
   {
+    "name": "org.apache.kafka.clients.consumer.RoundRobinAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.consumer.StickyAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.producer.RoundRobinPartitioner",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.apache.kafka.common.metrics.JmxReporter",
     "condition": {
       "typeReachable": "org.apache.kafka.common.utils.Utils"

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qkafka/kafka-version.properties\\E",
+        "condition": {
+          "typeReachable": "org.apache.kafka.common.utils.AppInfoParser"
+        }
+      }
+    ]
+  }
+}

--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
@@ -8,5 +8,13 @@
         }
       }
     ]
-  }
+  },
+  "bundles": [
+    {
+      "name": "sun.security.util.Resources",
+      "classNames": [
+        "sun.security.util.Resources"
+      ]
+    }
+  ]
 }

--- a/metadata/org.apache.kafka/kafka-clients/index.json
+++ b/metadata/org.apache.kafka/kafka-clients/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "3.5.1",
+    "module": "org.apache.kafka:kafka-clients",
+    "tested-versions": [
+      "3.5.1"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -154,6 +154,17 @@
     ]
   },
   {
+    "test-project-path" : "org.apache.kafka/kafka-clients/3.5.1",
+    "libraries" : [
+      {
+        "name" : "org.apache.kafka:kafka-clients",
+        "versions" : [
+          "3.5.1"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.apache.tomcat.embed/tomcat-embed-core/10.0.20",
     "libraries": [
       {

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/.gitignore
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/build.gradle
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.kafka:kafka-clients:$libraryVersion"
+    testImplementation "org.apache.kafka:kafka-clients:$libraryVersion:test"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.5'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.5.1'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.5.1:test'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/gradle.properties
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 3.5.1
+metadata.dir = org.apache.kafka/kafka-clients/3.5.1/

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/metadata-extra-filter.json
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/metadata-extra-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.kafka.**"}
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/metadata-user-code-filter.json
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.kafka.**"}
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/settings.gradle
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.kafka.kafka-clients_tests'

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RoundRobinPartitioner;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.BooleanDeserializer;
 import org.apache.kafka.common.serialization.BooleanSerializer;
@@ -119,11 +118,8 @@ class KafkaClientsTest {
         properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://" + KAFKA_SERVER);
         try (Admin admin = Admin.create(properties)) {
             NewTopic newTopic = new NewTopic("test_topic", 1, (short) 1);
-
             CreateTopicsResult result = admin.createTopics(Collections.singleton(newTopic));
-
-            KafkaFuture<Void> future = result.values().get("test_topic");
-            future.get();
+            result.values().get("test_topic").get();
         }
 
         Map<String, Object> producerProperties = new HashMap<>();

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RoundRobinPartitioner;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.BooleanDeserializer;
 import org.apache.kafka.common.serialization.BooleanSerializer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -274,4 +275,19 @@ class KafkaClientsTest {
             assertThat(consumer).isNotNull();
         }
     }
+
+    @Test
+    void testSaslPlain() {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+        consumerProperties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        consumerProperties.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.plain.PlainLoginModule required username=admin password=admin-pass;");
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThat(consumer).isNotNull();
+        }
+    }
+
 }

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -22,15 +22,39 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.BooleanDeserializer;
+import org.apache.kafka.common.serialization.BooleanSerializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.UUIDDeserializer;
+import org.apache.kafka.common.serialization.UUIDSerializer;
+import org.apache.kafka.common.serialization.VoidDeserializer;
+import org.apache.kafka.common.serialization.VoidSerializer;
 import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +69,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KafkaClientsTest {
 
+    private static final Logger logger = LoggerFactory.getLogger("KafkaClientsTest");
+
     private static final String KAFKA_SERVER = "localhost:9092";
 
     private EmbeddedZookeeper zookeeper;
@@ -54,21 +80,25 @@ class KafkaClientsTest {
     @BeforeAll
     void beforeAll() {
         zookeeper = new EmbeddedZookeeper();
+        logger.info("Embedded zookeeper started");
         Properties brokerProperties = new Properties();
         brokerProperties.setProperty("zookeeper.connect", "localhost:" + zookeeper.port());
         brokerProperties.setProperty("log.dirs", TestUtils.tempDir().getPath());
         brokerProperties.setProperty("listeners", "PLAINTEXT://" + KAFKA_SERVER);
         brokerProperties.setProperty("offsets.topic.replication.factor", "1");
         kafkaServer = TestUtils.createServer(new KafkaConfig(brokerProperties), Time.SYSTEM);
+        logger.info("Embedded kafka server started");
     }
 
     @AfterAll
     void afterAll() {
         if (kafkaServer != null) {
             kafkaServer.shutdown();
+            logger.info("Embedded kafka server stopped");
         }
         if (zookeeper != null) {
             zookeeper.shutdown();
+            logger.info("Embedded zookeeper stopped");
         }
     }
 
@@ -116,5 +146,51 @@ class KafkaClientsTest {
         assertThat(receivedMessages)
                 .hasSize(2)
                 .containsExactly("message0", "message1");
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            BooleanSerializer.class,
+            BytesSerializer.class,
+            ByteArraySerializer.class,
+            ByteBufferSerializer.class,
+            DoubleSerializer.class,
+            FloatSerializer.class,
+            IntegerSerializer.class,
+            LongSerializer.class,
+            ShortSerializer.class,
+            StringSerializer.class,
+            UUIDSerializer.class,
+            VoidSerializer.class})
+    void testSerializers(Class valueSerializer) {
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
+        KafkaProducer<Integer, String> producer = new KafkaProducer<>(producerProperties);
+        assertThat(producer).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            BooleanDeserializer.class,
+            BytesDeserializer.class,
+            ByteArrayDeserializer.class,
+            ByteBufferDeserializer.class,
+            DoubleDeserializer.class,
+            FloatDeserializer.class,
+            IntegerDeserializer.class,
+            LongDeserializer.class,
+            ShortDeserializer.class,
+            StringDeserializer.class,
+            UUIDDeserializer.class,
+            VoidDeserializer.class})
+    void testDeserializers(Class valueDeserializer) {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProperties);
+        assertThat(consumer).isNotNull();
     }
 }

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_clients;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.TestUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KafkaClientsTest {
+
+    private static final String KAFKA_SERVER = "localhost:9092";
+
+    private EmbeddedZookeeper zookeeper;
+
+    private KafkaServer kafkaServer;
+
+    @BeforeAll
+    void beforeAll() {
+        zookeeper = new EmbeddedZookeeper();
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("zookeeper.connect", "localhost:" + zookeeper.port());
+        brokerProperties.setProperty("log.dirs", TestUtils.tempDir().getPath());
+        brokerProperties.setProperty("listeners", "PLAINTEXT://" + KAFKA_SERVER);
+        brokerProperties.setProperty("offsets.topic.replication.factor", "1");
+        kafkaServer = TestUtils.createServer(new KafkaConfig(brokerProperties), Time.SYSTEM);
+    }
+
+    @AfterAll
+    void afterAll() {
+        if (kafkaServer != null) {
+            kafkaServer.shutdown();
+        }
+        if (zookeeper != null) {
+            zookeeper.shutdown();
+        }
+    }
+
+    @Test
+    void test() throws Exception {
+        Properties properties = new Properties();
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://" + KAFKA_SERVER);
+        try (Admin admin = Admin.create(properties)) {
+            NewTopic newTopic = new NewTopic("test_topic", 1, (short) 1);
+
+            CreateTopicsResult result = admin.createTopics(Collections.singleton(newTopic));
+
+            KafkaFuture<Void> future = result.values().get("test_topic");
+            future.get();
+        }
+
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "consumer");
+        consumerProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProperties);
+        consumer.subscribe(Arrays.asList("test_topic"));
+
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        producerProperties.put(ProducerConfig.LINGER_MS_CONFIG, 50);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        KafkaProducer<Integer, String> producer = new KafkaProducer<>(producerProperties);
+        producer.send(new ProducerRecord<>("test_topic", 0, 0, "message0")).get();
+        producer.send(new ProducerRecord<>("test_topic", 0, 1, "message1")).get();
+
+        List<String> receivedMessages = new ArrayList<>();
+
+        while (receivedMessages.size() < 2) {
+            ConsumerRecords<String, String> records = consumer.poll(100);
+            for (ConsumerRecord<String, String> record : records) {
+                receivedMessages.add(record.value());
+            }
+        }
+
+        assertThat(receivedMessages)
+                .hasSize(2)
+                .containsExactly("message0", "message1");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/META-INF/native-image/kafka-tests-only/reflect-config.json
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/META-INF/native-image/kafka-tests-only/reflect-config.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "org.apache.zookeeper.ClientCnxnSocketNIO",
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.ZooKeeper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.zookeeper.client.ZKClientConfig"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.zookeeper.server.watch.WatchManager",
+    "condition": {
+      "typeReachable": "org.apache.zookeeper.server.watch.WatchManagerFactory"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sun.security.provider.ConfigFile",
+    "condition": {
+      "typeReachable": "javax.security.auth.login.Configuration$2"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/META-INF/native-image/kafka-tests-only/resource-config.json
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/META-INF/native-image/kafka-tests-only/resource-config.json
@@ -1,0 +1,14 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qlogback.xml\\E",
+        "condition": {
+          "typeReachable": "ch.qos.logback.core.util.Loader"
+        }
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/logback.xml
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="org_apache_kafka.kafka_clients" level="INFO"/>
+    <logger name="KafkaClientsTest" level="INFO"/>
 
     <root level="ERROR">
         <appender-ref ref="STDOUT" />

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/logback.xml
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org_apache_kafka.kafka_clients" level="INFO"/>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## What does this PR do?
Adds metadata for org.apache.kafka:kafka-clients:3.5.1

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
