### PR TITLE
Fix MySQL metadata when prepared statement caching is enabled

### DIFF
--- a/metadata/com.mysql/mysql-connector-j/8.0.31/reflect-config.json
+++ b/metadata/com.mysql/mysql-connector-j/8.0.31/reflect-config.json
@@ -120,6 +120,13 @@
   },
   {
     "condition": {
+      "typeReachable": "com.mysql.cj.jdbc.ConnectionImpl"
+    },
+    "allPublicConstructors": true,
+    "name": "com.mysql.cj.PerConnectionLRUFactory"
+  },
+  {
+    "condition": {
       "typeReachable": "com.mysql.cj.protocol.ExportControlled"
     },
     "allPublicConstructors": true,

--- a/tests/src/com.mysql/mysql-connector-j/8.0.31/src/test/java/mysql/MySQLTests.java
+++ b/tests/src/com.mysql/mysql-connector-j/8.0.31/src/test/java/mysql/MySQLTests.java
@@ -20,9 +20,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * This test uses docker to start a MySQL database to test against.
@@ -40,9 +43,14 @@ public class MySQLTests {
     private static Process process;
 
     private static Connection openConnection() throws SQLException {
+        return openConnection(Collections.emptyMap());
+    }
+
+    private static Connection openConnection(Map<String, String> additionalProperties) throws SQLException {
         Properties props = new Properties();
         props.setProperty("user", USERNAME);
         props.setProperty("password", PASSWORD);
+        props.putAll(additionalProperties);
         return DriverManager.getConnection(JDBC_URL, props);
     }
 
@@ -139,4 +147,10 @@ public class MySQLTests {
             }
         }
     }
+
+    @Test
+    void preparedStatementCaching() {
+        assertThatNoException().isThrownBy(() -> openConnection(Map.of("cachePrepStmts", "true")).close());
+    }
+
 }


### PR DESCRIPTION
Fixes gh-549

## What does this PR do?

Fixes the MySQL metadata to avoid a failure when `cachePrepStmts` is `true`.

## Code sections where the PR accesses files, network, docker or some external service

The newly added test uses Docker, but only in the same way as the existing tests.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
