### PR TITLE
Additional metadata entries for ch.qos.logback:logback-classic 1.4.9+

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.4.9/resource-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/resource-config.json
@@ -12,6 +12,18 @@
         "condition": {
           "typeReachable": "org.slf4j.LoggerFactory"
         }
+      },
+      {
+        "condition": {
+          "typeReachable": "ch.qos.logback.classic.util.ClassicVersionUtil"
+        },
+        "pattern": "\\Qch/qos/logback/classic/logback-classic-version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "ch.qos.logback.core.util.VersionUtil"
+        },
+        "pattern": "\\Qch/qos/logback/core/logback-core-version.properties\\E"
       }
     ]
   },


### PR DESCRIPTION
## What does this PR do?

Fixes: #992

In this PR we are adding the additional metadata entries in the `resource-config.json` for `ch.qos.logback:logback-classic`.