### PR TITLE
Force upgrade `wildfly-common`.

### DIFF
--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation "io.undertow:undertow-servlet:$libraryVersion"
     testImplementation "io.undertow:undertow-websockets-jsr:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.wildfly.common:wildfly-common:1.7.0.Final"
 }
 
 graalvmNative {

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -91,7 +91,7 @@ if (project.hasProperty("baseCommit")) {
 
 def matrixDefault = [
         "version": ["17",
-                    "21"
+                    "latest-ea"
 //                    "dev"
         ],
         "os"     : ["ubuntu-latest"] // TODO: Add support for "windows-latest", "macos-latest"


### PR DESCRIPTION
This avoids substitutions incompatible with GraalVM for JDK 22+.