### PR TITLE
Update test and metadata locations for iText Core modules and iText add-ons

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -501,7 +501,7 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/barcodes/src/test"
         ]
       }
     ]
@@ -514,7 +514,8 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/test",
+          "https://github.com/itext/itext-java/tree/develop/sign/src/test"
         ]
       }
     ]
@@ -528,20 +529,8 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
-        ]
-      }
-    ]
-  },
-  {
-    "artifact": "com.itextpdf:bouncy-castle-fips-adapter",
-    "details": [
-      {
-        "minimum_version": "8.0.4",
-        "test_level": "fully-tested",
-        "metadata_locations": [],
-        "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/test",
+          "https://github.com/itext/itext-java/tree/develop/sign/src/test"
         ]
       }
     ]
@@ -554,7 +543,23 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/commons/src/test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:font-asian",
+    "description": "iText Asian fonts for use in conjunction with iText.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/develop/io/src/main/resources/META-INF/native-image/com.itextpdf/io"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/develop/io/src/test"
         ]
       }
     ]
@@ -567,10 +572,42 @@
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
         "metadata_locations": [
-          "https://github.com/itext/itext-java/tree/master/forms/src/main/resources/META-INF/native-image"
+          "https://github.com/itext/itext-java/tree/develop/forms/src/main/resources/META-INF/native-image/com.itextpdf/forms"
         ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/forms/src/test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:html2pdf",
+    "description": "pdfHTML is an iText add-on that lets you to parse (X)HTML snippets and the associated CSS and converts them to PDF.",
+    "details": [
+      {
+        "minimum_version": "6.1.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-pdfhtml-java/tree/develop/src/main/resources/META-INF/native-image/com.itextpdf/html2pdf"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-pdfhtml-java/tree/develop/src/test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:hyph",
+    "description": "XML files that can be used for hyphenation in layout module.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/develop/layout/src/main/resources/META-INF/native-image/com.itextpdf/layout"
+        ],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/develop/layout/src/test"
         ]
       }
     ]
@@ -583,10 +620,10 @@
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
         "metadata_locations": [
-          "https://github.com/itext/itext-java/tree/master/io/src/main/resources/META-INF/native-image"
+          "https://github.com/itext/itext-java/tree/develop/io/src/main/resources/META-INF/native-image/com.itextpdf/io"
         ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/io/src/test"
         ]
       }
     ]
@@ -598,9 +635,24 @@
       {
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
-        "metadata_locations": [],
+        "metadata_locations": [
+          "https://github.com/itext/itext-java/tree/develop/forms/src/main/resources/META-INF/native-image/com.itextpdf/forms",
+          "https://github.com/itext/itext-java/tree/develop/io/src/main/resources/META-INF/native-image/com.itextpdf/io",
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/main/resources/META-INF/native-image/com.itextpdf/kernel",
+          "https://github.com/itext/itext-java/tree/develop/layout/src/main/resources/META-INF/native-image/com.itextpdf/layout",
+          "https://github.com/itext/itext-java/tree/develop/svg/src/main/resources/META-INF/native-image/com.itextpdf/svg"
+        ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/barcodes/src/test",
+          "https://github.com/itext/itext-java/tree/develop/forms/src/test",
+          "https://github.com/itext/itext-java/tree/develop/io/src/test",
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/test",
+          "https://github.com/itext/itext-java/tree/develop/layout/src/test",
+          "https://github.com/itext/itext-java/tree/develop/pdfa/src/test",
+          "https://github.com/itext/itext-java/tree/develop/pdfua/src/test",
+          "https://github.com/itext/itext-java/tree/develop/sign/src/test",
+          "https://github.com/itext/itext-java/tree/develop/styled-xml-parser/src/test",
+          "https://github.com/itext/itext-java/tree/develop/svg/src/test"
         ]
       }
     ]
@@ -613,10 +665,10 @@
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
         "metadata_locations": [
-          "https://github.com/itext/itext-java/tree/master/kernel/src/main/resources/META-INF/native-image"
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/main/resources/META-INF/native-image/com.itextpdf/kernel"
         ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/kernel/src/test"
         ]
       }
     ]
@@ -629,10 +681,10 @@
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
         "metadata_locations": [
-          "https://github.com/itext/itext-java/tree/master/layout/src/main/resources/META-INF/native-image"
+          "https://github.com/itext/itext-java/tree/develop/layout/src/main/resources/META-INF/native-image/com.itextpdf/layout"
         ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/layout/src/test"
         ]
       }
     ]
@@ -646,7 +698,21 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/pdfa/src/test"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.itextpdf:pdftest",
+    "description": "iText Core module containing a set of tools to execute iText Core tests.",
+    "details": [
+      {
+        "minimum_version": "8.0.4",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/itext/itext-java/tree/develop/pdftest/src/test"
         ]
       }
     ]
@@ -660,7 +726,7 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/pdfua/src/test"
         ]
       }
     ]
@@ -674,7 +740,7 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/sign/src/test"
         ]
       }
     ]
@@ -688,7 +754,7 @@
         "test_level": "fully-tested",
         "metadata_locations": [],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/styled-xml-parser/src/test"
         ]
       }
     ]
@@ -701,10 +767,10 @@
         "minimum_version": "8.0.4",
         "test_level": "fully-tested",
         "metadata_locations": [
-          "https://github.com/itext/itext-java/tree/master/svg/src/main/resources/META-INF/native-image"
+          "https://github.com/itext/itext-java/tree/develop/svg/src/main/resources/META-INF/native-image/com.itextpdf/svg"
         ],
         "tests_locations": [
-          "https://github.com/itext/itext-java/tree/master/native-image-test"
+          "https://github.com/itext/itext-java/tree/develop/svg/src/test"
         ]
       }
     ]


### PR DESCRIPTION
## What does this PR do?
This PR updates test and metadata locations for iText Core modules and adds iText pdfHtml to the list of tested libraries and frameworks.

## Code sections where the PR accesses files, network, docker or some external service


## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
