### PR TITLE
Add support for `org.apache.curator:curator-client:5.5.0`

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -294,6 +294,10 @@
   "directory" : "io.opentelemetry/opentelemetry-sdk-trace",
   "module" : "io.opentelemetry:opentelemetry-sdk-trace"
 }, {
+  "allowed-packages" : [ "org.apache.curator" ],
+  "directory" : "org.apache.curator/curator-client",
+  "module" : "org.apache.curator:curator-client"
+}, {
   "allowed-packages" : [ "jakarta.servlet" ],
   "directory" : "jakarta.servlet/jakarta.servlet-api",
   "module" : "jakarta.servlet:jakarta.servlet-api"

--- a/metadata/org.apache.curator/curator-client/5.5.0/index.json
+++ b/metadata/org.apache.curator/curator-client/5.5.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.apache.curator/curator-client/5.5.0/reflect-config.json
+++ b/metadata/org.apache.curator/curator-client/5.5.0/reflect-config.json
@@ -1,0 +1,29 @@
+[
+  {
+    "condition":{"typeReachable":"org.apache.curator.retry.RetryForever"},
+    "name":"java.lang.Object",
+    "methods":[{"name":"toString","parameterTypes":[] }]
+  },
+  {
+    "condition":{"typeReachable":"org.apache.curator.retry.RetryForever"},
+    "name":"java.lang.StackWalker",
+    "methods":[
+      {"name":"getInstance","parameterTypes":["java.util.Set","int"] },
+      {"name":"walk","parameterTypes":["java.util.function.Function"] }
+    ]
+  },
+  {
+    "condition":{"typeReachable":"org.apache.curator.retry.RetryForever"},
+    "name":"java.lang.StackWalker$Option"
+  },
+  {
+    "condition":{"typeReachable":"org.apache.curator.retry.RetryForever"},
+    "name":"java.lang.StackWalker$StackFrame",
+    "methods":[
+      {"name":"getClassName","parameterTypes":[] },
+      {"name":"getFileName","parameterTypes":[] },
+      {"name":"getLineNumber","parameterTypes":[] },
+      {"name":"getMethodName","parameterTypes":[] }
+    ]
+  }
+]

--- a/metadata/org.apache.curator/curator-client/index.json
+++ b/metadata/org.apache.curator/curator-client/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "5.5.0",
+    "module": "org.apache.curator:curator-client",
+    "tested-versions": [
+      "5.5.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -454,6 +454,12 @@
     "name" : "io.opentelemetry:opentelemetry-sdk-trace",
     "versions" : [ "1.19.0" ]
   } ]
