### PR TITLE
Improve MariaDB client test

### DIFF
--- a/tests/src/org.mariadb.jdbc/mariadb-java-client/3.0.6/src/test/java/mariadb/MariaDbTests.java
+++ b/tests/src/org.mariadb.jdbc/mariadb-java-client/3.0.6/src/test/java/mariadb/MariaDbTests.java
@@ -39,8 +39,10 @@ public class MariaDbTests {
     private static final String DATABASE = "test";
 
     private static final String DOCKER_IMAGE = "mariadb:11";
-    public static final File STD_OUT = new File("mariadb-stdout.txt");
-    public static final File STD_ERR = new File("mariadb-stderr.txt");
+
+    private static final File STD_OUT = new File("mariadb-stdout.txt");
+
+    private static final File STD_ERR = new File("mariadb-stderr.txt");
 
     private static String jdbcUrl;
 


### PR DESCRIPTION
- Uses an ephemeral port for docker
- Uses `127.0.0.1` instead of `localhost`
- Updates MariaDB from `10.8` to `11` (which hopefully passes the vulnerability scanners)
- Fails fast if docker process exits early
- print stdout and stderr if docker process exits early