### PR TITLE
Fix liquibase metadata for complete reflection types

### DIFF
--- a/metadata/org.liquibase/liquibase-core/5.0.1/reflect-config.json
+++ b/metadata/org.liquibase/liquibase-core/5.0.1/reflect-config.json
@@ -495,6 +495,7 @@
       "typeReachable": "liquibase.command.core.helpers.DatabaseChangelogCommandStep"
     },
     "name": "liquibase.change.AddColumnConfig",
+    "allDeclaredFields": true,
     "methods": [
       {
         "name": "<init>",
@@ -521,6 +522,7 @@
       "typeReachable": "liquibase.change.AbstractChange"
     },
     "name": "liquibase.change.ColumnConfig",
+    "allDeclaredFields": true,
     "methods": [
       {
         "name": "<init>",


### PR DESCRIPTION
## What does this PR do?

Adds missing registrations to the liquibase metadata, made necessary by the switch to complete reflection types. This new metadata is necessary because `ColumnConfig.getSerializableFields()` and `AddColumnConfig.getSerializableFields()` currently return empty arrays, which is incorrect behavior. This is due to `ReflectionSerializer.getFields` performing a call to `Class.getDeclaredMethods()` in the background.

https://github.com/oracle/graal/pull/12521 fixes Native Image behavior by returning a correct list of fields in this situation for types registered for reflection. Fields returned by `getSerializableFields()` are then used to access the field values, and should therefore be registered for reflective access.

## Code sections where the PR accesses files, network, docker or some external service

_none_

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
