### PR TITLE
Allow Flyway 10.20 to load its LogCreator implementations reflectively

### DIFF
--- a/metadata/org.flywaydb/flyway-core/10.20.0/reflect-config.json
+++ b/metadata/org.flywaydb/flyway-core/10.20.0/reflect-config.json
@@ -147,6 +147,27 @@
     ]
   },
   {
+    "name": "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator",
+    "condition": {
+      "typeReachable": "org.apache.commons.logging.Log"
+    },
+    "allPublicConstructors": true
+  },
+  {
+    "name": "org.flywaydb.core.internal.logging.log4j2.Log4j2LogCreator",
+    "condition": {
+      "typeReachable": "org.apache.logging.log4j.Logger"
+    },
+    "allPublicConstructors": true
+  },
+  {
+    "name": "org.flywaydb.core.internal.logging.slf4j.Slf4jLogCreator",
+    "condition": {
+      "typeReachable": "org.slf4j.Logger"
+    },
+    "allPublicConstructors": true
+  },
+  {
     "name": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub",
     "condition": {
       "typeReachable": "org.flywaydb.core.api.configuration.ClassicConfiguration"


### PR DESCRIPTION
## What does this PR do?

Adds metadata for Flyway's `LogCreator` implementations that it loads using reflection. This brings the metadata for Flyway 10.20 into line with the metadata for earlier versions.

## Code sections where the PR accesses files, network, docker or some external service

None.


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
