### PR TITLE
Fix flyway-database-postgresql's transactional lock setting

### DIFF
--- a/metadata/org.flywaydb/flyway-database-postgresql/10.10.0/reflect-config.json
+++ b/metadata/org.flywaydb/flyway-database-postgresql/10.10.0/reflect-config.json
@@ -6,5 +6,13 @@
     },
     "allPublicConstructors": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org.flywaydb.database.postgresql.TransactionalModel",
+    "condition": {
+      "typeReachable": "org.flywaydb.core.internal.plugin.PluginRegister"
+    },
+    "allPublicConstructors": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/org.flywaydb/flyway-database-postgresql/10.10.0/src/test/java/flyway/database/postgresql/FlywayDatabasePostgresqlTests.java
+++ b/tests/src/org.flywaydb/flyway-database-postgresql/10.10.0/src/test/java/flyway/database/postgresql/FlywayDatabasePostgresqlTests.java
@@ -17,6 +17,7 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.api.output.MigrateResult;
+import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,9 @@ public class FlywayDatabasePostgresqlTests {
                 .dataSource(dataSource)
                 .encoding(StandardCharsets.UTF_8)
                 .resourceProvider(new FixedResourceProvider());
+        configuration.getPluginRegister()
+                .getPlugin(PostgreSQLConfigurationExtension.class)
+                .setTransactionalLock(false);
 
         Flyway flyway = new Flyway(configuration);
         MigrateResult migration = flyway.migrate();


### PR DESCRIPTION
## What does this PR do?

The metadata for `flyway-database-postgresql` did not allow `org.flywaydb.database.postgresql.TransactionalModel` to be serialized to JSON. This resulted in a failure if the `setTransactionalLock` method on `PostgreSQLConfigurationExtension` was called in a native image.

This PR adds the necessary metadata and updates the existing test to cover this code path.


## Code sections where the PR accesses files, network, docker or some external service
 
No additional access.

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
