### PR TITLE
Fix tests for Flyway to generate correct reflection metadata

### DIFF
--- a/metadata/org.flywaydb/flyway-core/10.20.0/reflect-config.json
+++ b/metadata/org.flywaydb/flyway-core/10.20.0/reflect-config.json
@@ -147,6 +147,45 @@
     ]
   },
   {
+    "name": "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator",
+    "condition": {
+      "typeReachable": "org.flywaydb.core.internal.util.ClassUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.flywaydb.core.internal.logging.log4j2.Log4j2LogCreator",
+    "condition": {
+      "typeReachable": "org.flywaydb.core.internal.util.ClassUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.flywaydb.core.internal.logging.slf4j.Slf4jLogCreator",
+    "condition": {
+      "typeReachable": "org.flywaydb.core.internal.util.ClassUtils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub",
     "condition": {
       "typeReachable": "org.flywaydb.core.api.configuration.ClassicConfiguration"

--- a/tests/src/org.flywaydb/flyway-core/10.20.0/build.gradle
+++ b/tests/src/org.flywaydb/flyway-core/10.20.0/build.gradle
@@ -12,9 +12,12 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.flywaydb:flyway-core:$libraryVersion"
-    testImplementation 'com.h2database:h2:2.1.210'
+    testImplementation 'com.h2database:h2:2.2.224'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:2.0.16'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-api:2.24.1'
+    testRuntimeOnly 'commons-logging:commons-logging:1.3.4'
 }
 
 graalvmNative {

--- a/tests/src/org.flywaydb/flyway-core/10.20.0/src/test/java/flyway/FlywayTests.java
+++ b/tests/src/org.flywaydb/flyway-core/10.20.0/src/test/java/flyway/FlywayTests.java
@@ -28,7 +28,8 @@ public class FlywayTests {
         Configuration configuration = new FluentConfiguration()
                 .dataSource(dataSource)
                 .encoding(StandardCharsets.UTF_8)
-                .resourceProvider(new FixedResourceProvider());
+                .resourceProvider(new FixedResourceProvider())
+                .loggers("slf4j", "log4j2", "apache-commons");
 
         Flyway flyway = new Flyway(configuration);
         MigrateResult migration = flyway.migrate();


### PR DESCRIPTION
This fixes the test which we use to generate the metadata for flyway. It also adds the entries found missing by @wilkinsona in https://github.com/oracle/graalvm-reachability-metadata/pull/556. This supersedes https://github.com/oracle/graalvm-reachability-metadata/pull/556.