### PR TITLE
Add org.thymeleaf.engine.IterationStatusVar

### DIFF
--- a/metadata/org.thymeleaf/thymeleaf/3.1.0.RC1/reflect-config.json
+++ b/metadata/org.thymeleaf/thymeleaf/3.1.0.RC1/reflect-config.json
@@ -404,5 +404,17 @@
     "condition": {
       "typeReachable": "org.thymeleaf.standard.expression.StandardExpressionParser"
     }
+  },
+  {
+    "name": "org.thymeleaf.engine.IterationStatusVar",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true,
+    "condition": {
+      "typeReachable": "org.thymeleaf.standard.expression.OGNLVariableExpressionEvaluator"
+    }
   }
 ]

--- a/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ThymeleafTest.java
+++ b/tests/src/org.thymeleaf/thymeleaf/3.1.0.RC1/src/test/java/org/thymeleaf/ThymeleafTest.java
@@ -185,5 +185,13 @@ public class ThymeleafTest {
         assertThat(output).startsWith("<p>15/06/1981</p>");
     }
 
-
+    @Test
+    void renderIteratorStatus() {
+        TemplateEngine templateEngine = new TemplateEngine();
+        Context context = new Context();
+        context.setVariable("array", new String[] {"one", "two"});
+        String template = "<ul><li th:each=\"v, iterStat:${array}\" th:class=\"${iterStat.odd}? 'odd'\" th:text=\"${v}\">value</li></ul>";
+        String output = templateEngine.process(template, context);
+        assertThat(output).startsWith("<ul><li class=\"odd\">one</li><li>two</li></ul>");
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Add `org.thymeleaf.engine.IterationStatusVar` in Thymeleaf's reflect-config.json.

Ref. https://github.com/thymeleaf/thymeleaf/issues/987

## Code sections where the PR accesses files, network, docker or some external service

- No I/O, just the added unit test.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
