### PR TITLE
Add -Pcoordinates fallback for gradle tasks

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
@@ -44,8 +44,19 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
 
     @Option(option = "coordinates", description = "Coordinates in the form of group:artifact:version")
     void setCoordinates(String coords) {
-        this.coordinates = Coordinates.parse(coords);
+        extractCoordinates(coords);
+    }
 
+    {
+        // Prefer task option, fallback to -Pcoordinates
+        String prop = (String) getProject().findProperty("coordinates");
+        if (prop != null && !getIndexFile().isPresent()) {
+            extractCoordinates(prop);
+        }
+    }
+
+    private void extractCoordinates(String c) {
+        this.coordinates = Coordinates.parse(c);
         File coordinatesMetadataRoot = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", coordinates));
         getMetadataRoot().set(coordinatesMetadataRoot);
 
@@ -54,7 +65,6 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
 
         this.allowedPackages = getAllowedPackages();
     }
-
 
     @TaskAction
     void run() throws IllegalArgumentException, FileNotFoundException {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -29,7 +29,19 @@ import java.util.List;
 public abstract class TestedVersionUpdaterTask extends DefaultTask {
 
     @Option(option = "coordinates", description = "GAV coordinates of the library")
-    void extractInformationFromCoordinates(String c) {
+    void setCoordinates(String c) {
+        extractInformationFromCoordinates(c);
+    }
+
+    {
+        // Prefer task option, fallback to -Pcoordinates
+        String coordinates = (String) getProject().findProperty("coordinates");
+        if (coordinates != null && !getIndexFile().isPresent()) {
+            extractInformationFromCoordinates(coordinates);
+        }
+    }
+
+    private void extractInformationFromCoordinates(String c) {
         String[] coordinatesParts = c.split(":");
         if (coordinatesParts.length != 3) {
             throw new IllegalArgumentException("Maven coordinates should have 3 parts");


### PR DESCRIPTION
## What does this PR do?

Currently, the CI calls gradle task with the usage of `-Pcoordinates`, while some of the gradle tasks only support `--coordinates`. In this PR we add the ability to use `-Pcoordinates` with these tasks.
