### PR TITLE
Fix PullAllowedDockerImages task to resolve correct requried-docker-images.txt path

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -236,9 +236,6 @@ public final class MetadataGenerationUtils {
      */
     public static void addNewEntryToTestsIndex(ProjectLayout layout, Coordinates newCoords) throws IOException {
         Path indexPath = GeneralUtils.getPathFromProject(layout, "tests/src/index.json");
-        if (!Files.exists(indexPath)) {
-            return;
-        }
 
         ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 


### PR DESCRIPTION
## What does this PR do?

Fixes: #900

This PR updates the `PullAllowedDockerImages` task to correctly resolve the required-docker-images.txt file path by using the mapped `test-directory-path` value from the _tests/src/index.json_, rather than directly searching it based on the provided coordinates. This ensures that, for libraries mapped to a single test directory but used for multiple versions, the correct Docker images file is always found and used.