### PR TITLE
Make vulnerabilities scanner less strict

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/DockerUtils.java
@@ -1,7 +1,6 @@
 package org.graalvm.internal.tck;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
@@ -10,10 +9,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class DockerUtils {
-    private static final String ALLOWED_DOCKER_IMAGES = "/allowed-docker-images";
+    public static final String ALLOWED_DOCKER_IMAGES = "/allowed-docker-images";
 
     private static URL getDockerfileDirectory() {
         URL url = DockerUtils.class.getResource(ALLOWED_DOCKER_IMAGES);
@@ -47,7 +45,7 @@ public class DockerUtils {
         return images.get(0);
     }
 
-    private static String fileNameFromJar(URL jarFile) {
+    public static String fileNameFromJar(URL jarFile) {
         return jarFile.toString().split("!")[1];
     }
 
@@ -76,6 +74,10 @@ public class DockerUtils {
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static String getImageName(String imageWithVersion) {
+        return imageWithVersion.split(":")[0];
     }
 
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
@@ -51,13 +51,7 @@ public abstract class GrypeTask extends DefaultTask {
         }
 
         public boolean isLessVulnerable(DockerImage other) {
-            // first check number of critical vulnerabilities
-            if (this.vulnerabilities.critical() < other.vulnerabilities().critical()) {
-                return true;
-            }
-
-            // if number of critical vulnerabilities is the same => check number of high vulnerabilities
-            return this.vulnerabilities.critical() == other.vulnerabilities().critical() && this.vulnerabilities.high() < other.vulnerabilities().high();
+            return this.vulnerabilities.critical() < other.vulnerabilities().critical() && this.vulnerabilities.high() < other.vulnerabilities().high();
         }
 
         public void printVulnerabilityStatus() {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/grype/GrypeEntry.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/grype/GrypeEntry.java
@@ -1,0 +1,67 @@
+package org.graalvm.internal.tck.model.grype;
+
+/*
+ * JSON model for metadata/index.json.
+ */
+import java.util.List;
+import java.util.Map;
+
+public class GrypeEntry {
+    public String id;
+    public String dataSource;
+    public String namespace;
+    public String severity;
+    public List<String> urls;
+    public String description;
+    public List<Cvss> cvss;
+    public List<KnownExploited> knownExploited;
+    public List<Epss> epss;
+    public Fix fix;
+    public List<Object> advisories; // unknown structure
+    public Double risk;
+}
+
+class Cvss {
+    public String source;
+    public String type;
+    public String version;
+    public String vector;
+    public Metrics metrics;
+    public Map<String, Object> vendorMetadata;
+}
+class Metrics {
+    public Double baseScore;
+    public Double exploitabilityScore;
+    public Double impactScore;
+}
+
+class KnownExploited {
+    public String cve;
+    public String vendorProject;
+    public String product;
+    public String dateAdded;
+    public String requiredAction;
+    public String dueDate;
+    public String knownRansomwareCampaignUse;
+    public String notes;
+    public List<String> urls;
+    public List<String> cwes;
+}
+
+class Epss {
+    public String cve;
+    public Double epss;
+    public Double percentile;
+    public String date;
+}
+
+class Fix {
+    public List<String> versions;
+    public String state;
+    public List<AvailableFix> available;
+}
+class AvailableFix {
+    public String version;
+    public String date;
+    public String kind;
+}


### PR DESCRIPTION
## What does this PR do?

Make vulnerabilities scanner less strict in order to accept slightly vulnerable images that are less vulnerable than the currently existing allowed images.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/540