### PR TITLE
Add missing metadata for Hibernate Reactive (needed for some collections mappings)

### DIFF
--- a/metadata/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/reflect-config.json
@@ -139,6 +139,10 @@
     },
     {
         "name": "org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister",
+        "queryAllPublicMethods": true,
+        "condition": {
+            "typeReachable": "org.hibernate.reactive.session.impl.ReactiveSessionFactoryImpl"
+        },
         "methods": [
             {
                 "name": "<init>",

--- a/metadata/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/reflect-config.json
@@ -136,5 +136,18 @@
         "condition": {
             "typeReachable": "org.hibernate.reactive.pool.impl.DefaultSqlClientPool"
         }
+    },
+    {
+        "name": "org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "org.hibernate.mapping.Collection",
+                    "org.hibernate.cache.spi.access.CollectionDataAccess",
+                    "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
+                ]
+            }
+        ]
     }
 ]

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Course.java
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Course.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 package org_hibernate_reactive.hibernate_reactive_core.entity;
 
 import jakarta.persistence.ElementCollection;

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Course.java
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Course.java
@@ -1,0 +1,79 @@
+package org_hibernate_reactive.hibernate_reactive_core.entity;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "course")
+public class Course {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String title;
+
+    @ManyToMany(mappedBy = "courses", fetch = FetchType.EAGER)
+    private Set<Student> students = new HashSet<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> notes;
+
+    public Course() {
+    }
+
+    public Course(String title) {
+        this(title, Set.of());
+    }
+
+    public Course(String title, Set<Student> students) {
+        this(title, students, List.of());
+    }
+
+    public Course(String title, Set<Student> students, List<String> notes) {
+        this.title = title;
+        this.students = students;
+        this.notes = notes;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Set<Student> getStudents() {
+        return students;
+    }
+
+    public void setStudents(Set<Student> students) {
+        this.students = students;
+    }
+
+    public List<String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<String> notes) {
+        this.notes = notes;
+    }
+}

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Student.java
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Student.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 package org_hibernate_reactive.hibernate_reactive_core.entity;
 
 import jakarta.persistence.Entity;

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Student.java
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/java/org_hibernate_reactive/hibernate_reactive_core/entity/Student.java
@@ -1,0 +1,68 @@
+package org_hibernate_reactive.hibernate_reactive_core.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "student")
+public class Student {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "student_course",
+        joinColumns = @JoinColumn(name = "student_id"),
+        inverseJoinColumns = @JoinColumn(name = "course_id")
+    )
+    private Set<Course> courses = new HashSet<>();
+
+    public Student() {
+    }
+
+    public Student(String name) {
+        this(name, Set.of());
+    }
+
+    public Student(String name, Set<Course> courses) {
+        this.name = name;
+        this.courses = courses;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Course> getCourses() {
+        return courses;
+    }
+
+    public void setCourses(Set<Course> courses) {
+        this.courses = courses;
+    }
+
+}

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/resources/META-INF/native-image/hibernate-reactive-core-tests-only/reflect-config.json
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/resources/META-INF/native-image/hibernate-reactive-core-tests-only/reflect-config.json
@@ -115,5 +115,71 @@
         ]
       }
     ]
+  },
+  {
+    "name": "org_hibernate_reactive.hibernate_reactive_core.entity.Course",
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      },
+      {
+        "name": "getId",
+        "parameterTypes": [
+
+        ]
+      },
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "java.lang.Long"
+        ]
+      },
+      {
+        "name": "suite",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org_hibernate_reactive.hibernate_reactive_core.entity.Student",
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      },
+      {
+        "name": "getId",
+        "parameterTypes": [
+
+        ]
+      },
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "java.lang.Long"
+        ]
+      },
+      {
+        "name": "suite",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
   }
 ]

--- a/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/resources/META-INF/persistence.xml
+++ b/tests/src/org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final/src/test/resources/META-INF/persistence.xml
@@ -8,6 +8,8 @@
 
         <class>org_hibernate_reactive.hibernate_reactive_core.entity.Author</class>
         <class>org_hibernate_reactive.hibernate_reactive_core.entity.Book</class>
+        <class>org_hibernate_reactive.hibernate_reactive_core.entity.Course</class>
+        <class>org_hibernate_reactive.hibernate_reactive_core.entity.Student</class>
 
         <properties>
             <property name="hibernate.connection.pool_size" value="10"/>


### PR DESCRIPTION
## What does this PR do?

Adds missing metadata for Hibernate Reactive. Without this, when there are entities with `@ManyToMany` or `@ElementCollection` then following error was being thrown:
```
Caused by: org.hibernate.MappingException: Could not find appropriate constructor for org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister
```

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)
The test was already using mysql community docker so I have not added anything extra.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
