### PR TITLE
fix(activemq-client:6.0.0): resolve test failures

### DIFF
--- a/metadata/org.apache.activemq/activemq-client/6.0.0/index.json
+++ b/metadata/org.apache.activemq/activemq-client/6.0.0/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.apache.activemq/activemq-client/6.0.0/reflect-config.json
+++ b/metadata/org.apache.activemq/activemq-client/6.0.0/reflect-config.json
@@ -1,0 +1,108 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.activemq.ActiveMQConnectionFactory"},
+  "name":"org.apache.activemq.ActiveMQConnectionFactory",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"setAlwaysSessionAsync","parameterTypes":["boolean"] }, {"name":"setAlwaysSyncSend","parameterTypes":["boolean"] }, {"name":"setAuditDepth","parameterTypes":["int"] }, {"name":"setAuditMaximumProducerNumber","parameterTypes":["int"] }, {"name":"setCheckForDuplicates","parameterTypes":["boolean"] }, {"name":"setClientID","parameterTypes":["java.lang.String"] }, {"name":"setCloseTimeout","parameterTypes":["int"] }, {"name":"setConsumerExpiryCheckEnabled","parameterTypes":["boolean"] }, {"name":"setCopyMessageOnSend","parameterTypes":["boolean"] }, {"name":"setDisableTimeStampsByDefault","parameterTypes":["boolean"] }, {"name":"setDispatchAsync","parameterTypes":["boolean"] }, {"name":"setNestedMapAndListEnabled","parameterTypes":["boolean"] }, {"name":"setNonBlockingRedelivery","parameterTypes":["boolean"] }, {"name":"setObjectMessageSerializationDefered","parameterTypes":["boolean"] }, {"name":"setOptimizeAcknowledge","parameterTypes":["boolean"] }, {"name":"setOptimizeAcknowledgeTimeOut","parameterTypes":["long"] }, {"name":"setOptimizedAckScheduledAckInterval","parameterTypes":["long"] }, {"name":"setOptimizedMessageDispatch","parameterTypes":["boolean"] }, {"name":"setUseAsyncSend","parameterTypes":["boolean"] }, {"name":"setUseCompression","parameterTypes":["boolean"] }, {"name":"setUseRetroactiveConsumer","parameterTypes":["boolean"] }, {"name":"setWarnAboutUnstartedConnectionTimeout","parameterTypes":["long"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.ActiveMQConnectionFactory"},
+  "name":"org.apache.activemq.ActiveMQPrefetchPolicy",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"setDurableTopicPrefetch","parameterTypes":["int"] }, {"name":"setMaximumPendingMessageLimit","parameterTypes":["int"] }, {"name":"setOptimizeDurableTopicPrefetch","parameterTypes":["int"] }, {"name":"setQueueBrowserPrefetch","parameterTypes":["int"] }, {"name":"setQueuePrefetch","parameterTypes":["int"] }, {"name":"setTopicPrefetch","parameterTypes":["int"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.ActiveMQConnectionFactory"},
+  "name":"org.apache.activemq.RedeliveryPolicy",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"setBackOffMultiplier","parameterTypes":["double"] }, {"name":"setCollisionAvoidancePercent","parameterTypes":["short"] }, {"name":"setInitialRedeliveryDelay","parameterTypes":["long"] }, {"name":"setMaximumRedeliveries","parameterTypes":["int"] }, {"name":"setMaximumRedeliveryDelay","parameterTypes":["long"] }, {"name":"setPreDispatchCheck","parameterTypes":["boolean"] }, {"name":"setRedeliveryDelay","parameterTypes":["long"] }, {"name":"setUseCollisionAvoidance","parameterTypes":["boolean"] }, {"name":"setUseExponentialBackOff","parameterTypes":["boolean"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.ActiveMQConnectionFactory"},
+  "name":"org.apache.activemq.blob.BlobTransferPolicy",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"setBrokerUploadUrl","parameterTypes":["java.lang.String"] }, {"name":"setBufferSize","parameterTypes":["int"] }, {"name":"setUploadUrl","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.openwire.OpenWireFormatFactory",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCacheEnabled","parameterTypes":["boolean"] }, {"name":"setCacheSize","parameterTypes":["int"] }, {"name":"setHost","parameterTypes":["java.lang.String"] }, {"name":"setMaxFrameSize","parameterTypes":["long"] }, {"name":"setMaxFrameSizeEnabled","parameterTypes":["boolean"] }, {"name":"setMaxInactivityDuration","parameterTypes":["long"] }, {"name":"setMaxInactivityDurationInitalDelay","parameterTypes":["long"] }, {"name":"setSizePrefixDisabled","parameterTypes":["boolean"] }, {"name":"setStackTraceEnabled","parameterTypes":["boolean"] }, {"name":"setTcpNoDelayEnabled","parameterTypes":["boolean"] }, {"name":"setTightEncodingEnabled","parameterTypes":["boolean"] }, {"name":"setVersion","parameterTypes":["int"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.tcp.TcpTransportFactory"},
+  "name":"org.apache.activemq.openwire.OpenWireFormatFactory",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.openwire.OpenWireFormat"},
+  "name":"org.apache.activemq.openwire.v1.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.openwire.v1.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.openwire.OpenWireFormat"},
+  "name":"org.apache.activemq.openwire.v10.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.openwire.v10.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.openwire.OpenWireFormat"},
+  "name":"org.apache.activemq.openwire.v11.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.openwire.v11.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.openwire.OpenWireFormat"},
+  "name":"org.apache.activemq.openwire.v12.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.openwire.OpenWireFormat"},
+  "name":"org.apache.activemq.openwire.v9.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.openwire.v9.MarshallerFactory",
+  "methods":[{"name":"createMarshallerMap","parameterTypes":["org.apache.activemq.openwire.OpenWireFormat"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.tcp.TcpTransportFactory"},
+  "name":"org.apache.activemq.transport.InactivityMonitor",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.transport.WireFormatNegotiator",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.tcp.TcpTransportFactory"},
+  "name":"org.apache.activemq.transport.tcp.TcpTransport",
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"setConnectionTimeout","parameterTypes":["int"] }, {"name":"setDynamicManagement","parameterTypes":["boolean"] }, {"name":"setJmxPort","parameterTypes":["int"] }, {"name":"setLogWriterName","parameterTypes":["java.lang.String"] }, {"name":"setMinmumWireFormatVersion","parameterTypes":["int"] }, {"name":"setSoTimeout","parameterTypes":["int"] }, {"name":"setSocketBufferSize","parameterTypes":["int"] }, {"name":"setStartLogging","parameterTypes":["boolean"] }, {"name":"setTrace","parameterTypes":["boolean"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+  "name":"org.apache.activemq.transport.tcp.TcpTransportFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.activemq.util.LongSequenceGenerator"},
+  "name":"org.apache.activemq.util.LongSequenceGenerator",
+  "fields":[{"name":"lastSequenceId"}]
+}
+]

