### PR TITLE
fix(jetty-client:12.0.0.beta0): resolve test failures

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/index.json
+++ b/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/reflect-config.json
+++ b/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/reflect-config.json
@@ -1,0 +1,265 @@
+[
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"apple.security.AppleProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.AESCipher$General",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.ARCFOURCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.DESCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.DESedeCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.DHParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"com.sun.crypto.provider.TlsMasterSecretGenerator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Boolean",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Byte",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Double",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Float",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Integer",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Long",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"java.lang.Short",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"java.lang.Thread",
+  "methods":[{"name":"isVirtual","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"java.security.AlgorithmParametersSpi"
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"java.security.KeyStoreSpi"
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"java.util.concurrent.Executors",
+  "methods":[{"name":"newVirtualThreadPerTaskExecutor","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"javax.security.auth.x500.X500Principal",
+  "fields":[{"name":"thisX500Name"}],
+  "methods":[{"name":"<init>","parameterTypes":["sun.security.x509.X500Name"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+  "name":"org.eclipse.jetty.util.TypeUtil",
+  "methods":[{"name":"getClassLoaderLocation","parameterTypes":["java.lang.Class"] }, {"name":"getCodeSourceLocation","parameterTypes":["java.lang.Class"] }, {"name":"getModuleLocation","parameterTypes":["java.lang.Class"] }, {"name":"getSystemClassLoaderLocation","parameterTypes":["java.lang.Class"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.pkcs12.PKCS12KeyStore",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.DSA$SHA224withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.DSA$SHA256withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.JavaKeyStore$JKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.SHA2$SHA224",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.SHA2$SHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.SHA5$SHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.SHA5$SHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.provider.X509Factory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.rsa.PSSParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.rsa.RSAKeyFactory$Legacy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.rsa.RSAPSSSignature",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.rsa.RSASignature$SHA224withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.ssl.SSLContextImpl$TLSContext",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.AuthorityInfoAccessExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.AuthorityKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.BasicConstraintsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.CRLDistributionPointsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.CertificatePoliciesExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.ExtendedKeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.IssuerAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.KeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.NetscapeCertTypeExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.PrivateKeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.SubjectAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+  "name":"sun.security.x509.SubjectKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+}
+]

--- a/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/resource-config.json
+++ b/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/resource-config.json
@@ -1,14 +1,8 @@
 {
   "resources":{
   "includes":[{
-    "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
-    "pattern":"\\QMETA-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder\\E"
-  }, {
     "condition":{"typeReachable":"org.eclipse.jetty.client.HttpClient"},
     "pattern":"\\Qorg/eclipse/jetty/version/build.properties\\E"
-  }, {
-    "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
-    "pattern":"java.base:\\Qjdk/internal/icu/impl/data/icudt67b/nfc.nrm\\E"
   }]},
   "bundles":[]
 }

--- a/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/resource-config.json
+++ b/metadata/org.eclipse.jetty/jetty-client/12.0.0.beta0/resource-config.json
@@ -1,0 +1,14 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.eclipse.jetty.client.http.HttpReceiverOverHTTP"},
+    "pattern":"\\QMETA-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder\\E"
+  }, {
+    "condition":{"typeReachable":"org.eclipse.jetty.client.HttpClient"},
+    "pattern":"\\Qorg/eclipse/jetty/version/build.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.eclipse.jetty.client.AbstractConnectorHttpClientTransport"},
+    "pattern":"java.base:\\Qjdk/internal/icu/impl/data/icudt67b/nfc.nrm\\E"
+  }]},
+  "bundles":[]
+}

--- a/metadata/org.eclipse.jetty/jetty-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-client/index.json
@@ -1,5 +1,13 @@
 [
   {
+    "latest": true,
+    "metadata-version": "12.0.0.beta0",
+    "module": "org.eclipse.jetty:jetty-client",
+    "tested-versions": [
+      "12.0.0.beta0"
+    ]
+  },
+  {
     "metadata-version" : "11.0.12",
     "tested-versions" : [
       "11.0.12",
@@ -20,7 +28,6 @@
       "12.0.0.alpha2",
       "12.0.0.alpha3"
     ],
-    "latest" : true,
     "module" : "org.eclipse.jetty:jetty-client"
   }
 ]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -377,6 +377,12 @@
     "versions" : [ "11.0.12" ]
   } ]
 }, {
+  "test-project-path" : "org.eclipse.jetty/jetty-client/12.0.0.beta0",
+  "libraries" : [ {
+    "name" : "org.eclipse.jetty:jetty-client",
+    "versions" : [ "12.0.0.beta0" ]
+  } ]
+}, {
   "test-project-path" : "org.eclipse.jetty/jetty-server/11.0.12",
   "libraries" : [ {
     "name" : "org.eclipse.jetty:jetty-server",

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/build.gradle
@@ -12,7 +12,7 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.eclipse.jetty:jetty-client:11.0.12"
+    testImplementation "org.eclipse.jetty:jetty-client:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.slf4j:slf4j-api:2.0.5'
     testImplementation 'org.slf4j:slf4j-simple:2.0.5'

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-client:11.0.12"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.slf4j:slf4j-api:2.0.5'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.5'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--enable-preview')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = false
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.eclipse.jetty/jetty-client/")
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 12.0.0.beta0
+metadata.dir = org.eclipse.jetty/jetty-client/12.0.0.beta0/

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/required-docker-images.txt
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/required-docker-images.txt
@@ -1,0 +1,1 @@
+nginx:1-alpine-slim

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-client_tests'

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_client;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JettyClientTest {
+
+    private static final String DOCKER_HOST = "127.0.0.1";
+
+    private static int hostPort;
+
+    private static Process process;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        hostPort = findAvailablePort();
+        System.out.printf("Starting nginx on port %d ...%n", hostPort);
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "-p", DOCKER_HOST + ":" + hostPort + ":80",
+                "nginx:1-alpine-slim")
+                .redirectOutput(new File("nginx-stdout.txt"))
+                .redirectError(new File("nginx-stderr.txt"))
+                .start();
+
+        // Wait until connection can be established
+        waitUntilContainerStarted(60);
+
+        System.out.printf("nginx started on port %d%n", hostPort);
+    }
+
+    private static int findAvailablePort() throws IOException {
+        try (ServerSocket serverSocket = new ServerSocket()) {
+            serverSocket.bind(null);
+            return serverSocket.getLocalPort();
+        }
+    }
+
+    private static void waitUntilContainerStarted(int startupTimeoutSeconds) {
+        System.out.println("Waiting for nginx container to become available");
+
+        Exception lastConnectionException = null;
+
+        long end = System.currentTimeMillis() + startupTimeoutSeconds * 1000L;
+        while (System.currentTimeMillis() < end) {
+            if (!process.isAlive()) {
+                throw new IllegalStateException("Process has already exited with code %d".formatted(process.exitValue()));
+            }
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                // continue
+            }
+            try (Socket socket = new Socket()) {
+                socket.setSoTimeout(100);
+                socket.connect(new InetSocketAddress(DOCKER_HOST, hostPort), 100);
+                if (!check(socket)) {
+                    continue;
+                }
+                return;
+            } catch (Exception e) {
+                lastConnectionException = e;
+            }
+        }
+        throw new IllegalStateException("nginx container cannot be accessed on %s:%d".formatted(DOCKER_HOST, hostPort), lastConnectionException);
+    }
+
+    private static boolean check(Socket socket) throws IOException {
+        try {
+            // -1 indicates the socket has been closed immediately
+            // Other responses or a timeout are considered as success
+            if (socket.getInputStream().read() == -1) {
+                return false;
+            }
+        } catch (SocketTimeoutException ex) {
+            // Ignore
+        }
+        return true;
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (process != null && process.isAlive()) {
+            System.out.println("Shutting down nginx");
+            process.destroy();
+        }
+    }
+
+    @Test
+    void test() throws Exception {
+        HttpClient client = new HttpClient();
+        client.start();
+        try {
+            ContentResponse response = client.GET("http://%s:%d/".formatted(DOCKER_HOST, hostPort));
+            assertThat(response.getStatus()).isEqualTo(200);
+        } finally {
+            client.stop();
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/src/test/java/org_eclipse_jetty/jetty_client/JettyClientTest.java
@@ -14,7 +14,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.ContentResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-client/12.0.0.beta0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?
- Updated the version of 'org.eclipse.jetty:jetty-client' to 11.0.12 in the testImplementation scope and regenerated metadata.

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [X] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
