### PR TITLE
Add timeouts to verify-new-library-version-compatibility.yml and print stacktraces

### DIFF
--- a/.github/workflows/scripts/run-consecutive-tests.sh
+++ b/.github/workflows/scripts/run-consecutive-tests.sh
@@ -6,7 +6,7 @@
 
 set -u
 
-TIMEOUT="10m"
+TIMEOUT="5m"
 
 if [ $# -ne 2 ]; then
   echo "Usage: $0 <test-coordinates> <versions-json-array>"
@@ -43,15 +43,15 @@ run_multiple_attempts() {
       echo "Re-running stage '$stage' (attempt $((attempt + 1))/$max_attempts)"
     fi
 
-    timeout "$TIMEOUT" bash -c "$cmd_str"
+    timeout --signal=QUIT --kill-after=20s "$TIMEOUT" bash -c "$cmd_str"
     result=$?
 
     if [ "$result" -eq 0 ]; then
       return 0
     fi
 
-    if [ "$result" -eq 124 ]; then
-      echo "⚠️  TIMEOUT: '$stage' for $VERSION took longer than $TIMEOUT."
+    if [ "$result" -eq 124 ] || [ "$result" -eq 131 ] || [ "$result" -eq 137 ]; then
+      echo "⚠️  TIMEOUT: '$stage' for $VERSION took longer than $TIMEOUT (exit code $result)."
     else
       echo "❌ ERROR: '$stage' for $VERSION failed with exit code $result."
     fi


### PR DESCRIPTION
## What does this PR do?

In this PR we fix existing issues with `verify-new-library-version-compatibility.yml`:

The workflow has no timeouts for running tests, so if a test gets "stuck" without ever finishing, it won't fail and its job will get skipped, causing the global `Process Results` job to get skipped and no PR to get generated. In this PR, we add a `10m` timeout to all tests, where if a test fails 3 times due to a timeout, an issue will be opened for the test and the workflow will proceed as usual. When this happens, we also send a `SIGQUIT` (or `SIGKILL` if needed) to the process, so we can get the full stacktrace where the process "hanged" and timed out at.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/910