### PR TITLE
Add script to check if a library is supported by the GraalVM Reachability Metadata repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ To get out-of-the-box support, use the [GraalVM Gradle Plugin](https://graalvm.g
 
 ### 🔎 Check if Your Library or Framework Is Supported
 
-To see whether your library or framework is supported, visit [this page](https://www.graalvm.org/native-image/libraries-and-frameworks/). It lists libraries and frameworks that are tested and ready for GraalVM Native Image.  
+To quickly check whether reachability metadata exists for a specific library, you can run the following command directly from your terminal (works on **Linux** and **macOS**, or on **Windows** with Git Bash / WSL):
+```bash
+curl -sSL https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/check-library-support.sh | bash -s "<groupId>:<artifactId>:<version>"
+```
+
+For a broader overview of supported libraries and frameworks, you can visit [this page](https://www.graalvm.org/native-image/libraries-and-frameworks/). It lists libraries and frameworks that are tested and ready for GraalVM Native Image.  
 
 If you’d like yours to appear there as well, open a pull request updating [this JSON file](https://github.com/oracle/graalvm-reachability-metadata/blob/master/library-and-framework-list.json).  
 Before submitting a pull request, please read [this guide](docs/CONTRIBUTING.md#tested-libraries-and-frameworks).
-
-You can also check if metadata for a library exists on the repository directly from your terminal without cloning it using:
-```
-curl -sSL https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/check-library-support.sh | bash -s "<groupId>:<artifactId>:<version>"
-```
 
 ### 📚 Request Support for a New Library
 

--- a/check-library-support.sh
+++ b/check-library-support.sh
@@ -13,6 +13,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 GAV="$1"
+
+if ! [[ "$GAV" =~ ^[^:]+:[^:]+:[^:]+$ ]]; then
+    echo "Invalid library format: '$GAV'"
+    echo "Expected format: <groupId>:<artifactId>:<version>"
+    exit 1
+fi
+
 IFS=':' read -r GROUP ARTIFACT VERSION <<< "$GAV"
 
 REMOTE_BASE_URL="https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/metadata"


### PR DESCRIPTION
## What does this PR do?

In this PR we introduce a script for easy checking if a library is supported by the GraalVM Reachability Metadata repository. We do this by parsing the `index.json` file for the particular library (if it exists) and looking for the requested version under `tested-versions`. If it exists, the library is supported.

To use the script, position yourself in the root of the repository and call: `./check-library-support.sh <groupId:artifactId:version>` (e.g.: `org.hibernate.orm:hibernate-core:7.0.0.Final`).

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/808.

P.S: We should wait for the merge of https://github.com/oracle/graalvm-reachability-metadata/pull/802 before merging this PR, as we should add the usage of the script to the `README.md`.