### PR TITLE
New GenerateMetadataTask gradle task for collecting metadata for specific library version

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,6 +39,18 @@ After it collects your answers, the task will:
 - generate metadata and store it in the proper location
 - ask you if you want to create a pull request, or you want to keep working on it locally
 
+If you already have the test project structure in this repository and need to generate or regenerate metadata, use the `generateMetadata` task:
+
+```shell
+./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0
+```
+
+To change the user-code-filter used during collection, pass `--allowedPackages` with a comma-separated list of packages:
+
+```shell
+./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0 --allowedPackages=com.example.pkg,org.acme.lib
+```
+
 ### Checklist
 In order to ensure that all contributions follow the same standards of quality we have devised a following list of requirements for each new added library.
 `org.example:library` project is also included as a template for new libraries.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -88,6 +88,19 @@ Each stage of the testing can be run with `-Pcoordinates=[group:artifact:version
 ./gradlew test -Pcoordinates=[group:artifact:version|k/n|all]
 ```
 
+### Generating Metadata
+
+Generates metadata for a single library coordinate. If `agentAllowedPackages` is provided, a new user-code-filter.json will be created or updated to include those packages.
+
+- `coordinates`: group:artifact:version (single coordinate only)
+- `agentAllowedPackages`: comma-separated package list; use `-` for none
+
+Examples:
+   ```console
+   ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3
+   ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
+   ```
+
 ### Docker image vulnerability scanning
 
 1. Scan only images affected in a commit range:
@@ -130,6 +143,7 @@ These tasks support the scheduled workflow that checks newer upstream library ve
 - Format check: `./gradlew spotlessCheck`
 - Pull images (single lib): `./gradlew pullAllowedDockerImages -Pcoordinates=[group:artifact:version|k/n|all]`
 - Check metadata (single lib): `./gradlew checkMetadataFiles -Pcoordinates=[group:artifact:version|k/n|all]`
+- Generate metadata (single lib): `./gradlew generateMetadata -Pcoordinates=group:artifact:version`
 - Test (single lib): `./gradlew test -Pcoordinates=[group:artifact:version|k/n|all]`
 - Scan changed Docker images: `./gradlew checkAllowedDockerImages --baseCommit=<sha1> --newCommit=<sha2>`
 - Scan all Docker images: `./gradlew checkAllowedDockerImages`

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -17,6 +17,7 @@ import org.graalvm.internal.tck.MetadataFilesCheckerTask
 import org.graalvm.internal.tck.DockerUtils
 import org.graalvm.internal.tck.ScaffoldTask
 import org.graalvm.internal.tck.GrypeTask
+import org.graalvm.internal.tck.GenerateMetadataTask
 import org.graalvm.internal.tck.TestedVersionUpdaterTask
 import org.graalvm.internal.tck.harness.tasks.TestInvocationTask
 import org.graalvm.internal.tck.harness.tasks.CheckstyleInvocationTask
