### PR TITLE
Allow Logback to load its BasicConfigurator using reflection

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.4.9/reflect-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/reflect-config.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "ch.qos.logback.classic.BasicConfigurator",
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "ch.qos.logback.classic.PatternLayout",
     "condition": {
       "typeReachable": "ch.qos.logback.core.LayoutBase"


### PR DESCRIPTION
Fixes gh-454

## What does this PR do?

Allows Logback to load `BasicConfigurator` using reflection.

## Code sections where the PR accesses files, network, docker or some external service

None.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
