### PR TITLE
Added metadata for ch.qos.logback:logback-classic:1.4.9

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.4.9/index.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/ch.qos.logback/logback-classic/1.4.9/reflect-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/reflect-config.json
@@ -1,0 +1,649 @@
+[
+  {
+    "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.ImplicitModelHandler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.joran.SerializedModelConfigurator",
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.CallerDataConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ClassOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ContextNameConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.DateConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.FileOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.KeyValuePairConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LevelConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LineOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.pattern.parser.Compiler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LocalSequenceNumberConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LoggerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MDCConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MarkerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MessageConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.pattern.parser.Compiler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MethodOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MicrosecondConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.NopThrowableInformationConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.PrefixCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.PropertyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.RelativeTimeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.RootCauseFirstThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.SequenceNumberConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ThreadConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.color.HighlightingCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.AppenderModelHandler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setWithJansi",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.OutputStreamAppender",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.util.PropertySetter"
+    },
+    "methods": [
+      {
+        "name": "setEncoder",
+        "parameterTypes": [
+          "ch.qos.logback.core.encoder.Encoder"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.util.PropertySetter"
+    },
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.IdentityCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.ImplicitModelHandler"
+    },
+    "methods": [
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.ReplacingCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BlackCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BlueCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldBlueCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldCyanCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldGreenCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldMagentaCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldRedCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldWhiteCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldYellowCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.CyanCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.GrayCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.GreenCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.MagentaCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.RedCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.WhiteCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.YellowCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.spi.ContextAware",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.ImplicitModelHandler"
+    },
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/ch.qos.logback/logback-classic/1.4.9/resource-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/resource-config.json
@@ -1,0 +1,20 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/services/org.slf4j.spi.SLF4JServiceProvider\\E",
+        "condition": {
+          "typeReachable": "org.slf4j.LoggerFactory"
+        }
+      },
+      {
+        "pattern": "\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E",
+        "condition": {
+          "typeReachable": "org.slf4j.LoggerFactory"
+        }
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/metadata/ch.qos.logback/logback-classic/index.json
+++ b/metadata/ch.qos.logback/logback-classic/index.json
@@ -1,7 +1,15 @@
 [
   {
     "latest": true,
+    "metadata-version": "1.4.9",
+    "module": "ch.qos.logback:logback-classic",
+    "tested-versions": [
+      "1.4.9"
+    ]
+  },
+  {
     "metadata-version": "1.4.1",
+    "default-for": "1\\.4\\.[0-8]",
     "module": "ch.qos.logback:logback-classic",
     "tested-versions": [
       "1.4.1"
@@ -9,6 +17,7 @@
   },
   {
     "metadata-version": "1.2.11",
+    "default-for": "1\\.[0-3]\\..*",
     "module": "ch.qos.logback:logback-classic",
     "tested-versions": [
       "1.2.11"

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -188,7 +188,7 @@
   "test-project-path" : "ch.qos.logback/logback-classic/1.4.1",
   "libraries" : [ {
     "name" : "ch.qos.logback:logback-classic",
-    "versions" : [ "1.4.1" ]
+    "versions" : [ "1.4.1", "1.4.9" ]
   } ]
 }, {
   "test-project-path" : "ch.qos.logback.contrib/logback-jackson/0.1.5",


### PR DESCRIPTION
## What does this PR do?
Adds metadata for ch.qos.logback:logback-classic:1.4.9

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)


## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
