### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-sqlserver:10.13.0

### DIFF
--- a/metadata/org.flywaydb/flyway-sqlserver/10.13.0/reflect-config.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/10.13.0/reflect-config.json
@@ -1,0 +1,180 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBaselineMigrationPrefix",
+        "parameterTypes": []
+      },
+      {
+        "name": "setBaselineMigrationPrefix",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.extensibility.ConfigurationExtension",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getClean",
+        "parameterTypes": []
+      },
+      {
+        "name": "setClean",
+        "parameterTypes": [
+          "org.flywaydb.core.internal.command.clean.CleanModel"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.internal.command.clean.CleanModel",
+    "allPublicConstructors": true,
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.internal.command.clean.SchemaModel",
+    "allPublicConstructors": true,
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "isPublishResult",
+        "parameterTypes": []
+      },
+      {
+        "name": "setPublishResult",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.database.sqlserver.KerberosModel",
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLogin",
+        "parameterTypes": []
+      },
+      {
+        "name": "setLogin",
+        "parameterTypes": [
+          "org.flywaydb.database.sqlserver.LoginModel"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.database.sqlserver.LoginModel",
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFile",
+        "parameterTypes": []
+      },
+      {
+        "name": "setFile",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    "name": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+    "allDeclaredFields": true,
+    "allPublicConstructors": true,
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getClean",
+        "parameterTypes": []
+      },
+      {
+        "name": "getKerberos",
+        "parameterTypes": []
+      },
+      {
+        "name": "setClean",
+        "parameterTypes": [
+          "org.flywaydb.core.internal.command.clean.CleanModel"
+        ]
+      },
+      {
+        "name": "setKerberos",
+        "parameterTypes": [
+          "org.flywaydb.database.sqlserver.KerberosModel"
+        ]
+      }
+    ]
+  }
+]

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -2,6 +2,13 @@
   {
     "latest" : true,
     "module" : "org.flywaydb:flyway-sqlserver",
+    "metadata-version" : "10.13.0",
+    "tested-versions" : [
+      "10.13.0"
+    ]
+  },
+  {
+    "module" : "org.flywaydb:flyway-sqlserver",
     "metadata-version" : "10.10.0",
     "tested-versions" : [
       "10.10.0",

--- a/tests/src/index.json
+++ b/tests/src/index.json
@@ -966,7 +966,8 @@
       {
         "name" : "org.flywaydb:flyway-sqlserver",
         "versions" : [
-          "10.10.0"
+          "10.10.0",
+          "10.13.0"
         ]
       }
     ]

--- a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle
@@ -23,4 +23,12 @@ graalvmNative {
             buildArgs.add("-H:+AddAllCharsets")
         }
     }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
 }

--- a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #739 

This PR provides new metadata needed for the `org.flywaydb:flyway-sqlserver:10.13.0`, addressing Native Image run failures caused by changes in the updated library version.
