### PR TITLE
Adding Kafka Streams 3.7.0 missing hints

### DIFF
--- a/metadata/org.apache.kafka/kafka-streams/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-streams/3.5.1/reflect-config.json
@@ -57,5 +57,19 @@
   "allDeclaredMethods": true,
   "allPublicConstructors": true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name": "org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$InMemoryDslStoreSuppliers",
+  "condition": {
+    "typeReachable": "org.apache.kafka.streams.kstream.internals.AbstractConfigurableStoreFactory"
+  },
+  "allPublicConstructors": true
+},
+{
+  "name": "org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$RocksDBDslStoreSuppliers",
+  "condition": {
+    "typeReachable": "org.apache.kafka.streams.kstream.internals.AbstractConfigurableStoreFactory"
+  },
+  "allPublicConstructors": true
 }
 ]


### PR DESCRIPTION
* Adding a few missing hints in Kafka Streams version 3.7.0

   - Missing hints for BuiltInDslStoreSuppliers$RocksDBDslStoreSuppliers
   - Missing hints for BuiltInDslStoreSuppliers$InMemoryDslStoreSuppliers
