### PR TITLE
Add support for `@ConstructorProperties` to `jackson-databind`

### DIFF
--- a/metadata/com.fasterxml.jackson.core/jackson-databind/2.15.2/reflect-config.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-databind/2.15.2/reflect-config.json
@@ -68,5 +68,12 @@
     "condition": {
       "typeReachable": "javax.xml.datatype.XMLGregorianCalendar"
     }
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+    "allDeclaredConstructors": true,
+    "condition": {
+      "typeReachable": "com.fasterxml.jackson.databind.ext.Java7Support"
+    }
   }
 ]

--- a/tests/src/com.fasterxml.jackson.core/jackson-databind/2.15.2/src/test/java/com_fasterxml_jackson_core/jackson_databind/JacksonConstructorPropertiesTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-databind/2.15.2/src/test/java/com_fasterxml_jackson_core/jackson_databind/JacksonConstructorPropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_core.jackson_databind;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonConstructorPropertiesTest {
+
+    static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void deserializeConstructorProperties() throws JsonProcessingException {
+        Foo foo = mapper.readValue("{ \"bar\": \"baz\" }", Foo.class);
+        assertThat(foo.getBar()).isEqualTo("baz");
+    }
+
+    static class Foo {
+
+        private String bar;
+
+        @ConstructorProperties("bar")
+        Foo(String bar) {
+            this.bar = bar;
+        }
+
+        String getBar() {
+            return bar;
+        }
+    }
+
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-databind/2.15.2/src/test/resources/META-INF/native-image/jackson-databind-test-metadata/reflect-config.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-databind/2.15.2/src/test/resources/META-INF/native-image/jackson-databind-test-metadata/reflect-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "com_fasterxml_jackson_core.jackson_databind.JacksonConstructorPropertiesTest$Foo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]


### PR DESCRIPTION
## What does this PR do?

It adds support for `@ConstructorProperties` to `jackson-databind` as discussed in https://github.com/spring-projects/spring-framework/issues/32288.