### PR TITLE
Re-enable testcontainers tests

### DIFF
--- a/tests/src/org.testcontainers/testcontainers/1.17.6/required-docker-images.txt
+++ b/tests/src/org.testcontainers/testcontainers/1.17.6/required-docker-images.txt
@@ -1,1 +1,2 @@
 nginx:1-alpine-slim
+testcontainers/ryuk:0.10.2

--- a/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
+++ b/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
@@ -17,31 +17,16 @@ import java.net.http.HttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// This test is pulling testcontainers/ryuk docker image version with many known vulnerabilities. It should be ignored until testcontainers change this image.
-// ISSUE: https://github.com/oracle/graalvm-reachability-metadata/issues/250
 class TestcontainersTest {
     private static final boolean DEBUG = false;
 
-    // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-    // tests should be disabled until testconatiners/ryuk is fixed
-    private static final boolean IS_DISABLED = true;
-
     @BeforeAll
     static void beforeAll() {
-        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-        if (IS_DISABLED) {
-            return;
-        }
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", DEBUG ? "debug" : "warn");
     }
 
     @Test
     void test() throws Exception {
-        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-        if (IS_DISABLED) {
-            return;
-        }
-
         try (GenericContainer<?> nginx = new GenericContainer<>("nginx:1-alpine-slim")) {
             nginx.withExposedPorts(80).start();
             HttpClient httpClient = HttpClient.newBuilder().build();

--- a/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/resources/META-INF/native-image/org/testcontainers/testcontainers/test/resource-config.json
+++ b/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/resources/META-INF/native-image/org/testcontainers/testcontainers/test/resource-config.json
@@ -1,0 +1,10 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qtestcontainers.properties\\E"
+      }
+    ]
+  }
+}

--- a/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/resources/testcontainers.properties
+++ b/tests/src/org.testcontainers/testcontainers/1.17.6/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.10.2

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/required-docker-images.txt
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/required-docker-images.txt
@@ -1,1 +1,2 @@
 nginx:1-alpine-slim
+testcontainers/ryuk:0.10.2

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/java/org_testcontainers/testcontainers/TestcontainersTest.java
@@ -17,31 +17,16 @@ import java.net.http.HttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// This test is pulling testcontainers/ryuk docker image version with many known vulnerabilities. It should be ignored until testcontainers change this image.
-// ISSUE: https://github.com/oracle/graalvm-reachability-metadata/issues/250
 class TestcontainersTest {
     private static final boolean DEBUG = false;
 
-    // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-    // tests should be disabled until testconatiners/ryuk is fixed
-    private static final boolean IS_DISABLED = true;
-
     @BeforeAll
     static void beforeAll() {
-        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-        if (IS_DISABLED) {
-            return;
-        }
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", DEBUG ? "debug" : "warn");
     }
 
     @Test
     void test() throws Exception {
-        // DO NOT REMOVE THIS! READ THE COMMENT ABOVE THE CLASS
-        if (IS_DISABLED) {
-            return;
-        }
-
         try (GenericContainer<?> nginx = new GenericContainer<>("nginx:1-alpine-slim")) {
             nginx.withExposedPorts(80).start();
             HttpClient httpClient = HttpClient.newBuilder().build();

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/resources/META-INF/native-image/org/testcontainers/testcontainers/test/resource-config.json
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/resources/META-INF/native-image/org/testcontainers/testcontainers/test/resource-config.json
@@ -1,0 +1,10 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qtestcontainers.properties\\E"
+      }
+    ]
+  }
+}

--- a/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/resources/testcontainers.properties
+++ b/tests/src/org.testcontainers/testcontainers/1.19.8/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.10.2


### PR DESCRIPTION
## What does this PR do?

Re-enable `Testcontainers` tests using the latest Ryuk image, `v0.10.2`, which does not package vulnerabilities - added it to the allow-list in #547 

There is one separate commit for each testcontainers version.

Closes #250 .

## Code sections where the PR accesses files, network, docker or some external service

Both tests now access Docker; the `testcontainers/ryuk:0.10.2` image has been added to the list of required images.


## Checklist before merging

- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)

Not applicable:

- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))