### PR TITLE
Added metadata for org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -381,6 +381,13 @@
     ]
   },
   {
+    "directory" : "org.eclipse.jgit/org.eclipse.jgit",
+    "module" : "org.eclipse.jgit:org.eclipse.jgit",
+    "allowed-packages" : [
+      "org.eclipse.jgit"
+    ]
+  },
+  {
     "directory" : "org.eclipse.paho/org.eclipse.paho.client.mqttv3",
     "module" : "org.eclipse.paho:org.eclipse.paho.client.mqttv3",
     "allowed-packages" : [

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/index.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/reflect-config.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/reflect-config.json
@@ -21,9 +21,65 @@
     }
   },
   {
+    "name": "org.eclipse.jgit.lib.CoreConfig$AutoCRLF",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.treewalk.WorkingTreeOptions"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$CheckStat",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.treewalk.WorkingTreeOptions"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$EOL",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.treewalk.WorkingTreeOptions"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
     "condition": {
       "typeReachable": "org.eclipse.jgit.internal.storage.file.FileRepository"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.treewalk.WorkingTreeOptions"
     },
     "methods": [
       {
@@ -52,6 +108,20 @@
     "name": "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
     "condition": {
       "typeReachable": "org.eclipse.jgit.lib.CoreConfig"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$SymLinks",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.treewalk.WorkingTreeOptions"
     },
     "methods": [
       {

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/reflect-config.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/reflect-config.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "org.eclipse.jgit.internal.JGitText",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.nls.GlobalBundleCache"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.internal.JGitText",
+    "allPublicFields": true,
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.nls.TranslationBundle"
+    }
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.internal.storage.file.FileRepository"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.internal.storage.file.ReflogWriter"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.lib.CoreConfig"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.internal.storage.file.RefDirectory"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.eclipse.jgit.util.sha1.SHA1$Sha1Implementation",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.util.sha1.SHA1"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/resource-config.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "bundles": [
+    {
+      "name": "org.eclipse.jgit.internal.JGitText"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "6.5.0.202303070854-r",
+    "module": "org.eclipse.jgit:org.eclipse.jgit",
+    "tested-versions": [
+      "6.5.0.202303070854-r"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -572,6 +572,17 @@
     ]
   },
   {
+    "test-project-path" : "org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r",
+    "libraries" : [
+      {
+        "name" : "org.eclipse.jgit:org.eclipse.jgit",
+        "versions" : [
+          "6.5.0.202303070854-r"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path" : "org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.5",
     "libraries" : [
       {

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/.gitignore
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/build.gradle
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/build.gradle
@@ -14,6 +14,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.eclipse.jgit:org.eclipse.jgit:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.5'
 }
 
 graalvmNative {

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/build.gradle
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jgit:org.eclipse.jgit:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/gradle.properties
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 6.5.0.202303070854-r
+metadata.dir = org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/metadata-extra-filter.json
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/metadata-extra-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.eclipse.jgit.**"}
+  ]
+}

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/metadata-user-code-filter.json
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.eclipse.jgit.**"}
+  ]
+}

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/settings.gradle
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jgit.org.eclipse.jgit_tests'

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jgit.org_eclipse_jgit;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OrgEclipseJGitTest {
+
+    private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+
+    private Repository remoteRepository;
+
+    @BeforeAll
+    void beforeAll() throws Exception {
+        remoteRepository = createFileRepository("remote");
+    }
+
+    @AfterAll
+    void afterAll() {
+        if (remoteRepository != null) {
+            remoteRepository.close();
+        }
+    }
+
+    @Test
+    void test() throws Exception {
+        try (Repository localRepository = createFileRepository("local")) {
+            StoredConfig config = localRepository.getConfig();
+            RemoteConfig remoteConfig = new RemoteConfig(config, "test");
+            remoteConfig.addURI(new URIish(remoteRepository.getDirectory().toURI().toURL()));
+            remoteConfig.update(config);
+            config.save();
+
+            Git git = new Git(localRepository);
+            RevCommit commit = git.commit().setMessage("initial commit").call();
+            git.push().setRemote("test").setRefSpecs(new RefSpec("refs/heads/master:refs/heads/x")).call();
+
+            ObjectId remoteCommitId = remoteRepository.resolve(commit.getId().getName() + "^{commit}");
+            assertThat(remoteCommitId).isEqualTo(commit.getId());
+        }
+    }
+
+    private FileRepository createFileRepository(String suffix) throws Exception {
+        File gitDir = new File(TMP_DIR, "test_jgit_" + suffix + "_repo_" + System.currentTimeMillis() + "/.git");
+        FileRepository fileRepository = new FileRepository(gitDir);
+        fileRepository.create();
+        return fileRepository;
+    }
+
+}

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
@@ -58,6 +58,14 @@ class OrgEclipseJGitTest {
         logger.info("Committed '{}' file to remote repository: {}", TEST_FILE_NAME, revCommit.getName());
     }
 
+    private void writeFile(Repository repository, String name, String data) throws IOException {
+        File parentFile = repository.getWorkTree();
+        File file = new File(parentFile, name);
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
+            w.write(data);
+        }
+    }
+
     @AfterAll
     void afterAll() {
         if (remoteRepository != null) {
@@ -90,14 +98,6 @@ class OrgEclipseJGitTest {
             localGit.getRepository().close();
         } finally {
             deleteDir(localRepositoryDir);
-        }
-    }
-
-    public void writeFile(Repository repository, String name, String data) throws IOException {
-        File parentFile = repository.getWorkTree();
-        File file = new File(parentFile, name);
-        try (Writer w = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
-            w.write(data);
         }
     }
 

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/java/org_eclipse_jgit/org_eclipse_jgit/OrgEclipseJGitTest.java
@@ -8,32 +8,54 @@ package org_eclipse_jgit.org_eclipse_jgit;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
-import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.transport.RefSpec;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.URIish;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OrgEclipseJGitTest {
 
+    private static final Logger logger = LoggerFactory.getLogger("OrgEclipseJGitTest");
+
     private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+
+    private static final String TEST_FILE_NAME = "Test.txt";
+
+    private static final String GIT_DIR_NAME = ".git";
+
+    private File remoteRepositoryDir;
 
     private Repository remoteRepository;
 
+    private Git remoteGit;
+
     @BeforeAll
     void beforeAll() throws Exception {
-        remoteRepository = createFileRepository("remote");
+        remoteRepositoryDir = new File(TMP_DIR, "test_jgit_remote_repo_" + System.currentTimeMillis());
+        remoteRepository = new FileRepository(new File(remoteRepositoryDir, GIT_DIR_NAME));
+        remoteRepository.create();
+        logger.info("Created remote repository: {}", remoteRepositoryDir);
+        remoteGit = new Git(remoteRepository);
+        writeFile(remoteRepository, TEST_FILE_NAME, "Test Message");
+        remoteGit.add().addFilepattern(TEST_FILE_NAME).call();
+        RevCommit revCommit = remoteGit.commit().setMessage("Initial commit").call();
+        logger.info("Committed '{}' file to remote repository: {}", TEST_FILE_NAME, revCommit.getName());
     }
 
     @AfterAll
@@ -41,31 +63,57 @@ class OrgEclipseJGitTest {
         if (remoteRepository != null) {
             remoteRepository.close();
         }
+        deleteDir(remoteRepositoryDir);
     }
 
     @Test
     void test() throws Exception {
-        try (Repository localRepository = createFileRepository("local")) {
-            StoredConfig config = localRepository.getConfig();
-            RemoteConfig remoteConfig = new RemoteConfig(config, "test");
-            remoteConfig.addURI(new URIish(remoteRepository.getDirectory().toURI().toURL()));
-            remoteConfig.update(config);
-            config.save();
+        File localRepositoryDir = new File(TMP_DIR, "test_jgit_local_repo_" + System.currentTimeMillis());
+        try {
+            Git localGit = Git.cloneRepository()
+                    .setDirectory(localRepositoryDir)
+                    .setURI("file://" + remoteGit.getRepository().getWorkTree().getPath())
+                    .call();
+            logger.info("Created local repository: {}", localRepositoryDir);
 
-            Git git = new Git(localRepository);
-            RevCommit commit = git.commit().setMessage("initial commit").call();
-            git.push().setRemote("test").setRefSpecs(new RefSpec("refs/heads/master:refs/heads/x")).call();
+            File[] localFiles = localRepositoryDir.listFiles();
+            if (localFiles != null) {
+                logger.info("Found files in local repository: {}", Arrays.toString(localFiles));
+                assertThat(localFiles)
+                        .hasSize(2)
+                        .extracting(File::getName)
+                        .contains(TEST_FILE_NAME, GIT_DIR_NAME);
+            } else {
+                fail("Files not found in local repository");
+            }
 
-            ObjectId remoteCommitId = remoteRepository.resolve(commit.getId().getName() + "^{commit}");
-            assertThat(remoteCommitId).isEqualTo(commit.getId());
+            localGit.getRepository().close();
+        } finally {
+            deleteDir(localRepositoryDir);
         }
     }
 
-    private FileRepository createFileRepository(String suffix) throws Exception {
-        File gitDir = new File(TMP_DIR, "test_jgit_" + suffix + "_repo_" + System.currentTimeMillis() + "/.git");
-        FileRepository fileRepository = new FileRepository(gitDir);
-        fileRepository.create();
-        return fileRepository;
+    public void writeFile(Repository repository, String name, String data) throws IOException {
+        File parentFile = repository.getWorkTree();
+        File file = new File(parentFile, name);
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
+            w.write(data);
+        }
+    }
+
+    private void deleteDir(File file) {
+        if (file != null) {
+            File[] childFiles = file.listFiles();
+            if (childFiles != null) {
+                for (File childFile : childFiles) {
+                    deleteDir(childFile);
+                }
+            }
+            boolean deleted = file.delete();
+            if (!deleted) {
+                logger.warn("File '{}' not deleted", file);
+            }
+        }
     }
 
 }

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/resources/META-INF/native-image/jgit-tests-only/resource-config.json
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/resources/META-INF/native-image/jgit-tests-only/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qlogback.xml\\E",
+        "condition": {
+          "typeReachable": "ch.qos.logback.core.util.Loader"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/resources/logback.xml
+++ b/tests/src/org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="OrgEclipseJGitTest" level="INFO"/>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## What does this PR do?
Adds metadata for `org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r`

## Code sections where the PR accesses files, network, docker or some external service

- The `OrgEclipseJGitTest` creates two git repositories in the `tmp` folder and deletes it at the end of the test execution.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
