### PR TITLE
Remove 'latest' key from index.json for itext metadata

### DIFF
--- a/metadata/com.itextpdf/forms/index.json
+++ b/metadata/com.itextpdf/forms/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "metadata-version": "8.0.3",
     "module": "com.itextpdf:forms",
     "tested-versions": [

--- a/metadata/com.itextpdf/io/index.json
+++ b/metadata/com.itextpdf/io/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "metadata-version": "8.0.3",
     "module": "com.itextpdf:io",
     "tested-versions": [

--- a/metadata/com.itextpdf/kernel/index.json
+++ b/metadata/com.itextpdf/kernel/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "metadata-version": "8.0.3",
     "module": "com.itextpdf:kernel",
     "tested-versions": [

--- a/metadata/com.itextpdf/layout/index.json
+++ b/metadata/com.itextpdf/layout/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "metadata-version": "8.0.3",
     "module": "com.itextpdf:layout",
     "tested-versions": [

--- a/metadata/com.itextpdf/svg/index.json
+++ b/metadata/com.itextpdf/svg/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "metadata-version": "8.0.3",
     "module": "com.itextpdf:svg",
     "tested-versions": [


### PR DESCRIPTION
Starting from 8.0.4 itext core includes reachability metadata into library.

## What does this PR do?
Looking at https://www.graalvm.org/native-image/libraries-and-frameworks/ it seems there is a redundancy in terms of supported versions of itext core libs. I believe removing 'latest' key from index.json should remove '8.0.3 - latest' range from the page above and leave only 8.0.3. Though I don't see any similar example in the whole repo so not sure.

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
