### PR TITLE
Add reflection hints for io.netty.util.internal.PlatformDependent0 when JDK 21

### DIFF
--- a/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
+++ b/metadata/io.netty/netty-common/4.1.80.Final/reflect-config.json
@@ -3762,6 +3762,21 @@
   },
   {
     "condition": {
+      "typeReachable": "io.netty.util.internal.PlatformDependent0"
+    },
+    "name": "java.nio.DirectByteBuffer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long",
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
       "typeReachable": "io.netty.util.internal.PlatformDependent0$5"
     },
     "name": "java.nio.DirectByteBuffer",
@@ -3771,6 +3786,21 @@
         "parameterTypes": [
           "long",
           "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.util.internal.PlatformDependent0$5"
+    },
+    "name": "java.nio.DirectByteBuffer",
+    "queriedMethods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long",
+          "long"
         ]
       }
     ]
@@ -4256,6 +4286,21 @@
       {
         "name": "getUnsafe",
         "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.util.internal.PlatformDependent0$8"
+    },
+    "name": "jdk.internal.misc.Unsafe",
+    "methods": [
+      {
+        "name": "allocateUninitializedArray",
+        "parameterTypes": [
+          "java.lang.Class",
+          "int"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## What does this PR do?

Netty project has added a reflection specific for `JDK 21` with https://github.com/netty/netty/pull/13366 
The reflection hints need to be updated to cover also this JDK version.

The exception below is observed in the logs when running without these hints:

```
java.lang.NoSuchMethodException: java.nio.DirectByteBuffer.<init>(long, long)
        at java.base@21.0.1/java.lang.Class.checkMethod(DynamicHub.java:1065) ~[spring.graalvm:na]
        at java.base@21.0.1/java.lang.Class.getConstructor0(DynamicHub.java:1228) ~[spring.graalvm:na]
        at java.base@21.0.1/java.lang.Class.getDeclaredConstructor(DynamicHub.java:2930) ~[spring.graalvm:na]
        at io.netty.util.internal.PlatformDependent0$5.run(PlatformDependent0.java:291) ~[na:na]
        at java.base@21.0.1/java.security.AccessController.executePrivileged(AccessController.java:129) ~[na:na]
        at java.base@21.0.1/java.security.AccessController.doPrivileged(AccessController.java:319) ~[na:na]
        at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:286) ~[na:na]
        at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:331) ~[na:na]
        at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:86) ~[na:na]
```

## Code sections where the PR accesses files, network, docker or some external service

- N/A


## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- N/A [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- N/A [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- N/A [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)

Test is not provided because the current `Gradle` version that the project uses does not support `JDK21`.