### PR TITLE
Add support for `org.apache.curator:curator-framework:5.5.0`

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -68,6 +68,10 @@
   "directory" : "commons-logging/commons-logging",
   "module" : "commons-logging:commons-logging"
 }, {
+    "allowed-packages" : [ "org.apache.curator" ],
+    "directory" : "org.apache.curator/curator-framework",
+    "module" : "org.apache.curator:curator-framework"
+}, {
   "allowed-packages" : [ "io.grpc" ],
   "directory" : "io.grpc/grpc-netty",
   "module" : "io.grpc:grpc-netty"

--- a/metadata/org.apache.curator/curator-framework/5.5.0/index.json
+++ b/metadata/org.apache.curator/curator-framework/5.5.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.apache.curator/curator-framework/5.5.0/reflect-config.json
+++ b/metadata/org.apache.curator/curator-framework/5.5.0/reflect-config.json
@@ -1,0 +1,12 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.curator.framework.imps.NamespaceFacadeCache"},
+  "name":"org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture",
+  "fields":[{"name":"listeners"}, {"name":"value"}, {"name":"waiters"}]
+},
+{
+  "condition":{"typeReachable":"org.apache.curator.framework.imps.NamespaceFacadeCache"},
+  "name":"org.apache.curator.shaded.com.google.common.util.concurrent.AbstractFuture$Waiter",
+  "fields":[{"name":"next"}, {"name":"thread"}]
+}
+]

