### PR TITLE
FixTestNativeImageRun Gradle task to resolve test failures on Native Image run

### DIFF
--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -7,6 +7,7 @@ on:
      - master
     paths:
       - 'ci.json'
+      - 'java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java'
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Be assertive in code.
 - Write type annotations in all functions and most variables.
 - Document code without being too verbose.
-- In java, always import classes and use them without qualified names.
+- In Java and Groovy, always import classes and use them without qualified names.
 
 ## Testing individual components
 
@@ -46,6 +46,17 @@
   - ./gradlew pullAllowedDockerImages -Pcoordinates=1/64
   - ./gradlew checkMetadataFiles -Pcoordinates=1/64
   - ./gradlew test -Pcoordinates=1/64
+
+### Generating Metadata
+- Generate metadata for a certain library version:
+   - ./gradlew generateMetadata -Pcoordinates=com.hazelcast:hazelcast:5.2.1
+- Generate metadata for a certain library version and create or update the user-code-filter.json:
+   - ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
+
+### Fix failing tasks
+
+- Generates new metadata for library's new version which is failing native-image run:
+  - ./gradlew fixTestNativeImageRun -PtestLibraryCoordinates=org.postgresql:postgresql:42.7.3 -PnewLibraryVersion=42.7.4
 
 ## Docker Image Vulnerability Scanning
 - Changed images between commits:

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import groovy.json.JsonSlurper
+
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -150,6 +152,157 @@ static List<Map> testAllCommands(String gradleCmd, String target) {
     }
 }
 
