### PR TITLE
Allow Thymeleaf to check for allowed method access of Java supertypes

### DIFF
--- a/metadata/org.thymeleaf/thymeleaf/3.1.0.M2/reflect-config.json
+++ b/metadata/org.thymeleaf/thymeleaf/3.1.0.M2/reflect-config.json
@@ -1,5 +1,54 @@
 [
   {
+    "name": "java.util.Collection",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.lang.Iterable",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.List",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Map",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Map$Entry",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Set",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Calendar",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
     "name": "org.thymeleaf.expression.Dates",
     "allPublicMethods": true,
     "condition": {

--- a/metadata/org.thymeleaf/thymeleaf/3.1.0.RC1/reflect-config.json
+++ b/metadata/org.thymeleaf/thymeleaf/3.1.0.RC1/reflect-config.json
@@ -1,5 +1,68 @@
 [
   {
+    "name": "java.util.Collection",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.lang.Iterable",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Iterator",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.List",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Map",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Map$Entry",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Set",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.Calendar",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
+    "name": "java.util.stream.Stream",
+    "allDeclaredMethods": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.util.ExpressionUtils"
+    }
+  },
+  {
     "name": "org.thymeleaf.expression.Dates",
     "allPublicMethods": true,
     "condition": {

--- a/tests/src/org.thymeleaf/thymeleaf/3.1.0.M2/src/test/java/org/thymeleaf/ExpressionUtilsTest.java
+++ b/tests/src/org.thymeleaf/thymeleaf/3.1.0.M2/src/test/java/org/thymeleaf/ExpressionUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.thymeleaf;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.thymeleaf.util.ExpressionUtils.isMemberAllowed;
+
+/**
+ * Not including test for {@link java.util.Set} here, as it doesn't have any methods of its own.
+ *
+ * @see org.thymeleaf.util.ExpressionUtils#ALLOWED_JAVA_SUPERS
+ */
+public class ExpressionUtilsTest {
+
+    @Test
+    void allowsCollectionMethods() {
+        assertThat(isMemberAllowed(Collections.emptySet(), "isEmpty")).isTrue();
+    }
+
+    @Test
+    void allowsIterableMethods() {
+        assertThat(isMemberAllowed(Collections.emptyList(), "iterator")).isTrue();
+    }
+
+    @Test
+    void allowsListMethods() {
+        assertThat(isMemberAllowed(Collections.emptyList(), "get")).isTrue();
+    }
+
+    @Test
+    void allowsMapMethods() {
+        assertThat(isMemberAllowed(Collections.emptyMap(), "put")).isTrue();
+    }
+
+    @Test
+    void allowsMapEntryMethods() {
+        Map.Entry<String, String> entry = Collections.singletonMap("key", "value").entrySet().iterator().next();
+        assertThat(isMemberAllowed(entry, "getKey")).isTrue();
+    }
+
+    @Test
+    void allowsCalendarMethods() {
+        assertThat(isMemberAllowed(Calendar.getInstance(), "clear")).isTrue();
+    }
+}

--- a/tests/src/org.thymeleaf/thymeleaf/3.1.0.M2/src/test/java/org/thymeleaf/ThymeleafTest.java
+++ b/tests/src/org.thymeleaf/thymeleaf/3.1.0.M2/src/test/java/org/thymeleaf/ThymeleafTest.java
@@ -37,7 +37,7 @@ public class ThymeleafTest {
         Context context = new Context();
         Date date = new Date(81, 5, 15);
         context.setVariable("date", date);
-        String template = "<p th:text=\"${#dates.format(date)}\"></p>";
+        String template = "<p th:text=\"${#dates.format(date, 'MMMM dd, YYYY')}\"></p>";
         String output = templateEngine.process(template, context);
         assertThat(output).startsWith("<p>June 15, 1981");
     }

--- a/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ExpressionUtilsTest.java
+++ b/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ExpressionUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.thymeleaf;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.thymeleaf.util.ExpressionUtils.isMemberAllowed;
+
+/**
+ * Not including test for {@link java.util.Set} here, as it doesn't have any methods of its own.
+ *
+ * @see org.thymeleaf.util.ExpressionUtils#ALLOWED_JAVA_SUPERS
+ */
+public class ExpressionUtilsTest {
+
+    @Test
+    void allowsCollectionMethods() {
+        assertThat(isMemberAllowed(Collections.emptySet(), "isEmpty")).isTrue();
+    }
+
+    @Test
+    void allowsIterableMethods() {
+        assertThat(isMemberAllowed(Collections.emptyList(), "iterator")).isTrue();
+    }
+
+    @Test
+    void allowsListMethods() {
+        assertThat(isMemberAllowed(Collections.emptyList(), "get")).isTrue();
+    }
+
+    @Test
+    void allowsMapMethods() {
+        assertThat(isMemberAllowed(Collections.emptyMap(), "put")).isTrue();
+    }
+
+    @Test
+    void allowsMapEntryMethods() {
+        Map.Entry<String, String> entry = Collections.singletonMap("key", "value").entrySet().iterator().next();
+        assertThat(isMemberAllowed(entry, "getKey")).isTrue();
+    }
+
+    @Test
+    void allowsCalendarMethods() {
+        assertThat(isMemberAllowed(Calendar.getInstance(), "clear")).isTrue();
+    }
+}

--- a/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ThymeleafTest.java
+++ b/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ThymeleafTest.java
@@ -38,7 +38,7 @@ public class ThymeleafTest {
         Context context = new Context();
         Date date = new Date(81, 5, 15);
         context.setVariable("date", date);
-        String template = "<p th:text=\"${#dates.format(date)}\"></p>";
+        String template = "<p th:text=\"${#dates.format(date, 'MMMM dd, YYYY')}\"></p>";
         String output = templateEngine.process(template, context);
         assertThat(output).startsWith("<p>June 15, 1981");
     }


### PR DESCRIPTION
## What does this PR do?

To prevent Thymeleaf templates from accessing methods on built-in Java types that are not allowed, it ships with a list of allowed supertypes. Its `org.thymeleaf.util.ExpressionUtils` type has an `isMemberAllowed` method that calls `getDeclaredMethods()` on those types, so that needs to work for all these types in a native image. This PR ensures that.

Recent versions of Thymeleaf have expanded the list with two additional types, which is why the M2 version has 7 new entries while the RC1 / latest has 9. For details, check out
[the source code.](https://github.com/thymeleaf/thymeleaf/blob/3.1-master/lib/thymeleaf/src/main/java/org/thymeleaf/util/ExpressionUtils.java)

## Code sections where the PR accesses files, network, docker or some external service

None.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