@@ -319,5 +320,11 @@ tasks.register("scaffold", ScaffoldTask.class) { task ->
 
 tasks.register("contribute", ContributionTask.class) { task ->
     task.setDescription("Generates metadata and prepares pull request for contibuting on metadata repository based on provided tests.")
+    task.setGroup(METADATA_GROUP)
+}
+
+// gradle generateMetadata --coordinates=<maven-coordinates> [or -Pcoordinates=<maven-coordinates>] --agentAllowedPackages=<comma-separated list of packages>
+tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
+    task.setDescription("Generates metadata based on provided tests.")
     task.setGroup(METADATA_GROUP)
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
@@ -2,8 +2,6 @@ package org.graalvm.internal.tck;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.graalvm.internal.tck.exceptions.ContributingException;
@@ -13,6 +11,8 @@ import org.graalvm.internal.tck.utils.ConfigurationStringBuilder;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
 import org.graalvm.internal.tck.utils.FilesUtils;
 import org.graalvm.internal.tck.utils.InteractiveTaskUtils;
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
+import org.graalvm.internal.tck.utils.GeneralUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.ProjectLayout;
@@ -20,16 +20,12 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,8 +37,7 @@ import java.util.Set;
 public abstract class ContributionTask extends DefaultTask {
     private static final String BRANCH_NAME_PREFIX = "add-support-for-";
     private static final String METADATA_INDEX = "metadata/index.json";
-    private static final String BUILD_FILE = "build.gradle";
-    private static final String USER_CODE_FILTER_FILE = "user-code-filter.json";
+    private static final String GRADLEW = "gradlew";
     private static final String REQUIRED_DOCKER_IMAGES_FILE = "required-docker-images.txt";
 
     @Inject
@@ -56,24 +51,15 @@ public abstract class ContributionTask extends DefaultTask {
 
     private final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT).setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-    private Path gradlew;
+    private Path gradlewPath;
     private Path testsDirectory;
-    private Path metadataDirectory;
 
-    private Coordinates coordinates;
+    String coordinates;
 
-    private record ContributingQuestion(String question, String help) {}
+    private record ContributingQuestion(String question, String help) {
+    }
+
     private final Map<String, ContributingQuestion> questions = new HashMap<>();
-
-    private void initializeWorkingDirectories(){
-        testsDirectory = getPathFromProject(CoordinateUtils.replace("tests/src/$group$/$artifact$/$version$", coordinates));
-        metadataDirectory = getPathFromProject(CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", coordinates));
-        gradlew = getPathFromProject("gradlew");
-    }
-
-    private Path getPathFromProject(String fileName) {
-        return Path.of(getProjectFile(fileName).getAbsolutePath());
-    }
 
     private File getProjectFile(String fileName) {
         return getLayout().getProjectDirectory().file(fileName).getAsFile();
@@ -97,7 +83,7 @@ public abstract class ContributionTask extends DefaultTask {
         coordinates = getCoordinates();
         InteractiveTaskUtils.closeSection();
 
-        Path coordinatesMetadataRoot = getPathFromProject(CoordinateUtils.replace("metadata/$group$/$artifact$", coordinates));
+        Path coordinatesMetadataRoot = GeneralUtils.getPathFromProject(getLayout(), CoordinateUtils.replace("metadata/$group$/$artifact$", CoordinateUtils.fromString(coordinates)));
         boolean isExistingLibrary = Files.exists(coordinatesMetadataRoot);
 
         Path testsLocation = getTestsLocation();
@@ -112,11 +98,13 @@ public abstract class ContributionTask extends DefaultTask {
         List<String> packages = getAllowedPackages();
         InteractiveTaskUtils.closeSection();
 
-        List<Coordinates> additionalTestImplementationDependencies = getAdditionalDependencies();
+        List<String> additionalTestImplementationDependencies = getAdditionalDependencies();
         InteractiveTaskUtils.closeSection();
 
         // initialize project
-        initializeWorkingDirectories();
+        gradlewPath = GeneralUtils.getPathFromProject(getLayout(), GRADLEW);
+        testsDirectory = GeneralUtils.computeTestsDirectory(getLayout(), coordinates);
+
         createStubs(isExistingLibrary);
         updateAllowedPackages(packages, isExistingLibrary);
 
@@ -124,17 +112,17 @@ public abstract class ContributionTask extends DefaultTask {
         addTests(testsLocation);
         addResources(resourcesLocation);
         addDockerImages(dockerImages);
-        addUserCodeFilterFile(packages);
+        MetadataGenerationUtils.addUserCodeFilterFile(testsDirectory, packages);
         addAdditionalDependencies(additionalTestImplementationDependencies);
-        addAgentConfigBlock();
+        MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
 
         // run agent in conditional mode
-        collectMetadata();
+        MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
 
         // create a PR
         boolean shouldCreatePR = shouldCreatePullRequest();
         if (shouldCreatePR) {
-            String branch = BRANCH_NAME_PREFIX + coordinates.toString().replace(':', '-');
+            String branch = BRANCH_NAME_PREFIX + coordinates.replace(':', '-');
             createPullRequest(branch);
 
             InteractiveTaskUtils.printUserInfo("After your pull requests gets generated, please update the pull request description to mention all places where your pull request" +
@@ -144,15 +132,9 @@ public abstract class ContributionTask extends DefaultTask {
         InteractiveTaskUtils.printSuccessfulStatement("Contribution successfully completed! Thank you!");
     }
 
-    private Coordinates getCoordinates() {
+    private String getCoordinates() {
         ContributingQuestion question = questions.get("coordinates");
-        return InteractiveTaskUtils.askQuestion(question.question(), question.help(), (answer) -> {
-            try {
-                return CoordinateUtils.fromString(answer);
-            } catch (IllegalArgumentException ex) {
-                throw new ContributingException(ex.getMessage());
-            }
-        });
+        return InteractiveTaskUtils.askQuestion(question.question(), question.help(), (answer) -> answer);
     }
 
     private Path getTestsLocation() {
@@ -201,7 +183,7 @@ public abstract class ContributionTask extends DefaultTask {
         }
     }
 
-    private Path getResourcesLocation(){
+    private Path getResourcesLocation() {
         ContributingQuestion question = questions.get("resourcesLocation");
         return InteractiveTaskUtils.askQuestion(question.question(), question.help(), (answer) -> {
             if (answer.equalsIgnoreCase("-")) {
@@ -242,21 +224,15 @@ public abstract class ContributionTask extends DefaultTask {
         return InteractiveTaskUtils.askRecurringQuestions(question.question(), question.help(), 1, answer -> answer);
     }
 
-    private List<Coordinates> getAdditionalDependencies() {
+    private List<String> getAdditionalDependencies() {
         ContributingQuestion question = questions.get("additionalDependencies");
-        return InteractiveTaskUtils.askRecurringQuestions(question.question(), question.help(), 0, answer -> {
-            try {
-                return CoordinateUtils.fromString(answer);
-            } catch (IllegalArgumentException ex) {
-                throw new ContributingException(ex.getMessage());
-            }
-        });
+        return InteractiveTaskUtils.askRecurringQuestions(question.question(), question.help(), 0, answer -> answer);
     }
 
     private void createStubs(boolean shouldUpdate) {
-        InteractiveTaskUtils.printUserInfo("Generating stubs for: " + coordinates );
+        InteractiveTaskUtils.printUserInfo("Generating stubs for: " + coordinates);
         String opt = shouldUpdate ? "--update" : "";
-        invokeCommand(gradlew + " scaffold --coordinates " + coordinates + " --skipTests " + opt, "Cannot generate stubs for: " + coordinates);
+        GeneralUtils.invokeCommand(getExecOperations(), gradlewPath + " scaffold --coordinates " + coordinates + " --skipTests " + opt, "Cannot generate stubs for: " + coordinates);
     }
 
     private void updateAllowedPackages(List<String> allowedPackages, boolean libraryAlreadyExists) throws IOException {
@@ -265,8 +241,9 @@ public abstract class ContributionTask extends DefaultTask {
 
         List<MetadataIndexEntry> entries = objectMapper.readValue(metadataIndex, new TypeReference<>() {});
         int replaceEntryIndex = -1;
+        Coordinates dependencyCoordinates = CoordinateUtils.fromString(coordinates);
         for (int i = 0; i < entries.size(); i++) {
-            if (entries.get(i).module().equals(coordinates.group() + ":" + coordinates.artifact())) {
+            if (entries.get(i).module().equals(dependencyCoordinates.group() + ":" + dependencyCoordinates.artifact())) {
                 replaceEntryIndex = i;
                 break;
             }
@@ -290,7 +267,7 @@ public abstract class ContributionTask extends DefaultTask {
         objectMapper.writeValue(metadataIndex, entries);
     }
 
-    private void addTests(Path originalTestsLocation){
+    private void addTests(Path originalTestsLocation) {
         Path destination = testsDirectory.resolve("src").resolve("test").resolve("java");
         Path allTests = originalTestsLocation.resolve(".");
 
@@ -302,7 +279,7 @@ public abstract class ContributionTask extends DefaultTask {
         });
     }
 
-    private void addResources(Path originalResourcesDirectory){
+    private void addResources(Path originalResourcesDirectory) {
         if (originalResourcesDirectory == null) {
             return;
         }
@@ -312,8 +289,8 @@ public abstract class ContributionTask extends DefaultTask {
 
         InteractiveTaskUtils.printUserInfo("Copying resources from: " + originalResourcesDirectory + " to " + destination);
         getFileSystemOperations().copy(copySpec -> {
-           copySpec.from(originalResourcesDirectory);
-           copySpec.into(destination);
+            copySpec.from(originalResourcesDirectory);
+            copySpec.into(destination);
         });
     }
 
@@ -331,35 +308,20 @@ public abstract class ContributionTask extends DefaultTask {
         }
 
         for (String image : images) {
-            writeToFile(destination, image.concat(System.lineSeparator()), StandardOpenOption.APPEND);
+            GeneralUtils.writeToFile(destination, image.concat(System.lineSeparator()), StandardOpenOption.APPEND);
         }
     }
 
-    private void addUserCodeFilterFile(List<String> packages) throws IOException {
-        InteractiveTaskUtils.printUserInfo("Generating " + USER_CODE_FILTER_FILE);
-        List<Map<String, String>> filterFileRules = new ArrayList<>();
-
-        // add exclude classes
-        filterFileRules.add(Map.of("excludeClasses", "**"));
-
-        // add include classes
-        packages.forEach(p -> filterFileRules.add(Map.of("includeClasses", p + ".**")));
-
-        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
-        prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
-        objectMapper.writer(prettyPrinter).writeValue(testsDirectory.resolve(USER_CODE_FILTER_FILE).toFile(), Map.of("rules", filterFileRules));
-    }
-
-    private void addAdditionalDependencies(List<Coordinates> dependencies) throws IOException {
+    private void addAdditionalDependencies(List<String> dependencies) throws IOException {
         if (dependencies.isEmpty()) {
             return;
         }
 
-        Path buildFilePath = testsDirectory.resolve(BUILD_FILE);
-        InteractiveTaskUtils.printUserInfo("Adding following dependencies to " + BUILD_FILE + " file: " + dependencies);
+        Path buildFilePath = testsDirectory.resolve(MetadataGenerationUtils.BUILD_FILE);
+        InteractiveTaskUtils.printUserInfo("Adding following dependencies to " + MetadataGenerationUtils.BUILD_FILE + " file: " + dependencies);
 
         if (!Files.isRegularFile(buildFilePath)) {
-            throw new RuntimeException("Cannot add additional dependencies to " + buildFilePath + ". Please check if a " + BUILD_FILE + " exists on that location.");
+            throw new RuntimeException("Cannot add additional dependencies to " + buildFilePath + ". Please check if a " + MetadataGenerationUtils.BUILD_FILE + " exists on that location.");
         }
 
         ConfigurationStringBuilder sb = new ConfigurationStringBuilder();
@@ -369,39 +331,13 @@ public abstract class ContributionTask extends DefaultTask {
             if (line.trim().equalsIgnoreCase("dependencies {")) {
                 sb.indent();
                 for (var dependency : dependencies) {
-                    sb.append("testImplementation").space().quote(dependency.toString()).newLine();
+                    sb.append("testImplementation").space().quote(dependency).newLine();
                 }
                 sb.unindent();
             }
         }
 
-        writeToFile(buildFilePath, sb.toString(), StandardOpenOption.WRITE);
-    }
-
-    private void addAgentConfigBlock() throws IOException {
-        Path buildFilePath = testsDirectory.resolve(BUILD_FILE);
-        InteractiveTaskUtils.printUserInfo("Configuring agent block in: " + BUILD_FILE);
-
-        if (!Files.isRegularFile(buildFilePath)) {
-            throw new RuntimeException("Cannot add agent block to " + buildFilePath + ". Please check if a " + BUILD_FILE + " exists on that location.");
-        }
-
-        try(InputStream stream = ContributionTask.class.getResourceAsStream("/contributing/agent.template")) {
-            if (stream == null) {
-                throw new RuntimeException("Cannot find template for the graalvm configuration block");
-            }
-
-            String content = System.lineSeparator() + (new String(stream.readAllBytes(), StandardCharsets.UTF_8));
-            writeToFile(buildFilePath, content, StandardOpenOption.APPEND);
-        }
-    }
-
-    private void collectMetadata() {
-        InteractiveTaskUtils.printUserInfo("Generating metadata");
-        invokeCommand(gradlew + " -Pagent test", "Cannot generate metadata", testsDirectory);
-
-        InteractiveTaskUtils.printUserInfo("Performing metadata copy");
-        invokeCommand(gradlew + " metadataCopy --task test --dir " + metadataDirectory, "Cannot perform metadata copy", testsDirectory);
+        GeneralUtils.writeToFile(buildFilePath, sb.toString(), StandardOpenOption.WRITE);
     }
 
     private boolean shouldCreatePullRequest() {
@@ -411,51 +347,18 @@ public abstract class ContributionTask extends DefaultTask {
 
     private void createPullRequest(String branch) {
         InteractiveTaskUtils.printUserInfo("Creating new branch: " + branch);
-        invokeCommand("git switch -C " + branch, "Cannot create a new branch");
+        GeneralUtils.invokeCommand(getExecOperations(), "git switch -C " + branch, "Cannot create a new branch");
 
         InteractiveTaskUtils.printUserInfo("Staging changes");
-        invokeCommand("git add .", "Cannot add changes");
+        GeneralUtils.invokeCommand(getExecOperations(), "git add .", "Cannot add changes");
 
         InteractiveTaskUtils.printUserInfo("Committing changes");
-        invokeCommand("git", List.of("commit", "-m", "Add metadata for " + coordinates), "Cannot commit changes", null);
+        GeneralUtils.invokeCommand(getExecOperations(), "git", List.of("commit", "-m", "Add metadata for " + coordinates), "Cannot commit changes", null);
 
         InteractiveTaskUtils.printUserInfo("Pushing changes");
-        invokeCommand("git push origin " + branch, "Cannot push to origin");
+        GeneralUtils.invokeCommand(getExecOperations(), "git push origin " + branch, "Cannot push to origin");
 
         InteractiveTaskUtils.printUserInfo("Complete pull request creation on the above link");
-    }
-
-    private void writeToFile(Path path, String content, StandardOpenOption writeOption) throws IOException {
-        Files.createDirectories(path.getParent());
-        Files.writeString(path, content, StandardCharsets.UTF_8, writeOption);
-    }
-
-    private void invokeCommand(String command, String errorMessage) {
-        invokeCommand(command, errorMessage, null);
-    }
-
-    private void invokeCommand(String command, String errorMessage, Path workingDirectory) {
-        String[] commandParts = command.split(" ");
-        String executable = commandParts[0];
-
-        List<String> args = List.of(Arrays.copyOfRange(commandParts, 1, commandParts.length));
-        invokeCommand(executable, args, errorMessage, workingDirectory);
-    }
-
-    private void invokeCommand(String executable, List<String> args, String errorMessage, Path workingDirectory) {
-        ByteArrayOutputStream execOutput = new ByteArrayOutputStream();
-        var result = getExecOperations().exec(execSpec -> {
-            if (workingDirectory != null) {
-                execSpec.setWorkingDir(workingDirectory);
-            }
-            execSpec.setExecutable(executable);
-            execSpec.setArgs(args);
-            execSpec.setStandardOutput(execOutput);
-        });
-
-        if (result.getExitValue() != 0) {
-            throw new RuntimeException(errorMessage + ". See: " + execOutput);
-        }
     }
 
     private void ensureFileBelongsToProject(Path file) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
@@ -1,0 +1,81 @@
+package org.graalvm.internal.tck;
+
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
+import org.graalvm.internal.tck.utils.GeneralUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.process.ExecOperations;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Generates metadata for the given library coordinates and, if packages list is provided, creates a new user-code-filter.json.
+ */
+public abstract class GenerateMetadataTask extends DefaultTask {
+    private static final String GRADLEW = "gradlew";
+
+    private String coordinates;
+    private String agentAllowedPackages;
+
+    {
+        Object coordsProp = getProject().findProperty("coordinates");
+        if ((this.coordinates == null || this.coordinates.isBlank()) && coordsProp != null) {
+            this.coordinates = coordsProp.toString();
+        }
+    }
+
+    @Inject
+    protected abstract ProjectLayout getLayout();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @Option(option = "coordinates", description = "Coordinates in the form of group:artifact:version")
+    public void setCoordinates(String coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    @Input
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    @Option(option = "agentAllowedPackages", description = "Comma separated allowed packages (or - for none)")
+    public void setAgentAllowedPackages(String agentAllowedPackages) {
+        this.agentAllowedPackages = agentAllowedPackages;
+    }
+
+    @Input
+    @Optional
+    public String getAgentAllowedPackages() {
+        return agentAllowedPackages;
+    }
+
+    @TaskAction
+    public void run() throws IOException {
+        Path testsDirectory = GeneralUtils.computeTestsDirectory(getLayout(), coordinates);
+        Path gradlewPath = GeneralUtils.getPathFromProject(getLayout(), GRADLEW);
+        
+        List<String> packageList = (agentAllowedPackages == null || agentAllowedPackages.isBlank() || agentAllowedPackages.equals("-"))
+                ? List.of()
+                : Arrays.stream(agentAllowedPackages.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+
+        if (!packageList.isEmpty()) {
+            MetadataGenerationUtils.addUserCodeFilterFile(testsDirectory, packageList);
+            MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
+        }
+        MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
+    }
+}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
@@ -1,0 +1,74 @@
+package org.graalvm.internal.tck.utils;
+
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.process.ExecOperations;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * General utilities shared across TCK build logic.
+ */
+public final class GeneralUtils {
+
+    private GeneralUtils() {
+    }
+
+    /**
+     * Resolves and returns the Path of a file inside the Gradle project directory.
+     */
+    public static Path getPathFromProject(ProjectLayout layout, String fileName) {
+        return layout.getProjectDirectory().file(fileName).getAsFile().toPath();
+    }
+
+    public static void writeToFile(Path path, String content, StandardOpenOption writeOption) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8, writeOption);
+    }
+
+    public static void invokeCommand(ExecOperations execOps, String command, String errorMessage) {
+        invokeCommand(execOps, command, errorMessage, null);
+    }
+
+    public static void invokeCommand(ExecOperations execOps, String command, String errorMessage, Path workingDirectory) {
+        String[] commandParts = command.split(" ");
+        String executable = commandParts[0];
+
+        List<String> args = List.of(Arrays.copyOfRange(commandParts, 1, commandParts.length));
+        invokeCommand(execOps, executable, args, errorMessage, workingDirectory);
+    }
+
+    /**
+     * Executes the given executable with arguments in an optional working directory via Gradle ExecOperations.
+     * Captures output and throws a RuntimeException if the exit code is non-zero.
+     */
+    public static void invokeCommand(ExecOperations execOps, String executable, List<String> args, String errorMessage, Path workingDirectory) {
+        ByteArrayOutputStream execOutput = new ByteArrayOutputStream();
+        var result = execOps.exec(execSpec -> {
+            if (workingDirectory != null) {
+                execSpec.setWorkingDir(workingDirectory);
+            }
+            execSpec.setExecutable(executable);
+            execSpec.setArgs(args);
+            execSpec.setStandardOutput(execOutput);
+        });
+
+        if (result.getExitValue() != 0) {
+            throw new RuntimeException(errorMessage + ". See: " + execOutput);
+        }
+    }
+
+    public static Path computeTestsDirectory(ProjectLayout layout, String coordinates) {
+        return getPathFromProject(layout, CoordinateUtils.replace("tests/src/$group$/$artifact$/$version$", CoordinateUtils.fromString(coordinates)));
+    }
+
+    public static Path computeMetadataDirectory(ProjectLayout layout, String coordinates) {
+        return getPathFromProject(layout, CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", CoordinateUtils.fromString(coordinates)));
+    }
+}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -1,0 +1,99 @@
+package org.graalvm.internal.tck.utils;
+
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.process.ExecOperations;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+/**
+ * Static utility class for operations shared by ContributionTask and GenerateMetadataTask.
+ */
+public final class MetadataGenerationUtils {
+
+    public static final String BUILD_FILE = "build.gradle";
+    private static final String USER_CODE_FILTER_FILE = "user-code-filter.json";
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    private MetadataGenerationUtils() {
+    }
+
+
+    /**
+     * Creates a user-code-filter.json file including the given packages (and excluding all others),
+     * used to restrict metadata generation to user code.
+     */
+    public static void addUserCodeFilterFile(Path testsDirectory, List<String> packages) throws IOException {
+        InteractiveTaskUtils.printUserInfo("Generating " + USER_CODE_FILTER_FILE);
+        List<Map<String, String>> filterFileRules = new ArrayList<>();
+
+        // add exclude classes
+        filterFileRules.add(Map.of("excludeClasses", "**"));
+
+        // add include classes
+        packages.forEach(p -> filterFileRules.add(Map.of("includeClasses", p + ".**")));
+
+        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+        prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+        File out = testsDirectory.resolve(USER_CODE_FILTER_FILE).toFile();
+        objectMapper.writer(prettyPrinter).writeValue(out, Map.of("rules", filterFileRules));
+    }
+
+    /**
+     * Appends the agent configuration block to the build.gradle in the tests directory
+     * if it does not already exist.
+     */
+    public static void addAgentConfigBlock(Path testsDirectory) throws IOException {
+        Path buildFilePath = testsDirectory.resolve(BUILD_FILE);
+        InteractiveTaskUtils.printUserInfo("Configuring agent block in: " + BUILD_FILE);
+
+        if (!Files.isRegularFile(buildFilePath)) {
+            throw new RuntimeException("Cannot add agent block to " + buildFilePath + ". Please check if a " + BUILD_FILE + " exists on that location.");
+        }
+
+        // Skip generation if agent block already exists
+        String buildGradle = Files.readString(buildFilePath, StandardCharsets.UTF_8);
+        boolean hasAgentBlock = Pattern.compile("(?s)\\bagent\\s*\\{").matcher(buildGradle).find();
+        if (hasAgentBlock) {
+            InteractiveTaskUtils.printUserInfo("Agent block already present in: " + BUILD_FILE + " - skipping");
+            return;
+        }
+
+        try (InputStream stream = MetadataGenerationUtils.class.getResourceAsStream("/contributing/agent.template")) {
+            if (stream == null) {
+                throw new RuntimeException("Cannot find template for the graalvm configuration block");
+            }
+
+            String content = System.lineSeparator() + (new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            GeneralUtils.writeToFile(buildFilePath, content, StandardOpenOption.APPEND);
+        }
+    }
+
+    /**
+     * Runs Gradle tasks to generate metadata using the agent and then copies
+     * the results into the computed metadata directory for the given coordinates.
+     */
+    public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout,  String coordinates, Path gradlew) {
+        Path metadataDirectory = GeneralUtils.computeMetadataDirectory(layout, coordinates);
+
+        InteractiveTaskUtils.printUserInfo("Generating metadata");
+        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("-Pagent", "test"), "Cannot generate metadata", testsDirectory);
+
+        InteractiveTaskUtils.printUserInfo("Performing metadata copy");
+        GeneralUtils.invokeCommand(execOps, gradlew + " metadataCopy --task test --dir " + metadataDirectory, "Cannot perform metadata copy", testsDirectory);
+    }
+}


### PR DESCRIPTION
## What does this PR do?


Fixes: #682.
The task should be called with following options: 

- `--coordinates` - Maven coordinates of the library you want to test
- `--allowedPackages` - packages that you want to include in your metadata

**Example**:
`./gradlew generateMetadata -Pcoordinates=com.hazelcast:hazelcast:5.2.1 --agentAllowedPackages=com.hazelcast`

This PR also introduces `MetadataGenerationUtils` utility class for operations shared by `ContributionTask` and `GenerateMetadataTask`.
