### PR TITLE
Fix NBT snapshots running on master workflows

### DIFF
--- a/.github/actions/setup-native-build-tools/action.yml
+++ b/.github/actions/setup-native-build-tools/action.yml
@@ -65,7 +65,7 @@ runs:
         SELECTED="$INPUT_FALLBACK_REF"
         SAME_BRANCH="false"
 
-        if [ "${INPUT_PREFER_SAME}" = "true" ] && [ -n "$CANDIDATE" ]; then
+        if [ "${INPUT_PREFER_SAME}" = "true" ] && [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "master" ]; then
           # Use git to check for the branch existence on the public repository (no API/token required)
           REMOTE_URL="https://github.com/${INPUT_REPO}.git"
           if git ls-remote --heads "$REMOTE_URL" "$CANDIDATE" >/dev/null 2>&1; then
@@ -81,7 +81,11 @@ runs:
             echo "git ls-remote failed (network or repo issue). Using fallback: ${INPUT_FALLBACK_REF}"
           fi
         else
-          echo "Prefer-same-branch disabled or no candidate branch detected. Using fallback: ${INPUT_FALLBACK_REF}"
+          if [ "$CANDIDATE" = "master" ]; then
+            echo "Branch matching ignored for 'master'. Using fallback: ${INPUT_FALLBACK_REF}"
+          else
+            echo "Prefer-same-branch disabled or no candidate branch detected. Using fallback: ${INPUT_FALLBACK_REF}"
+          fi
         fi
 
         echo "nbt-ref=${SELECTED}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -191,6 +191,9 @@ jobs:
 
             update_new_versions
 
+            # Do not commit changes to the NBT version catalog in this workflow
+            git restore --source=HEAD --staged --worktree gradle/libs.versions.toml || true
+
             # If nothing changed, exit early
             if git status --porcelain | grep -q .; then
               git add -u


### PR DESCRIPTION
## What does this PR do?

In this PR, we skip using the latest buildtools snapshot in the CI when the pull request branch is `master` (which happens on `cron` scheduled workflows). Also in this PR, we avoid updating `libs.versions.toml` from the `verify-new-library-version-compatibility.yml`, as that breaks gate runs (and we shouldn't update it there).

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/987
