### PR TITLE
Added metadata resouce-config.json for org.apache.commons:commons-dbcp2:2.12.0

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -181,6 +181,10 @@
   "module" : "org.apache.commons:commons-compress"
 }, {
   "allowed-packages" : [ "org.apache.commons" ],
+  "directory" : "org.apache.commons/commons-dbcp2",
+  "module" : "org.apache.commons:commons-dbcp2"
+}, {
+  "allowed-packages" : [ "org.apache.commons" ],
   "directory" : "org.apache.commons/commons-pool2",
   "module" : "org.apache.commons:commons-pool2"
 }, {

--- a/metadata/org.apache.commons/commons-dbcp2/2.12.0/index.json
+++ b/metadata/org.apache.commons/commons-dbcp2/2.12.0/index.json
@@ -1,0 +1,3 @@
+[
+  "resource-config.json"
+]

--- a/metadata/org.apache.commons/commons-dbcp2/2.12.0/resource-config.json
+++ b/metadata/org.apache.commons/commons-dbcp2/2.12.0/resource-config.json
@@ -1,0 +1,5 @@
+{
+  "bundles": [
+    {"name": "org.apache.commons.dbcp2.LocalStrings"}
+  ]
+}

--- a/metadata/org.apache.commons/commons-dbcp2/index.json
+++ b/metadata/org.apache.commons/commons-dbcp2/index.json
@@ -1,0 +1,10 @@
+[
+  {
+    "latest": true,
+    "metadata-version": "2.12.0",
+    "module": "org.apache.commons:commons-dbcp2",
+    "tested-versions": [
+      "2.12.0"
+    ]
+  }
+]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -281,6 +281,12 @@
     "versions" : [ "1.23.0" ]
   } ]
 }, {
+  "test-project-path" : "org.apache.commons/commons-dbcp2/2.12.0",
+  "libraries" : [ {
+    "name" : "org.apache.commons:commons-dbcp2",
+    "versions" : [ "2.12.0" ]
+  } ]
+}, {
   "test-project-path" : "org.apache.commons/commons-pool2/2.11.1",
   "libraries" : [ {
     "name" : "org.apache.commons:commons-pool2",

--- a/tests/src/org.apache.commons/commons-dbcp2/2.12.0/.gitignore
+++ b/tests/src/org.apache.commons/commons-dbcp2/2.12.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.commons/commons-dbcp2/2.12.0/build.gradle
+++ b/tests/src/org.apache.commons/commons-dbcp2/2.12.0/build.gradle
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.commons:commons-dbcp2:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'com.h2database:h2:2.3.230'
+}

--- a/tests/src/org.apache.commons/commons-dbcp2/2.12.0/gradle.properties
+++ b/tests/src/org.apache.commons/commons-dbcp2/2.12.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 2.12.0
+metadata.dir = org.apache.commons/commons-dbcp2/2.12.0/

--- a/tests/src/org.apache.commons/commons-dbcp2/2.12.0/settings.gradle
+++ b/tests/src/org.apache.commons/commons-dbcp2/2.12.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.commons.commons-dbcp2_tests'

--- a/tests/src/org.apache.commons/commons-dbcp2/2.12.0/src/test/java/org_apache_commons/commons_dbcp2/CommonsDbcp2Test.java
+++ b/tests/src/org.apache.commons/commons-dbcp2/2.12.0/src/test/java/org_apache_commons/commons_dbcp2/CommonsDbcp2Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_dbcp2;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSourceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsDbcp2Test {
+    private BasicDataSource dataSource;
+    private Connection connection;
+
+    @BeforeEach
+    public void setUp() throws SQLException {
+        Properties properties = new Properties();
+        properties.setProperty("driverClassName", "org.h2.Driver");
+        properties.setProperty("url", "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        properties.setProperty("username", "fred");
+        properties.setProperty("password", "secret");
+        properties.setProperty("initialSize", "2");
+        properties.setProperty("minIdle", "1");
+        properties.setProperty("testOnBorrow", "true");
+        properties.setProperty("testOnConnect", "true");
+        properties.setProperty("validationQuery", "select 1");
+        BasicDataSourceFactory dataSourceFactory = new BasicDataSourceFactory();
+        dataSource = dataSourceFactory.createDataSource(properties);
+        connection = dataSource.getConnection();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        dataSource.close();
+        if (connection != null) {
+            connection.close();
+            connection = null;
+        }
+    }
+
+    @Test
+    void testPreparedStatement() throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE person (id INT NOT NULL, name VARCHAR(255), PRIMARY KEY (id))");
+        }
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO person(id, name) VALUES( ?, ?)")) {
+            preparedStatement.setInt(1, 1);
+            preparedStatement.setString(2, "Elly");
+            int count = preparedStatement.executeUpdate();
+            assertThat(count).isEqualTo(1);
+        }
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT id, name FROM person WHERE name = ?")) {
+            preparedStatement.setString(1, "Elly");
+            try (ResultSet rs = preparedStatement.executeQuery()) {
+                assertThat(rs.next()).isEqualTo(true);
+                assertThat(rs.getInt(1)).isEqualTo(1);
+                assertThat(rs.getString(2)).isEqualTo("Elly");
+                // No more records
+                assertThat(rs.next()).isEqualTo(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds resource-config.json or else resource locales won't be loaded in GraalVM and an error is thrown: 
```
 java.util.MissingResourceException: Can't find bundle for base name org.apache.commons.dbcp2.LocalStrings, locale en_US
```

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)
Using H2 in memory database for the test.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
