### PR TITLE
Update codeowners for allowed-doceker-images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *       @oracle/graalvm-reachability-maintainer
-tests/tck-build-logic/src/main/resources/allowed-docker-images/* @matneu
+tests/tck-build-logic/src/main/resources/allowed-docker-images/* @matneu @matteoldani
 library-and-framework-list.json @fniephaus


### PR DESCRIPTION
## What does this PR do?
Add @matteoldani as a codeowner of allowed-doceker-images
