### PR TITLE
Additional metadata for org.liquibase:liquibase-core:5.0.1

### DIFF
--- a/metadata/org.liquibase/liquibase-core/5.0.1/reflect-config.json
+++ b/metadata/org.liquibase/liquibase-core/5.0.1/reflect-config.json
@@ -8160,5 +8160,19 @@
     },
     "name": "liquibase.ui.LoggerUIService",
     "allPublicConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "liquibase.configuration.LiquibaseConfiguration"
+    },
+    "name": "liquibase.change.core.SQLFileChange",
+    "methods": [
+      {
+        "name": "setPath",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #909 

This PR adds additional metadata for `org.liquibase:liquibase-core:5.0.1` required for Spring Boot support.
