### PR TITLE
Make clean task recognize test coordinates

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -16,10 +16,11 @@ import org.graalvm.internal.tck.ConfigFilesChecker
 import org.graalvm.internal.tck.ScaffoldTask
 import org.graalvm.internal.tck.GrypeTask
 import org.graalvm.internal.tck.TestedVersionUpdaterTask
+import org.graalvm.internal.tck.harness.tasks.TestInvocationTask
 import org.graalvm.internal.tck.harness.tasks.CheckstyleInvocationTask
+import org.graalvm.internal.tck.harness.tasks.CleanInvocationTask
 import org.graalvm.internal.tck.updaters.FetchExistingLibrariesWithNewerVersionsTask
 import org.graalvm.internal.tck.updaters.GroupUnsupportedLibraries
-import org.graalvm.internal.tck.harness.tasks.TestInvocationTask
 
 
 import static org.graalvm.internal.tck.Utils.generateTaskName
@@ -62,6 +63,14 @@ for (String coordinates in matchingCoordinates) {
     }
     checkstyle.configure {
         dependsOn(checkstyleTaskName)
+    }
+
+    String cleanTaskName = generateTaskName("clean", coordinates)
+    if ((!tasks.getNames().contains(cleanTaskName))) {
+        tasks.register(cleanTaskName, CleanInvocationTask, coordinates)
+    }
+    clean.configure {
+        dependsOn(cleanTaskName)
     }
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CleanInvocationTask.groovy
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CleanInvocationTask.groovy
@@ -1,0 +1,25 @@
+package org.graalvm.internal.tck.harness.tasks
+
+import org.gradle.api.tasks.Input
+
+import javax.inject.Inject
+
+abstract class CleanInvocationTask extends AbstractSubprojectTask {
+
+    @Inject
+    CleanInvocationTask(String coordinates) {
+        super(coordinates)
+    }
+
+    @Override
+    @Input
+    List<String> getCommand() {
+        return [tckExtension.repoRoot.get().asFile.toPath().resolve("gradlew").toString(), "clean"]
+    }
+
+    @Override
+    protected String getErrorMessage(int exitCode) {
+        "Clean task failed"
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?

When running `./gradlew clean test -Pcoordinates=<maven-gav-coordinates>`, Gradle won't clean `build` directory made in a sub-project on the location specified with `-Pcoordinates`. At the moment user can't force clean sub-project build directory before running test.

In some cases Gradle may think that there are no changes since last run (for example if we just change environment variable) and therefore it won't build a new image. In this case, we would like to force a clean, before running the test.

This PR implements the fix for that.

**Note:** with this implementation, if we run `./gradlew clean` it will perform a clean on all sub-projects. Since `./gradlew test` runs all tests from all sub-projects, I would say that this is desirable behavior.