### PR TITLE
Add io.avaje:avaje-config to library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -131,6 +131,22 @@
     ]
   },
   {
+    "artifact": "io.avaje:avaje-config",
+    "description": "Avaje Configuration.",
+    "details": [
+      {
+        "minimum_version": "3.9",
+        "metadata_locations": [
+          "https://github.com/avaje/avaje-config/tree/master/avaje-config/src/main/resources/META-INF/native-image/io.avaje.config.avaje-config"
+        ],
+        "tests_locations": [
+          "https://github.com/avaje/avaje-config/tree/master/tests/test-native-image"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "io.helidon.config:helidon-config",
     "description": "Helidon Configuration.",
     "details": [

--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -140,8 +140,8 @@
           "https://github.com/avaje/avaje-config/tree/master/avaje-config/src/main/resources/META-INF/native-image/io.avaje.config.avaje-config"
         ],
         "tests_locations": [
-          "https://github.com/avaje/avaje-config/tree/master/tests/test-native-image",
-          "https://github.com/avaje/avaje-config/actions/workflows/native-image.yml"
+          "https://github.com/avaje/avaje-config/actions/workflows/native-image.yml",
+          "https://github.com/avaje/avaje-config/tree/master/tests/test-native-image"
         ],
         "test_level": "fully-tested"
       }

--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -140,7 +140,8 @@
           "https://github.com/avaje/avaje-config/tree/master/avaje-config/src/main/resources/META-INF/native-image/io.avaje.config.avaje-config"
         ],
         "tests_locations": [
-          "https://github.com/avaje/avaje-config/tree/master/tests/test-native-image"
+          "https://github.com/avaje/avaje-config/tree/master/tests/test-native-image",
+          "https://github.com/avaje/avaje-config/actions/workflows/native-image.yml"
         ],
         "test_level": "fully-tested"
       }


### PR DESCRIPTION
With version 3.9 avaje-config includes the native-image metadata in with the library in
META-INF/native-image/io.avaje.config.avaje-config

## What does this PR do?

Add io.avaje:avaje-config to library-and-framework-list.json


## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
