### PR TITLE
[Automation] Generated metadata for org.jooq:jooq:3.20.0

### DIFF
--- a/metadata/index.json
+++ b/metadata/index.json
@@ -338,7 +338,7 @@
   "module" : "org.jline:jline-terminal",
   "requires" : [ "org.jline:jline" ]
 }, {
-  "allowed-packages" : [ "org.jooq" ],
+  "allowed-packages" : [ "org.jooq", "org_jooq" ],
   "directory" : "org.jooq/jooq",
   "module" : "org.jooq:jooq"
 }, {

--- a/metadata/org.jooq/jooq/3.20.0/index.json
+++ b/metadata/org.jooq/jooq/3.20.0/index.json
@@ -1,0 +1,3 @@
+[
+  "reflect-config.json"
+]

--- a/metadata/org.jooq/jooq/3.20.0/reflect-config.json
+++ b/metadata/org.jooq/jooq/3.20.0/reflect-config.json
@@ -1,0 +1,333 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Boolean;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Byte;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Double;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Float;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Integer;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Long;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.Short;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.math.BigDecimal;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.math.BigInteger;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.sql.Date;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.sql.Time;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.sql.Timestamp;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.Instant;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.LocalDate;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.LocalDateTime;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.LocalTime;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.OffsetDateTime;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.OffsetTime;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.time.Year;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Ljava.util.UUID;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.Decfloat;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.Geography;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.Geometry;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.JSON;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.JSONB;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.Record;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.Result;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.RowId;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.XML;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.DayToSecond;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.UByte;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.UInteger;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.ULong;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.UShort;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.YearToMonth;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "[Lorg.jooq.types.YearToSecond;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.DefaultDSLContext"
+    },
+    "name": "org.jooq.impl.SQLDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.DefaultDataType"
+    },
+    "name": "org.jooq.impl.SQLDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org_jooq.jooq.JooqTest"
+    },
+    "name": "org.jooq.impl.SQLDataType",
+    "allPublicFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.impl.SQLDataTypes$ClickHouseDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.impl.SQLDataTypes$DuckDBDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.impl.SQLDataTypes$TrinoDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.cubrid.CUBRIDDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.derby.DerbyDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.firebird.FirebirdDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.h2.H2DataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.hsqldb.HSQLDBDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.ignite.IgniteDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.mariadb.MariaDBDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.mysql.MySQLDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.postgres.PostgresDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.sqlite.SQLiteDataType"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.jooq.impl.SQLDataType"
+    },
+    "name": "org.jooq.util.yugabytedb.YugabyteDBDataType"
+  }
+]

