### PR TITLE
Add reflection metadata for Jetty's ForwardedRequestCustomizer

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-server/12.0.1/reflect-config.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.0.1/reflect-config.json
@@ -548,5 +548,67 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.eclipse.jetty.server.ForwardedRequestCustomizer"
+    },
+    "name": "org.eclipse.jetty.server.ForwardedRequestCustomizer$Forwarded",
+    "methods": [
+      {
+        "name": "handleRFC7239",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedHost",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedFor",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedPort",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleProto",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleHttps",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleForwardedServer",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleCipherSuite",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      },
+      {
+        "name": "handleSslSessionId",
+        "parameterTypes": [
+          "org.eclipse.jetty.http.HttpField"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Closes https://github.com/oracle/graalvm-reachability-metadata/issues/476