### PR TITLE
Don't test on JDK 21

### DIFF
--- a/ci.json
+++ b/ci.json
@@ -1,19 +1,19 @@
 {
   "buildArgs": ["-verbose", "-Ob", "-H:+ReportExceptionStackTraces"],
   "generateMatrixBatchedCoordinates": {
-    "java": ["21", "25", "latest-ea"],
+    "java": ["25", "latest-ea"],
     "os": ["ubuntu-latest"]
   },
   "generateChangedCoordinatesMatrix": {
-    "java": ["21", "25", "latest-ea"],
+    "java": ["25", "latest-ea"],
     "os": ["ubuntu-latest"]
   },
   "generateInfrastructureChangedCoordinatesMatrix": {
-    "java": ["21", "25", "latest-ea"],
+    "java": ["25", "latest-ea"],
     "os": ["ubuntu-latest"]
   },
   "generateMatrixMatchingCoordinates": {
-    "java": ["21", "25","latest-ea"],
+    "java": ["25","latest-ea"],
     "os": ["ubuntu-latest"]
   }
 }


### PR DESCRIPTION
Fixes: #862 

GraalVM 21 implementation has proven to be incomplete and hence passing all the tests is hard, time-consuming, and blocks the development workflow.

We opted in for disabling this testing on GraalVM 21 to allow us to move faster. 

The metadata produced on GraalVM 25 will still be valid on GraalVM 21 distributions.