--- a/metadata/org.jooq/jooq/index.json
+++ b/metadata/org.jooq/jooq/index.json
@@ -2,6 +2,13 @@
   {
     "latest" : true,
     "module" : "org.jooq:jooq",
+    "metadata-version" : "3.20.0",
+    "tested-versions" : [
+      "3.20.0"
+    ]
+  },
+  {
+    "module" : "org.jooq:jooq",
     "metadata-version" : "3.18.2",
     "tested-versions" : [
       "3.18.2",

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -1,43 +1,43 @@
 [
   {
-    "test-project-path": "ch.qos.logback.contrib/logback-jackson/0.1.5",
-    "libraries": [
+    "test-project-path" : "ch.qos.logback.contrib/logback-jackson/0.1.5",
+    "libraries" : [
       {
-        "name": "ch.qos.logback.contrib:logback-jackson",
-        "versions": [
+        "name" : "ch.qos.logback.contrib:logback-jackson",
+        "versions" : [
           "0.1.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "ch.qos.logback.contrib/logback-json-classic/0.1.5",
-    "libraries": [
+    "test-project-path" : "ch.qos.logback.contrib/logback-json-classic/0.1.5",
+    "libraries" : [
       {
-        "name": "ch.qos.logback.contrib:logback-json-classic",
-        "versions": [
+        "name" : "ch.qos.logback.contrib:logback-json-classic",
+        "versions" : [
           "0.1.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "ch.qos.logback/logback-classic/1.2.11",
-    "libraries": [
+    "test-project-path" : "ch.qos.logback/logback-classic/1.2.11",
+    "libraries" : [
       {
-        "name": "ch.qos.logback:logback-classic",
-        "versions": [
+        "name" : "ch.qos.logback:logback-classic",
+        "versions" : [
           "1.2.11"
         ]
       }
     ]
   },
   {
-    "test-project-path": "ch.qos.logback/logback-classic/1.4.1",
-    "libraries": [
+    "test-project-path" : "ch.qos.logback/logback-classic/1.4.1",
+    "libraries" : [
       {
-        "name": "ch.qos.logback:logback-classic",
-        "versions": [
+        "name" : "ch.qos.logback:logback-classic",
+        "versions" : [
           "1.4.1",
           "1.4.9"
         ]
@@ -45,1188 +45,1189 @@
     ]
   },
   {
-    "test-project-path": "com.ecwid.consul/consul-api/1.4.5",
-    "libraries": [
+    "test-project-path" : "com.ecwid.consul/consul-api/1.4.5",
+    "libraries" : [
       {
-        "name": "com.ecwid.consul:consul-api",
-        "versions": [
+        "name" : "com.ecwid.consul:consul-api",
+        "versions" : [
           "1.4.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.fasterxml.jackson.core/jackson-databind/2.15.2",
-    "libraries": [
+    "test-project-path" : "com.fasterxml.jackson.core/jackson-databind/2.15.2",
+    "libraries" : [
       {
-        "name": "com.fasterxml.jackson.core:jackson-databind",
-        "versions": [
+        "name" : "com.fasterxml.jackson.core:jackson-databind",
+        "versions" : [
           "2.15.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.github.ben-manes.caffeine/caffeine/2.9.3",
-    "libraries": [
+    "test-project-path" : "com.github.ben-manes.caffeine/caffeine/2.9.3",
+    "libraries" : [
       {
-        "name": "com.github.ben-manes.caffeine:caffeine",
-        "versions": [
+        "name" : "com.github.ben-manes.caffeine:caffeine",
+        "versions" : [
           "2.9.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.github.ben-manes.caffeine/caffeine/3.1.2",
-    "libraries": [
+    "test-project-path" : "com.github.ben-manes.caffeine/caffeine/3.1.2",
+    "libraries" : [
       {
-        "name": "com.github.ben-manes.caffeine:caffeine",
-        "versions": [
+        "name" : "com.github.ben-manes.caffeine:caffeine",
+        "versions" : [
           "3.1.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.github.luben/zstd-jni/1.5.2-5",
-    "libraries": [
+    "test-project-path" : "com.github.luben/zstd-jni/1.5.2-5",
+    "libraries" : [
       {
-        "name": "com.github.luben:zstd-jni",
-        "versions": [
+        "name" : "com.github.luben:zstd-jni",
+        "versions" : [
           "1.5.2-5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.google.protobuf/protobuf-java-util/3.21.12",
-    "libraries": [
+    "test-project-path" : "com.google.protobuf/protobuf-java-util/3.21.12",
+    "libraries" : [
       {
-        "name": "com.google.protobuf:protobuf-java-util",
-        "versions": [
+        "name" : "com.google.protobuf:protobuf-java-util",
+        "versions" : [
           "3.21.12"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.google.protobuf/protobuf-java-util/3.22.0",
-    "libraries": [
+    "test-project-path" : "com.google.protobuf/protobuf-java-util/3.22.0",
+    "libraries" : [
       {
-        "name": "com.google.protobuf:protobuf-java-util",
-        "versions": [
+        "name" : "com.google.protobuf:protobuf-java-util",
+        "versions" : [
           "3.22.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.graphql-java/graphql-java-extended-validation/19.1",
-    "libraries": [
+    "test-project-path" : "com.graphql-java/graphql-java-extended-validation/19.1",
+    "libraries" : [
       {
-        "name": "com.graphql-java:graphql-java-extended-validation",
-        "versions": [
+        "name" : "com.graphql-java:graphql-java-extended-validation",
+        "versions" : [
           "19.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.graphql-java/graphql-java/19.2",
-    "libraries": [
+    "test-project-path" : "com.graphql-java/graphql-java/19.2",
+    "libraries" : [
       {
-        "name": "com.graphql-java:graphql-java",
-        "versions": [
+        "name" : "com.graphql-java:graphql-java",
+        "versions" : [
           "19.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.h2database/h2/2.1.210",
-    "libraries": [
+    "test-project-path" : "com.h2database/h2/2.1.210",
+    "libraries" : [
       {
-        "name": "com.h2database:h2",
-        "versions": [
+        "name" : "com.h2database:h2",
+        "versions" : [
           "2.1.210"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.hazelcast/hazelcast/5.2.1",
-    "libraries": [
+    "test-project-path" : "com.hazelcast/hazelcast/5.2.1",
+    "libraries" : [
       {
-        "name": "com.hazelcast:hazelcast",
-        "versions": [
+        "name" : "com.hazelcast:hazelcast",
+        "versions" : [
           "5.2.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.hazelcast/hazelcast/5.5.0",
-    "libraries": [
+    "test-project-path" : "com.hazelcast/hazelcast/5.5.0",
+    "libraries" : [
       {
-        "name": "com.hazelcast:hazelcast",
-        "versions": [
+        "name" : "com.hazelcast:hazelcast",
+        "versions" : [
           "5.5.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.itextpdf/forms/8.0.3",
-    "libraries": [
+    "test-project-path" : "com.itextpdf/forms/8.0.3",
+    "libraries" : [
       {
-        "name": "com.itextpdf:forms",
-        "versions": [
+        "name" : "com.itextpdf:forms",
+        "versions" : [
           "8.0.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.itextpdf/io/8.0.3",
-    "libraries": [
+    "test-project-path" : "com.itextpdf/io/8.0.3",
+    "libraries" : [
       {
-        "name": "com.itextpdf:io",
-        "versions": [
+        "name" : "com.itextpdf:io",
+        "versions" : [
           "8.0.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.itextpdf/kernel/8.0.3",
-    "libraries": [
+    "test-project-path" : "com.itextpdf/kernel/8.0.3",
+    "libraries" : [
       {
-        "name": "com.itextpdf:kernel",
-        "versions": [
+        "name" : "com.itextpdf:kernel",
+        "versions" : [
           "8.0.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.itextpdf/layout/8.0.3",
-    "libraries": [
+    "test-project-path" : "com.itextpdf/layout/8.0.3",
+    "libraries" : [
       {
-        "name": "com.itextpdf:layout",
-        "versions": [
+        "name" : "com.itextpdf:layout",
+        "versions" : [
           "8.0.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.itextpdf/svg/8.0.3",
-    "libraries": [
+    "test-project-path" : "com.itextpdf/svg/8.0.3",
+    "libraries" : [
       {
-        "name": "com.itextpdf:svg",
-        "versions": [
+        "name" : "com.itextpdf:svg",
+        "versions" : [
           "8.0.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.microsoft.sqlserver/mssql-jdbc/12.2.0.jre11",
-    "libraries": [
+    "test-project-path" : "com.microsoft.sqlserver/mssql-jdbc/12.2.0.jre11",
+    "libraries" : [
       {
-        "name": "com.microsoft.sqlserver:mssql-jdbc",
-        "versions": [
+        "name" : "com.microsoft.sqlserver:mssql-jdbc",
+        "versions" : [
           "12.2.0.jre11"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.mysql/mysql-connector-j/8.0.31",
-    "libraries": [
+    "test-project-path" : "com.mysql/mysql-connector-j/8.0.31",
+    "libraries" : [
       {
-        "name": "com.mysql:mysql-connector-j",
-        "versions": [
+        "name" : "com.mysql:mysql-connector-j",
+        "versions" : [
           "8.0.31"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.sun.mail/jakarta.mail/2.0.1",
-    "libraries": [
+    "test-project-path" : "com.sun.mail/jakarta.mail/2.0.1",
+    "libraries" : [
       {
-        "name": "com.sun.mail:jakarta.mail",
-        "versions": [
+        "name" : "com.sun.mail:jakarta.mail",
+        "versions" : [
           "2.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.zaxxer/HikariCP/5.0.1",
-    "libraries": [
+    "test-project-path" : "com.zaxxer/HikariCP/5.0.1",
+    "libraries" : [
       {
-        "name": "com.zaxxer:HikariCP",
-        "versions": [
+        "name" : "com.zaxxer:HikariCP",
+        "versions" : [
           "5.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "com.zaxxer/HikariCP/6.0.0",
-    "libraries": [
+    "test-project-path" : "com.zaxxer/HikariCP/6.0.0",
+    "libraries" : [
       {
-        "name": "com.zaxxer:HikariCP",
-        "versions": [
+        "name" : "com.zaxxer:HikariCP",
+        "versions" : [
           "6.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "commons-logging/commons-logging/1.2",
-    "libraries": [
+    "test-project-path" : "commons-logging/commons-logging/1.2",
+    "libraries" : [
       {
-        "name": "commons-logging:commons-logging",
-        "versions": [
+        "name" : "commons-logging:commons-logging",
+        "versions" : [
           "1.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.grpc/grpc-core/1.69.0",
-    "libraries": [
+    "test-project-path" : "io.grpc/grpc-core/1.69.0",
+    "libraries" : [
       {
-        "name": "io.grpc:grpc-core",
-        "versions": [
+        "name" : "io.grpc:grpc-core",
+        "versions" : [
           "1.69.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.grpc/grpc-netty/1.51.0",
-    "libraries": [
+    "test-project-path" : "io.grpc/grpc-netty/1.51.0",
+    "libraries" : [
       {
-        "name": "io.grpc:grpc-netty",
-        "versions": [
+        "name" : "io.grpc:grpc-netty",
+        "versions" : [
           "1.51.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.jsonwebtoken/jjwt-gson/0.11.5",
-    "libraries": [
+    "test-project-path" : "io.jsonwebtoken/jjwt-gson/0.11.5",
+    "libraries" : [
       {
-        "name": "io.jsonwebtoken:jjwt-gson",
-        "versions": [
+        "name" : "io.jsonwebtoken:jjwt-gson",
+        "versions" : [
           "0.11.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.jsonwebtoken/jjwt-jackson/0.11.5",
-    "libraries": [
+    "test-project-path" : "io.jsonwebtoken/jjwt-jackson/0.11.5",
+    "libraries" : [
       {
-        "name": "io.jsonwebtoken:jjwt-jackson",
-        "versions": [
+        "name" : "io.jsonwebtoken:jjwt-jackson",
+        "versions" : [
           "0.11.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.jsonwebtoken/jjwt-orgjson/0.11.5",
-    "libraries": [
+    "test-project-path" : "io.jsonwebtoken/jjwt-orgjson/0.11.5",
+    "libraries" : [
       {
-        "name": "io.jsonwebtoken:jjwt-orgjson",
-        "versions": [
+        "name" : "io.jsonwebtoken:jjwt-orgjson",
+        "versions" : [
           "0.11.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.jsonwebtoken/jjwt-orgjson/0.12.0",
-    "libraries": [
+    "test-project-path" : "io.jsonwebtoken/jjwt-orgjson/0.12.0",
+    "libraries" : [
       {
-        "name": "io.jsonwebtoken:jjwt-orgjson",
-        "versions": [
+        "name" : "io.jsonwebtoken:jjwt-orgjson",
+        "versions" : [
           "0.12.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.nats/jnats/2.16.11",
-    "libraries": [
+    "test-project-path" : "io.nats/jnats/2.16.11",
+    "libraries" : [
       {
-        "name": "io.nats:jnats",
-        "versions": [
+        "name" : "io.nats:jnats",
+        "versions" : [
           "2.16.11"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.netty/netty-common/4.1.115.Final",
-    "libraries": [
+    "test-project-path" : "io.netty/netty-common/4.1.115.Final",
+    "libraries" : [
       {
-        "name": "io.netty:netty-common",
-        "versions": [
+        "name" : "io.netty:netty-common",
+        "versions" : [
           "4.1.115.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.netty/netty-common/4.1.80.Final",
-    "libraries": [
+    "test-project-path" : "io.netty/netty-common/4.1.80.Final",
+    "libraries" : [
       {
-        "name": "io.netty:netty-common",
-        "versions": [
+        "name" : "io.netty:netty-common",
+        "versions" : [
           "4.1.80.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.netty/netty-transport/4.1.115.Final",
-    "libraries": [
+    "test-project-path" : "io.netty/netty-transport/4.1.115.Final",
+    "libraries" : [
       {
-        "name": "io.netty:netty-transport",
-        "versions": [
+        "name" : "io.netty:netty-transport",
+        "versions" : [
           "4.1.115.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.netty/netty-transport/4.1.80.Final",
-    "libraries": [
+    "test-project-path" : "io.netty/netty-transport/4.1.80.Final",
+    "libraries" : [
       {
-        "name": "io.netty:netty-transport",
-        "versions": [
+        "name" : "io.netty:netty-transport",
+        "versions" : [
           "4.1.80.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-exporter-jaeger/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-exporter-jaeger/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-exporter-jaeger",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-exporter-jaeger",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-exporter-logging/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-exporter-logging/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-exporter-logging",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-exporter-logging",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-exporter-otlp/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-exporter-otlp/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-exporter-otlp",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-exporter-otlp",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-exporter-zipkin",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-exporter-zipkin",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-sdk-metrics/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-sdk-metrics/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-sdk-metrics",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-sdk-metrics",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.opentelemetry/opentelemetry-sdk-trace/1.19.0",
-    "libraries": [
+    "test-project-path" : "io.opentelemetry/opentelemetry-sdk-trace/1.19.0",
+    "libraries" : [
       {
-        "name": "io.opentelemetry:opentelemetry-sdk-trace",
-        "versions": [
+        "name" : "io.opentelemetry:opentelemetry-sdk-trace",
+        "versions" : [
           "1.19.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.undertow/undertow-core/2.2.19.Final",
-    "libraries": [
+    "test-project-path" : "io.undertow/undertow-core/2.2.19.Final",
+    "libraries" : [
       {
-        "name": "io.undertow:undertow-core",
-        "versions": [
+        "name" : "io.undertow:undertow-core",
+        "versions" : [
           "2.2.19.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "io.undertow/undertow-core/2.3.0.Final",
-    "libraries": [
+    "test-project-path" : "io.undertow/undertow-core/2.3.0.Final",
+    "libraries" : [
       {
-        "name": "io.undertow:undertow-core",
-        "versions": [
+        "name" : "io.undertow:undertow-core",
+        "versions" : [
           "2.3.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "jakarta.servlet/jakarta.servlet-api/5.0.0",
-    "libraries": [
+    "test-project-path" : "jakarta.servlet/jakarta.servlet-api/5.0.0",
+    "libraries" : [
       {
-        "name": "jakarta.servlet:jakarta.servlet-api",
-        "versions": [
+        "name" : "jakarta.servlet:jakarta.servlet-api",
+        "versions" : [
           "5.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "javax.cache/cache-api/1.1.1",
-    "libraries": [
+    "test-project-path" : "javax.cache/cache-api/1.1.1",
+    "libraries" : [
       {
-        "name": "javax.cache:cache-api",
-        "versions": [
+        "name" : "javax.cache:cache-api",
+        "versions" : [
           "1.1.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "log4j/log4j/1.2.17",
-    "libraries": [
+    "test-project-path" : "log4j/log4j/1.2.17",
+    "libraries" : [
       {
-        "name": "log4j:log4j",
-        "versions": [
+        "name" : "log4j:log4j",
+        "versions" : [
           "1.2.17"
         ]
       }
     ]
   },
   {
-    "test-project-path": "mysql/mysql-connector-java/8.0.29",
-    "libraries": [
+    "test-project-path" : "mysql/mysql-connector-java/8.0.29",
+    "libraries" : [
       {
-        "name": "mysql:mysql-connector-java",
-        "versions": [
+        "name" : "mysql:mysql-connector-java",
+        "versions" : [
           "8.0.29"
         ]
       }
     ]
   },
   {
-    "test-project-path": "net.java.dev.jna/jna/5.8.0",
-    "libraries": [
+    "test-project-path" : "net.java.dev.jna/jna/5.8.0",
+    "libraries" : [
       {
-        "name": "net.java.dev.jna:jna",
-        "versions": [
+        "name" : "net.java.dev.jna:jna",
+        "versions" : [
           "5.8.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.activemq/activemq-broker/5.18.1",
-    "libraries": [
+    "test-project-path" : "org.apache.activemq/activemq-broker/5.18.1",
+    "libraries" : [
       {
-        "name": "org.apache.activemq:activemq-broker",
-        "versions": [
+        "name" : "org.apache.activemq:activemq-broker",
+        "versions" : [
           "5.18.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.activemq/activemq-broker/6.0.0",
-    "libraries": [
+    "test-project-path" : "org.apache.activemq/activemq-broker/6.0.0",
+    "libraries" : [
       {
-        "name": "org.apache.activemq:activemq-broker",
-        "versions": [
+        "name" : "org.apache.activemq:activemq-broker",
+        "versions" : [
           "6.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.activemq/activemq-client/5.18.1",
-    "libraries": [
+    "test-project-path" : "org.apache.activemq/activemq-client/5.18.1",
+    "libraries" : [
       {
-        "name": "org.apache.activemq:activemq-client",
-        "versions": [
+        "name" : "org.apache.activemq:activemq-client",
+        "versions" : [
           "5.18.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.activemq/activemq-client/6.0.0",
-    "libraries": [
+    "test-project-path" : "org.apache.activemq/activemq-client/6.0.0",
+    "libraries" : [
       {
-        "name": "org.apache.activemq:activemq-client",
-        "versions": [
+        "name" : "org.apache.activemq:activemq-client",
+        "versions" : [
           "6.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.activemq/artemis-jms-client/2.28.0",
-    "libraries": [
+    "test-project-path" : "org.apache.activemq/artemis-jms-client/2.28.0",
+    "libraries" : [
       {
-        "name": "org.apache.activemq:artemis-jms-client",
-        "versions": [
+        "name" : "org.apache.activemq:artemis-jms-client",
+        "versions" : [
           "2.28.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.commons/commons-compress/1.23.0",
-    "libraries": [
+    "test-project-path" : "org.apache.commons/commons-compress/1.23.0",
+    "libraries" : [
       {
-        "name": "org.apache.commons:commons-compress",
-        "versions": [
+        "name" : "org.apache.commons:commons-compress",
+        "versions" : [
           "1.23.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.commons/commons-dbcp2/2.12.0",
-    "libraries": [
+    "test-project-path" : "org.apache.commons/commons-dbcp2/2.12.0",
+    "libraries" : [
       {
-        "name": "org.apache.commons:commons-dbcp2",
-        "versions": [
+        "name" : "org.apache.commons:commons-dbcp2",
+        "versions" : [
           "2.12.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.commons/commons-pool2/2.11.1",
-    "libraries": [
+    "test-project-path" : "org.apache.commons/commons-pool2/2.11.1",
+    "libraries" : [
       {
-        "name": "org.apache.commons:commons-pool2",
-        "versions": [
+        "name" : "org.apache.commons:commons-pool2",
+        "versions" : [
           "2.11.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.httpcomponents/httpclient/4.5.14",
-    "libraries": [
+    "test-project-path" : "org.apache.httpcomponents/httpclient/4.5.14",
+    "libraries" : [
       {
-        "name": "org.apache.httpcomponents:httpclient",
-        "versions": [
+        "name" : "org.apache.httpcomponents:httpclient",
+        "versions" : [
           "4.5.14"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.kafka/kafka-clients/3.5.1",
-    "libraries": [
+    "test-project-path" : "org.apache.kafka/kafka-clients/3.5.1",
+    "libraries" : [
       {
-        "name": "org.apache.kafka:kafka-clients",
-        "versions": [
+        "name" : "org.apache.kafka:kafka-clients",
+        "versions" : [
           "3.5.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.kafka/kafka-streams/3.5.1",
-    "libraries": [
+    "test-project-path" : "org.apache.kafka/kafka-streams/3.5.1",
+    "libraries" : [
       {
-        "name": "org.apache.kafka:kafka-streams",
-        "versions": [
+        "name" : "org.apache.kafka:kafka-streams",
+        "versions" : [
           "3.5.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.tomcat.embed/tomcat-embed-core/10.0.20",
-    "libraries": [
+    "test-project-path" : "org.apache.tomcat.embed/tomcat-embed-core/10.0.20",
+    "libraries" : [
       {
-        "name": "org.apache.tomcat.embed:tomcat-embed-core",
-        "versions": [
+        "name" : "org.apache.tomcat.embed:tomcat-embed-core",
+        "versions" : [
           "10.0.20"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.apache.tomcat/tomcat-jdbc/10.1.7",
-    "libraries": [
+    "test-project-path" : "org.apache.tomcat/tomcat-jdbc/10.1.7",
+    "libraries" : [
       {
-        "name": "org.apache.tomcat:tomcat-jdbc",
-        "versions": [
+        "name" : "org.apache.tomcat:tomcat-jdbc",
+        "versions" : [
           "10.1.7"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.bouncycastle/bcpkix-jdk15on/1.70",
-    "libraries": [
+    "test-project-path" : "org.bouncycastle/bcpkix-jdk15on/1.70",
+    "libraries" : [
       {
-        "name": "org.bouncycastle:bcpkix-jdk15on",
-        "versions": [
+        "name" : "org.bouncycastle:bcpkix-jdk15on",
+        "versions" : [
           "1.70"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.bouncycastle/bcpkix-jdk15to18/1.77",
-    "libraries": [
+    "test-project-path" : "org.bouncycastle/bcpkix-jdk15to18/1.77",
+    "libraries" : [
       {
-        "name": "org.bouncycastle:bcpkix-jdk15to18",
-        "versions": [
+        "name" : "org.bouncycastle:bcpkix-jdk15to18",
+        "versions" : [
           "1.77"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.bouncycastle/bcpkix-jdk18on/1.77",
-    "libraries": [
+    "test-project-path" : "org.bouncycastle/bcpkix-jdk18on/1.77",
+    "libraries" : [
       {
-        "name": "org.bouncycastle:bcpkix-jdk18on",
-        "versions": [
+        "name" : "org.bouncycastle:bcpkix-jdk18on",
+        "versions" : [
           "1.77"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.angus/jakarta.mail/1.0.0",
-    "libraries": [
+    "test-project-path" : "org.eclipse.angus/jakarta.mail/1.0.0",
+    "libraries" : [
       {
-        "name": "org.eclipse.angus:jakarta.mail",
-        "versions": [
+        "name" : "org.eclipse.angus:jakarta.mail",
+        "versions" : [
           "1.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-client/11.0.12",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-client/11.0.12",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-client",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-client",
+        "versions" : [
           "11.0.12"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-client/12.0.0",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-client/12.0.0",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-client",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-client",
+        "versions" : [
           "12.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-server/11.0.12",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-server/11.0.12",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-server",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-server",
+        "versions" : [
           "11.0.12"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-server/12.0.1",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-server/12.0.1",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-server",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-server",
+        "versions" : [
           "12.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-server/12.1.3",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-server/12.1.3",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-server",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-server",
+        "versions" : [
           "12.1.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jetty/jetty-util/12.0.9",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jetty/jetty-util/12.0.9",
+    "libraries" : [
       {
-        "name": "org.eclipse.jetty:jetty-util",
-        "versions": [
+        "name" : "org.eclipse.jetty:jetty-util",
+        "versions" : [
           "12.0.9"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jgit/org.eclipse.jgit/6.5.0.202303070854-r",
+    "libraries" : [
       {
-        "name": "org.eclipse.jgit:org.eclipse.jgit",
-        "versions": [
+        "name" : "org.eclipse.jgit:org.eclipse.jgit",
+        "versions" : [
           "6.5.0.202303070854-r"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.jgit/org.eclipse.jgit/7.4.0.202509020913-r",
-    "libraries": [
+    "test-project-path" : "org.eclipse.jgit/org.eclipse.jgit/7.4.0.202509020913-r",
+    "libraries" : [
       {
-        "name": "org.eclipse.jgit:org.eclipse.jgit",
-        "versions": [
+        "name" : "org.eclipse.jgit:org.eclipse.jgit",
+        "versions" : [
           "7.4.0.202509020913-r"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.5",
-    "libraries": [
+    "test-project-path" : "org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.5",
+    "libraries" : [
       {
-        "name": "org.eclipse.paho:org.eclipse.paho.client.mqttv3",
-        "versions": [
+        "name" : "org.eclipse.paho:org.eclipse.paho.client.mqttv3",
+        "versions" : [
           "1.2.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.eclipse.paho/org.eclipse.paho.mqttv5.client/1.2.5",
-    "libraries": [
+    "test-project-path" : "org.eclipse.paho/org.eclipse.paho.mqttv5.client/1.2.5",
+    "libraries" : [
       {
-        "name": "org.eclipse.paho:org.eclipse.paho.mqttv5.client",
-        "versions": [
+        "name" : "org.eclipse.paho:org.eclipse.paho.mqttv5.client",
+        "versions" : [
           "1.2.5"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.ehcache/ehcache/3.10.8-jakarta",
-    "libraries": [
+    "test-project-path" : "org.ehcache/ehcache/3.10.8-jakarta",
+    "libraries" : [
       {
-        "name": "org.ehcache:ehcache",
-        "versions": [
+        "name" : "org.ehcache:ehcache",
+        "versions" : [
           "3.10.8-jakarta"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.example/library/0.0.1",
-    "libraries": [
+    "test-project-path" : "org.example/library/0.0.1",
+    "libraries" : [
       {
-        "name": "org.example:library",
-        "versions": [
+        "name" : "org.example:library",
+        "versions" : [
           "0.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/10.10.0",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/10.10.0",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "10.10.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/10.15.0",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/10.15.0",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "10.15.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/10.20.0",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/10.20.0",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "10.20.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/10.20.1",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/10.20.1",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "10.20.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/11.14.1",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/11.14.1",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "11.14.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-core/9.0.1",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-core/9.0.1",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-core",
-        "versions": [
+        "name" : "org.flywaydb:flyway-core",
+        "versions" : [
           "9.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-database-postgresql/10.10.0",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-database-postgresql/10.10.0",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-database-postgresql",
-        "versions": [
+        "name" : "org.flywaydb:flyway-database-postgresql",
+        "versions" : [
           "10.10.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.flywaydb/flyway-sqlserver/10.10.0",
-    "libraries": [
+    "test-project-path" : "org.flywaydb/flyway-sqlserver/10.10.0",
+    "libraries" : [
       {
-        "name": "org.flywaydb:flyway-sqlserver",
-        "versions": [
+        "name" : "org.flywaydb:flyway-sqlserver",
+        "versions" : [
           "10.10.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.freemarker/freemarker/2.3.31",
-    "libraries": [
+    "test-project-path" : "org.freemarker/freemarker/2.3.31",
+    "libraries" : [
       {
-        "name": "org.freemarker:freemarker",
-        "versions": [
+        "name" : "org.freemarker:freemarker",
+        "versions" : [
           "2.3.31"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.glassfish.jaxb/jaxb-runtime/3.0.2",
-    "libraries": [
+    "test-project-path" : "org.glassfish.jaxb/jaxb-runtime/3.0.2",
+    "libraries" : [
       {
-        "name": "org.glassfish.jaxb:jaxb-runtime",
-        "versions": [
+        "name" : "org.glassfish.jaxb:jaxb-runtime",
+        "versions" : [
           "3.0.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hdrhistogram/HdrHistogram/2.1.12",
-    "libraries": [
+    "test-project-path" : "org.hdrhistogram/HdrHistogram/2.1.12",
+    "libraries" : [
       {
-        "name": "org.hdrhistogram:HdrHistogram",
-        "versions": [
+        "name" : "org.hdrhistogram:HdrHistogram",
+        "versions" : [
           "2.1.12"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/6.1.1.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/6.1.1.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "6.1.1.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/6.2.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/6.2.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "6.2.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/6.5.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/6.5.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "6.5.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/6.6.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/6.6.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "6.6.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/7.0.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/7.0.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "7.0.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-core/7.1.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-core/7.1.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-core",
+        "versions" : [
           "7.1.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.orm/hibernate-envers/6.1.1.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.orm/hibernate-envers/6.1.1.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.orm:hibernate-envers",
-        "versions": [
+        "name" : "org.hibernate.orm:hibernate-envers",
+        "versions" : [
           "6.1.1.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.reactive/hibernate-reactive-core/2.0.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.reactive:hibernate-reactive-core",
-        "versions": [
+        "name" : "org.hibernate.reactive:hibernate-reactive-core",
+        "versions" : [
           "2.0.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate.validator/hibernate-validator/7.0.4.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate.validator/hibernate-validator/7.0.4.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate.validator:hibernate-validator",
-        "versions": [
+        "name" : "org.hibernate.validator:hibernate-validator",
+        "versions" : [
           "7.0.4.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate/hibernate-core/5.6.14.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate/hibernate-core/5.6.14.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate:hibernate-core",
+        "versions" : [
           "5.6.14.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate/hibernate-core/6.0.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate/hibernate-core/6.0.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate:hibernate-core",
-        "versions": [
+        "name" : "org.hibernate:hibernate-core",
+        "versions" : [
           "6.0.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.hibernate/hibernate-spatial/6.5.0.Final",
-    "libraries": [
+    "test-project-path" : "org.hibernate/hibernate-spatial/6.5.0.Final",
+    "libraries" : [
       {
-        "name": "org.hibernate:hibernate-spatial",
-        "versions": [
+        "name" : "org.hibernate:hibernate-spatial",
+        "versions" : [
           "6.5.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jboss.logging/jboss-logging/3.5.0.Final",
-    "libraries": [
+    "test-project-path" : "org.jboss.logging/jboss-logging/3.5.0.Final",
+    "libraries" : [
       {
-        "name": "org.jboss.logging:jboss-logging",
-        "versions": [
+        "name" : "org.jboss.logging:jboss-logging",
+        "versions" : [
           "3.5.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final",
-    "libraries": [
+    "test-project-path" : "org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/2.0.0.Final",
+    "libraries" : [
       {
-        "name": "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
-        "versions": [
+        "name" : "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec",
+        "versions" : [
           "2.0.0.Final"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jctools/jctools-core/2.1.2",
-    "libraries": [
+    "test-project-path" : "org.jctools/jctools-core/2.1.2",
+    "libraries" : [
       {
-        "name": "org.jctools:jctools-core",
-        "versions": [
+        "name" : "org.jctools:jctools-core",
+        "versions" : [
           "2.1.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jetbrains.kotlin/kotlin-reflect/1.7.10",
-    "libraries": [
+    "test-project-path" : "org.jetbrains.kotlin/kotlin-reflect/1.7.10",
+    "libraries" : [
       {
-        "name": "org.jetbrains.kotlin:kotlin-reflect",
-        "versions": [
+        "name" : "org.jetbrains.kotlin:kotlin-reflect",
+        "versions" : [
           "1.7.10"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jetbrains.kotlin/kotlin-stdlib/1.7.10",
-    "libraries": [
+    "test-project-path" : "org.jetbrains.kotlin/kotlin-stdlib/1.7.10",
+    "libraries" : [
       {
-        "name": "org.jetbrains.kotlin:kotlin-stdlib",
-        "versions": [
+        "name" : "org.jetbrains.kotlin:kotlin-stdlib",
+        "versions" : [
           "1.7.10"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jline/jline/3.21.0",
-    "libraries": [
+    "test-project-path" : "org.jline/jline/3.21.0",
+    "libraries" : [
       {
-        "name": "org.jline:jline",
-        "versions": [
+        "name" : "org.jline:jline",
+        "versions" : [
           "3.21.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jooq/jooq/3.17.7",
-    "libraries": [
+    "test-project-path" : "org.jooq/jooq/3.17.7",
+    "libraries" : [
       {
-        "name": "org.jooq:jooq",
-        "versions": [
+        "name" : "org.jooq:jooq",
+        "versions" : [
           "3.17.7"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.jooq/jooq/3.18.2",
-    "libraries": [
+    "test-project-path" : "org.jooq/jooq/3.18.2",
+    "libraries" : [
       {
-        "name": "org.jooq:jooq",
-        "versions": [
-          "3.18.2"
+        "name" : "org.jooq:jooq",
+        "versions" : [
+          "3.18.2",
+          "3.20.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.liquibase/liquibase-core/4.17.0",
-    "libraries": [
+    "test-project-path" : "org.liquibase/liquibase-core/4.17.0",
+    "libraries" : [
       {
-        "name": "org.liquibase:liquibase-core",
-        "versions": [
+        "name" : "org.liquibase:liquibase-core",
+        "versions" : [
           "4.17.0",
           "4.20.0",
           "4.23.0"
@@ -1235,11 +1236,11 @@
     ]
   },
   {
-    "test-project-path": "org.liquibase/liquibase-core/4.25.0",
-    "libraries": [
+    "test-project-path" : "org.liquibase/liquibase-core/4.25.0",
+    "libraries" : [
       {
-        "name": "org.liquibase:liquibase-core",
-        "versions": [
+        "name" : "org.liquibase:liquibase-core",
+        "versions" : [
           "4.25.0",
           "4.25.1",
           "4.26.0",
@@ -1251,187 +1252,187 @@
     ]
   },
   {
-    "test-project-path": "org.liquibase/liquibase-core/5.0.1",
-    "libraries": [
+    "test-project-path" : "org.liquibase/liquibase-core/5.0.1",
+    "libraries" : [
       {
-        "name": "org.liquibase:liquibase-core",
-        "versions": [
+        "name" : "org.liquibase:liquibase-core",
+        "versions" : [
           "5.0.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.mariadb.jdbc/mariadb-java-client/3.0.6",
-    "libraries": [
+    "test-project-path" : "org.mariadb.jdbc/mariadb-java-client/3.0.6",
+    "libraries" : [
       {
-        "name": "org.mariadb.jdbc:mariadb-java-client",
-        "versions": [
+        "name" : "org.mariadb.jdbc:mariadb-java-client",
+        "versions" : [
           "3.0.6"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.mariadb.jdbc/mariadb-java-client/3.5.2",
-    "libraries": [
+    "test-project-path" : "org.mariadb.jdbc/mariadb-java-client/3.5.2",
+    "libraries" : [
       {
-        "name": "org.mariadb.jdbc:mariadb-java-client",
-        "versions": [
+        "name" : "org.mariadb.jdbc:mariadb-java-client",
+        "versions" : [
           "3.5.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.mariadb/r2dbc-mariadb/1.1.3",
-    "libraries": [
+    "test-project-path" : "org.mariadb/r2dbc-mariadb/1.1.3",
+    "libraries" : [
       {
-        "name": "org.mariadb:r2dbc-mariadb",
-        "versions": [
+        "name" : "org.mariadb:r2dbc-mariadb",
+        "versions" : [
           "1.1.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.mockito/mockito-core/4.8.1",
-    "libraries": [
+    "test-project-path" : "org.mockito/mockito-core/4.8.1",
+    "libraries" : [
       {
-        "name": "org.mockito:mockito-core",
-        "versions": [
+        "name" : "org.mockito:mockito-core",
+        "versions" : [
           "4.8.1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.mockito/mockito-core/5.0.0",
-    "libraries": [
+    "test-project-path" : "org.mockito/mockito-core/5.0.0",
+    "libraries" : [
       {
-        "name": "org.mockito:mockito-core",
-        "versions": [
+        "name" : "org.mockito:mockito-core",
+        "versions" : [
           "5.0.0"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.opengauss/opengauss-jdbc/3.1.0-og",
-    "libraries": [
+    "test-project-path" : "org.opengauss/opengauss-jdbc/3.1.0-og",
+    "libraries" : [
       {
-        "name": "org.opengauss:opengauss-jdbc",
-        "versions": [
+        "name" : "org.opengauss:opengauss-jdbc",
+        "versions" : [
           "3.1.0-og"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.postgresql/postgresql/42.3.4",
-    "libraries": [
+    "test-project-path" : "org.postgresql/postgresql/42.3.4",
+    "libraries" : [
       {
-        "name": "org.postgresql:postgresql",
-        "versions": [
+        "name" : "org.postgresql:postgresql",
+        "versions" : [
           "42.3.4"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.postgresql/postgresql/42.7.3",
-    "libraries": [
+    "test-project-path" : "org.postgresql/postgresql/42.7.3",
+    "libraries" : [
       {
-        "name": "org.postgresql:postgresql",
-        "versions": [
+        "name" : "org.postgresql:postgresql",
+        "versions" : [
           "42.7.3"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.quartz-scheduler/quartz/2.3.2",
-    "libraries": [
+    "test-project-path" : "org.quartz-scheduler/quartz/2.3.2",
+    "libraries" : [
       {
-        "name": "org.quartz-scheduler:quartz",
-        "versions": [
+        "name" : "org.quartz-scheduler:quartz",
+        "versions" : [
           "2.3.2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.testcontainers/testcontainers/1.17.6",
-    "libraries": [
+    "test-project-path" : "org.testcontainers/testcontainers/1.17.6",
+    "libraries" : [
       {
-        "name": "org.testcontainers:testcontainers",
-        "versions": [
+        "name" : "org.testcontainers:testcontainers",
+        "versions" : [
           "1.17.6"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.testcontainers/testcontainers/1.19.8",
-    "libraries": [
+    "test-project-path" : "org.testcontainers/testcontainers/1.19.8",
+    "libraries" : [
       {
-        "name": "org.testcontainers:testcontainers",
-        "versions": [
+        "name" : "org.testcontainers:testcontainers",
+        "versions" : [
           "1.19.8"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1",
-    "libraries": [
+    "test-project-path" : "org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.M1",
+    "libraries" : [
       {
-        "name": "org.thymeleaf.extras:thymeleaf-extras-springsecurity6",
-        "versions": [
+        "name" : "org.thymeleaf.extras:thymeleaf-extras-springsecurity6",
+        "versions" : [
           "3.1.0.M1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.thymeleaf/thymeleaf-spring6/3.1.0.M2",
-    "libraries": [
+    "test-project-path" : "org.thymeleaf/thymeleaf-spring6/3.1.0.M2",
+    "libraries" : [
       {
-        "name": "org.thymeleaf:thymeleaf-spring6",
-        "versions": [
+        "name" : "org.thymeleaf:thymeleaf-spring6",
+        "versions" : [
           "3.1.0.M2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.thymeleaf/thymeleaf/3.1.0.M2",
-    "libraries": [
+    "test-project-path" : "org.thymeleaf/thymeleaf/3.1.0.M2",
+    "libraries" : [
       {
-        "name": "org.thymeleaf:thymeleaf",
-        "versions": [
+        "name" : "org.thymeleaf:thymeleaf",
+        "versions" : [
           "3.1.0.M2"
         ]
       }
     ]
   },
   {
-    "test-project-path": "org.thymeleaf/thymeleaf/3.1.0.RC1",
-    "libraries": [
+    "test-project-path" : "org.thymeleaf/thymeleaf/3.1.0.RC1",
+    "libraries" : [
       {
-        "name": "org.thymeleaf:thymeleaf",
-        "versions": [
+        "name" : "org.thymeleaf:thymeleaf",
+        "versions" : [
           "3.1.0.RC1"
         ]
       }
     ]
   },
   {
-    "test-project-path": "samples/docker/image-pull",
-    "libraries": [
+    "test-project-path" : "samples/docker/image-pull",
+    "libraries" : [
       {
-        "name": "samples:docker",
-        "versions": [
+        "name" : "samples:docker",
+        "versions" : [
           "image-pull"
         ]
       }


### PR DESCRIPTION
## What does this PR do?

Fixes: #752

This PR provides new metadata needed for the org.jooq:jooq:3.20.0, addressing Native Image run failures caused by changes in the updated library version.
