### PR TITLE
Add support for `com.github.ben-manes.caffeine:caffeine:2.9.3`

### DIFF
--- a/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/index.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/reflect-config.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/reflect-config.json
@@ -1,0 +1,194 @@
+[
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BBHeader$ReadAndWriteCounterRef"},
+  "name":"com.github.benmanes.caffeine.cache.BBHeader$ReadAndWriteCounterRef",
+  "fields":[{"name":"writeCounter"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BBHeader$ReadCounterRef"},
+  "name":"com.github.benmanes.caffeine.cache.BBHeader$ReadCounterRef",
+  "fields":[{"name":"readCounter"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BLCHeader$DrainStatusRef"},
+  "name":"com.github.benmanes.caffeine.cache.BLCHeader$DrainStatusRef",
+  "fields":[{"name":"drainStatus"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueue"},
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueColdProducerFields",
+  "fields":[{"name":"producerLimit"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueue"},
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueConsumerFields",
+  "fields":[{"name":"consumerIndex"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueue"},
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueProducerFields",
+  "fields":[{"name":"producerIndex"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.Caffeine"},
+  "name":"com.github.benmanes.caffeine.cache.CacheLoader",
+  "methods":[{"name":"asyncLoadAll","parameterTypes":["java.lang.Iterable","java.util.concurrent.Executor"] }, {"name":"loadAll","parameterTypes":["java.lang.Iterable"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.LocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.CacheLoader",
+  "methods":[{"name":"loadAll","parameterTypes":["java.lang.Iterable"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.FW"},
+  "name":"com.github.benmanes.caffeine.cache.FW",
+  "fields":[{"name":"value"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.WI"},
+  "name":"com.github.benmanes.caffeine.cache.FW",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.NodeFactory"},
+  "name":"com.github.benmanes.caffeine.cache.PD",
+  "fields":[{"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.PS"},
+  "name":"com.github.benmanes.caffeine.cache.PS",
+  "fields":[{"name":"key"}, {"name":"value"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.PSA"},
+  "name":"com.github.benmanes.caffeine.cache.PSA",
+  "fields":[{"name":"accessTime"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSA"},
+  "name":"com.github.benmanes.caffeine.cache.PSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSSMS"},
+  "name":"com.github.benmanes.caffeine.cache.PSMS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSMW"},
+  "name":"com.github.benmanes.caffeine.cache.PSMW",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.PSR"},
+  "name":"com.github.benmanes.caffeine.cache.PSR",
+  "fields":[{"name":"writeTime"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSR"},
+  "name":"com.github.benmanes.caffeine.cache.PSR",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.PSW"},
+  "name":"com.github.benmanes.caffeine.cache.PSW",
+  "fields":[{"name":"writeTime"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSA"},
+  "name":"com.github.benmanes.caffeine.cache.PSW",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSW"},
+  "name":"com.github.benmanes.caffeine.cache.PSW",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSSMW"},
+  "name":"com.github.benmanes.caffeine.cache.PSWMW",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.NodeFactory"},
+  "name":"com.github.benmanes.caffeine.cache.PW",
+  "fields":[{"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache"},
+  "name":"com.github.benmanes.caffeine.cache.SI",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSA",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSMS",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.LocalCacheFactory"},
+  "name":"com.github.benmanes.caffeine.cache.SSMSW",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSMW",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSR",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSSMS",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSSMWW",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.SSW",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.StripedBuffer"},
+  "name":"com.github.benmanes.caffeine.cache.StripedBuffer",
+  "fields":[{"name":"tableBusy"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalLoadingCache"},
+  "name":"com.github.benmanes.caffeine.cache.WI",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.StripedBuffer"},
+  "name":"java.lang.Thread",
+  "fields":[{"name":"threadLocalRandomProbe"}]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.SSMSR"},
+  "name":"com.github.benmanes.caffeine.cache.PSRMS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.NodeFactory"},
+  "name":"com.github.benmanes.caffeine.cache.PSWMS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.benmanes.caffeine.cache.NodeFactory"},
+  "name":"com.github.benmanes.caffeine.cache.SSMWW",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]
+}
+]

--- a/metadata/com.github.ben-manes.caffeine/caffeine/index.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/index.json
@@ -6,5 +6,12 @@
     "tested-versions": [
       "3.1.2"
     ]
+  },
+  {
+    "metadata-version": "2.9.3",
+    "module": "com.github.ben-manes.caffeine:caffeine",
+    "tested-versions": [
+      "2.9.3"
+    ]
   }
 ]

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/.gitignore
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/build.gradle
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.github.ben-manes.caffeine:caffeine:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'com.google.guava:guava-testlib:32.1.2-jre'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/com.github.ben-manes.caffeine/caffeine")
+        }
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/gradle.properties
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 2.9.3
+metadata.dir = com.github.ben-manes.caffeine/caffeine/2.9.3/

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/settings.gradle
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.ben-manes.caffeine.caffeine_tests'

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/CaffeineTest.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/CaffeineTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.google.common.testing.FakeTicker;
+import org.junit.jupiter.api.Test;
+
+import java.lang.ref.Cleaner;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class CaffeineTest {
+    @Test
+    void testRefresh() {
+        TestRefreshLoader testRefreshLoader = new TestRefreshLoader();
+        LoadingCache<String, CompletableFuture<String>> cache = Caffeine.newBuilder()
+                .refreshAfterWrite(Duration.ofMillis(100))
+                .build(testRefreshLoader::load);
+        cache.get("Hello");
+        CompletableFuture<String> firstValue = cache.getIfPresent("Hello");
+        assertThat(firstValue).isNotNull();
+        assertEquals("World", firstValue.join());
+        testRefreshLoader.setFlag(true);
+        cache.refresh("Hello");
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            CompletableFuture<String> secondValue = cache.getIfPresent("Hello");
+            assertThat(secondValue).isNotNull();
+            assertEquals("Universe", secondValue.join());
+        });
+    }
+
+    @Test
+    void testStatistics() {
+        Cache<String, String> graphs = Caffeine.newBuilder().maximumSize(10_000).recordStats().build();
+        graphs.put("Hello", "World");
+        assertThat(graphs.getIfPresent("Hello")).isEqualTo("World");
+        CacheStats cacheStats = graphs.stats();
+        assertThat(cacheStats.hitCount()).isEqualTo(1);
+        assertThat(cacheStats.missCount()).isEqualTo(0);
+        assertThat(cacheStats.evictionCount()).isEqualTo(0);
+    }
+
+    @Test
+    void testSpecification() {
+        CaffeineSpec spec = CaffeineSpec.parse("maximumWeight=1000, expireAfterWrite=10m");
+        LoadingCache<String, String> graphs = Caffeine.from(spec).weigher((String key, String graph) -> graph.length())
+                .build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(graphs.get("Hello")).isEqualTo("World");
+    }
+
+    @Test
+    void testCleanup() {
+        FakeTicker ticker = new FakeTicker();
+        LoadingCache<String, String> firstGraphs = Caffeine.newBuilder()
+                .scheduler(Scheduler.systemScheduler())
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .ticker(ticker::read)
+                .build(key -> key.equals("Hello") ? "World" : "Universe");
+        firstGraphs.put("Hello", "World");
+        assertNotEquals(0, firstGraphs.estimatedSize());
+        assertThat(firstGraphs.getIfPresent("Hello")).isEqualTo("World");
+        ticker.advance(10, TimeUnit.MINUTES);
+        firstGraphs.cleanUp();
+        assertEquals(0, firstGraphs.estimatedSize());
+        Cache<String, String> secondGraphs = Caffeine.newBuilder().weakValues().build();
+        Cleaner cleaner = Cleaner.create();
+        cleaner.register("World", secondGraphs::cleanUp);
+        secondGraphs.put("Hello", "World");
+        assertThat(secondGraphs.getIfPresent("Hello")).isEqualTo("World");
+    }
+
+    @Test
+    void testTesting() {
+        FakeTicker ticker = new FakeTicker();
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .executor(Runnable::run)
+                .ticker(ticker::read)
+                .maximumSize(10)
+                .build();
+        cache.put("Hello", "World");
+        ticker.advance(30, TimeUnit.MINUTES);
+        assertThat(cache.getIfPresent("Hello")).isNull();
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/EvictionTest.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/EvictionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EvictionTest {
+    @Test
+    void testSizeBased() {
+        LoadingCache<String, String> firstGraphs = Caffeine.newBuilder().maximumSize(10_000).build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(firstGraphs.get("Hello")).isEqualTo("World");
+        LoadingCache<String, String> secondGraphs = Caffeine.newBuilder().maximumWeight(10_000).weigher((String key, String graph) -> graph.length())
+                .build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(secondGraphs.get("Hello")).isEqualTo("World");
+    }
+
+    @Test
+    void testTimeBased() {
+        LoadingCache<String, String> firstGraphs = Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES)
+                .build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(firstGraphs.get("Hello")).isEqualTo("World");
+        LoadingCache<String, String> secondGraphs = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES)
+                .build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(secondGraphs.get("Hello")).isEqualTo("World");
+        LoadingCache<String, String> thirdGraphs = Caffeine.newBuilder().expireAfter(new Expiry<String, String>() {
+            public long expireAfterCreate(String key, String graph, long currentTime) {
+                long seconds = ZonedDateTime.now().plusHours(5).minus(System.currentTimeMillis(), MILLIS).toEpochSecond();
+                return TimeUnit.SECONDS.toNanos(seconds);
+            }
+
+            public long expireAfterUpdate(String key, String graph, long currentTime, long currentDuration) {
+                return currentDuration;
+            }
+
+            public long expireAfterRead(String key, String graph, long currentTime, long currentDuration) {
+                return currentDuration;
+            }
+        }).build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(thirdGraphs.get("Hello")).isEqualTo("World");
+    }
+
+    @Test
+    void testReferenceBased() {
+        LoadingCache<String, String> firstGraphs = Caffeine.newBuilder().weakKeys().weakValues().build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(firstGraphs.get("Hello")).isEqualTo("World");
+        LoadingCache<String, String> secondGraphs = Caffeine.newBuilder().softValues().build(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(secondGraphs.get("Hello")).isEqualTo("World");
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/PolicyTest.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/PolicyTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyTest {
+    @Test
+    void testSizeBased() {
+        Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10_000).build();
+        cache.policy().eviction().ifPresent(eviction -> eviction.setMaximum(2 * eviction.getMaximum()));
+        cache.put("Hello", "World");
+        assertThat(cache.getIfPresent("Hello")).isEqualTo("World");
+    }
+
+    @Test
+    void testTimeBased() {
+        Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10_000).build();
+        cache.policy().expireAfterAccess().ifPresent(eviction -> eviction.setExpiresAfter(Duration.ofMinutes(5)));
+        cache.policy().expireAfterWrite().ifPresent(eviction -> eviction.setExpiresAfter(Duration.ofMinutes(5)));
+        cache.policy().expireVariably().ifPresent(eviction -> eviction.setExpiresAfter("Hello", Duration.ofMinutes(5)));
+        cache.policy().refreshAfterWrite().ifPresent(refresh -> refresh.setExpiresAfter(Duration.ofMinutes(5)));
+        cache.put("Hello", "World");
+        assertThat(cache.getIfPresent("Hello")).isEqualTo("World");
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/PopulationTest.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/PopulationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.testing.FakeTicker;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PopulationTest {
+    @Test
+    void testManual() {
+        Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10_000).build();
+        assertThat(cache.getIfPresent("Hello")).isNull();
+        assertThat(cache.get("Hello", k -> "World")).isEqualTo("World");
+        cache.put("Hello", "World");
+        assertThat(cache.getIfPresent("Hello")).isEqualTo("World");
+        cache.invalidate("Hello");
+        assertThat(cache.getIfPresent("Hello")).isNull();
+    }
+
+    @Test
+    void testExpireAfterWrite() {
+        FakeTicker ticker = new FakeTicker();
+        Cache<String, String> cache = Caffeine.newBuilder().ticker(ticker::read).expireAfterWrite(100, TimeUnit.MINUTES).build();
+        cache.put("Aloha", "Universe");
+        assertEquals("Universe", cache.getIfPresent("Aloha"));
+        ticker.advance(Duration.ofMinutes(200));
+        assertNull(cache.getIfPresent("Aloha"));
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testAsynchronousManual() throws ExecutionException, InterruptedException {
+        AsyncCache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10_000).buildAsync();
+        assertThat(cache.getIfPresent("Hello")).isNull();
+        assertThat(cache.get("Hello", k -> "World").get()).isEqualTo("World");
+        cache.put("Hello", CompletableFuture.supplyAsync(() -> "World"));
+        assertThat(cache.getIfPresent("Hello").get()).isEqualTo("World");
+        cache.synchronous().invalidate("Hello");
+        assertThat(cache.getIfPresent("Hello")).isNull();
+    }
+
+    @Test
+    void testAsynchronouslyLoading() throws ExecutionException, InterruptedException {
+        AsyncLoadingCache<String, String> firstCache = Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(10, TimeUnit.MINUTES)
+                .buildAsync((key, executor) ->
+                        key.equals("Hello") ? CompletableFuture.supplyAsync(() -> "World") : CompletableFuture.supplyAsync(() -> "Universe"));
+        assertThat(firstCache.get("Hello").get()).isEqualTo("World");
+        assertThat(firstCache.getAll(List.of("Hi", "Aloha")).get()).isEqualTo(Map.of("Hi", "Universe", "Aloha", "Universe"));
+        AsyncLoadingCache<String, String> secondCache = Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(10, TimeUnit.MINUTES)
+                .buildAsync(key -> key.equals("Hello") ? "World" : "Universe");
+        assertThat(secondCache.get("Hello").get()).isEqualTo("World");
+        assertThat(secondCache.getAll(List.of("Hi", "Aloha")).get()).isEqualTo(Map.of("Hi", "Universe", "Aloha", "Universe"));
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/RemovalTest.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/RemovalTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemovalTest {
+    @Test
+    void testExplicitRemovals() {
+        Map<String, String> map = Map.of("Hello", "World", "Hi", "Universe", "Aloha", "Universe");
+        Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10_000).build();
+        cache.putAll(map);
+        assertThat(cache.getAll(List.of("Hello", "Hi", "Aloha"), key -> null)).isEqualTo(map);
+        cache.invalidate("Hello");
+        assertThat(cache.getIfPresent("Hello")).isNull();
+        cache.invalidateAll(List.of("Hi", "Aloha"));
+        Stream.of("Hi", "Aloha").forEach(s -> assertThat(cache.getIfPresent(s)).isNull());
+        cache.put("Ciao", "Earth");
+        cache.invalidateAll();
+        Stream.of("Hello", "Hi", "Aloha", "Ciao").forEach(s -> assertThat(cache.getIfPresent(s)).isNull());
+    }
+
+    @Test
+    void testRemovalListeners() {
+        Cache<String, String> graphs = Caffeine.newBuilder()
+                .evictionListener((String key, String graph, RemovalCause cause) -> System.out.printf("Key %s was evicted (%s)%n", key, cause))
+                .removalListener((String key, String graph, RemovalCause cause) -> System.out.printf("Key %s was removed (%s)%n", key, cause))
+                .build();
+        graphs.put("Hello", "World");
+        assertThat(graphs.getIfPresent("Hello")).isEqualTo("World");
+        graphs.invalidate("Hello");
+        assertThat(graphs.getIfPresent("Hello")).isNull();
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/TestRefreshLoader.java
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/src/test/java/com_github_ben_manes_caffeine/caffeine/TestRefreshLoader.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ben_manes_caffeine.caffeine;
+
+import java.util.concurrent.CompletableFuture;
+
+public class TestRefreshLoader {
+    private Boolean flag = false;
+
+    public CompletableFuture<String> load(String ignoredKey) {
+        if (getFlag()) {
+            return CompletableFuture.completedFuture("Universe");
+        }
+        return CompletableFuture.completedFuture("World");
+    }
+
+    public Boolean getFlag() {
+        return flag;
+    }
+
+    public void setFlag(Boolean flag) {
+        this.flag = flag;
+    }
+}

--- a/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/user-code-filter.json
+++ b/tests/src/com.github.ben-manes.caffeine/caffeine/2.9.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.github.benmanes.caffeine.cache.**"
+    }
+  ]
+}

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -35,6 +35,12 @@
     "versions" : [ "2.15.2" ]
   } ]
 }, {
+    "test-project-path" : "com.github.ben-manes.caffeine/caffeine/2.9.3",
+    "libraries" : [ {
+      "name" : "com.github.ben-manes.caffeine:caffeine",
+      "versions" : [ "2.9.3" ]
+    } ]
+}, {
   "test-project-path" : "com.github.ben-manes.caffeine/caffeine/3.1.2",
   "libraries" : [ {
     "name" : "com.github.ben-manes.caffeine:caffeine",


### PR DESCRIPTION
## What does this PR do?

- Fixes #384 .
- Add support for `com.github.ben-manes.caffeine:caffeine:2.9.3`.
- According to my test at https://github.com/linghengqian/graalvm-trace-metadata-smoketest/commit/2f29acb8845ddde5c3fc7d3d6072dfd8f5574f48 and https://github.com/linghengqian/graalvm-trace-metadata-smoketest/commit/15ef51ecf88beb819e3844c634b35b115da37a52,  the test results of the APIs of `2.9.3` and `3.1.2` are quite inconsistent.
- This PR is related to the Error detected at https://github.com/apache/shardingsphere/issues/21347 .


## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)

- Null.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
