### PR TITLE
Add support for the OpenAI Java SDK

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -783,6 +783,22 @@
     ]
   },
   {
+    "artifact": "com.openai:openai-java",
+    "description": "The OpenAI Java SDK provides convenient access to the OpenAI REST API from applications written in Java.",
+    "details": [
+      {
+        "minimum_version": "2.16.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [
+          "https://github.com/openai/openai-java/blob/2494220eae4101844d2fbc99c9a3045324c27fd5/.github/workflows/create-releases.yml#L58-L68"
+        ],
+        "tests_locations": [
+          "https://github.com/openai/openai-java/blob/2494220eae4101844d2fbc99c9a3045324c27fd5/.github/workflows/create-releases.yml#L54-L56"
+        ]
+      }
+    ]
+  },
+  {
     "artifact": "com.oracle.apm.agent.java:apm-java-agent-helidon",
     "description": "Oracle Application Performance Monoitoring(APM) Java Tracer for Helidon 2.x based applications",
     "details": [


### PR DESCRIPTION
As discussed with @fniephaus at https://github.com/openai/openai-java/pull/534 this adds native metadata for the OpenAI Java SDK.