### PR TITLE
Introduce new Gradle tasks for easier index.json updates

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -30,6 +30,7 @@ import org.graalvm.internal.tck.harness.tasks.FetchExistingLibrariesWithNewerVer
 import org.gradle.util.internal.VersionNumber
 import org.graalvm.internal.tck.harness.tasks.ComputeAndPullAllowedDockerImagesTask
 import org.graalvm.internal.tck.utils.CoordinateUtils
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils
 
 
 import static org.graalvm.internal.tck.Utils.generateTaskName
@@ -333,4 +334,32 @@ tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
 tasks.register("fixTestNativeImageRun", FixTestNativeImageRun.class) { task ->
     task.setDescription("Fix test that fails Native Image run for new library version.")
     task.setGroup(METADATA_GROUP)
+}
+
+// gradle addNewEntryTestsIndexJson -Pcoordinates=<maven-coordinates>
+tasks.register("addNewEntryTestsIndexJson", DefaultTask) { task ->
+    task.setDescription("Adds a new entry to tests/src/index.json for a new library version.")
+    task.setGroup(METADATA_GROUP)
+    task.doFirst {
+        if (!project.hasProperty("coordinates")) {
+            throw new GradleException("Missing 'coordinates' property! Rerun Gradle with -Pcoordinates=<group:artifact:version>")
+        }
+        def coordsStr = project.findProperty("coordinates").toString()
+        def coords = CoordinateUtils.fromString(coordsStr)
+        MetadataGenerationUtils.addNewEntryToTestsIndex(project.layout, coords)
+    }
+}
+
+// gradle addLibraryAsLatestMetadataIndexJson -Pcoordinates=<maven-coordinates>
+tasks.register("addLibraryAsLatestMetadataIndexJson", DefaultTask) { task ->
+    task.setDescription("Marks given coordinates as latest in metadata/group/artifact/index.json")
+    task.setGroup(METADATA_GROUP)
+    task.doFirst {
+        if (!project.hasProperty("coordinates")) {
+            throw new GradleException("Missing 'coordinates' property! Rerun Gradle with -Pcoordinates=<group:artifact:version>")
+        }
+        def coordsStr = project.findProperty("coordinates").toString()
+        def coords = CoordinateUtils.fromString(coordsStr)
+        MetadataGenerationUtils.makeVersionLatestInIndexJson(project.layout, coords)
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #836

This PR adds new functions to `MetadataGenerationUtils` and registers them as independent tasks. These enhancements allow for more granular and reusable infrastructure update steps within workflows, helping to eliminate redundancy and improve.

**Usage:**
- `./gradle addNewEntryTestsIndexJson -Pcoordinates=<maven-coordinates>` - adds new entry in the `tests/src/index.json` for the provided library, if library does not already exist in file. 

- `./gradle addLibraryAsLatestMetadataIndexJson -Pcoordinates=<maven-coordinates>` - adds new entry and marks it as `latest` in the `metadata/group/artifact/index.json` for the given library coordinates.