### PR TITLE
Add 'default-for' entries for Flyway

### DIFF
--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -10,6 +10,7 @@
   {
     "metadata-version": "10.15.0",
     "module": "org.flywaydb:flyway-core",
+    "default-for": "10\\.(15|16|17|18|19)\\..*",
     "tested-versions": [
       "10.15.0"
     ]
@@ -17,12 +18,14 @@
   {
     "metadata-version": "10.10.0",
     "module": "org.flywaydb:flyway-core",
+    "default-for": "10\\.(0|1|2|3|4|5|6|7|8|9|10|11|12|13|14)\\..*",
     "tested-versions": [
       "10.10.0"
     ]
   },
   {
     "metadata-version": "9.0.1",
+    "default-for": "9\\..*",
     "module": "org.flywaydb:flyway-core",
     "tested-versions": [
       "9.0.1"


### PR DESCRIPTION
## What does this PR do?

Adds `default-for` entries for Flyway:

* `9.0.1` to be use for all `9.x`
* `10.10.0` for `10.0.x` to `10.14.x`
* `10.15.0` for `10.15.x` to `10.19.x`
* `10.20.0` for `10.20.0` and all subsequent versions