### PR TITLE
Fix typo in the zstd-jni resource config

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.2-5/resource-config.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.2-5/resource-config.json
@@ -6,7 +6,7 @@
         "condition": {
           "typeReachable": "com.github.luben.zstd.util.Native"
         },
-        "pattern": "[a-z]+/[a-z0-9]+/libzstd-jni-[0-9.-]+(so|dll|dylyb)"
+        "pattern": "[a-z]+/[a-z0-9]+/libzstd-jni-[0-9.-]+(so|dll|dylib)"
       }
     ]
   }


### PR DESCRIPTION
MacOS shared objects have `dylib` suffix, not `dylyb`

## What does this PR do?

Fixes a bug


## Code sections where the PR accesses files, network, docker or some external service

none


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
