### PR TITLE
[GenAI] Test fix for org.apache.activemq:activemq-broker:6.0.0 using GPT-5

### DIFF
--- a/metadata/org.apache.activemq/activemq-broker/6.0.0/index.json
+++ b/metadata/org.apache.activemq/activemq-broker/6.0.0/index.json
@@ -1,0 +1,4 @@
+[
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/metadata/org.apache.activemq/activemq-broker/6.0.0/reflect-config.json
+++ b/metadata/org.apache.activemq/activemq-broker/6.0.0/reflect-config.json
@@ -1,0 +1,52 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.util.IntrospectionSupport"
+    },
+    "name": "org.apache.activemq.broker.BrokerService",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setPersistent",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.broker.BrokerFactory"
+    },
+    "name": "org.apache.activemq.broker.DefaultBrokerFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.transport.TransportFactory"
+    },
+    "name": "org.apache.activemq.transport.vm.VMTransportFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.util.LongSequenceGenerator"
+    },
+    "name": "org.apache.activemq.util.LongSequenceGenerator",
+    "fields": [
+      {
+        "name": "lastSequenceId"
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.activemq/activemq-broker/6.0.0/resource-config.json
+++ b/metadata/org.apache.activemq/activemq-broker/6.0.0/resource-config.json
@@ -1,0 +1,25 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.broker.BrokerFactory"
+        },
+        "pattern": "\\QMETA-INF/services/org/apache/activemq/broker/broker\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.transport.TransportFactory"
+        },
+        "pattern": "\\QMETA-INF/services/org/apache/activemq/transport/vm\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.broker.BrokerService"
+        },
+        "pattern": "\\Qorg/apache/activemq/version.txt\\E"
+      }
+    ]
+  },
+  "bundles": []
+}

--- a/metadata/org.apache.activemq/activemq-broker/index.json
+++ b/metadata/org.apache.activemq/activemq-broker/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "module" : "org.apache.activemq:activemq-broker",
     "metadata-version" : "5.18.1",
     "tested-versions" : [
@@ -13,6 +12,14 @@
       "5.18.7",
       "5.19.0",
       "5.19.1"
+    ]
+  },
+  {
+    "latest": true,
+    "metadata-version": "6.0.0",
+    "module": "org.apache.activemq:activemq-broker",
+    "tested-versions": [
+      "6.0.0"
     ]
   }
 ]

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -299,6 +299,12 @@
     "versions" : [ "5.18.1" ]
   } ]
 }, {
+  "test-project-path": "org.apache.activemq/activemq-broker/6.0.0",
+  "libraries": [ {
+    "name": "org.apache.activemq:activemq-broker",
+    "versions": [ "6.0.0" ]
+  } ]
+}, {
   "test-project-path" : "org.apache.activemq/activemq-client/5.18.1",
   "libraries" : [ {
     "name" : "org.apache.activemq:activemq-client",

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/.gitignore
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/build.gradle
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.activemq:activemq-broker:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/gradle.properties
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 6.0.0
+metadata.dir = org.apache.activemq/activemq-broker/6.0.0/

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/metadata-extra-filter.json
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/metadata-extra-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {"includeClasses": "**"},
+    {"excludeClasses": "com.sun.**"},
+    {"excludeClasses": "java.lang.**"},
+    {"excludeClasses": "java.math.**"},
+    {"excludeClasses": "java.util.**"},
+    {"excludeClasses": "javax.management.**"},
+    {"excludeClasses": "jdk.management.**"},
+    {"excludeClasses": "sun.management.**"},
+    {"excludeClasses": "org.apache.activemq.broker.jmx.**"}
+  ]
+}

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/metadata-user-code-filter.json
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/metadata-user-code-filter.json
@@ -1,0 +1,6 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.activemq.**"},
+    {"excludeClasses": "org.apache.activemq.broker.jmx.**"}
+  ]
+}

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/settings.gradle
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.activemq.activemq-broker_tests'

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/src/test/java/org_apache_activemq/activemq_broker/ActivemqBrokerTest.java
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/src/test/java/org_apache_activemq/activemq_broker/ActivemqBrokerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.activemq_broker;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.junit.jupiter.api.Test;
+
+import jakarta.jms.Connection;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivemqBrokerTest {
+
+    private static final String BROKER_URL_BASE = "vm://" + UUID.randomUUID().toString().replaceAll("-", "") + "?broker.persistent=false";
+
+    @Test
+    void testEmbeddedBrokerConnection() throws Exception {
+        BrokerService brokerService = new BrokerService();
+        brokerService.addConnector(BROKER_URL_BASE);
+        brokerService.setUseJmx(false);
+        brokerService.getManagementContext().setCreateConnector(false);
+        brokerService.setUseShutdownHook(false);
+        brokerService.setPersistent(false);
+        brokerService.setBrokerName("embedded-broker");
+        brokerService.start();
+        brokerService.waitUntilStarted();
+
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(BROKER_URL_BASE);
+        try (Connection connection = connectionFactory.createConnection()) {
+            assertThat(connection).isNotNull();
+        }
+
+        brokerService.stop();
+        brokerService.waitUntilStopped();
+    }
+}

--- a/tests/src/org.apache.activemq/activemq-broker/6.0.0/user-code-filter.json
+++ b/tests/src/org.apache.activemq/activemq-broker/6.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.activemq.**"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: #741

This PR provides test fixes and new metadata for `org.apache.activemq:activemq-broker:6.0.0`, addressing compile java failures caused by changes in the updated library version. The fixes were generated using GPT-5.

Summary:
Tokens used: 28119
Entries found: 14
Iterations: 1