### PR TITLE
Add Kafka Streams 3.9.0 missing hints

### DIFF
--- a/metadata/org.apache.kafka/kafka-streams/3.5.1/reflect-config.json
+++ b/metadata/org.apache.kafka/kafka-streams/3.5.1/reflect-config.json
@@ -24,6 +24,14 @@
     "allPublicConstructors": true
   },
   {
+    "name": "org.apache.kafka.streams.errors.LogAndFailProcessingExceptionHandler",
+    "condition": {
+      "typeReachable": "org.apache.kafka.streams.StreamsConfig"
+    },
+    "allDeclaredMethods": true,
+    "allPublicConstructors": true
+  },
+  {
     "name": "org.apache.kafka.streams.processor.FailOnInvalidTimestamp",
     "condition": {
       "typeReachable": "org.apache.kafka.streams.StreamsConfig"


### PR DESCRIPTION
Add the missing hints in Kafka Streams for org.apache.kafka.streams.errors.LogAndFailProcessingExceptionHandler

