### PR TITLE
Add missing metadata for hibernate-7.0.x annotations without attributes.

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/7.1.0.Final/reflect-config.json
+++ b/metadata/org.hibernate.orm/hibernate-core/7.1.0.Final/reflect-config.json
@@ -5920,6 +5920,84 @@
 },
 {
   "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.EmbeddableJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Embeddable", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.EmbeddedId", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Embedded", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.EnumeratedValueJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.EnumeratedValue", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.ExcludeDefaultListenersJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.ExcludeDefaultListeners", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.ExcludeSuperclassListenersJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.ExcludeSuperclassListeners", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
     "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
   },
   "name" : "org.hibernate.boot.models.annotations.internal.AttributeAccessorAnnotation",
@@ -5948,6 +6026,149 @@
   }, {
     "name": "<init>",
     "parameterTypes": [ "java.util.Map", "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.LobJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Lob", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.MappedSuperclassJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.MappedSuperclass", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PostLoadJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PostLoad", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PostPersistJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PostPersist", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PostRemoveJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PostRemove", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PostUpdateJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PostUpdate", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PrePersistJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PrePersist", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PreRemoveJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PreRemove", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PreUpdateJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.PreUpdate", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.TransientJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Transient", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.VersionJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Version", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
   } ]
 },
 {
@@ -6917,6 +7138,16 @@
 },
 {
   "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.XmlAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.AbstractXmlAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
     "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
   },
   "name" : "org.hibernate.boot.models.annotations.internal.FetchAnnotation",
@@ -6945,6 +7176,136 @@
   }, {
     "name": "<init>",
     "parameterTypes": [ "java.util.Map", "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.BagAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.Bag", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.ConcreteProxyAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.ConcreteProxy", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.DynamicInsertAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.DynamicInsert", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.DynamicUpdateAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.DynamicUpdate", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.ImmutableAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.Immutable", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.NationalizedAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.Nationalized", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.ParentAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.Parent", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.PartitionKeyAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.PartitionKey", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.SortNaturalAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.SortNatural", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.HibernateAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.TenantIdAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.annotations.TenantId", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
   } ]
 },
 {
@@ -8141,6 +8502,19 @@
   }, {
     "name": "<init>",
     "parameterTypes": [ "java.util.Map", "org.hibernate.models.spi.ModelsContext" ]
+  } ]
+},
+{
+  "condition" : {
+    "typeReachable" : "org.hibernate.boot.models.JpaAnnotations"
+  },
+  "name" : "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ "jakarta.persistence.Id", "org.hibernate.models.spi.ModelsContext" ]
+  }, {
+    "name" : "<init>",
+    "parameterTypes" : [ "org.hibernate.models.spi.ModelsContext" ]
   } ]
 },
 {

--- a/tests/src/org.hibernate.orm/hibernate-core/7.1.0.Final/src/test/java/org_hibernate_orm/hibernate_core/OrmAnnotationHelperTest.java
+++ b/tests/src/org.hibernate.orm/hibernate-core/7.1.0.Final/src/test/java/org_hibernate_orm/hibernate_core/OrmAnnotationHelperTest.java
@@ -42,10 +42,14 @@ public class OrmAnnotationHelperTest {
 
         OrmAnnotationHelper.forEachOrmAnnotation(annotationDescriptor -> {
 
-            Map<String, Object> attributes = createAttributeMap(annotationDescriptor);
+            if (!annotationDescriptor.getAttributes().isEmpty()) {
+                Map<String, Object> attributes = createAttributeMap(annotationDescriptor);
 
-            for (AttributeDescriptor<?> attributeDescriptor : annotationDescriptor.getAttributes()) {
-                createInstances(annotationDescriptor, attributeDescriptor, attributes, ctx);
+                for (AttributeDescriptor<?> attributeDescriptor : annotationDescriptor.getAttributes()) {
+                    createInstances(annotationDescriptor, attributeDescriptor, attributes, ctx);
+                }
+            } else {
+                instanceViaCtors(annotationDescriptor);
             }
         });
     }


### PR DESCRIPTION
This PR updates `hibernate-core` metadata and the test that captures annotations without attributes.
Those had been missed when collecting metadata in earlier runs since the loop did not consider the case of empty attributes returned by the `AnnotationDescriptor`. In case the annotation does not have any attributes the constructors of the hibernate internal annotation implementing types are now invoked, simulating what hibernate does internally during bootstrap via its `ModelHelper` .

## What does this PR do?

Fixes: #700 

## Code sections where the PR accesses files, network, docker or some external service

- n/a


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
