### PR TITLE
Add Focus Shift Jollyday to library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -131,6 +131,24 @@
     ]
   },
   {
+    "artifact": "de.focus-shift:jollyday",
+    "description": "The library to retrieve holiday information for a given year, country and state/region.",
+    "details": [
+      {
+        "minimum_version": "0.21.0",
+        "metadata_locations": [
+          "https://repo1.maven.org/maven2/de/focus-shift/jollyday/",
+          "https://repo1.maven.org/maven2/de/focus-shift/jollyday-core/",
+          "https://repo1.maven.org/maven2/de/focus-shift/jollyday-jaxb/"
+        ],
+        "tests_locations": [
+          "https://github.com/focus-shift/jollyday/blob/main/.github/workflows/build-native.yaml"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "io.avaje:avaje-config",
     "description": "Avaje Configuration.",
     "details": [


### PR DESCRIPTION
## What does this PR do?

Adds Focus Shift Jollyday to library-and-framework-list.json.

## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
