### PR TITLE
[Automation] Generated metadata for org.apache.activemq:artemis-jms-client:2.32.0

### DIFF
--- a/metadata/org.apache.activemq/artemis-jms-client/2.32.0/reflect-config.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/2.32.0/reflect-config.json
@@ -1,0 +1,1317 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[B"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[C"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[D"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[F"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[I"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[J"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.io.File;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Boolean;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Byte;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Character;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Class;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Double;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Float;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Integer;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Long;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.Short;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.lang.String;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.math.BigDecimal;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.math.BigInteger;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.net.URL;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.sql.Date;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.sql.Time;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.sql.Timestamp;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.util.Calendar;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Ljava.util.Date;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.actors.ProcessorBase"
+    },
+    "name": "[Ljava.util.Iterator;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl"
+    },
+    "name": "[Lorg.apache.activemq.artemis.api.core.Pair;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.collections.LinkedListImpl"
+    },
+    "name": "[Lorg.apache.activemq.artemis.utils.collections.LinkedListImpl$Iterator;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl"
+    },
+    "name": "[Lorg.apache.activemq.artemis.utils.collections.LinkedListImpl;"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[S"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "[Z"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl"
+    },
+    "name": "com.github.benmanes.caffeine.cache.PS",
+    "fields": [
+      {
+        "name": "key"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl"
+    },
+    "name": "com.github.benmanes.caffeine.cache.StripedBuffer",
+    "fields": [
+      {
+        "name": "tableBusy"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+    },
+    "name": "io.netty.channel.ChannelDuplexHandler",
+    "methods": [
+      {
+        "name": "bind",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "close",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "connect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "deregister",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "disconnect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "flush",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "read",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "write",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object",
+          "io.netty.channel.ChannelPromise"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQClientProtocolManager"
+    },
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+    },
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+    },
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "methods": [
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+    },
+    "name": "io.netty.channel.ChannelInitializer",
+    "methods": [
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.DefaultFileRegion"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+    },
+    "name": "io.netty.channel.epoll.EpollSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.unix.DatagramSocketAddress"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.unix.DomainDatagramSocketAddress"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.unix.FileDescriptor",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "io.netty.channel.unix.PeerCredentials"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQClientProtocolManager"
+    },
+    "name": "io.netty.handler.codec.ByteToMessageDecoder",
+    "methods": [
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "java.net.InetSocketAddress"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+    },
+    "name": "java.net.PortUnreachableException"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "javax.jms.ConnectionFactory",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "javax.jms.XAConnectionFactory",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "javax.naming.Referenceable",
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.api.core.RefCountMessage"
+    },
+    "name": "org.apache.activemq.artemis.api.core.RefCountMessage",
+    "fields": [
+      {
+        "name": "durableRefCount"
+      },
+      {
+        "name": "refCount"
+      },
+      {
+        "name": "usageCount"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.api.core.client.ServerLocator",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl$2"
+    },
+    "name": "org.apache.activemq.artemis.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.logs.BundleFactory"
+    },
+    "name": "org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle_impl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.slf4j.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "getHost",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getPort",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isHost",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isPort",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImplCustomizer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.core.cluster.DiscoveryListener",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.journal.impl.JournalFileImpl"
+    },
+    "name": "org.apache.activemq.artemis.core.journal.impl.JournalFileImpl",
+    "fields": [
+      {
+        "name": "addRecordField"
+      },
+      {
+        "name": "liveBytesField"
+      },
+      {
+        "name": "posCountField"
+      },
+      {
+        "name": "replaceableCountField"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.journal.impl.JournalTransaction"
+    },
+    "name": "org.apache.activemq.artemis.core.journal.impl.JournalTransaction",
+    "fields": [
+      {
+        "name": "counter"
+      },
+      {
+        "name": "up"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl"
+    },
+    "name": "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl",
+    "fields": [
+      {
+        "name": "deliveryCount"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl"
+    },
+    "name": "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl",
+    "fields": [
+      {
+        "name": "added"
+      },
+      {
+        "name": "addedPersistentSize"
+      },
+      {
+        "name": "persistentSize"
+      },
+      {
+        "name": "recordedSize"
+      },
+      {
+        "name": "recordedValue"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.postoffice.QueueInfo"
+    },
+    "name": "org.apache.activemq.artemis.core.postoffice.QueueInfo",
+    "fields": [
+      {
+        "name": "consumersCount"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.postoffice.impl.BindingsImpl"
+    },
+    "name": "org.apache.activemq.artemis.core.postoffice.impl.BindingsImpl",
+    "fields": [
+      {
+        "name": "version"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.postoffice.impl.CopyOnWriteBindings$BindingsAndPosition"
+    },
+    "name": "org.apache.activemq.artemis.core.postoffice.impl.CopyOnWriteBindings$BindingsAndPosition",
+    "fields": [
+      {
+        "name": "nextPosition"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "org.apache.activemq.artemis.core.protocol.core.impl.CoreProtocolManagerBeanInfo"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "org.apache.activemq.artemis.core.protocol.core.impl.CoreProtocolManagerCustomizer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+    },
+    "name": "org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQChannelHandler",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQClientProtocolManager"
+    },
+    "name": "org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQFrameDecoder2"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+    },
+    "name": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+    },
+    "name": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$ActiveMQClientChannelHandler"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl$2"
+    },
+    "name": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory",
+    "methods": [
+      {
+        "name": "getCallFailoverTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCallTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "getClientFailureCheckPeriod",
+        "parameterTypes": []
+      },
+      {
+        "name": "getClientID",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCompressionLevel",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConfirmationWindowSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConnectionLoadBalancingPolicyClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConnectionTTL",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConsumerMaxRate",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConsumerWindowSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDeserializationAllowList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDeserializationBlackList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDeserializationDenyList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDeserializationWhiteList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDupsOKBatchSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFactoryType",
+        "parameterTypes": []
+      },
+      {
+        "name": "getGroupID",
+        "parameterTypes": []
+      },
+      {
+        "name": "getIncomingInterceptorList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInitialConnectAttempts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInitialMessagePacketSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxRetryInterval",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMinLargeMessageSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOutgoingInterceptorList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPassword",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPasswordCodec",
+        "parameterTypes": []
+      },
+      {
+        "name": "getProducerMaxRate",
+        "parameterTypes": []
+      },
+      {
+        "name": "getProducerWindowSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getProtocolManagerFactoryStr",
+        "parameterTypes": []
+      },
+      {
+        "name": "getReconnectAttempts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRetryInterval",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRetryIntervalMultiplier",
+        "parameterTypes": []
+      },
+      {
+        "name": "getScheduledThreadPoolMaxSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getThreadPoolMaxSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTransactionBatchSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUser",
+        "parameterTypes": []
+      },
+      {
+        "name": "isAutoGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "isBlockOnAcknowledge",
+        "parameterTypes": []
+      },
+      {
+        "name": "isBlockOnDurableSend",
+        "parameterTypes": []
+      },
+      {
+        "name": "isBlockOnNonDurableSend",
+        "parameterTypes": []
+      },
+      {
+        "name": "isCacheDestinations",
+        "parameterTypes": []
+      },
+      {
+        "name": "isCacheLargeMessagesClient",
+        "parameterTypes": []
+      },
+      {
+        "name": "isCompressLargeMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "isEnable1xPrefixes",
+        "parameterTypes": []
+      },
+      {
+        "name": "isEnableSharedClientID",
+        "parameterTypes": []
+      },
+      {
+        "name": "isFailoverOnInitialConnection",
+        "parameterTypes": []
+      },
+      {
+        "name": "isHA",
+        "parameterTypes": []
+      },
+      {
+        "name": "isIgnoreJTA",
+        "parameterTypes": []
+      },
+      {
+        "name": "isPreAcknowledge",
+        "parameterTypes": []
+      },
+      {
+        "name": "isUseGlobalPools",
+        "parameterTypes": []
+      },
+      {
+        "name": "isUseTopologyForLoadBalancing",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "getHost",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getPort",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isHost",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isPort",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactoryBeanInfo"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactoryCustomizer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jms.client.ConnectionFactoryOptions",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jndi.JNDIStorable",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jndi.JNDIStorableBeanInfo"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.URISchema"
+    },
+    "name": "org.apache.activemq.artemis.jndi.JNDIStorableCustomizer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.logs.AuditLogger"
+    },
+    "name": "org.apache.activemq.artemis.logs.AuditLogger_impl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.slf4j.Logger"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+    },
+    "name": "org.apache.activemq.artemis.spi.core.protocol.ProtocolManager",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptions",
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "getUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isUserInfo",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setHost",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPort",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptionsBeanInfo"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+    },
+    "name": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptionsCustomizer"
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor$ThreadPoolQueue"
+    },
+    "name": "org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor$ThreadPoolQueue",
+    "fields": [
+      {
+        "name": "threadTaskDelta"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.ReferenceCounterUtil"
+    },
+    "name": "org.apache.activemq.artemis.utils.ReferenceCounterUtil",
+    "fields": [
+      {
+        "name": "use"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.SizeAwareMetric"
+    },
+    "name": "org.apache.activemq.artemis.utils.SizeAwareMetric",
+    "fields": [
+      {
+        "name": "elements"
+      },
+      {
+        "name": "flag"
+      },
+      {
+        "name": "size"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.actors.ProcessorBase"
+    },
+    "name": "org.apache.activemq.artemis.utils.actors.ProcessorBase",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.collections.ConcurrentLongHashMap$Section"
+    },
+    "name": "org.apache.activemq.artemis.utils.collections.ConcurrentLongHashMap$Section",
+    "fields": [
+      {
+        "name": "capacity"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl"
+    },
+    "name": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl",
+    "fields": [
+      {
+        "name": "size"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.collections.UpdatableIterator"
+    },
+    "name": "org.apache.activemq.artemis.utils.collections.UpdatableIterator",
+    "fields": [
+      {
+        "name": "changedIterator"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.critical.CriticalMeasure"
+    },
+    "name": "org.apache.activemq.artemis.utils.critical.CriticalMeasure",
+    "fields": [
+      {
+        "name": "measuring"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.apache.activemq.artemis.utils.runnables.AtomicRunnable"
+    },
+    "name": "org.apache.activemq.artemis.utils.runnables.AtomicRunnable",
+    "fields": [
+      {
+        "name": "ran"
+      }
+    ]
+  }
+]

--- a/metadata/org.apache.activemq/artemis-jms-client/2.32.0/resource-config.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/2.32.0/resource-config.json
@@ -1,0 +1,73 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants"
+        },
+        "pattern": "\\QMETA-INF/io.netty.versions.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+        },
+        "pattern": "\\QMETA-INF/native/libnetty_transport_native_epoll_x86_64.so\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+        },
+        "pattern": "\\QMETA-INF/services/java.net.spi.InetAddressResolverProvider\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.commons.shaded.johnzon.core.JsonProviderImpl"
+        },
+        "pattern": "\\QMETA-INF/services/org.apache.activemq.artemis.commons.shaded.johnzon.core.spi.JsonPointerFactory\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.spi.core.protocol.MessagePersister"
+        },
+        "pattern": "\\QMETA-INF/services/org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactoryProvider"
+        },
+        "pattern": "\\QMETA-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactoryProvider"
+        },
+        "pattern": "\\QMETA-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+        },
+        "pattern": "\\QMETA-INF/services/org.apache.commons.logging.LogFactory\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.utils.VersionLoader"
+        },
+        "pattern": "\\Qactivemq-version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+        },
+        "pattern": "\\Qcommons-logging.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.apache.activemq.artemis.utils.ClassloadingUtil"
+        },
+        "pattern": "\\Qorg.apache.activemq.artemis.api.jms.ActiveMQJMSClient.properties\\E"
+      }
+    ]
+  },
+  "bundles": []
+}

--- a/metadata/org.apache.activemq/artemis-jms-client/index.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/index.json
@@ -2,6 +2,13 @@
   {
     "latest" : true,
     "module" : "org.apache.activemq:artemis-jms-client",
+    "metadata-version" : "2.32.0",
+    "tested-versions" : [
+      "2.32.0"
+    ]
+  },
+  {
+    "module" : "org.apache.activemq:artemis-jms-client",
     "metadata-version" : "2.29.0",
     "tested-versions" : [
       "2.29.0"

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -613,7 +613,8 @@
         "name" : "org.apache.activemq:artemis-jms-client",
         "versions" : [
           "2.28.0",
-          "2.29.0"
+          "2.29.0",
+          "2.32.0"
         ]
       }
     ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #878 

This PR provides new metadata needed for the `org.apache.activemq:artemis-jms-client:2.32.0`, addressing Native Image run failures caused by changes in the updated library version.
