### PR TITLE
Add metadata for Netty KQueue transport

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/jni-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/jni-config.json
@@ -84,7 +84,19 @@
   },
   {
     "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.ChannelException"
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name": "io.netty.channel.unix.Buffer"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
     },
     "name": "io.netty.channel.unix.Buffer"
   },
@@ -96,6 +108,24 @@
     "methods": [
       {
         "name": "<init>",
+        "parameterTypes": [
+          "byte[]",
+          "int",
+          "int",
+          "int",
+          "io.netty.channel.unix.DatagramSocketAddress"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.unix.DatagramSocketAddress",
+    "methods": [
+      {
+        "name":"<init>",
         "parameterTypes": [
           "byte[]",
           "int",
@@ -124,7 +154,29 @@
   },
   {
     "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.unix.DomainDatagramSocketAddress",
+    "methods": [
+      {
+        "name":"<init>",
+        "parameterTypes": [
+          "byte[]",
+          "int",
+          "io.netty.channel.unix.DomainDatagramSocketAddress"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name": "io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
     },
     "name": "io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
   },
@@ -136,13 +188,31 @@
   },
   {
     "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.unix.FileDescriptor"
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
     },
     "name": "io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
   },
   {
     "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name": "io.netty.channel.unix.Socket"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
     },
     "name": "io.netty.channel.unix.Socket"
   },
@@ -640,5 +710,59 @@
       "typeReachable": "io.netty.util.internal.NativeLibraryUtil"
     },
     "name": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.DefaultFileRegion",
+    "fields": [
+      {
+        "name":"file"
+      },
+      {
+        "name":"transferred"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.kqueue.BsdSocket"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.kqueue.KQueueEventArray"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.kqueue.Native"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.util.internal.NativeLibraryUtil"
+    },
+    "name": "io.netty.channel.unix.PeerCredentials",
+    "methods": [
+      {
+        "name":"<init>",
+        "parameterTypes": [
+          "int",
+          "int",
+          "int[]"
+        ]
+      }
+    ]
   }
 ]

--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -1328,6 +1328,12 @@
   },
   {
     "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.channel.DefaultFileRegion"
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.channel.SimpleChannelInboundHandler"
     },
     "name": "io.netty.channel.SimpleChannelInboundHandler",
@@ -1531,6 +1537,12 @@
   {
     "condition": {
       "typeReachable": "io.netty.channel.epoll.Native"
+    },
+    "name": "io.netty.channel.unix.PeerCredentials"
+  },
+  {
+    "condition": {
+      "typeReachable":"io.netty.channel.kqueue.Native"
     },
     "name": "io.netty.channel.unix.PeerCredentials"
   },

--- a/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
@@ -16,6 +16,12 @@
       },
       {
         "condition": {
+          "typeReachable": "io.netty.util.internal.NativeLibraryLoader"
+        },
+        "pattern": "\\QMETA-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib\\E"
+      },
+      {
+        "condition": {
           "typeReachable": "io.netty.handler.codec.compression.Brotli"
         },
         "pattern": "\\Qlib/linux-x86_64/libbrotli.so\\E"

--- a/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/resource-config.json
@@ -10,6 +10,12 @@
       },
       {
         "condition": {
+          "typeReachable":"io.netty.util.internal.NativeLibraryLoader"
+        },
+        "pattern": "\\QMETA-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib\\E"
+      },
+      {
+        "condition": {
           "typeReachable": "io.netty.handler.codec.compression.Brotli"
         },
         "pattern": "\\Qlib/linux-x86_64/libbrotli.so\\E"


### PR DESCRIPTION
## What does this PR do?

This PR adds metadata for Netty KQueue transport.
Netty KQueue transport can be used by the users that are on Mac OS and do not want to use Java NIO transport. (similar to Epoll transport for Linux)

## Code sections where the PR accesses files, network, docker or some external service

N/A

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- N/A [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- N/A [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- N/A [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)


Test is not provided because the fix is relevant only for Mac OS.