### PR TITLE
Disable strict configuration for tests

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -78,7 +78,6 @@ graalvmNative {
             if (override) {
                 excludeConfig.put(libraryGAV, [".*"])
             }
-            buildArgs.add('-H:+StrictConfiguration') // Necessary in order to test metadata properly
             verbose = true
             quickBuild = true
         }


### PR DESCRIPTION
## What does this PR do?

Removes the `-H:+StrictConfiguration` option from test runs, as this option causes failures where a simple warning would be sufficient. See #721 for an example.

## Code sections where the PR accesses files, network, docker or some external service

_none_

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
