### PR TITLE
Add missing metadata for hibernate-core

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/6.2.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.2.0.Final/reflect-config.json
@@ -455,6 +455,46 @@
   },
   {
     "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+    "name":"org.hibernate.generator.internal.CurrentTimestampGeneration",
+    "queryAllDeclaredConstructors":true,
+    "methods":[
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.CreationTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.CurrentTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.UpdateTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }
+    ]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+    "name":"org.hibernate.generator.internal.GeneratedAlwaysGeneration",
+    "queryAllDeclaredConstructors":true,
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+    "name":"org.hibernate.generator.internal.GeneratedGeneration",
+    "queryAllDeclaredConstructors":true,
+    "methods":[
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.Generated"] }, 
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.GenerationTime"] }
+    ]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+    "name":"org.hibernate.generator.internal.SourceGeneration",
+    "queryAllDeclaredConstructors":true,
+    "methods":[
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.Source","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+      {"name":"<init>","parameterTypes":["org.hibernate.annotations.SourceType","java.lang.Class","org.hibernate.generator.GeneratorCreationContext"] }
+    ]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+    "name":"org.hibernate.generator.internal.TenantIdGeneration",
+    "queryAllDeclaredConstructors":true,
+    "methods":[{"name":"<init>","parameterTypes":["org.hibernate.annotations.TenantId","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }]
+  },
+  {
+    "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
     "name":"org.hibernate.id.Assigned",
     "methods":[{"name":"<init>","parameterTypes":[] }]
   },

--- a/metadata/org.hibernate.orm/hibernate-core/6.5.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/6.5.0.Final/reflect-config.json
@@ -520,6 +520,46 @@
 },
 {
   "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+  "name":"org.hibernate.generator.internal.CurrentTimestampGeneration",
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.CreationTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.CurrentTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.UpdateTimestamp","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }
+  ]
+},
+{
+  "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+  "name":"org.hibernate.generator.internal.GeneratedAlwaysGeneration",
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+  "name":"org.hibernate.generator.internal.GeneratedGeneration",
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.Generated"] }, 
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.GenerationTime"] }
+  ]
+},
+{
+  "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+  "name":"org.hibernate.generator.internal.SourceGeneration",
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.Source","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }, 
+    {"name":"<init>","parameterTypes":["org.hibernate.annotations.SourceType","java.lang.Class","org.hibernate.generator.GeneratorCreationContext"] }
+  ]
+},
+{
+  "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
+  "name":"org.hibernate.generator.internal.TenantIdGeneration",
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":["org.hibernate.annotations.TenantId","java.lang.reflect.Member","org.hibernate.generator.GeneratorCreationContext"] }]
+},
+{
+  "condition":{"typeReachable":"org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"},
   "name":"org.hibernate.id.Assigned",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },

--- a/tests/src/org.hibernate.orm/hibernate-core/6.5.0.Final/src/test/java/org_hibernate_orm/hibernate_core/IdentifierGeneratorTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/6.5.0.Final/src/test/java/org_hibernate_orm/hibernate_core/IdentifierGeneratorTest.java
@@ -26,11 +26,32 @@ public class IdentifierGeneratorTest {
             org.hibernate.id.ForeignGenerator.class
     };
 
+    private static final Class[] VALUE_GENERATION_TYPE_GENERATORS_FROM_ANNOTATIONS = new Class[]{
+        org.hibernate.generator.internal.CurrentTimestampGeneration.class,
+        org.hibernate.generator.internal.GeneratedAlwaysGeneration.class,
+        org.hibernate.generator.internal.GeneratedGeneration.class,
+        org.hibernate.generator.internal.SourceGeneration.class,
+        org.hibernate.generator.internal.TenantIdGeneration.class
+    };
+
     @Test
     public void testIdentifierGenerators() throws Exception {
         for (Class clazz : identifierGenerators) {
             Constructor constructor = clazz.getConstructor();
             assertThat(constructor).isNotNull();
+        }
+    }
+
+    /**
+     * {@link org.hibernate.annotations.ValueGenerationType#generatedBy()}  may hold types reflectively instantiated.
+     * This uses a list of those to make sure hints are present.
+     */
+    @Test
+    public void testValueGenerationTypes() throws Exception {
+        for (Class clazz : VALUE_GENERATION_TYPE_GENERATORS_FROM_ANNOTATIONS) {
+           for (Constructor<?> ctor : clazz.getDeclaredConstructors()) {
+               assertThat(clazz.getConstructor(ctor.getParameterTypes())).isEqualTo(ctor);
+           }
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Add missing metadata for hibernate-core required to instantiate generator types retrieved from annotation attribute.
Closes: #323 

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