--- a/metadata/org.apache.curator/curator-framework/index.json
+++ b/metadata/org.apache.curator/curator-framework/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "5.5.0",
+    "module": "org.apache.curator:curator-framework",
+    "tested-versions": [
+      "5.5.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -275,6 +275,12 @@
     "versions" : [ "10.1.7" ]
   } ]
 }, {
+  "test-project-path" : "org.apache.curator/curator-framework/5.5.0",
+  "libraries" : [ {
+    "name" : "org.apache.curator:curator-framework",
+    "versions" : [ "5.5.0" ]
+  } ]
+}, {
   "test-project-path" : "org.bouncycastle/bcpkix-jdk15on/1.70",
   "libraries" : [ {
     "name" : "org.bouncycastle:bcpkix-jdk15on",

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/.gitignore
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/build.gradle
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.curator:curator-framework:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.apache.curator:curator-test:$libraryVersion"
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.apache.zookeeper:zookeeper:3.9.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.apache.curator/curator-framework")
+        }
+    }
+    metadataRepository {
+        enabled = true
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/gradle.properties
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.5.0
+metadata.dir = org.apache.curator/curator-framework/5.5.0/

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/settings.gradle
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.curator.curator-framework_tests'

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/java/org_apache_curator/curator_framework/CuratorFrameworkTest.java
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/java/org_apache_curator/curator_framework/CuratorFrameworkTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CuratorFrameworkTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        EmbedTestingServer.start();
+    }
+
+    @Test
+    void testCreateClient() {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(EmbedTestingServer.getConnectString(),
+                new ExponentialBackoffRetry(1000, 3))) {
+            client.start();
+            assertDoesNotThrow(() -> client.blockUntilConnected());
+        }
+        try (CuratorFramework client = getCuratorFramework()) {
+            client.start();
+            assertDoesNotThrow(() -> client.blockUntilConnected());
+        }
+    }
+
+    @Test
+    void testCRUD() {
+        try (CuratorFramework client = getCuratorFramework()) {
+            client.start();
+            assertDoesNotThrow(() -> client.blockUntilConnected());
+            client.create().forPath("/testCreate", new byte[0]);
+            client.create().withMode(CreateMode.EPHEMERAL).forPath("/testCreateEphemeral", new byte[0]);
+            client.create().withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/testCreateEphemeralSequential", new byte[0]);
+            client.create().idempotent().forPath("/testCreateIdempotent", new byte[0]);
+            assertThat(client.getChildren().watched().forPath("/testCreate")).isEmpty();
+            assertThat(client.getChildren().watched().forPath("/testCreateEphemeral")).isEmpty();
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/testCreateEphemeralSequential"));
+            assertThat(client.getChildren().watched().forPath("/testCreateIdempotent")).isEmpty();
+            client.setData().forPath("/testCreate", "firstTestWord".getBytes(StandardCharsets.UTF_8));
+            assertThat(client.getChildren().watched().forPath("/testCreate")).isEmpty();
+            client.getCuratorListenable().addListener((client1, event) -> {
+            });
+            client.setData().inBackground().forPath("/testCreate", "secondTestWord".getBytes(StandardCharsets.UTF_8));
+            assertThat(client.getChildren().watched().forPath("/testCreate")).isEmpty();
+            client.setData().idempotent().withVersion(2).forPath("/testCreate", "thirdTestWord".getBytes(StandardCharsets.UTF_8));
+            assertThat(client.getChildren().watched().forPath("/testCreate")).isEmpty();
+            client.delete().forPath("/testCreate");
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/testCreate"));
+            client.delete().guaranteed().forPath("/testCreateEphemeral");
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/testCreateEphemeral"));
+            client.delete().idempotent().withVersion(0).forPath("/testCreateIdempotent");
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/testCreateIdempotent"));
+            client.create().forPath("/deleteIdempotentFirst", new byte[0]);
+            client.create().forPath("/deleteIdempotentSecond", new byte[0]);
+            client.create().forPath("/deleteIdempotentThird", new byte[0]);
+            client.delete().idempotent().forPath("/deleteIdempotentFirst");
+            client.delete().quietly().withVersion(0).forPath("/deleteIdempotentSecond");
+            client.delete().quietly().forPath("/deleteIdempotentThird");
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/deleteIdempotentFirst"));
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/deleteIdempotentSecond"));
+            assertThrows(KeeperException.NoNodeException.class, () -> client.getChildren().watched().forPath("/deleteIdempotentThird"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testTransaction() {
+        try (CuratorFramework client = getCuratorFramework()) {
+            client.start();
+            assertDoesNotThrow(() -> client.blockUntilConnected());
+            client.create().forPath("/testFirst", new byte[0]);
+            client.create().forPath("/testSecond", new byte[0]);
+            client.create().forPath("/testSecond/path", new byte[0]);
+            client.create().forPath("/testThird", new byte[0]);
+            client.create().forPath("/testThird/testSagittarius", new byte[0]);
+            client.create().forPath("/testThird/testSagittarius/path", new byte[0]);
+            CuratorOp createOp = client.transactionOp().create().forPath("/testFirst/path", "some data".getBytes());
+            CuratorOp setDataOp = client.transactionOp().setData().forPath("/testSecond/path", "other data".getBytes());
+            CuratorOp deleteOp = client.transactionOp().delete().forPath("/testThird/testSagittarius/path");
+            List<CuratorTransactionResult> results = client.transaction().forOperations(createOp, setDataOp, deleteOp);
+            assertThat(results.get(0).getForPath()).isEqualTo("/testFirst/path");
+            assertThat(results.get(1).getForPath()).isEqualTo("/testSecond/path");
+            assertThat(results.get(2).getForPath()).isEqualTo("/testThird/testSagittarius/path");
+            assertThat(results.get(0).getForPath()).isEqualTo("/testFirst/path");
+            assertThat(results.get(1).getForPath()).isEqualTo("/testSecond/path");
+            assertThat(results.get(2).getForPath()).isEqualTo("/testThird/testSagittarius/path");
+            for (CuratorTransactionResult result : results) {
+                System.out.println(result.getForPath() + " - " + result.getType());
+
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CuratorFramework getCuratorFramework() {
+        return CuratorFrameworkFactory.builder()
+                .connectString(EmbedTestingServer.getConnectString())
+                .retryPolicy(new ExponentialBackoffRetry(1000, 3))
+                .connectionTimeoutMs(10000)
+                .sessionTimeoutMs(10000)
+                .build();
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/java/org_apache_curator/curator_framework/EmbedTestingServer.java
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/java/org_apache_curator/curator_framework/EmbedTestingServer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_curator.curator_framework;
+
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.KeeperException.ConnectionLossException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.awaitility.Awaitility;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class EmbedTestingServer {
+    private static final int PORT = 3192;
+    private static volatile TestingServer testingServer;
+    private static final Object INIT_LOCK = new Object();
+
+    private EmbedTestingServer() {
+    }
+
+    public static void start() {
+        if (null != testingServer) {
+            return;
+        }
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                return;
+            }
+            try {
+                testingServer = new TestingServer(PORT, true);
+            } catch (final Exception ex) {
+                if (!(ex instanceof ConnectionLossException || ex instanceof NoNodeException || ex instanceof NodeExistsException)) {
+                    throw new RuntimeException(ex);
+                }
+            } finally {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    try {
+                        testingServer.close();
+                    } catch (final IOException ignored) {
+                    }
+                }));
+            }
+            try (CuratorZookeeperClient client = new CuratorZookeeperClient(getConnectString(),
+                    60 * 1000, 500, null,
+                    new ExponentialBackoffRetry(500, 3, 500 * 3))) {
+                client.start();
+                Awaitility.await()
+                        .atMost(Duration.ofMillis(500 * 60))
+                        .untilAsserted(() -> assertTrue(client.isConnected()));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static String getConnectString() {
+        return "localhost:" + PORT;
+    }
+}

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/src/test/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
@@ -1,0 +1,56 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.ZooKeeper"},
+  "name":"org.apache.zookeeper.ClientCnxnSocketNIO",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.zookeeper.client.ZKClientConfig"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.quorum.QuorumPeerConfig"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.NIOServerCnxnFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.watch.WatchManagerFactory"},
+  "name":"org.apache.zookeeper.server.watch.WatchManager",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/tests/src/org.apache.curator/curator-framework/5.5.0/user-code-filter.json
+++ b/tests/src/org.apache.curator/curator-framework/5.5.0/user-code-filter.json
@@ -1,0 +1,6 @@
+{
+  "rules": [
+    {"excludeClasses": "**"},
+    {"includeClasses": "org.apache.curator.framework.**"}
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/163 .
- Fixes https://github.com/oracle/graalvm-reachability-metadata/pull/219 .
- Add support for `org.apache.curator:curator-framework:5.5.0`.

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)
- Null.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
