### PR TITLE
Added metadata for org.apache.commons:commons-compress:1.23.0

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -213,6 +213,13 @@
     ]
   },
   {
+    "directory" : "org.apache.commons/commons-compress",
+    "module" : "org.apache.commons:commons-compress",
+    "allowed-packages" : [
+      "org.apache.commons"
+    ]
+  },
+  {
     "directory": "org.apache.commons/commons-pool2",
     "module": "org.apache.commons:commons-pool2",
     "allowed-packages": [

--- a/metadata/org.apache.commons/commons-compress/1.23.0/index.json
+++ b/metadata/org.apache.commons/commons-compress/1.23.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.apache.commons/commons-compress/1.23.0/reflect-config.json
+++ b/metadata/org.apache.commons/commons-compress/1.23.0/reflect-config.json
@@ -1,0 +1,198 @@
+[
+  {
+    "name": "org.apache.commons.compress.archivers.zip.AsiExtraField",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.JarMarker",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.ResourceAlignmentExtraField",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.UnicodeCommentExtraField",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.UnicodePathExtraField",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X000A_NTFS",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X0014_X509Certificates",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X0015_CertificateIdForFile",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X0016_CertificateIdForCentralDirectory",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X0017_StrongEncryptionHeader",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X0019_EncryptionRecipientCertificateList",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.X7875_NewUnix",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.compress.archivers.zip.Zip64ExtendedInformationExtraField",
+    "condition": {
+      "typeReachable": "org.apache.commons.compress.archivers.zip.ExtraFieldUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.commons/commons-compress/index.json
+++ b/metadata/org.apache.commons/commons-compress/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "1.23.0",
+    "module": "org.apache.commons:commons-compress",
+    "tested-versions": [
+      "1.23.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -297,6 +297,17 @@
     ]
   },
   {
+    "test-project-path" : "org.apache.commons/commons-compress/1.23.0",
+    "libraries" : [
+      {
+        "name" : "org.apache.commons:commons-compress",
+        "versions" : [
+          "1.23.0"
+        ]
+      }
+    ]
+  },
+  {
     "test-project-path": "org.apache.commons/commons-pool2/2.11.1",
     "libraries": [
       {

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/.gitignore
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/build.gradle
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.commons:commons-compress:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/gradle.properties
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.23.0
+metadata.dir = org.apache.commons/commons-compress/1.23.0/

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/metadata-user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.commons.compress.**"}
+  ]
+}

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/settings.gradle
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.commons.commons-compress_tests'

--- a/tests/src/org.apache.commons/commons-compress/1.23.0/src/test/java/org_apache_commons/commons_compress/CommonsCompressTest.java
+++ b/tests/src/org.apache.commons/commons-compress/1.23.0/src/test/java/org_apache_commons/commons_compress/CommonsCompressTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_compress;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CommonsCompressTest {
+
+    private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+
+    private File testDir;
+
+    @BeforeAll
+    void beforeAll() {
+        testDir = new File(TMP_DIR, "metadata_compress_test_" + System.currentTimeMillis());
+        testDir.mkdir();
+    }
+
+    @AfterAll
+    void afterAll() {
+        deleteDir(testDir);
+    }
+
+    @Test
+    void testZipArchiveStreams() throws Exception {
+        File zipFile = new File(testDir, "test.zip");
+        try (ZipArchiveOutputStream zipOutputStream = new ZipArchiveOutputStream(zipFile)) {
+            zipOutputStream.putArchiveEntry(new ZipArchiveEntry("test_file.txt"));
+            zipOutputStream.write("Test Content".getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeArchiveEntry();
+            zipOutputStream.finish();
+        }
+
+        File[] localFiles = testDir.listFiles();
+        if (localFiles != null) {
+            assertThat(localFiles)
+                    .hasSize(1)
+                    .extracting(File::getName)
+                    .containsExactly("test.zip");
+        } else {
+            fail("'test.zip' not found in: " + testDir);
+        }
+
+        try (ZipArchiveInputStream zipInputStream = new ZipArchiveInputStream(new BufferedInputStream(new FileInputStream(zipFile)))) {
+            ZipArchiveEntry entry = zipInputStream.getNextZipEntry();
+            try (OutputStream out = new FileOutputStream(new File(testDir, entry.getName()))) {
+                IOUtils.copy(zipInputStream, out);
+            }
+        }
+
+        localFiles = testDir.listFiles();
+        if (localFiles != null) {
+            assertThat(localFiles)
+                    .hasSize(2)
+                    .extracting(File::getName)
+                    .contains("test.zip", "test_file.txt");
+        } else {
+            fail("'test.zip' and 'test_file.txt' not found in: " + testDir);
+        }
+    }
+
+    private void deleteDir(File file) {
+        if (file != null) {
+            File[] childFiles = file.listFiles();
+            if (childFiles != null) {
+                for (File childFile : childFiles) {
+                    deleteDir(childFile);
+                }
+            }
+            boolean deleted = file.delete();
+            if (!deleted) {
+                System.out.println("File '" + file + " not deleted");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Adds metadata for `org.apache.commons:commons-compress:1.23.0`

## Code sections where the PR accesses files, network, docker or some external service

- The `CommonsCompressTest` creates a test directory in the `tmp` folder and deletes it at the end of the test execution.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
