### PR TITLE
Add verify-new-library-version-compatibility.yml step for closing pre-release issues when full release is present

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -281,6 +281,7 @@ jobs:
         if: steps.runtests.outputs.successful_versions != '' || steps.runtests.outputs.failed_version != ''
         env:
           REPO: ${{ github.repository }}
+          PRE_RELEASE_SUFFIX: "(alpha[0-9]*|beta[0-9]*|rc[0-9]*|cr[0-9]*|m[0-9]+|ea[0-9]*|b[0-9]+|[0-9]+|preview)"
         run: |
           set -euo pipefail
           git config --local user.email "actions@github.com"
@@ -299,7 +300,7 @@ jobs:
             if [[ -z "$VERSION" ]]; then continue; fi
           
             # Parse version
-            VERSION_REGEX="^([0-9]+(\.[0-9]+)*)(\.Final)?([-.](alpha[0-9]*|beta[0-9]*|rc[0-9]*|cr[0-9]*|m[0-9]+|ea[0-9]*|b[0-9]+|[0-9]+|preview)([-.].*)?)?$"
+            VERSION_REGEX="^([0-9]+(\.[0-9]+)*)(\.Final)?([-.]$PRE_RELEASE_SUFFIX([-.].*)?)?$"
             if [[ "$VERSION" =~ $VERSION_REGEX ]]; then
               BASE_VERSION="${BASH_REMATCH[1]}"
               PRE_RELEASE_TAG="${BASH_REMATCH[4]-}"
@@ -314,7 +315,6 @@ jobs:
               continue
             fi
           
-            PRE_RELEASE_SUFFIX="(alpha[0-9]*|beta[0-9]*|rc[0-9]*|cr[0-9]*|m[0-9]+|ea[0-9]*|b[0-9]+|[0-9]+|preview)"
             PRE_RELEASE_REGEX="$BASE_VERSION[-.]$PRE_RELEASE_SUFFIX"
           
             GROUP_ID="$(echo "${{ matrix.item.name }}" | cut -d: -f1)"


### PR DESCRIPTION
## What does this PR do?

This PR introduces automatic closing of open GitHub pre-release version issues generated by automation, when the corresponding full release version becomes available.

The workflow step closes issues in two situations:

1. If a test fails for the full version (and we open an issue for that version), we close the pre-release issue for that version.
2. If a test passes for a full release version and a pre-release issue exists for that version, we close the pre-release issue.

The changes to the workflow have been tested on a fork. Examples of both situations can be found here:

1. Situation 1: [pre-release issue closed when full version fails](https://github.com/jormundur00/graalvm-reachability-metadata/actions/runs/19671968469/job/56343005646)
2. Situation 2: [pre-release issue closed when full version passes](https://github.com/jormundur00/graalvm-reachability-metadata/actions/runs/19667578256/job/56328320251)

The new workflow step uses the same regex logic when looking for pre-release versions as it does in the `tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java`, just converted to a `bash` compatible regex.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/807