+/*
+ * Helper utilities for environment setup, and backup/restore
+ * used by testMetadataGeneration.
+ */
+def withUnsetTckDir(List<String> baseArgs) {
+    if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        ["cmd.exe", "/d", "/c", "set GVM_TCK_TCKDIR= && " + baseArgs.join(' ')]
+    } else {
+        ["/usr/bin/env", "-u", "GVM_TCK_TCKDIR"] + baseArgs
+    }
+}
+
+def backupDirIfExists(File srcDir, File backupDir) {
+    boolean had = srcDir?.isDirectory()
+    if (had) {
+        backupDir.parentFile?.mkdirs()
+        project.copy {
+            from(srcDir)
+            into(backupDir)
+        }
+    }
+    had
+}
+
+def restoreDir(boolean had, File srcDir, File backupDir) {
+    if (had) {
+        project.delete(srcDir)
+        srcDir.mkdirs()
+        project.copy {
+            from(backupDir)
+            into(srcDir)
+        }
+    } else {
+        project.delete(srcDir)
+    }
+}
+def backupFileIfExists(File srcFile, File backupFile) {
+    boolean had = srcFile?.isFile()
+    if (had) {
+        backupFile.parentFile?.mkdirs()
+        backupFile.text = srcFile.getText('UTF-8')
+    }
+    had
+}
+def restoreFileIfBackedUp(boolean had, File srcFile, File backupFile) {
+    if (had && backupFile?.isFile()) {
+        srcFile.text = backupFile.getText('UTF-8')
+    }
+}
+
+// Test metadata generation tasks
+def testMetadataGeneration(String coordinate, String gradleCmd, File logsDir, String newVersion) {
+
+    def fileSuffix = coordinate.replaceAll(File.separator, "-")
+
+    // Compute paths and snapshot current state to allow revert after the test
+    def parts = coordinate.split(":")
+    if (parts.length != 3) {
+        throw new GradleException("Invalid coordinates '${coordinate}'. Expected 'group:artifact:version'.")
+    }
+    def group = parts[0]
+    def artifact = parts[1]
+    def version = parts[2]
+    def gaPath = "${group}/${artifact}"
+    def versionPath = "${gaPath}/${version}"
+
+    def versionDir = new File(tck.metadataRoot.get().asFile, versionPath)
+    def testsDir = new File(tck.testRoot.get().asFile, versionPath)
+
+    def backupRoot = layout.buildDirectory.dir("gm-backups/${fileSuffix}").get().asFile
+    def backupMetadataDir = new File(backupRoot, "metadata-backup")
+    def backupTestsDir = new File(backupRoot, "tests-backup")
+    backupRoot.mkdirs()
+    boolean hadVersionDir = backupDirIfExists(versionDir, backupMetadataDir)
+    boolean hadTestsDir = backupDirIfExists(testsDir, backupTestsDir)
+
+    try {
+        // Build base args once, then prepend an OS-specific unset of GVM_TCK_TCKDIR
+        def baseGenArgs = [gradleCmd, "generateMetadata", "-Pcoordinates=${coordinate}", "--agentAllowedPackages=org.postgresql"]
+        List<String> genArgs = withUnsetTckDir(baseGenArgs)
+        def genLogFile = new File(logsDir, "generateMetadata-${fileSuffix}.log")
+        int genExit = project.ext.runLoggedCommand(genArgs, "generateMetadata (${coordinate})", genLogFile, project.rootDir)
+        if (genExit != 0) {
+            throw new GradleException("generateMetadata failed with exit code ${genExit} (see ${genLogFile})")
+        }
+
+        // Verify output directory and index.json for the specific version
+        if (!versionDir.isDirectory()) {
+            throw new GradleException("Version directory not found: ${versionDir}")
+        }
+        def indexFile = new File(versionDir, "index.json")
+        if (!indexFile.isFile()) {
+            throw new GradleException("Missing index.json in ${versionDir}")
+        }
+
+        def actualFiles = versionDir.listFiles()?.findAll { it.isFile() && it.name != 'index.json' }?.collect { it.name }?.sort() ?: []
+        if (actualFiles.isEmpty()) {
+            throw new GradleException("No metadata files found in ${versionDir} (besides index.json)")
+        }
+
+        def indexList = (List) new JsonSlurper().parse(indexFile)
+        def sortedIndex = indexList.collect { it.toString() }.sort()
+        if (!sortedIndex.equals(actualFiles)) {
+            println("==== BEGIN index.json mismatch (${coordinate})")
+            println("index.json: ${sortedIndex}")
+            println("actual:     ${actualFiles}")
+            println("==== END index.json mismatch (${coordinate})")
+            throw new GradleException("index.json does not match files in ${versionDir}")
+        }
+        println("Verified generated metadata for ${coordinate}: ${versionDir}")
+    } finally {
+        // Revert metadata directory changes
+        restoreDir(hadVersionDir, versionDir, backupMetadataDir)
+        // Revert tests directory changes (including build.gradle and user-code-filter.json)
+        restoreDir(hadTestsDir, testsDir, backupTestsDir)
+        // Cleanup backups
+        project.delete(backupRoot)
+    }
+
+
+    def newVersionDir = new File(tck.metadataRoot.get().asFile, "${gaPath}/${newVersion}")
+
+    def moduleIndexFile = new File(tck.metadataRoot.get().asFile, "${gaPath}/index.json")
+
+    def fixBackupRoot = layout.buildDirectory.dir("fixnir-backups/${fileSuffix}").get().asFile
+    def backupNewMetadataDir = new File(fixBackupRoot, "new-metadata-backup")
+    def fixBackupTestsDir = new File(fixBackupRoot, "new-metadata-backup")
+    def backupModuleIndexFile = new File(fixBackupRoot, "module-index.json.bak")
+    fixBackupRoot.mkdirs()
+    hadTestsDir = backupDirIfExists(testsDir, fixBackupTestsDir)
+    def hadNewVersionDir = backupDirIfExists(newVersionDir, backupNewMetadataDir)
+    def hadModuleIndexFile = backupFileIfExists(moduleIndexFile, backupModuleIndexFile)
+
+    try {
+        def baseFixArgs = [gradleCmd, "fixTestNativeImageRun", "-PtestLibraryCoordinates=${coordinate}", "-PnewLibraryVersion=${newVersion}"]
+        List<String> fixArgs = withUnsetTckDir(baseFixArgs)
+        def fixLogFile = new File(logsDir, "fixTestNativeImageRun-${fileSuffix}.log")
+        int fixExit = project.ext.runLoggedCommand(fixArgs, "fixTestNativeImageRun (${coordinate} -> ${newVersion})", fixLogFile, project.rootDir)
+        if (fixExit != 0) {
+            throw new GradleException("fixTestNativeImageRun failed with exit code ${fixExit} (see ${fixLogFile})")
+        }
+    } finally {
+        // Revert changes
+        restoreDir(hadNewVersionDir, newVersionDir, backupNewMetadataDir)
+        restoreDir(hadTestsDir, testsDir, fixBackupTestsDir)
+        restoreFileIfBackedUp(hadModuleIndexFile, moduleIndexFile, backupModuleIndexFile)
+        // Cleanup backups
+        project.delete(fixBackupRoot)
+    }
+}
+
 tasks.register('testAllParallel') { t ->
     t.group = "verification"
     t.setDescription("For each target, run clean and pullAllowedDockerImages first (sequentially), then run style checks and individual testing stages (${testAllCommands('', '').collect { it.name }.join(', ')}) concurrently with isolated logs. Options: -Pcoordinates to specify a single coordinate or 1/64 for the pull step; -Pparallelism to control the number of concurrent tasks.")
@@ -244,9 +397,11 @@ tasks.register('testAllParallel') { t ->
                 println("All commands succeeded for coordinates=${coordinate}. Logs in: ${logsDir}")
             }
         }
