### PR TITLE
Include MongoDB in library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -2282,6 +2282,22 @@
     ]
   },
   {
+    "artifact": "org.mongodb:mongodb-driver-sync",
+    "description": "Official MongoDB Driver for Java",
+    "details": [
+      {
+        "minimum_version": "5.1.0",
+        "metadata_locations": [
+          "https://github.com/mongodb/mongo-java-driver/tree/master/graalvm-native-image-app/src/main/resources/META-INF/native-image"
+        ],
+        "tests_locations": [
+          "https://github.com/mongodb/mongo-java-driver/tree/master/graalvm-native-image-app"
+        ],
+        "test_level": "fully-tested"
+      }
+    ]
+  },
+  {
     "artifact": "software.amazon.awssdk:*",
     "description": "AWS SDK for Java v2.0",
     "details": [


### PR DESCRIPTION
## What does this PR do?
This PR adds MongoDB to the list of GraalVM-tested libraries.

## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
