### PR TITLE
Remove confusing example in library-and-framework-list-schema.json

### DIFF
--- a/library-and-framework-list-schema.json
+++ b/library-and-framework-list-schema.json
@@ -15,17 +15,6 @@
             "https://github.com/netty/netty/actions"
           ],
           "test_level": "fully-tested"
-        },
-        {
-          "minimum_version": "2.0",
-          "maximum_version": "4.0",
-          "metadata_locations": [
-            "https://github.com/oracle/graalvm-reachability-metadata/tree/master/metadata/io.netty"
-          ],
-          "tests_locations": [
-            "https://github.com/oracle/graalvm-reachability-metadata/actions"
-          ],
-          "test_level": "community-tested"
         }
       ]
     }


### PR DESCRIPTION
## What does this PR do?

That 2nd details entry in the example was confusing, because if the Native Image config is tracked in this repo vs upstream then that would be tracked in files such as https://github.com/oracle/graalvm-reachability-metadata/blob/master/metadata/io.netty/netty-common/index.json and not in https://github.com/oracle/graalvm-reachability-metadata/blob/master/library-and-framework-list.json which seems to only be when it is in upsteam.

## Checklist before merging
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))