### PR TITLE
Add metadata for testcontainers:1.19.8

### DIFF
--- a/metadata/org.testcontainers/testcontainers/1.19.8/index.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/index.json
@@ -1,0 +1,5 @@
+[
+  "proxy-config.json",
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.testcontainers/testcontainers/1.19.8/proxy-config.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/proxy-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy"
+    },
+    "interfaces": [
+      "org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy$LibC"
+    ]
+  }
+]

--- a/metadata/org.testcontainers/testcontainers/1.19.8/reflect-config.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/reflect-config.json
@@ -1,0 +1,3759 @@
+[
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CopyArchiveFromContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveServiceCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListSecretsCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ConnectToNetworkCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.PingCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListTasksCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveSwarmNodeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CopyArchiveToContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateSecretCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.UpdateContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectConfigCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListVolumesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListContainersCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListNetworksCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InitializeSwarmCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ContainerDiffCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.UpdateSwarmCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InpectNetworkCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveNetworkCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.PruneCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.KillContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.SearchImagesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InfoCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectExecCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateConfigCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.JoinSwarmCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.SaveImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.SaveImagesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveConfigCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.LeaveSwarmCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListConfigsCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ResizeContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RenameContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateServiceCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.PauseContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.VersionCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateNetworkCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.UpdateSwarmNodeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.TopContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveSecretCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.UpdateServiceCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RestartContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.StopContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.StartContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.TagImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.DisconnectFromNetworkCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListServicesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.UnpauseContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CopyFileFromContainerCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectSwarmNodeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListImagesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectServiceCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectVolumeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ListSwarmNodesCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.LoadImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectSwarmCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ResizeExecCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateImageCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateVolumeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.CommitCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.RemoveVolumeCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.AuthCmdImpl",
+        "allDeclaredFields": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.NetworkSettings",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Node",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceUpdateStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Link",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectExecResponse$Container",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmOrchestration",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceReplicatedModeOptions",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.UpdateConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.NetworkAttachmentConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Ulimit",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PidsStatsConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.HealthStateLog",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResponseItem$AuxDetail",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BlkioWeightDevice",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ConfigSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.AuthConfigurations",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerNetworkSettings",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.DeviceRequest",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Secret",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecPrivileges",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse$Mount",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.TopContainerResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectExecResponse$ProcessConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeEngineDescription",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerNetwork$Ipam",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ExternalCA",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.EventActor",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Statistics",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Endpoint",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecSecret",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodePlatform",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.WaitResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.InfoRegistryConfig$IndexConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerMount",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResponseItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecFile",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Version",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.DriverStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmVersion",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateVolumeResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Device",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResourceSpecs",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodePluginDescription",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ObjectVersion",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResourceVersion",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateSecretResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse$Node",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.TmpfsOptions",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.ExecCreateCmdResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.EndpointVirtualIP",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNode",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.StatisticNetworksConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BlkioStatEntry",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Service",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerHostConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectImageResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ThrottlingDataConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.MemoryStatsConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse$ContainerState",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.HealthState",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.GraphData",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectExecResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ClusterInfo",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ErrorDetail",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceRestartPolicy",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.VersionPlatform",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmCAConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeResources",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.VolumeBind",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Network",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Network$Ipam",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.StatsConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.TaskDefaults",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeVersion",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.InfoRegistryConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerNetwork",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResponseItem$ProgressDetail",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Ports$Binding",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateContainerResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Task",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PortConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceGlobalModeOptions",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateImageResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Container",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateConfigResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Mount",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PeerNode",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmJoinTokens",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SecretSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.TaskSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateNetworkResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.ListVolumesResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServicePlacement",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmDispatcherConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Network$ContainerNetworkConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PortBinding",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Identifier",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BlkioStatsConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResourceRequirements",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ResponseItem$ErrorDetail",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Network$Ipam$Config",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeManagerStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmNodeDescription",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SearchItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.EndpointSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.RestartPolicy",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.RuntimeInfo",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.InspectVolumeResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.TaskStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.HealthCheck",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Config",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerPort",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Repository",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmInfo",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.CreateServiceResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Info",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ChangeLog",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Bind",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.VolumeOptions",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ServiceModeConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.VersionComponent",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.TaskStatusContainerStatus",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.GraphDriver",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Frame",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BindOptions",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.command.RootFS",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Driver",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BlkioRateDevice",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Event",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecPrivilegesSELinuxContext",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.LogConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.CpuUsageConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerDNSConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.CpuStatsConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.AuthResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Image",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.SwarmRaftConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecPrivilegesCredential",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.ContainerSpecConfig",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.LxcConf",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PruneResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.NamedResourceSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.DiscreteResourceSpec",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.BuildResponseItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PullResponseItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.PushResponseItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.UpdateContainerResponse",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.LoadResponseItem",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "name": "com.github.dockerjava.api.model.Swarm",
+        "allDeclaredFields": true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory"
+        },
+        "name": "org.testcontainers.shaded.org.hamcrest.TypeSafeMatcher",
+        "allDeclaredMethods": true
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.Capability;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.BeanSerializerFactory"
+        }
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.Device;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.BeanSerializerFactory"
+        }
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.LxcConf;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.BeanSerializerFactory"
+        }
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.Ulimit;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.BeanSerializerFactory"
+        }
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.VolumesFrom;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer"
+        }
+    },
+    {
+        "name": "[Lcom.github.dockerjava.api.model.VolumesFrom;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.BeanSerializerFactory"
+        }
+    },
+    {
+        "name": "[Ljava.lang.String;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.StringArrayDeserializer"
+        }
+    },
+    {
+        "name": "[Ljava.lang.String;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        }
+    },
+    {
+        "name": "[Lorg.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ArrayBuilders"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.AsyncDockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.CreateContainerResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.CreateContainerResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.CreateContainerResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.CreateContainerResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "setId",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            },
+            {
+                "name": "setWarnings",
+                "parameterTypes": [
+                    "java.lang.String[]"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.DockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.DockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.ExecCreateCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.ExecCreateCmdResponse",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.ExecStartCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.GraphData",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.GraphData",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectImageCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.GraphDriver",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.GraphDriver",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectImageCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectContainerResponse$ContainerState",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "com.github.dockerjava.api.command.InspectContainerResponse"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectExecResponse",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectExecCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectExecResponse$Container",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectExecCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "queryAllPublicConstructors": true
+    },
+    {
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectExecCmdExec"
+        },
+        "queryAllDeclaredConstructors": true,
+        "queryAllPublicConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "com.github.dockerjava.api.command.InspectExecResponse"
+                ]
+            }
+        ],
+        "name": "com.github.dockerjava.api.command.InspectExecResponse$ProcessConfig",
+        "queryAllDeclaredMethods": true,
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectImageResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectImageResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectImageResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectImageCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.InspectImageResponse",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectImageCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.RootFS",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.RootFS",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.RootFS",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectImageCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.command.RootFS",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectImageCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.command.SyncDockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.DockerClientProviderStrategy"
+        },
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.TestcontainersHostPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "getAuth",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getEmail",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getIdentitytoken",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPassword",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getRegistryAddress",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getRegistrytoken",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getStackOrchestrator",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getUsername",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.AbstrDockerCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.AuthConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Binds",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Binds",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Binds",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.StdValueInstantiator"
+        },
+        "methods": [
+            {
+                "name": "fromPrimitive",
+                "parameterTypes": [
+                    "java.lang.String[]"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Binds",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Binds",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "toPrimitive",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ClusterInfo",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ContainerConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ContainerConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectImageCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ContainerNetwork",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.DockerClientProviderStrategy"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.TestcontainersHostPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.DeserializationContext"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.CollectionDeserializer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.AnyGetterWriter"
+        },
+        "methods": [
+            {
+                "name": "getRawValues",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.AbstrDockerCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectExecCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.DockerObject",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ListImagesCmdExec"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Driver",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPort",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.DeserializationContext"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPort",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BasicDeserializerFactory"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPort",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.DeserializerCache"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPort",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPort",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.introspect.BasicBeanDescription"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPorts",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPorts",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPorts",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerBase"
+        },
+        "methods": [
+            {
+                "name": "fromPrimitive",
+                "parameterTypes": [
+                    "java.util.Map"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPorts",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExposedPorts",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "toPrimitive",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExternalCA",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ExternalCAProtocol",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "getAutoRemove",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioDeviceReadBps",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioDeviceReadIOps",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioDeviceWriteBps",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioDeviceWriteIOps",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioWeight",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getBlkioWeightDevice",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCapAdd",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCapDrop",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCgroup",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCgroupParent",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCgroupnsMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getConsoleSize",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getContainerIDFile",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuCount",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuPercent",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuPeriod",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuQuota",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuRealtimePeriod",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuRealtimeRuntime",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpuShares",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpusetCpus",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getCpusetMems",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDeviceCgroupRules",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDeviceRequests",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDevices",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDiskQuota",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDns",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDnsOptions",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getDnsSearch",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getExtraHosts",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getGroupAdd",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getInit",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getIoMaximumBandwidth",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getIoMaximumIOps",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getIpcMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getIsolation",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getKernelMemory",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getLxcConf",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getMemory",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getMemoryReservation",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getMemorySwap",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getMemorySwappiness",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getMounts",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getNanoCPUs",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getNetworkMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getOomKillDisable",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getOomScoreAdj",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPidMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPidsLimit",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPortBindings",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPrivileged",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPublishAllPorts",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getReadonlyRootfs",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getRestartPolicy",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getRuntime",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getSecurityOpts",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getShmSize",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getStorageOpt",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getSysctls",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getTmpFs",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getUlimits",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getUsernsMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getUtSMode",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getVolumeDriver",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getVolumesFrom",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.HostConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Image",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ListImagesCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Info",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.InfoRegistryConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.InfoRegistryConfig$IndexConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Isolation",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "fromValue",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Links",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Links",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Links",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Links",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "toPrimitive",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.LocalNodeState",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "forValue",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.LogConfig",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "setType",
+                "parameterTypes": [
+                    "com.github.dockerjava.api.model.LogConfig$LoggingType"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.LogConfig$LoggingType",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "fromValue",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.NetworkSettings",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.PeerNode",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Ports",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Ports",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Ports",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Ports",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "toPrimitive",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Ports",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "fromPrimitive",
+                "parameterTypes": [
+                    "java.util.Map"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.ResourceVersion",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.RestartPolicy",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InspectContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.RuntimeInfo",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "setPath",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmCAConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmDispatcherConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmInfo",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmOrchestration",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmRaftConfig",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.SwarmSpec",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.TaskDefaults",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.InfoCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Version",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Version",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.VersionCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.VersionComponent",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.VersionComponent",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.VersionCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.VersionPlatform",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.DockerClientFactory"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "com.github.dockerjava.api.model.VersionPlatform",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.VersionCmdExec"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Volume",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Volumes",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Volumes",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Volumes",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
+        }
+    },
+    {
+        "name": "com.github.dockerjava.api.model.Volumes",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateContainerCmdExec"
+        },
+        "methods": [
+            {
+                "name": "toPrimitive",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.dockerclient.UnixSocketClientProviderStrategy",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.DockerClientProviderStrategy"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7Support"
+        },
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.DockerClientProviderStrategy"
+        },
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.dockerclient.TestcontainersHostPropertyClientProviderStrategy"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "setAuths",
+                "parameterTypes": [
+                    "java.util.Map"
+                ]
+            },
+            {
+                "name": "setCurrentContext",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints$Docker",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints$Docker",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints$Docker",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
+        },
+        "allDeclaredFields": true,
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrAsyncDockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true,
+        "methods": [
+            {
+                "name": "getContainerId",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getEnv",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getPrivileged",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getUser",
+                "parameterTypes": [
+                    
+                ]
+            },
+            {
+                "name": "getWorkingDir",
+                "parameterTypes": [
+                    
+                ]
+            }
+        ]
+    },
+    {
+        "name": "org.testcontainers.shaded.com.github.dockerjava.core.command.ExecStartCmdImpl",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"
+        },
+        "allDeclaredFields": true,
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.org.hamcrest.TypeSafeMatcher"
+        }
+    },
+    {
+        "name": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.org.hamcrest.internal.ReflectiveTypeFinder"
+        }
+    },
+    {
+        "name": "java.util.HashMap",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"
+        },
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "java.util.LinkedHashMap",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"
+        },
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "java.util.LinkedHashMap",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer"
+        }
+    },
+    {
+        "name": "java.util.ArrayList",
+        "queryAllDeclaredMethods": true,
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"
+        },
+        "queryAllDeclaredConstructors": true
+    },
+    {
+        "name": "java.util.ArrayList",
+        "condition": {
+            "typeReachable": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BasicDeserializerFactory"
+        }
+    }
+]

