### PR TITLE
Add io.ebean:ebean-migration to library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -165,6 +165,23 @@
     ]
   },
   {
+    "artifact": "io.ebean:ebean-migration",
+    "description": "Ebean database migration runner.",
+    "details": [
+      {
+        "minimum_version": "13.10.0",
+        "metadata_locations": [
+          "https://github.com/ebean-orm/ebean-migration/tree/master/ebean-migration/src/main/resources/META-INF/native-image/io.ebean.migration.ebean-migration"
+        ],
+        "tests_locations": [
+          "https://github.com/ebean-orm/ebean-migration/blob/master/.github/workflows/native-image.yml",
+          "https://github.com/ebean-orm/ebean-migration/tree/master/test-native-image"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "io.helidon.config:helidon-config",
     "description": "Helidon Configuration.",
     "details": [


### PR DESCRIPTION
With version 13.10.0 ebean-migration includes the native-image metadata in with the library in META-INF/native-image/io.ebean.migration.ebean-migration

## What does this PR do?

Add io.ebean:ebean-migration to library-and-framework-list.json



## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
