### PR TITLE
Run tests against GraalVM for JDK 21.

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -91,6 +91,7 @@ if (project.hasProperty("baseCommit")) {
 
 def matrixDefault = [
         "version": ["17",
+                    "21"
 //                    "dev"
         ],
         "os"     : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"


### PR DESCRIPTION
## What does this PR do?

Adds GraalVM for JDK 21 to the test matrix.

## Checklist before merging
- n/a