### PR TITLE
Add itext core libraries into library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -493,6 +493,223 @@
     ]
   },
   {
+    "artifact": "com.itextpdf:barcodes",
+    "description": "iText Core module for barcodes creation.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:bouncy-castle-adapter",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:bouncy-castle-connector",
+    "description": "iText Core module which allows to pick cryptography library, bouncy castle or bouncy castle fips, for PDF manipulations.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:bouncy-castle-fips-adapter",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:commons",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:forms",
+    "description": "iText Core module for form fields manipulations.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/master/forms/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:io",
+    "description": "Low level iText Core module for reading data to be used in PDF (image streams, font programs etc).",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/master/io/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:itext-core",
+    "description": "Umbrella module which includes all iText Core modules.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:kernel",
+    "description": "iText Core module responsible for low level PDF creation and manipulation.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/master/kernel/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:layout",
+    "description": "iText Core module that performs operations of transforming abstract elements (like Paragraph, Table, List etc) into low level PDF syntax on actual document pages.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/master/layout/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:pdfa",
+    "description": "iText Core module to ease PDF/A documents creation.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:pdfua",
+    "description": "iText Core module to ease PDF/UA documents creation.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:sign",
+    "description": "iText Core module used to sign PDF documents and validate signatures.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:styled-xml-parser",
+    "description": "iText Core module to parse HTML and XML.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:svg",
+    "description": "iText Core module that allows you to integrate SVG images in your PDF creation and manipulation process.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/master/svg/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/master/native-image-test"
+        ]
+      }
+    ]
+  },
+  {
     "artifact": "com.oracle.apm.agent.java:apm-java-agent-helidon",
     "description": "Oracle Application Performance Monoitoring(APM) Java Tracer for Helidon 2.x based applications",
     "details": [


### PR DESCRIPTION
## What does this PR do?
Starting with 8.0.4 itext core includes reachability metadata into library.

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
