### PR TITLE
Only Run Weekly Docker Image Scan on Origin

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -31,5 +31,5 @@ jobs:
         if: github.event_name == 'pull_request'
         run: ./gradlew checkAllowedDockerImages --baseCommit=${{ github.event.pull_request.base.sha }} --newCommit=${{ github.event.pull_request.head.sha }}
       - name: "🔎 Check all docker images"
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'oracle/graalvm-reachability-metadata'
         run: ./gradlew checkAllowedDockerImages


### PR DESCRIPTION
Weekly docker image scan should be run only on origin repository and not on forks