### PR TITLE
Skip GitHub issue creation if one already exists instead of failing verify-new-version-compatibility.yml workflow

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -92,22 +92,24 @@ jobs:
           GROUP_ID="$(echo "${{ matrix.item.name }}" | cut -d: -f1)"
           ARTIFACT_ID="$(echo "${{ matrix.item.name }}" | cut -d: -f2)"
           
-          GAV_COORDINATES_VERSIONLESS="$GROUP_ID:$ARTIFACT_ID"
-          TITLE_END_VERSIONLESS="${{ env.ISSUE_TITLE_MIDDLE }}$GAV_COORDINATES_VERSIONLESS"
+          readarray -t VERSIONS < <(echo '${{ toJson(matrix.item.versions) }}' | jq -r '.[]')
+          FIRST_TESTING_VERSION="${VERSIONS[0]}"
+          GAV_COORDINATES="$GROUP_ID:$ARTIFACT_ID:$FIRST_TESTING_VERSION"
+          TITLE_END="${{ env.ISSUE_TITLE_MIDDLE }}$GAV_COORDINATES"
           
           ISSUE_NUMBER=$(
             gh issue list \
               --repo "${{ github.repository }}" \
               --state open \
-              --search "\"$TITLE_END_VERSIONLESS\" in:title" \
+              --search "\"$TITLE_END\" in:title" \
               --json number,title \
-              --jq ".[] | select(.title | startswith(\"${{ env.ISSUE_TITLE_PREFIX }}\") and test(\"$TITLE_END_VERSIONLESS(:.*)?\")) | .number"
+              --jq ".[] | select(.title | (startswith(\"${{ env.ISSUE_TITLE_PREFIX }}\") and endswith(\"$TITLE_END\"))) | .number"
           )
           
           echo "Found the issue(s) $ISSUE_NUMBER"
           if [[ -n "$ISSUE_NUMBER" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "There is no progress since last time for the $GAV_COORDINATES_VERSIONLESS. Skipping further testing!"
+            echo "There is no progress since last time for the $GAV_COORDINATES. Skipping further testing!"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -238,9 +240,8 @@ jobs:
               --jq ".[] | select(.title | (startswith(\"${{ env.ISSUE_TITLE_PREFIX }}\") and endswith(\"$TITLE_END\"))) | .number"
           )
           if [ -n "$ISSUE_NUMBER" ]; then
-            echo "Must not reach here as the issue already exists: $ISSUE_NUMBER"
-            echo "The previous stage should of failed before."
-            exit 1
+            echo "Issue already exists: $ISSUE_NUMBER. Skipping creation."
+            exit 0
           fi
 
           BODY_FILE=$(mktemp)


### PR DESCRIPTION
## What does this PR do?

This PR updates the workflow in `verify-new-library-version-compatibility.yml` so that the creation of a GitHub issue for a failing library version is **skipped if an issue already exists**, instead of failing the workflow.

Previously, when the workflow detected an existing issue for a failing version, it would trigger a “should-not-reach-here” failure, causing the job to fail. With this change:

- If an issue for the failing version already exists, no new issue is created.
- The workflow continues without failing.
- New issues are only created for versions that do not yet have an existing issue.

This prevents duplicate issues while keeping the workflow stable.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/823