--- a/metadata/org.testcontainers/testcontainers/1.19.8/resource-config.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/resource-config.json
@@ -1,0 +1,15 @@
+{
+    "resources": {
+        "includes": [
+            {
+                "pattern": "\\QMETA-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy\\E",
+                "condition": {
+                    "typeReachable": "org.testcontainers.DockerClientFactory"
+                }
+            }
+        ]
+    },
+    "bundles": [
+        
+    ]
+}

--- a/metadata/org.testcontainers/testcontainers/index.json
+++ b/metadata/org.testcontainers/testcontainers/index.json
@@ -1,6 +1,13 @@
 [
   {
     "latest": true,
+    "metadata-version": "1.19.8",
+    "module": "org.testcontainers:testcontainers",
+    "tested-versions": [
+      "1.19.8"
+    ]
+  },
+  {
     "metadata-version": "1.17.6",
     "module": "org.testcontainers:testcontainers",
     "tested-versions": [

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -599,6 +599,12 @@
     "versions" : [ "1.17.6" ]
   } ]
 }, {
+  "test-project-path" : "org.testcontainers/testcontainers/1.19.8",
+  "libraries" : [ {
+    "name" : "org.testcontainers:testcontainers",
+    "versions" : [ "1.19.8" ]
+  } ]
+}, {
   "test-project-path" : "org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1",
   "libraries" : [ {
     "name" : "org.thymeleaf.extras:thymeleaf-extras-springsecurity6",

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/.gitignore
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/README.md
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/README.md
@@ -1,0 +1,30 @@
+# Testcontainers metadata
+
+Run the `main` method and merge it together with the agent-generated `reflect-config.json`. Additionally, this has to
+be added:
+
+```json
+{
+  "condition": {
+    "typeReachable": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory"
+  },
+  "name": "org.testcontainers.shaded.org.hamcrest.TypeSafeMatcher",
+  "allDeclaredMethods": true
+}
+```
+
+This has to be put in the `proxy-config.json`:
+
+```json
+[
+  {
+    "condition": {
+      "typeReachable": "org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy"
+    },
+    "interfaces": [
+      "org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy$LibC"
+    ]
+  }
+]
+
+```

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/build.gradle
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    implementation('org.reflections:reflections:0.10.2')
+    implementation "org.testcontainers:testcontainers:$libraryVersion"
+    runtimeOnly "org.slf4j:slf4j-simple:1.7.36"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.testcontainers/testcontainers")
+        }
+    }
+}

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/gradle.properties
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 1.19.8
+metadata.dir = org.testcontainers/testcontainers/1.19.8/

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/required-docker-images.txt
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/required-docker-images.txt
@@ -1,0 +1,1 @@
+nginx:1-alpine-slim

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/settings.gradle
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.testcontainers.testcontainers_tests'

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/java/org_testcontainers/testcontainers/FindJsonSerialization.java
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/java/org_testcontainers/testcontainers/FindJsonSerialization.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_testcontainers.testcontainers;
+
+import com.github.dockerjava.api.model.DockerObject;
+import org.reflections.Reflections;
+import org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import static org.reflections.scanners.Scanners.SubTypes;
+
+class FindJsonSerialization {
+    public static void main(String[] args) throws IOException {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "off");
+
+        printClasses(new Reflections("org.testcontainers"), AbstrDockerCmd.class, "/DockerCommand-template.txt");
+        printClasses(new Reflections("com.github.dockerjava.api"), DockerObject.class, "/DockerObject-template.txt");
+    }
+
+    private static void printClasses(Reflections reflections, Class<?> baseClass, String template) throws IOException {
+        Set<Class<?>> subTypes = reflections.get(SubTypes.of(baseClass).asClass());
+        String loadedTemplate = loadTemplate(template);
+
+        for (Class<?> subType : subTypes) {
+            if (!Modifier.isPublic(subType.getModifiers()) || subType.isInterface() || Modifier.isAbstract(subType.getModifiers())) {
+                continue;
+            }
+            System.out.printf(loadedTemplate, subType.getName());
+        }
+    }
+
+    private static String loadTemplate(String resource) throws IOException {
+        try (InputStream stream = FindJsonSerialization.class.getResourceAsStream(resource)) {
+            if (stream == null) {
+                throw new IOException(String.format("Resource '%s' not found", resource));
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/resources/DockerCommand-template.txt
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/resources/DockerCommand-template.txt
@@ -1,0 +1,7 @@
+{
+  "condition": {
+    "typeReachable": "org.testcontainers.DockerClientFactory"
+  },
+  "name": "%s",
+  "allDeclaredFields": true
+},

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/resources/DockerObject-template.txt
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/main/resources/DockerObject-template.txt
@@ -1,0 +1,8 @@
+{
+  "condition": {
+    "typeReachable": "org.testcontainers.DockerClientFactory"
+  },
+  "name": "%s",
+  "allDeclaredFields": true,
+  "allDeclaredConstructors": true
+},

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_testcontainers.testcontainers;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// This test is pulling testcontainers/ryuk docker image version with many known vulnerabilities. It should be ignored until testcontainers change this image.
+// ISSUE: https://github.com/oracle/graalvm-reachability-metadata/issues/250
+class TestcontainersTest {
+    private static final boolean DEBUG = false;
+
+    // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
+    // tests should be disabled until testconatiners/ryuk is fixed
+    private static final boolean IS_DISABLED = true;
+
+    @BeforeAll
+    static void beforeAll() {
+        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
+        if (IS_DISABLED) {
+            return;
+        }
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", DEBUG ? "debug" : "warn");
+    }
+
+    @Test
+    void test() throws Exception {
+        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
+        if (IS_DISABLED) {
+            return;
+        }
+
+        try (GenericContainer<?> nginx = new GenericContainer<>("nginx:1-alpine-slim")) {
+            nginx.withExposedPorts(80).start();
+            HttpClient httpClient = HttpClient.newBuilder().build();
+            String url = String.format("http://%s:%d", nginx.getHost(), nginx.getFirstMappedPort());
+            HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder().GET().uri(URI.create(url)).build(), HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains("<h1>Welcome to nginx!</h1>");
+        }
+    }
+}

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/user-code-filter.json
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.testcontainers.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Adds support for Testcontainers `1.19.8` and up, used by the current Spring Boot `3.3.x` line. Reuses #132 + #301 and upgrades the version.

Closes #492.

## Code sections where the PR accesses files, network, docker or some external service

Tests are not enabled, same as current tests for Testcontainers `1.17.6` because it pulls a docker image with critical CVEs.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
