### PR TITLE
Missing resource for Testcontainers

### DIFF
--- a/metadata/org.testcontainers/testcontainers/1.19.8/resource-config.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/resource-config.json
@@ -6,6 +6,12 @@
                 "condition": {
                     "typeReachable": "org.testcontainers.DockerClientFactory"
                 }
+            },
+            {
+                "pattern": "\\Qorg/testcontainers/utility/ResourceReaper.class\\E",
+                "condition": {
+                    "typeReachable": "org.testcontainers.DockerClientFactory"
+                }
             }
         ]
     },


### PR DESCRIPTION
## What does this PR do?

Testcontainers uses `ResourceReaper.class` as a resource. When I run testcontainers with GraalVM I get following exception:
```
Caused by: java.lang.IllegalArgumentException: Resource with path 
org/testcontainers/utility/ResourceReaper.class 
could not be found on any of these classloaders: 
[jdk.internal.loader.ClassLoaders$AppClassLoader@2f7c7260]
  org.testcontainers.utility.MountableFile.getClasspathResource(MountableFile.java:158)
  org.testcontainers.utility.MountableFile.forClasspathResource(MountableFile.java:103)
  org.testcontainers.utility.MountableFile.forClasspathResource(MountableFile.java:72)
  org.testcontainers.DockerClientFactory.checkMountableFile(DockerClientFactory.java:274)
  org.testcontainers.DockerClientFactory.isFileMountingSupported(DockerClientFactory.java:97)
  [...]
```

## Code sections where the PR accesses files, network, docker or some external service
It starts here:
https://github.com/testcontainers/testcontainers-java/blob/main/core/src/main/java/org/testcontainers/DockerClientFactory.java#L288


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
