### PR TITLE
Fix org.eclipse.angus:jakarta.mail metadata and tests

### DIFF
--- a/metadata/org.eclipse.angus/jakarta.mail/1.0.0/resource-config.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/1.0.0/resource-config.json
@@ -2,21 +2,39 @@
   "resources": {
     "includes": [
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/hk2-locator/default\\E"
       },
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/gfprobe-provider.xml\\E"
       },
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/javamail.charset.map\\E"
       },
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/javamail.default.address.map\\E"
       },
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/javamail.default.providers\\E"
       },
       {
+        "condition": {
+          "typeReachable": "jakarta.activation.MailcapCommandMap"
+        },
         "pattern": "\\QMETA-INF/mailcap\\E"
       }
     ]

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/required-docker-images.txt
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/required-docker-images.txt
@@ -1,0 +1,1 @@
+greenmail/standalone:2.1.0-alpha-4

--- a/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/src/test/java/com/sun/mail/JakartaMailTest.java
+++ b/tests/src/org.eclipse.angus/jakarta.mail/1.0.0/src/test/java/com/sun/mail/JakartaMailTest.java
@@ -35,7 +35,7 @@ public class JakartaMailTest {
     static void beforeAll() throws IOException {
         System.out.println("Starting email server ...");
         new ProcessBuilder("docker", "run", "--cidfile", "greenmail.cid", "-p", "3025:3025", "--rm", "-e",
-                "GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose", "greenmail/standalone:1.6.10")
+                "GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose", "greenmail/standalone:2.1.0-alpha-4")
                 .redirectOutput(new File("greenmail-stdout.txt"))
                 .redirectError(new File("greenmail-stderr.txt")).start();
         Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> {


### PR DESCRIPTION
## What does this PR do?

The tests for `org.eclipse.angus:jakarta.mail:1.0.0` used a docker image that was not specified by `required-docker-images.txt` (and a version that we don't support at that), so we added the missing file and changed the version to the one supported by the repo.

Also, `MetadataFilesCheckerTask` failed for this libraries metadata, as the `resource-config.json` file was missing conditions for its entries.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/872