### PR TITLE
Fix vulnerability scanner not working in the GitHub actions CI and make it less strict

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
@@ -57,7 +57,7 @@ public abstract class GrypeTask extends DefaultTask {
             return vulnerabilities.critical() > 0 || vulnerabilities.high() > 0;
         }
 
-        public boolean isNoMoreVulnerable(DockerImage other) {
+        public boolean isNotMoreVulnerable(DockerImage other) {
             return this.vulnerabilities.critical() <= other.vulnerabilities().critical() && this.vulnerabilities.high() <= other.vulnerabilities().high();
         }
 
@@ -91,7 +91,7 @@ public abstract class GrypeTask extends DefaultTask {
 
     /**
      * Scans images that have been changed between org.graalvm.internal.tck.GrypeTask#baseCommit and org.graalvm.internal.tck.GrypeTask#newCommit.
-     * If changed images are no more vulnerable than previously allowed images, they won't be reported as vulnerable
+     * If changed images are not more vulnerable than previously allowed images, they won't be reported as vulnerable
      */
     private void scanChangedImages() throws IOException, URISyntaxException {
         Set<DockerImage> imagesToCheck = getChangedImages().stream().map(this::makeDockerImage).collect(Collectors.toSet());
@@ -109,13 +109,13 @@ public abstract class GrypeTask extends DefaultTask {
                         .filter(allowedImage -> DockerUtils.getImageName(allowedImage).equalsIgnoreCase(image.getImageName()))
                         .findFirst();
 
-                // check if a new image is no more vulnerable than the existing one
+                // check if a new image is not more vulnerable than the existing one
                 if (existingAllowedImage.isPresent()) {
                     DockerImage imageToCompare = makeDockerImage(existingAllowedImage.get());
                     imageToCompare.printVulnerabilityStatus();
 
-                    if (image.isNoMoreVulnerable(imageToCompare)) {
-                        System.out.println("Accepting: " + image.image() + " because it has no more vulnerabilities than existing: " + imageToCompare.image());
+                    if (image.isNotMoreVulnerable(imageToCompare)) {
+                        System.out.println("Accepting: " + image.image() + " because it does not have more vulnerabilities than existing: " + imageToCompare.image());
                         acceptedImages++;
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

In this PR, we make the vulnerability scanner less strict by accepting newer versions of docker images if they have less or equal vulnerabilities to the current version (while currently we only accept if they have strictly less vulnerabilities).

Also in this PR, we fix `org.graalvm.internal.tck.GrypeTask#getAllowedImagesFromMaster` not working in the GitHub actions CI. Previously, whenever this method is reached in the CI, the task would fail with: `fatal: invalid object name 'master'.`. This happens because the `master` branch does not exist in the CI, while `origin/master` does. The change in this PR just made it so we check the `origin/master` when we fetch allowed images.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/770