--- a/metadata/org.apache.activemq/activemq-client/6.0.0/resource-config.json
+++ b/metadata/org.apache.activemq/activemq-client/6.0.0/resource-config.json
@@ -1,0 +1,14 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.apache.activemq.transport.TransportFactory"},
+    "pattern":"\\QMETA-INF/services/org/apache/activemq/transport/tcp\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.activemq.transport.tcp.TcpTransportFactory"},
+    "pattern":"\\QMETA-INF/services/org/apache/activemq/wireformat/default\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.activemq.broker.BrokerService"},
+    "pattern":"\\Qorg/apache/activemq/version.txt\\E"
+  }]},
+  "bundles":[]
+}

--- a/metadata/org.apache.activemq/activemq-client/index.json
+++ b/metadata/org.apache.activemq/activemq-client/index.json
@@ -1,4 +1,11 @@
-[
+[ {
+    "latest": true,
+    "metadata-version": "6.0.0",
+    "module": "org.apache.activemq:activemq-client",
+    "tested-versions": [
+      "6.0.0"
+  ]
+  },
   {
     "metadata-version" : "5.18.1",
     "tested-versions" : [
@@ -9,7 +16,6 @@
       "5.18.5",
       "5.18.6"
     ],
-    "latest" : true,
     "module" : "org.apache.activemq:activemq-client"
   }
 ]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -281,6 +281,12 @@
     "versions" : [ "5.18.1" ]
   } ]
 }, {
+  "test-project-path" : "org.apache.activemq/activemq-client/6.0.0",
+  "libraries" : [ {
+    "name" : "org.apache.activemq:activemq-client",
+    "versions" : [ "6.0.0" ]
+  } ]
+}, {
   "test-project-path" : "org.apache.activemq/artemis-jms-client/2.28.0",
   "libraries" : [ {
     "name" : "org.apache.activemq:artemis-jms-client",

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/.gitignore
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/build.gradle
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.activemq:activemq-client:$libraryVersion"
+    testImplementation "org.apache.activemq:activemq-broker:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.5'
+    testImplementation 'javax.jms:javax.jms-api:2.0.1'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/gradle.properties
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 6.0.0
+metadata.dir = org.apache.activemq/activemq-client/6.0.0/

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/metadata-extra-filter.json
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/metadata-extra-filter.json
@@ -1,0 +1,7 @@
+{
+  "rules": [
+    {"includeClasses": "**"},
+    {"excludeClasses": "java.lang.**"},
+    {"excludeClasses": "org.apache.activemq.transport.TransportLoggerFactorySPI"}
+  ]
+}

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/metadata-user-code-filter.json
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.activemq.**"}
+  ]
+}

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/settings.gradle
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.activemq.activemq-client_tests'

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/java/org_apache_activemq/activemq_client/ActiveMQClientTest.java
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/java/org_apache_activemq/activemq_client/ActiveMQClientTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.activemq_client;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ActiveMQPrefetchPolicy;
+import org.apache.activemq.RedeliveryPolicy;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.openwire.OpenWireFormat;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.jms.Connection;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ActiveMQClientTest {
+
+    private static final String QUEUE_NAME = "queue-test-" + new Random().nextLong();
+
+    private static final String BROKER_URL_BASE = "tcp://localhost:61616";
+
+    private static final String WIRE_FORMAT_BROKER_URL = BROKER_URL_BASE +
+            "?wireFormat.cacheEnabled=true" +
+            "&wireFormat.cacheSize=1024" +
+            "&wireFormat.maxInactivityDuration=30000" +
+            "&wireFormat.maxInactivityDurationInitalDelay=10000" +
+            "&wireFormat.maxFrameSize=" + OpenWireFormat.DEFAULT_MAX_FRAME_SIZE +
+            "&wireFormat.maxFrameSizeEnabled=true" +
+            "&wireFormat.sizePrefixDisabled=false" +
+            "&wireFormat.stackTraceEnabled=true" +
+            "&wireFormat.tcpNoDelayEnabled=true" +
+            "&wireFormat.tightEncodingEnabled=true";
+
+    private static final String JMS_BROKER_URL = BROKER_URL_BASE +
+            "?jms.alwaysSessionAsync=true" +
+            "&jms.alwaysSyncSend=false" +
+            "&jms.auditDepth=2048" +
+            "&jms.auditMaximumProducerNumber=64" +
+            "&jms.checkForDuplicates=true" +
+            "&jms.clientID=test-id" +
+            "&jms.closeTimeout=15000" +
+            "&jms.consumerExpiryCheckEnabled=true" +
+            "&jms.copyMessageOnSend=true" +
+            "&jms.disableTimeStampsByDefault=false" +
+            "&jms.dispatchAsync=false" +
+            "&jms.nestedMapAndListEnabled=true" +
+            "&jms.objectMessageSerializationDefered=false" +
+            "&jms.optimizeAcknowledge=false" +
+            "&jms.optimizeAcknowledgeTimeOut=300" +
+            "&jms.optimizedAckScheduledAckInterval=0" +
+            "&jms.optimizedMessageDispatch=true" +
+            "&jms.useAsyncSend=false" +
+            "&jms.useCompression=false" +
+            "&jms.useRetroactiveConsumer=false" +
+            "&jms.warnAboutUnstartedConnectionTimeout=500" +
+            "&jms.nonBlockingRedelivery=false" +
+            "&jms.prefetchPolicy.queuePrefetch=" + ActiveMQPrefetchPolicy.DEFAULT_QUEUE_PREFETCH +
+            "&jms.prefetchPolicy.queueBrowserPrefetch=" + ActiveMQPrefetchPolicy.DEFAULT_QUEUE_BROWSER_PREFETCH +
+            "&jms.prefetchPolicy.topicPrefetch=" + ActiveMQPrefetchPolicy.DEFAULT_TOPIC_PREFETCH +
+            "&jms.prefetchPolicy.durableTopicPrefetch=" + ActiveMQPrefetchPolicy.DEFAULT_DURABLE_TOPIC_PREFETCH +
+            "&jms.prefetchPolicy.optimizeDurableTopicPrefetch=" + ActiveMQPrefetchPolicy.DEFAULT_OPTIMIZE_DURABLE_TOPIC_PREFETCH +
+            "&jms.prefetchPolicy.maximumPendingMessageLimit=100" +
+            "&jms.redeliveryPolicy.collisionAvoidancePercent=10" +
+            "&jms.redeliveryPolicy.maximumRedeliveries=" + RedeliveryPolicy.DEFAULT_MAXIMUM_REDELIVERIES +
+            "&jms.redeliveryPolicy.maximumRedeliveryDelay=-1" +
+            "&jms.redeliveryPolicy.initialRedeliveryDelay=1000" +
+            "&jms.redeliveryPolicy.useCollisionAvoidance=false" +
+            "&jms.redeliveryPolicy.useExponentialBackOff=false" +
+            "&jms.redeliveryPolicy.backOffMultiplier=5.0" +
+            "&jms.redeliveryPolicy.redeliveryDelay=1000" +
+            "&jms.redeliveryPolicy.preDispatchCheck=true" +
+            "&jms.blobTransferPolicy.uploadUrl=http://localhost:8080/uploads/" +
+            "&jms.blobTransferPolicy.brokerUploadUrl=http://localhost:8080/uploads/" +
+            "&jms.blobTransferPolicy.bufferSize=" + 128 * 1024;
+
+    private static final Logger logger = LoggerFactory.getLogger("ActiveMQClientTest");
+
+    private BrokerService brokerService;
+
+    @BeforeAll
+    void beforeAll() throws Exception {
+        logger.info("Starting embedded ActiveMQ broker ...");
+        brokerService = new BrokerService();
+        brokerService.addConnector(BROKER_URL_BASE);
+        brokerService.setUseJmx(false);
+        brokerService.getManagementContext().setCreateConnector(false);
+        brokerService.setUseShutdownHook(false);
+        brokerService.setPersistent(false);
+        brokerService.setBrokerName("embedded-broker");
+        brokerService.start();
+        brokerService.waitUntilStarted();
+        logger.info("Started embedded ActiveMQ broker");
+    }
+
+    @AfterAll
+    void tearDown() {
+        if (brokerService != null) {
+            logger.info("Stopping embedded ActiveMQ broker ...");
+            if (!brokerService.isStopped()) {
+                try {
+                    brokerService.stop();
+                } catch (Exception ex) {
+                    logger.warn("Failed to stop embedded ActiveMQ broker", ex);
+                }
+            }
+            brokerService.waitUntilStopped();
+            logger.info("Stopped embedded ActiveMQ broker");
+        }
+    }
+
+    @Test
+    void testSendingAndReceivingMessage() throws Exception {
+        String text = "hello";
+        sendMessage(text);
+        assertThat(receiveMessage()).isEqualTo(text);
+    }
+
+    @Test
+    void testConnections() throws Exception {
+        List<Integer> wireFormatVersions = Arrays.asList(1, 9, 10, 11, 12);
+        for (Integer wireFormatVersion : wireFormatVersions) {
+            ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(BROKER_URL_BASE + "?wireFormat.version=" + wireFormatVersion);
+            try (Connection connection = connectionFactory.createConnection()) {
+                assertThat(connection).isNotNull();
+            }
+        }
+        List<String> brokerUrls = Arrays.asList(WIRE_FORMAT_BROKER_URL, JMS_BROKER_URL);
+        for (String brokerUrl : brokerUrls) {
+            ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(brokerUrl);
+            try (Connection connection = connectionFactory.createConnection()) {
+                assertThat(connection).isNotNull();
+            }
+        }
+    }
+
+    private Connection createConnection() throws JMSException {
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(BROKER_URL_BASE);
+        return connectionFactory.createConnection();
+    }
+
+    private void sendMessage(String text) throws Exception {
+        try (Connection connection = createConnection()) {
+            connection.start();
+            try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+                Destination destination = session.createQueue(QUEUE_NAME);
+                try (MessageProducer producer = session.createProducer(destination)) {
+                    producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+                    producer.send(session.createTextMessage(text));
+                    logger.info("Sent text message: {}", text);
+                }
+            }
+        }
+    }
+
+    private String receiveMessage() throws Exception {
+        try (Connection connection = createConnection()) {
+            connection.start();
+            connection.setExceptionListener(e -> logger.error("JMS Exception", e));
+            try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+                Destination destination = session.createQueue(QUEUE_NAME);
+                try (MessageConsumer consumer = session.createConsumer(destination)) {
+                    Message message = consumer.receive(1000);
+                    String text = ((TextMessage) message).getText();
+                    logger.info("Received text message: {}", text);
+                    return text;
+                }
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/resources/META-INF/native-image/activemq-tests-only/resource-config.json
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/resources/META-INF/native-image/activemq-tests-only/resource-config.json
@@ -1,0 +1,14 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qlogback.xml\\E",
+        "condition": {
+          "typeReachable": "ch.qos.logback.core.util.Loader"
+        }
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/resources/logback.xml
+++ b/tests/src/org.apache.activemq/activemq-client/6.0.0/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ActiveMQClientTest" level="INFO"/>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## What does this PR do?
- Removed reliance on the legacy javax.jms API and use jakarta.jms instead
- Regenerate GraalVM metadata for activemq-client 6.0.0

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
