### PR TITLE
Added missing kafka clients metadata and enabled tests

### DIFF
--- a/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
+++ b/metadata/org.apache.kafka/kafka-clients/3.5.1/resource-config.json
@@ -15,6 +15,9 @@
       "classNames": [
         "sun.security.util.Resources"
       ]
+    },
+    {
+      "name": "sun.security.util.resources.security"
     }
   ]
 }

--- a/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/3.5.1/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -59,7 +59,6 @@ import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -113,7 +112,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @Test
     void testProduceAndConsume() throws Exception {
         Properties properties = new Properties();
@@ -159,7 +157,6 @@ class KafkaClientsTest {
                 .containsExactly("message0", "message1");
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @ParameterizedTest
     @ValueSource(classes = {
             BooleanSerializer.class,
@@ -184,7 +181,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @ParameterizedTest
     @ValueSource(classes = {
             BooleanDeserializer.class,
@@ -209,7 +205,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @ParameterizedTest
     @ValueSource(classes = {
             Serdes.BooleanSerde.class,
@@ -235,7 +230,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @Test
     void testListDeserializers() {
         Map<String, Object> consumerProperties = new HashMap<>();
@@ -249,7 +243,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @Test
     void testRoundRobinPartitioner() {
         Map<String, Object> producerProperties = new HashMap<>();
@@ -262,7 +255,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @ParameterizedTest
     @ValueSource(classes = {
             RangeAssignor.class,
@@ -280,7 +272,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @Test
     void testSaslPlain() {
         Map<String, Object> consumerProperties = new HashMap<>();
@@ -295,7 +286,6 @@ class KafkaClientsTest {
         }
     }
 
-    @Disabled("Causes transitive failures on other pull requests")
     @Test
     void testSaslScramSHA512() {
         Map<String, Object> consumerProperties = new HashMap<>();


### PR DESCRIPTION
## What does this PR do?
Adds missing kafka clients metadata and enables tests

## Code sections where the PR accesses files, network, docker or some external service

- (example link to code section)


## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
