### PR TITLE
Add Avaje Validator to library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -148,6 +148,23 @@
     ]
   },
   {
+    "artifact": "io.avaje:avaje-validator",
+    "description": "Avaje Validator.",
+    "details": [
+      {
+        "minimum_version": "1.2",
+        "metadata_locations": [
+          "https://github.com/avaje/avaje-validator/blob/main/validator/src/main/resources/META-INF/native-image/io.avaje.validator.avaje-validator"
+        ],
+        "tests_locations": [
+          "https://github.com/avaje/avaje-validator/blob/main/.github/workflows/native-image.yml",
+          "https://github.com/avaje/avaje-validator/tree/main/test-native-image"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "io.helidon.config:helidon-config",
     "description": "Helidon Configuration.",
     "details": [


### PR DESCRIPTION
## What does this PR do?

Adds avaje-validator library to library-and-framework-list.json.


Avaje validator has:
- Added a `resource-config.json` with `bundles`
- Added a native image specific test building a native image with DE and EN locales via `-H:IncludeLocales=de,en` and confirms that the error message from the bundles are used as expected


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
