### PR TITLE
Add metadata for Jetty 12

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-server/12.0.1/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.0.1/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.eclipse.jetty/jetty-server/12.0.1/reflect-config.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.0.1/reflect-config.json
@@ -1,0 +1,552 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.webapp.StandardDescriptorProcessor"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+    },
+    "name": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.xml.XmlParser"
+    },
+    "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.security.SecurityUtils"
+    },
+    "name": "java.lang.System",
+    "methods": [
+      {
+        "name": "getSecurityManager",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.VirtualThreads"
+    },
+    "name": "java.lang.Thread",
+    "methods": [
+      {
+        "name": "isVirtual",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.statistic.SampleStatistic"
+    },
+    "name": "java.lang.Thread",
+    "fields": [
+      {
+        "name": "threadLocalRandomProbe"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.Uptime$DefaultImpl"
+    },
+    "name": "java.lang.management.ManagementFactory",
+    "methods": [
+      {
+        "name": "getRuntimeMXBean",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.Uptime$DefaultImpl"
+    },
+    "name": "java.lang.management.RuntimeMXBean",
+    "methods": [
+      {
+        "name": "getUptime",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.security.SecurityUtils"
+    },
+    "name": "java.security.AccessController",
+    "methods": [
+      {
+        "name": "doPrivileged",
+        "parameterTypes": [
+          "java.security.PrivilegedAction"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.session.DefaultSessionIdManager"
+    },
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.VirtualThreads"
+    },
+    "name": "java.util.concurrent.Executors",
+    "methods": [
+      {
+        "name": "newVirtualThreadPerTaskExecutor",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.statistic.SampleStatistic"
+    },
+    "name": "java.util.concurrent.atomic.Striped64",
+    "fields": [
+      {
+        "name": "base"
+      },
+      {
+        "name": "cellsBusy"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.security.SecurityUtils"
+    },
+    "name": "javax.security.auth.Subject",
+    "methods": [
+      {
+        "name": "doAs",
+        "parameterTypes": [
+          "javax.security.auth.Subject",
+          "java.security.PrivilegedAction"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.servlet.ServletHolder"
+    },
+    "name": "jetty.HelloWorldServlet",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.servlet.ServletHolder"
+    },
+    "name": "org.eclipse.jetty.ee10.servlet.DefaultServlet",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.servlet.ServletHolder"
+    },
+    "name": "org.eclipse.jetty.ee10.servlet.NoJspServlet",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.servlet.ListenerHolder"
+    },
+    "name": "org.eclipse.jetty.ee10.servlet.listener.IntrospectorCleaner",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.servlet.ServletContextHandler"
+    },
+    "name": "org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.webapp.ServletsConfiguration"
+    },
+    "name": "org.eclipse.jetty.ee10.servlets.PushCacheFilter"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.IncludeExcludeSet"
+    },
+    "name": "org.eclipse.jetty.ee10.webapp.ClassMatcher$ByLocationOrModule",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.IncludeExcludeSet"
+    },
+    "name": "org.eclipse.jetty.ee10.webapp.ClassMatcher$ByPackageOrName",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.webapp.IterativeDescriptorProcessor"
+    },
+    "name": "org.eclipse.jetty.ee10.webapp.StandardDescriptorProcessor",
+    "methods": [
+      {
+        "name": "visitListener",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLocaleEncodingList",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityConstraint",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServlet",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServletMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSessionConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitWelcomeFileList",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.webapp.StandardDescriptorProcessor"
+    },
+    "name": "org.eclipse.jetty.ee10.webapp.StandardDescriptorProcessor",
+    "methods": [
+      {
+        "name": "visitContextParam",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDefaultContextPath",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDenyUncoveredHttpMethods",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitDisplayName",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitErrorPage",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitFilter",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitFilterMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitJspConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitListener",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLocaleEncodingList",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitLoginConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitMimeMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitRequestCharacterEncoding",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitResponseCharacterEncoding",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityConstraint",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSecurityRole",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServlet",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitServletMapping",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitSessionConfig",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitTagLib",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      },
+      {
+        "name": "visitWelcomeFileList",
+        "parameterTypes": [
+          "org.eclipse.jetty.ee10.webapp.WebAppContext",
+          "org.eclipse.jetty.ee10.webapp.Descriptor",
+          "org.eclipse.jetty.xml.XmlParser$Node"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.ee10.webapp.JaasConfiguration"
+    },
+    "name": "org.eclipse.jetty.security.jaas.JAASLoginService"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.TypeUtil"
+    },
+    "name": "org.eclipse.jetty.util.TypeUtil",
+    "methods": [
+      {
+        "name": "getClassLoaderLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getCodeSourceLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getModuleLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "getSystemClassLoaderLocation",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.util.security.SecurityUtils"
+    },
+    "name": "org.eclipse.jetty.util.security.SecurityUtils",
+    "methods": [
+      {
+        "name": "callableToPrivilegedAction",
+        "parameterTypes": [
+          "java.util.concurrent.Callable"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.session.DefaultSessionIdManager"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.security.SecureRandomParameters"
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/org.eclipse.jetty/jetty-server/12.0.1/resource-config.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.0.1/resource-config.json
@@ -1,0 +1,248 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/j2ee_1_4.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/j2ee_web_services_client_1_1.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/jakartaee_9.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/jakartaee_web_services_client_2_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_5.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_6.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_7.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_8.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_web_services_client_1_2.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_web_services_client_1_3.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/javaee_web_services_client_1_4.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_2_2.dtd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_2_3.dtd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_2_4.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_2_5.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_3_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_3_1.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_4_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_5_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-app_6_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-common_3_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-common_3_1.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-common_4_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-common_5_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-common_6_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-fragment_3_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-fragment_3_1.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-fragment_4_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-fragment_5_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.BaseClassCatalog$CatalogReader"
+        },
+        "pattern": "\\Qjakarta/servlet/resources/web-fragment_6_0.xsd\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.ee10.webapp.WebDescriptor$WebDescriptorParser"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/ee10/webapp/catalog-ee10.xml\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.util.resource.ResourceFactory"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/ee10/webapp/webdefault-ee10.xml\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.http.MimeTypes$1"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/http/encoding.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.http.MimeTypes$1"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/http/mime.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.server.Server"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/server/jetty-dir.css\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.util.Jetty"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/version/build.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.util.resource.ResourceFactoryInternals"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/version/build.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.eclipse.jetty.xml.XmlParser"
+        },
+        "pattern": "\\Qorg/eclipse/jetty/xml/catalog-org.w3.xml\\E"
+      }
+    ]
+  },
+  "bundles": [
+    {
+      "name": "jakarta.servlet.LocalStrings",
+      "locales": [
+        "und"
+      ]
+    },
+    {
+      "name": "jakarta.servlet.http.LocalStrings",
+      "locales": [
+        "und"
+      ]
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/index.json
@@ -1,7 +1,15 @@
 [
   {
     "latest": true,
+    "metadata-version": "12.0.1",
+    "module": "org.eclipse.jetty:jetty-server",
+    "tested-versions": [
+      "12.0.1"
+    ]
+  },
+  {
     "metadata-version": "11.0.12",
+    "default-for": "11\\..*",
     "module": "org.eclipse.jetty:jetty-server",
     "tested-versions": [
       "11.0.12"

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -299,6 +299,12 @@
     "versions" : [ "11.0.12" ]
   } ]
 }, {
+    "test-project-path" : "org.eclipse.jetty/jetty-server/12.0.1",
+    "libraries" : [ {
+      "name" : "org.eclipse.jetty:jetty-server",
+      "versions" : [ "12.0.1" ]
+    } ]
+}, {
   "test-project-path" : "org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r",
   "libraries" : [ {
     "name" : "org.eclipse.jgit:org.eclipse.jgit",

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew
+gradlew.bat
+build/
+gradle/

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/README.md
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/README.md
@@ -1,0 +1,3 @@
+# Jetty 12
+
+Metadata has been collected with the GraalVM agent.

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-server:$libraryVersion"
+    testImplementation "org.eclipse.jetty.ee10:jetty-ee10-servlets:$libraryVersion"
+    testImplementation "org.eclipse.jetty.ee10:jetty-ee10-webapp:$libraryVersion"
+
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.9'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = false
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.eclipse.jetty/jetty-server")
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version=12.0.1
+metadata.dir=org.eclipse.jetty/jetty-server/12.0.1/

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jetty-tests'

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/HelloWorldServlet.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/HelloWorldServlet.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class HelloWorldServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setStatus(200);
+        resp.setHeader("Content-Type", "text/plain");
+        resp.getWriter().print("Hello world");
+        resp.getWriter().flush();
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jetty;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.TypeUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JettyTests {
+
+    private static final int PORT = 8080;
+
+    private static boolean DEBUG = false;
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", DEBUG ? "debug" : "warn");
+    }
+
+    @Test
+    void typeUtilWorks() {
+        assertThat(TypeUtil.fromName("java.lang.String")).isEqualTo(String.class);
+    }
+
+    @Test
+    void http() throws Exception {
+        Server server = new Server(PORT);
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) {
+                response.setStatus(200);
+                response.getHeaders().add("Content-Type", "text/plain");
+                response.write(true, ByteBuffer.wrap("Hello world".getBytes(StandardCharsets.UTF_8)), callback);
+                return true;
+            }
+        });
+        server.start();
+        try {
+            HttpResponse<String> response = doHttpRequest();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("Hello world");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void servlet() throws Exception {
+        Server server = new Server(PORT);
+        ServletContextHandler handler = new ServletContextHandler();
+        handler.setContextPath("/");
+        handler.addServlet(HelloWorldServlet.class, "/*");
+        server.setHandler(handler);
+        server.start();
+        try {
+            HttpResponse<String> response = doHttpRequest();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("Hello world");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    // This test doesn't work in a native image and fails with:
+    // java.lang.IllegalArgumentException: not an allowed scheme: resource:/org/eclipse/jetty/ee10/webapp/webdefault-ee10.xml
+    @DisabledInNativeImage
+    void webapp(@TempDir Path tempDir) throws Exception {
+        Server server = new Server(PORT);
+        WebAppContext context = new WebAppContext();
+        // EnvConfiguration and PlusConfiguration uses JNDI, which is not what we want to include
+        context.setBaseResourceAsPath(tempDir);
+        context.setContextPath("/");
+        context.getServletContext().addServlet("HelloWorld", HelloWorldServlet.class).addMapping("/*");
+        server.setHandler(context);
+        server.start();
+        try {
+            HttpResponse<String> response = doHttpRequest();
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isEqualTo("Hello world");
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static HttpResponse<String> doHttpRequest(String... headers) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1));
+        if (headers.length > 0) {
+            request.headers(headers);
+        }
+        return client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
@@ -14,9 +14,10 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.URLResourceFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -87,10 +88,12 @@ public class JettyTests {
     }
 
     @Test
-    // This test doesn't work in a native image and fails with:
-    // java.lang.IllegalArgumentException: not an allowed scheme: resource:/org/eclipse/jetty/ee10/webapp/webdefault-ee10.xml
-    @DisabledInNativeImage
     void webapp(@TempDir Path tempDir) throws Exception {
+        // This is needed to work in a native image, otherwise it fails with:
+        // java.lang.IllegalArgumentException: not an allowed scheme: resource:/org/eclipse/jetty/ee10/webapp/webdefault-ee10.xml
+        // See https://github.com/eclipse/jetty.project/issues/9116
+        ResourceFactory.registerResourceFactory("resource", new URLResourceFactory());
+
         Server server = new Server(PORT);
         WebAppContext context = new WebAppContext();
         // EnvConfiguration and PlusConfiguration uses JNDI, which is not what we want to include

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/resources/META-INF/native-image/test/reflect-config.json
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/resources/META-INF/native-image/test/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "jetty.HelloWorldServlet",
+    "allDeclaredConstructors": true
+  }
+]

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Add metadata for Jetty 12.

## Code sections where the PR accesses files, network, docker or some external service

- Starts a Jetty server inside the test and then accesses it with the `HttpClient`.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
