### PR TITLE
Add missing org.springframework entries in library-and-framework-list.json

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -2661,7 +2661,7 @@
     "description": "Implements Spring’s Servlet-based MVC framework for building HTTP web applications and RESTful service.",
     "details": [
       {
-        "minimum_version": "3.0.0",
+        "minimum_version": "6.0.0",
         "metadata_locations": [],
         "tests_locations": [
           "https://github.com/spring-projects/spring-aot-smoke-tests/tree/main/framework/webmvc-tomcat"


### PR DESCRIPTION
## What does this PR do?

Fixes: #953 

This PR adds missing entries for `org.springframework` in the _library-and-framework-list.json_, that were mentioned in the following issues:
- https://github.com/oracle/graalvm-reachability-metadata/issues/935
- https://github.com/oracle/graalvm-reachability-metadata/issues/937
- https://github.com/oracle/graalvm-reachability-metadata/issues/938