### PR TITLE
Add GitHub Action for Scheduled Releases

### DIFF
--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -59,7 +59,7 @@ jobs:
           echo "CURRENT_RELEASE_TAG=$CURRENT_RELEASE_TAG" >> ${GITHUB_ENV}
       - name: "⬆️ Update version"
         run: |
-          sed -i "s/project.version(\"0.3.10-SNAPSHOT\")/project.version(\"${{ env.CURRENT_RELEASE_TAG }}\")/g" build.gradle
+          sed -i "s/project.version(\"1.0.0-SNAPSHOT\")/project.version(\"${{ env.CURRENT_RELEASE_TAG }}\")/g" build.gradle
       - name: "🔍 Run spotless check"
         run: |
           ./gradlew spotlessCheck

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -1,0 +1,78 @@
+name: "Create scheduled release"
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+    - cron: "0 0 15 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  get-changed-metadata:
+    name: "📋 Get a list of changed metadata"
+    runs-on: "ubuntu-20.04"
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      none-found: ${{ steps.set-matrix.outputs.none-found }}
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "🔧 Setup java"
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'oracle'
+          java-version: '17'
+      - name: "🕸️ Get changed metadata matrix"
+        id: set-matrix
+        run: |
+          LATEST_TAG=$(ls -1 .git/refs/tags/ | sort -V | tail -1)
+          ./gradlew generateMatrixDiffCoordinates -PbaseCommit=$(git show-ref -s $LATEST_TAG) -PnewCommit=$(git rev-parse HEAD)
+
+  release:
+    needs: get-changed-metadata
+    if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
+    name: "🚀 Create a release"
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "🔧 Setup java"
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'graalvm'
+          java-version: '17'
+      - name: "⬆️ Update version"
+        run: |
+          PREVIOUS_RELEASE_TAG=$(ls -1 .git/refs/tags/ | sort -V | tail -1)
+          echo "PREVIOUS_RELEASE_TAG=$PREVIOUS_RELEASE_TAG" >> ${GITHUB_ENV}
+          
+          CURRENT_RELEASE_TAG=$(sed -E 's/^([0-9]+\.)([0-9]+\.)([0-9]+)/echo \1\2$((\3+1))/e' <<< $PREVIOUS_RELEASE_TAG)
+          echo "CURRENT_RELEASE_TAG=$CURRENT_RELEASE_TAG" >> ${GITHUB_ENV}
+          
+          sed -i "s/project.version(\"0.3.10-SNAPSHOT\")/project.version(\"$CURRENT_RELEASE_TAG\")/g" build.gradle
+      - name: "📄 Commit changes"
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+          git add .
+          git commit -m "Release version ${{ env.CURRENT_RELEASE_TAG }}"
+          git tag ${{ env.CURRENT_RELEASE_TAG }}
+          git push origin ${{ env.CURRENT_RELEASE_TAG }}
+      - name: "🔍 Run spotless check"
+        run: |
+          ./gradlew spotlessCheck
+      - name: "🏭 Generate release artifacts"
+        run: |
+          ./gradlew package
+      - name: "📝 Publish a release"
+        run: |
+          gh release create ${{ env.CURRENT_RELEASE_TAG }} build/graalvm-reachability-metadata-*.zip --generate-notes --notes-start-tag ${{ env.PREVIOUS_RELEASE_TAG }}

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'oracle'
-          java-version: '17'
+          java-version: '21'
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
         run: |
@@ -49,16 +49,23 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'graalvm'
-          java-version: '17'
-      - name: "⬆️ Update version"
+          java-version: '21'
+      - name: "Get tags"
         run: |
           PREVIOUS_RELEASE_TAG=$(ls -1 .git/refs/tags/ | sort -V | tail -1)
           echo "PREVIOUS_RELEASE_TAG=$PREVIOUS_RELEASE_TAG" >> ${GITHUB_ENV}
-          
+
           CURRENT_RELEASE_TAG=$(sed -E 's/^([0-9]+\.)([0-9]+\.)([0-9]+)/echo \1\2$((\3+1))/e' <<< $PREVIOUS_RELEASE_TAG)
           echo "CURRENT_RELEASE_TAG=$CURRENT_RELEASE_TAG" >> ${GITHUB_ENV}
-          
-          sed -i "s/project.version(\"0.3.10-SNAPSHOT\")/project.version(\"$CURRENT_RELEASE_TAG\")/g" build.gradle
+      - name: "⬆️ Update version"
+        run: |
+          sed -i "s/project.version(\"0.3.10-SNAPSHOT\")/project.version(\"${{ env.CURRENT_RELEASE_TAG }}\")/g" build.gradle
+      - name: "🔍 Run spotless check"
+        run: |
+          ./gradlew spotlessCheck
+      - name: "🏭 Generate release artifacts"
+        run: |
+          ./gradlew package
       - name: "📄 Commit changes"
         run: |
           git config --local user.email "actions@github.com"
@@ -67,12 +74,6 @@ jobs:
           git commit -m "Release version ${{ env.CURRENT_RELEASE_TAG }}"
           git tag ${{ env.CURRENT_RELEASE_TAG }}
           git push origin ${{ env.CURRENT_RELEASE_TAG }}
-      - name: "🔍 Run spotless check"
-        run: |
-          ./gradlew spotlessCheck
-      - name: "🏭 Generate release artifacts"
-        run: |
-          ./gradlew package
       - name: "📝 Publish a release"
         run: |
           gh release create ${{ env.CURRENT_RELEASE_TAG }} build/graalvm-reachability-metadata-*.zip --generate-notes --notes-start-tag ${{ env.PREVIOUS_RELEASE_TAG }}

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
         run: |
-          LATEST_TAG=$(ls -1 .git/refs/tags/ | sort -V | tail -1)
+          LATEST_TAG=$(git tag --list | sort -V | tail -1)
           ./gradlew generateMatrixDiffCoordinates -PbaseCommit=$(git show-ref -s $LATEST_TAG) -PnewCommit=$(git rev-parse HEAD)
 
   release:
@@ -52,7 +52,7 @@ jobs:
           java-version: '21'
       - name: "Get tags"
         run: |
-          PREVIOUS_RELEASE_TAG=$(ls -1 .git/refs/tags/ | sort -V | tail -1)
+          PREVIOUS_RELEASE_TAG=$(git tag --list | sort -V | tail -1)
           echo "PREVIOUS_RELEASE_TAG=$PREVIOUS_RELEASE_TAG" >> ${GITHUB_ENV}
 
           CURRENT_RELEASE_TAG=$(sed -E 's/^([0-9]+\.)([0-9]+\.)([0-9]+)/echo \1\2$((\3+1))/e' <<< $PREVIOUS_RELEASE_TAG)

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "🔧 Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'graalvm'
           java-version: '21'
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
     }
 }
 
-project.version("0.3.10-SNAPSHOT")
+project.version("1.0.0-SNAPSHOT")
 
 // gradle check
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ allprojects {
     }
 }
 
+// NOTE: this version serves only as a placeholder and will be overridden by the CI when creating a new release
 project.version("1.0.0-SNAPSHOT")
 
 // gradle check

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What does this PR do?
This PR introduces github workflow that creates automatic releases. The github action defined in workflow runs every two weeks.  

To make sure this PR works, we must have fixed `SNAPSHOT` version on master. Otherwise the process can't be fully automated and some steps may require manual maintainer inputs (since the master branch has protection rules that disallows direct committing onto it). With the fixed `SNAPSHOT` version on master, we are avoiding direct committing onto the protected master branch. 