+        def newVersionForFix = "42.7.4"
 
         // Run parallel phases sequentially: first the selectedArtifact, then the selectedBatch
         runPhaseForCoordinate(selectedArtifact)
+        testMetadataGeneration(selectedArtifact, gradleCmd, logsDir, newVersionForFix)
         runPhaseForCoordinate(selectedBatch)
     }
 }

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -106,6 +106,22 @@ Examples:
    ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
    ```
 
+### Fix failing tasks
+
+Use this when a library's new version causes native-image run test failures. The task will:
+- Update the module's metadata index.json to mark the new version as latest
+- Ensure the tests project has an agent block and a user-code-filter.json if missing
+- Run the agent to collect metadata, then re-run tests (with a retry if needed)
+
+Required properties:
+- -PtestLibraryCoordinates=group:artifact:version (coordinates of an existing tested version whose tests you run)
+- -PnewLibraryVersion=version (the new upstream version number only; do not include group or artifact)
+
+Example:
+```console
+./gradlew fixTestNativeImageRun -PtestLibraryCoordinates=org.postgresql:postgresql:42.7.3 -PnewLibraryVersion=42.7.4
+```
+
 ### Docker image vulnerability scanning
 
 1. Scan only images affected in a commit range:
@@ -150,6 +166,7 @@ These tasks support the scheduled workflow that checks newer upstream library ve
 - Pull images (single lib): `./gradlew pullAllowedDockerImages -Pcoordinates=[group:artifact:version|k/n|all]`
 - Check metadata (single lib): `./gradlew checkMetadataFiles -Pcoordinates=[group:artifact:version|k/n|all]`
 - Generate metadata (single lib): `./gradlew generateMetadata -Pcoordinates=group:artifact:version`
+- Fix test that fails Native Image run for new library version: `./gradlew fixTestNativeImageRun -PtestLibraryCoordinates=group:artifact:version -PnewLibraryVersion=version`
 - Test (single lib): `./gradlew test -Pcoordinates=[group:artifact:version|k/n|all]`
 - Scan changed Docker images: `./gradlew checkAllowedDockerImages --baseCommit=<sha1> --newCommit=<sha2>`
 - Scan all Docker images: `./gradlew checkAllowedDockerImages`

--- a/tests/src/AGENTS.md
+++ b/tests/src/AGENTS.md
@@ -1,0 +1,5 @@
+# Instructions when developing tests
+
+## Code Style
+- Tests should throw and assert against standard Java exceptions; do not use `GradleException` in test code.
+- The model may modify `buildArgs` in `build.gradle` only in `graalvmNative` and only to add `--add-opens` or `--add-exports arguments`.

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -16,6 +16,7 @@ import org.graalvm.internal.tck.DockerTask
 import org.graalvm.internal.tck.MetadataFilesCheckerTask
 import org.graalvm.internal.tck.DockerUtils
 import org.graalvm.internal.tck.ScaffoldTask
+import org.graalvm.internal.tck.FixTestNativeImageRun
 import org.graalvm.internal.tck.GrypeTask
 import org.graalvm.internal.tck.GenerateMetadataTask
 import org.graalvm.internal.tck.TestedVersionUpdaterTask
@@ -309,7 +310,6 @@ tasks.register("pullAllowedDockerImages", ComputeAndPullAllowedDockerImagesTask.
     task.setGroup(METADATA_GROUP)
 }
 
-
 // contributing tasks
 tasks.register("scaffold", ScaffoldTask.class) { task ->
     task.setDescription("Creates a metadata and test scaffold for the given coordindates")
@@ -323,8 +323,14 @@ tasks.register("contribute", ContributionTask.class) { task ->
     task.setGroup(METADATA_GROUP)
 }
 
-// gradle generateMetadata --coordinates=<maven-coordinates> [or -Pcoordinates=<maven-coordinates>] --agentAllowedPackages=<comma-separated list of packages>
+// gradle generateMetadata -Pcoordinates=<maven-coordinates> [or --coordinates=<maven-coordinates>] --agentAllowedPackages=<comma-separated list of packages>
 tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
     task.setDescription("Generates metadata based on provided tests.")
+    task.setGroup(METADATA_GROUP)
+}
+
+// gradle fixTestNIRun -PtestLibraryCoordinates=<maven-coordinates> -PnewLibraryVersion=<library version which needs fix>
+tasks.register("fixTestNativeImageRun", FixTestNativeImageRun.class) { task ->
+    task.setDescription("Fix test that fails Native Image run for new library version.")
     task.setGroup(METADATA_GROUP)
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck;
+
+import org.graalvm.internal.tck.utils.GeneralUtils;
+import org.graalvm.internal.tck.utils.InteractiveTaskUtils;
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.process.ExecOperations;
+import org.gradle.api.GradleException;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Gradle task to fix test failures during native-image runs.
+ * It regenerates reachability metadata for the specified library version and updates the
+ * module's index.json, then re-runs the tests.
+ *
+ * Properties:
+ *  -PtestLibraryCoordinates: Coordinates in the form group:artifact:version
+ *  -PnewLibraryVersion: New version of the library that is failing
+ */
+public abstract class FixTestNativeImageRun extends DefaultTask {
+    private static final String GRADLEW = "gradlew";
+
+    private String testLibraryCoordinates;
+    private String newLibraryVersion;
+
+    {
+        Object testCoordsProp = getProject().findProperty("testLibraryCoordinates");
+        if ((this.testLibraryCoordinates == null || this.testLibraryCoordinates.isBlank()) && testCoordsProp != null) {
+            this.testLibraryCoordinates = testCoordsProp.toString();
+        }
+        Object newCoordsProp = getProject().findProperty("newLibraryVersion");
+        if ((this.newLibraryVersion == null || this.newLibraryVersion.isBlank()) && newCoordsProp != null) {
+            this.newLibraryVersion = newCoordsProp.toString();
+        }
+    }
+
+    @Inject
+    protected abstract ProjectLayout getLayout();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @Option(option = "newLibraryVersion", description = "New version of library that is failing")
+    public void setNewLibraryVersion(String newLibraryVersion) {
+        this.newLibraryVersion = newLibraryVersion;
+    }
+
+    @Input
+    public String getNewLibraryVersion() {
+        return newLibraryVersion;
+    }
+
+    @Option(option = "testLibraryCoordinates", description = "Coordinates in the form of group:artifact:version")
+    public void setTestLibraryCoordinates(String testLibraryCoordinates) {
+        this.testLibraryCoordinates = testLibraryCoordinates;
+    }
+
+    @Input
+    public String getTestLibraryCoordinates() {
+        return testLibraryCoordinates;
+    }
+
+    @TaskAction
+    public void run() throws IOException {
+        Path testsDirectory = GeneralUtils.computeTestsDirectory(getLayout(), testLibraryCoordinates);
+        Path gradlewPath = GeneralUtils.getPathFromProject(getLayout(), GRADLEW);
+
+        Coordinates baseCoords = Coordinates.parse(testLibraryCoordinates);
+        String newCoordsString = baseCoords.group() + ":" + baseCoords.artifact() + ":" + newLibraryVersion;
+        Coordinates newCoords = Coordinates.parse(newCoordsString);
+        MetadataGenerationUtils.makeVersionLatestInIndexJson(getLayout(), newCoords);
+
+        Path metadataDirectory = GeneralUtils.computeMetadataDirectory(getLayout(), newCoordsString);
+        Files.createDirectories(metadataDirectory);
+
+        // Ensure the tests build.gradle has an agent block; if not, create user-code-filter.json and add the agent block.
+        Path buildFilePath = testsDirectory.resolve("build.gradle");
+        if (!Files.isRegularFile(buildFilePath)) {
+            throw new GradleException("Cannot find tests build file at: " + buildFilePath);
+        }
+        String buildGradle = Files.readString(buildFilePath, java.nio.charset.StandardCharsets.UTF_8);
+        boolean hasAgentBlock = Pattern.compile("(?s)\\bagent\\s*\\{").matcher(buildGradle).find();
+        if (!hasAgentBlock) {
+            MetadataGenerationUtils.addUserCodeFilterFile(testsDirectory, List.of(baseCoords.group()));
+            MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
+        }
+
+        MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), newCoordsString, gradlewPath, newLibraryVersion);
+
+        MetadataGenerationUtils.createIndexJsonSpecificVersion(metadataDirectory);
+
+        // At the end, attempt to run tests with the new library version.
+        // If the build fails, it can be due agent's non-deterministic nature.
+        GeneralUtils.printInfo("Running the test with updated metadata");
+        var execOutput = new java.io.ByteArrayOutputStream();
+        var testResult = runTestWithVersion(gradlewPath, testLibraryCoordinates, newLibraryVersion, execOutput);
+        if (testResult.getExitValue() != 0) {
+            GeneralUtils.printInfo("Test run failed, running agent again");
+            MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), newCoordsString, gradlewPath);
+            testResult = runTestWithVersion(gradlewPath, testLibraryCoordinates, newLibraryVersion, execOutput);
+            if (testResult.getExitValue() != 0) {
+                throw new GradleException("Test run failed. See output:\n" + execOutput);
+            }
+        }
+    }
+
+    private org.gradle.process.ExecResult runTestWithVersion(Path gradlewPath, String coords, String version, java.io.ByteArrayOutputStream execOutput) {
+        return getExecOperations().exec(execSpec -> {
+            execSpec.setExecutable(gradlewPath.toString());
+            execSpec.setArgs(List.of("test", "-Pcoordinates=" + coords));
+            execSpec.environment("GVM_TCK_LV", version);
+            execSpec.setStandardOutput(execOutput);
+        });
+    }
+}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 package org.graalvm.internal.tck;
 
 import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
@@ -77,5 +83,7 @@ public abstract class GenerateMetadataTask extends DefaultTask {
             MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
         }
         MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
+        Path metadataDirectory = GeneralUtils.computeMetadataDirectory(getLayout(), coordinates);
+        MetadataGenerationUtils.createIndexJsonSpecificVersion(metadataDirectory);
     }
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 package org.graalvm.internal.tck.utils;
 
 import org.gradle.api.file.ProjectLayout;
@@ -11,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * General utilities shared across TCK build logic.
@@ -49,10 +56,21 @@ public final class GeneralUtils {
      * Captures output and throws a RuntimeException if the exit code is non-zero.
      */
     public static void invokeCommand(ExecOperations execOps, String executable, List<String> args, String errorMessage, Path workingDirectory) {
+        invokeCommand(execOps, executable, args, null, errorMessage, workingDirectory);
+    }
+
+    /**
+     * Executes the given executable with arguments in an optional working directory via Gradle ExecOperations,
+     * allowing custom environment variables.
+     */
+    public static void invokeCommand(ExecOperations execOps, String executable, List<String> args, Map<String, String> env, String errorMessage, Path workingDirectory) {
         ByteArrayOutputStream execOutput = new ByteArrayOutputStream();
         var result = execOps.exec(execSpec -> {
             if (workingDirectory != null) {
                 execSpec.setWorkingDir(workingDirectory);
+            }
+            if (env != null && !env.isEmpty()) {
+                execSpec.environment(env);
             }
             execSpec.setExecutable(executable);
             execSpec.setArgs(args);
@@ -71,4 +89,9 @@ public final class GeneralUtils {
     public static Path computeMetadataDirectory(ProjectLayout layout, String coordinates) {
         return getPathFromProject(layout, CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", CoordinateUtils.fromString(coordinates)));
     }
+
+    public static void printInfo(String message) {
+        ColoredOutput.println("[INFO] " + message + "...", ColoredOutput.OUTPUT_COLOR.BLUE);
+    }
+
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/InteractiveTaskUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/InteractiveTaskUtils.java
@@ -96,7 +96,7 @@ public class InteractiveTaskUtils {
     }
 
     public static void printUserInfo(String message) {
-        ColoredOutput.println("[INFO] " + message + "...", ColoredOutput.OUTPUT_COLOR.BLUE);
+        GeneralUtils.printInfo(message);
         waitForUserToReadMessage();
     }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -1,9 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 package org.graalvm.internal.tck.utils;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.graalvm.internal.tck.Coordinates;
+import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.process.ExecOperations;
 
@@ -32,13 +42,12 @@ public final class MetadataGenerationUtils {
     private MetadataGenerationUtils() {
     }
 
-
     /**
      * Creates a user-code-filter.json file including the given packages (and excluding all others),
      * used to restrict metadata generation to user code.
      */
     public static void addUserCodeFilterFile(Path testsDirectory, List<String> packages) throws IOException {
-        InteractiveTaskUtils.printUserInfo("Generating " + USER_CODE_FILTER_FILE);
+        GeneralUtils.printInfo("Generating " + USER_CODE_FILTER_FILE);
         List<Map<String, String>> filterFileRules = new ArrayList<>();
 
         // add exclude classes
@@ -59,7 +68,7 @@ public final class MetadataGenerationUtils {
      */
     public static void addAgentConfigBlock(Path testsDirectory) throws IOException {
         Path buildFilePath = testsDirectory.resolve(BUILD_FILE);
-        InteractiveTaskUtils.printUserInfo("Configuring agent block in: " + BUILD_FILE);
+        GeneralUtils.printInfo("Configuring agent block in: " + BUILD_FILE);
 
         if (!Files.isRegularFile(buildFilePath)) {
             throw new RuntimeException("Cannot add agent block to " + buildFilePath + ". Please check if a " + BUILD_FILE + " exists on that location.");
@@ -69,7 +78,7 @@ public final class MetadataGenerationUtils {
         String buildGradle = Files.readString(buildFilePath, StandardCharsets.UTF_8);
         boolean hasAgentBlock = Pattern.compile("(?s)\\bagent\\s*\\{").matcher(buildGradle).find();
         if (hasAgentBlock) {
-            InteractiveTaskUtils.printUserInfo("Agent block already present in: " + BUILD_FILE + " - skipping");
+            GeneralUtils.printInfo("Agent block already present in: " + BUILD_FILE + " - skipping");
             return;
         }
 
@@ -90,10 +99,118 @@ public final class MetadataGenerationUtils {
     public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout,  String coordinates, Path gradlew) {
         Path metadataDirectory = GeneralUtils.computeMetadataDirectory(layout, coordinates);
 
-        InteractiveTaskUtils.printUserInfo("Generating metadata");
+        GeneralUtils.printInfo("Generating metadata");
         GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("-Pagent", "test"), "Cannot generate metadata", testsDirectory);
 
-        InteractiveTaskUtils.printUserInfo("Performing metadata copy");
+        GeneralUtils.printInfo("Performing metadata copy");
         GeneralUtils.invokeCommand(execOps, gradlew + " metadataCopy --task test --dir " + metadataDirectory, "Cannot perform metadata copy", testsDirectory);
+    }
+
+    /**
+     * Runs Gradle tasks to generate metadata using the agent with a specific GVM_TCK_LV
+     * and then copies the results into the computed metadata directory for the given coordinates.
+     */
+    public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout, String coordinates, Path gradlew, String gvmTckLv) {
+        Path metadataDirectory = GeneralUtils.computeMetadataDirectory(layout, coordinates);
+
+        Map<String, String> env = Map.of("GVM_TCK_LV", gvmTckLv);
+
+        GeneralUtils.printInfo("Generating metadata");
+        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("-Pagent", "test"), env, "Cannot generate metadata", testsDirectory);
+
+        GeneralUtils.printInfo("Performing metadata copy");
+        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("metadataCopy", "--task", "test", "--dir", metadataDirectory.toString()), env, "Cannot perform metadata copy", testsDirectory);
+    }
+
+    /**
+     * Creates index.json inside the given version directory, listing all files present in that directory.
+     */
+    public static void createIndexJsonSpecificVersion(Path metadataDirectory) throws IOException {
+        try (java.util.stream.Stream<Path> paths = Files.list(metadataDirectory)) {
+            List<String> files = paths
+                    .filter(Files::isRegularFile)
+                    .map(p -> p.getFileName().toString())
+                    .filter(name -> !"index.json".equals(name))
+                    .sorted()
+                    .toList();
+
+            DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+            printer.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+            String jsonVersionIndex = objectMapper.writer(printer).writeValueAsString(files);
+            if (!jsonVersionIndex.endsWith(System.lineSeparator())) {
+                jsonVersionIndex = jsonVersionIndex + System.lineSeparator();
+            }
+            Files.writeString(metadataDirectory.resolve("index.json"), jsonVersionIndex, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Marks the library version identified by {@code newCoords} as the {@code latest} entry
+     * within its corresponding {@code index.json}.
+     */
+    public static void makeVersionLatestInIndexJson(ProjectLayout layout, Coordinates newCoords) throws IOException {
+        String indexPathTemplate = "metadata/$group$/$artifact$/index.json";
+        File indexFile = GeneralUtils.getPathFromProject(layout, CoordinateUtils.replace(indexPathTemplate, newCoords)).toFile();
+
+        ObjectMapper objectMapper = new ObjectMapper()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        // Read existing entries if file exists, otherwise start fresh
+        List<MetadataVersionsIndexEntry> entries = new ArrayList<>();
+        if (indexFile.exists()) {
+            entries = objectMapper.readValue(indexFile, new TypeReference<>() {});
+        }
+
+        // If the version already exists, no update needed
+        String newVersion = newCoords.version();
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (newVersion.equals(entry.metadataVersion())) {
+                return;
+            }
+            List<String> tv = entry.testedVersions();
+            if (tv != null && tv.contains(newVersion)) {
+                return;
+            }
+        }
+
+        // Remove 'latest' flag from any existing latest entry
+        for (int i = 0; i < entries.size(); i++) {
+            MetadataVersionsIndexEntry entry = entries.get(i);
+            if (Boolean.TRUE.equals(entry.latest())) {
+                entries.set(i, new MetadataVersionsIndexEntry(
+                        null, // latest removed
+                        entry.override(),
+                        entry.module(),
+                        entry.defaultFor(),
+                        entry.metadataVersion(),
+                        entry.testedVersions(),
+                        entry.skippedVersions()
+                ));
+            }
+        }
+
+        // Add the new entry and mark it as latest
+        String moduleName = newCoords.group() + ":" + newCoords.artifact();
+        List<String> testedVersions = new ArrayList<>();
+        testedVersions.add(newCoords.version());
+        MetadataVersionsIndexEntry newEntry = new MetadataVersionsIndexEntry(
+                Boolean.TRUE,
+                null,
+                moduleName,
+                null,
+                newCoords.version(),
+                testedVersions,
+                new ArrayList<>()
+        );
+        entries.add(newEntry);
+
+        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+        prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+        String json = objectMapper.writer(prettyPrinter).writeValueAsString(entries);
+        if (!json.endsWith(System.lineSeparator())) {
+            json = json + System.lineSeparator();
+        }
+        Files.writeString(indexFile.toPath(), json, java.nio.charset.StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## What does this PR do?
Fixes: #786

This task runs the Java agent on failed tests for a new library version, and creates a version-specific metadata directory.
It will be executed by automation script #769 to update the metadata for each failing library version.