### PR TITLE
[Automation] Generated metadata for org.hibernate:hibernate-spatial:7.2.0.Final

### DIFF
--- a/metadata/org.hibernate/hibernate-spatial/7.2.0.Final/reflect-config.json
+++ b/metadata/org.hibernate/hibernate-spatial/7.2.0.Final/reflect-config.json
@@ -1,0 +1,106 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.BootLogging"
+    },
+    "name": "org.hibernate.boot.BootLogging_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.BootLogging"
+    },
+    "name": "org.hibernate.boot.BootLogging_$logger_en"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.boot.BootLogging"
+    },
+    "name": "org.hibernate.boot.BootLogging_$logger_en_US"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.internal.CoreMessageLogger"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.internal.CoreMessageLogger"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger_en"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.internal.CoreMessageLogger"
+    },
+    "name": "org.hibernate.internal.CoreMessageLogger_$logger_en_US"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.service.internal.ServiceLogger"
+    },
+    "name": "org.hibernate.service.internal.ServiceLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.service.internal.ServiceLogger"
+    },
+    "name": "org.hibernate.service.internal.ServiceLogger_$logger_en"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.service.internal.ServiceLogger"
+    },
+    "name": "org.hibernate.service.internal.ServiceLogger_$logger_en_US"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.spatial.integration.SpatialService"
+    },
+    "name": "org.hibernate.spatial.HSMessageLogger_$logger",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.spatial.integration.SpatialService"
+    },
+    "name": "org.hibernate.spatial.HSMessageLogger_$logger_en"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.hibernate.spatial.integration.SpatialService"
+    },
+    "name": "org.hibernate.spatial.HSMessageLogger_$logger_en_US"
+  }
+]

--- a/metadata/org.hibernate/hibernate-spatial/index.json
+++ b/metadata/org.hibernate/hibernate-spatial/index.json
@@ -2,6 +2,13 @@
   {
     "latest" : true,
     "module" : "org.hibernate:hibernate-spatial",
+    "metadata-version" : "7.2.0.Final",
+    "tested-versions" : [
+      "7.2.0.Final"
+    ]
+  },
+  {
+    "module" : "org.hibernate:hibernate-spatial",
     "metadata-version" : "6.5.0.Final",
     "tested-versions" : [
       "6.5.0.Final",

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -1130,7 +1130,8 @@
       {
         "name" : "org.hibernate:hibernate-spatial",
         "versions" : [
-          "6.5.0.Final"
+          "6.5.0.Final",
+          "7.2.0.Final"
         ]
       }
     ]

--- a/tests/src/org.hibernate/hibernate-spatial/6.5.0.Final/build.gradle
+++ b/tests/src/org.hibernate/hibernate-spatial/6.5.0.Final/build.gradle
@@ -14,3 +14,14 @@ dependencies {
     testImplementation "org.hibernate:hibernate-spatial:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #886

This PR provides new metadata needed for the `org.hibernate:hibernate-spatial:7.2.0.Final`, addressing Native Image run failures caused by changes in the updated library version.