+},
+  {"test-project-path" : "org.apache.curator/curator-client/5.5.0",
+  "libraries" : [ {
+    "name" : "org.apache.curator:curator-client",
+    "versions" : [ "5.5.0" ]
+  } ]
 }, {
   "test-project-path" : "jakarta.servlet/jakarta.servlet-api/5.0.0",
   "libraries" : [ {

--- a/tests/src/org.apache.curator/curator-client/5.5.0/.gitignore
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.curator/curator-client/5.5.0/build.gradle
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.curator:curator-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation "org.apache.curator:curator-test:$libraryVersion"
+    testImplementation 'org.apache.zookeeper:zookeeper:3.9.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.apache.curator/curator-client")
+        }
+    }
+    metadataRepository {
+        enabled = true
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.5.0/gradle.properties
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.5.0
+metadata.dir = org.apache.curator/curator-client/5.5.0/

--- a/tests/src/org.apache.curator/curator-client/5.5.0/settings.gradle
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.curator.curator-client_tests'

--- a/tests/src/org.apache.curator/curator-client/5.5.0/src/test/java/org_apache_curator/curator_client/CuratorClientTest.java
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/src/test/java/org_apache_curator/curator_client/CuratorClientTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.RetryLoop;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.retry.RetryUntilElapsed;
+import org.apache.curator.utils.DefaultZookeeperFactory;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class CuratorClientTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        EmbedTestingServer.start();
+    }
+
+    @Test
+    void testConstructor() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            String path = client.getZooKeeper().create("/testConstructor", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertEquals(path, "/testConstructor");
+        }
+    }
+
+    @Test
+    void testGetZooKeeper() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            assertThat(client.getZooKeeper()).isNotNull();
+        }
+    }
+
+    @Test
+    void testIsConnected() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            Awaitility.await()
+                    .atMost(Duration.ofMillis(4000))
+                    .untilAsserted(() -> assertTrue(client.isConnected()));
+        }
+    }
+
+    @Test
+    void testBlockUntilConnectedOrTimedOut() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            String path = client.getZooKeeper().create("/testBlockUntilConnectedOrTimedOut", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertEquals(path, "/testBlockUntilConnectedOrTimedOut");
+        }
+    }
+
+    @Test
+    void testClose() {
+        assertDoesNotThrow(() -> {
+            CuratorZookeeperClient client = getCuratorZookeeperClient();
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            client.close();
+        });
+    }
+
+    @Test
+    void testSetRetryPolicy() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            client.blockUntilConnectedOrTimedOut();
+            RetryPolicy originRetryPolicy = client.getRetryPolicy();
+            client.setRetryPolicy(new ExponentialBackoffRetry(1, 1));
+            client.setRetryPolicy(new RetryNTimes(1, 1));
+            client.setRetryPolicy(new RetryOneTime(1));
+            client.setRetryPolicy(new RetryUntilElapsed(1, 1));
+            client.setRetryPolicy(originRetryPolicy);
+            String path = client.getZooKeeper().create("/testSetRetryPolicy", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertEquals(path, "/testSetRetryPolicy");
+        }
+    }
+
+    @Test
+    void testNewRetryLoop() throws Exception {
+        try (CuratorZookeeperClient client = getCuratorZookeeperClient()) {
+            client.start();
+            int loopCount = 0;
+            RetryLoop retryLoop = client.newRetryLoop();
+            while (retryLoop.shouldContinue()) {
+                ++loopCount;
+                if (loopCount > 2) {
+                    fail();
+                    break;
+                }
+                try {
+                    client.getZooKeeper().create("/testNewRetryLoop", new byte[]{1, 2, 3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    retryLoop.markComplete();
+                } catch (Exception e) {
+                    retryLoop.takeException(e);
+                }
+            }
+            assertTrue(loopCount > 0);
+        }
+    }
+
+    private CuratorZookeeperClient getCuratorZookeeperClient() {
+        return new CuratorZookeeperClient(new DefaultZookeeperFactory(),
+                new FixedEnsembleProvider(EmbedTestingServer.getConnectString()),
+                10000, 10000, null, new RetryOneTime(1), false);
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.5.0/src/test/java/org_apache_curator/curator_client/EmbedTestingServer.java
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/src/test/java/org_apache_curator/curator_client/EmbedTestingServer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_client;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.KeeperException.ConnectionLossException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.awaitility.Awaitility;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class EmbedTestingServer {
+    private static final int PORT = 3191;
+    private static volatile TestingServer testingServer;
+    private static final Object INIT_LOCK = new Object();
+
+    private EmbedTestingServer() {
+    }
+
+    public static void start() {
+        if (null != testingServer) {
+            return;
+        }
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                return;
+            }
+            try {
+                testingServer = new TestingServer(PORT, true);
+            } catch (final Exception ex) {
+                if (!(ex instanceof ConnectionLossException || ex instanceof NoNodeException || ex instanceof NodeExistsException)) {
+                    throw new RuntimeException(ex);
+                }
+            } finally {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    try {
+                        testingServer.close();
+                    } catch (final IOException ignored) {
+                    }
+                }));
+            }
+            try (CuratorZookeeperClient client = new CuratorZookeeperClient(getConnectString(),
+                    60 * 1000, 500, null,
+                    new ExponentialBackoffRetry(500, 3, 500 * 3))) {
+                client.start();
+                Awaitility.await()
+                        .atMost(Duration.ofMillis(500 * 60))
+                        .untilAsserted(() -> assertTrue(client.isConnected()));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static String getConnectString() {
+        return "localhost:" + PORT;
+    }
+}

--- a/tests/src/org.apache.curator/curator-client/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/jni-config.json
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/jni-config.json
@@ -1,0 +1,7 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.util.Arrays",
+  "methods":[{"name":"asList","parameterTypes":["java.lang.Object[]"] }]
+}
+]

--- a/tests/src/org.apache.curator/curator-client/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
@@ -1,0 +1,203 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[B"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[C"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[D"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[F"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[I"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[J"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[Ljava.lang.String;"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[S"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"[Z"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Boolean",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Byte",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Character",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Deprecated",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Double",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Float",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Integer",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Long",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Short",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.StackTraceElement",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.String"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.ClientCnxn$SendThread"},
+  "name":"java.lang.Throwable",
+  "methods":[{"name":"getSuppressed","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.ClientCnxnSocketNIO"},
+  "name":"java.lang.Throwable",
+  "methods":[{"name":"getSuppressed","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.persistence.FileTxnLog$FileTxnIterator"},
+  "name":"java.lang.Throwable",
+  "methods":[{"name":"getSuppressed","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.lang.Void",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.math.BigDecimal"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.math.BigInteger"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.util.Date"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.util.PropertyPermission",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.util.logging.LogManager",
+  "methods":[{"name":"getLoggingMXBean","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.jmx.MBeanRegistry"},
+  "name":"java.util.logging.LoggingMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.ZooKeeper"},
+  "name":"org.apache.zookeeper.ClientCnxnSocketNIO",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.zookeeper.client.ZKClientConfig"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.quorum.QuorumPeerConfig"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.NIOServerCnxnFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.watch.WatchManagerFactory"},
+  "name":"org.apache.zookeeper.server.watch.WatchManager",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"sun.security.provider.ConfigFile",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.auth.DigestAuthenticationProvider"},
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/tests/src/org.apache.curator/curator-client/5.5.0/user-code-filter.json
+++ b/tests/src/org.apache.curator/curator-client/5.5.0/user-code-filter.json
@@ -1,0 +1,6 @@
+{
+  "rules": [
+    {"excludeClasses": "**"},
+    {"includeClasses": "org.apache.curator.**"}
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- For https://github.com/oracle/graalvm-reachability-metadata/issues/163 .
- Fixes https://github.com/oracle/graalvm-reachability-metadata/pull/219 .
- Add support for `org.apache.curator:curator-client:5.5.0`.

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)

- Null.
## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
