### PR TITLE
Add metadata for Netty SelectorProviderUtil

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -3840,6 +3840,34 @@
   },
   {
     "condition": {
+      "typeReachable": "io.netty.channel.socket.nio.NioServerSocketChannel"
+    },
+    "name": "java.nio.channels.spi.SelectorProvider",
+    "methods": [
+      {
+        "name": "openServerSocketChannel",
+        "parameterTypes": [
+          "java.net.ProtocolFamily"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.socket.nio.NioSocketChannel"
+    },
+    "name": "java.nio.channels.spi.SelectorProvider",
+    "methods": [
+      {
+        "name": "openSocketChannel",
+        "parameterTypes": [
+          "java.net.ProtocolFamily"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.util.internal.logging.Slf4JLoggerFactory"
     },
     "name": "java.security.AllPermission"


### PR DESCRIPTION
## What does this PR do?

Add reflection hints for Netty SelectorProviderUtil

Netty code in `io.netty.channel.socket.nio.SelectorProviderUtil`:
```java
@SuppressJava6Requirement(reason = "Usage guarded by java version check")
static Method findOpenMethod(String methodName) {
    if (PlatformDependent.javaVersion() >= 15) {
        try {
            return SelectorProvider.class.getMethod(methodName, java.net.ProtocolFamily.class);
        } catch (Throwable e) {
            logger.debug("SelectorProvider.{}(ProtocolFamily) not available, will use default", methodName, e);
        }
    }
    return null;
}
```

If Java version higher than or equals to 15, `SelectorProviderUtil` may invoke `java.nio.channels.spi.SelectorProvide` by reflection.

`SelectorProviderUtil.findOpenMethod` will be called in two Netty class: `NioSocketChannel` and `NioServerSocketChannel` corresponding to two `SelectorProvider` methods: `openSocketChannel` and `openServerSocketChannel`.

This PR add metadata for them.

## Code sections where the PR accesses files, network, docker or some external service

None

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
