### PR TITLE
[Automation] Generated metadata for ch.qos.logback:logback-classic:1.5.7

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.5.7/reflect-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.5.7/reflect-config.json
@@ -1,0 +1,1316 @@
+[
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.PatternLayout",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.GenericXMLConfigurator"
+    },
+    "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
+    "name": "ch.qos.logback.classic.joran.SerializedModelConfigurator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.log4j.XMLLayout",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setLocationInfo",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setProperties",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.pattern.CallerDataConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ClassOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ContextNameConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.DateConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.FileOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.KeyValuePairConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LevelConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LineOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.GenericXMLConfigurator"
+    },
+    "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.pattern.parser.Compiler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LocalSequenceNumberConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.LoggerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MDCConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MarkerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.pattern.MaskedKeyValuePairConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.pattern.PatternLayoutBase"
+    },
+    "name": "ch.qos.logback.classic.pattern.MessageConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MessageConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.pattern.parser.Compiler"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.MethodOfCallerConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.pattern.MicrosecondConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.NopThrowableInformationConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.PrefixCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.PropertyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.classic.pattern.RelativeTimeConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.RootCauseFirstThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.SequenceNumberConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ThreadConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.ThrowableProxyConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.pattern.color.HighlightingCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.GenericXMLConfigurator"
+    },
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setWithJansi",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setWithJansi",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.FileAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setAppend",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setFile",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPrudent",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.Layout",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor"
+    },
+    "name": "ch.qos.logback.core.OutputStreamAppender",
+    "methods": [
+      {
+        "name": "setEncoder",
+        "parameterTypes": [
+          "ch.qos.logback.core.encoder.Encoder"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.OutputStreamAppender",
+    "methods": [
+      {
+        "name": "setImmediateFlush",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007d00bc1874c0"
+    },
+    "name": "ch.qos.logback.core.encoder.Encoder",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+    },
+    "name": "ch.qos.logback.core.encoder.Encoder",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.util.PropertySetter"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.ImplicitModelHandler"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder"
+  },
+  {
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.util.PropertySetter"
+    },
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setLayout",
+        "parameterTypes": [
+          "ch.qos.logback.core.Layout"
+        ]
+      },
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setLayout",
+        "parameterTypes": [
+          "ch.qos.logback.core.Layout"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.IdentityCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.PatternLayoutBase",
+    "methods": [
+      {
+        "name": "setOutputPatternAsHeader",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.GenericXMLConfigurator"
+    },
+    "name": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+    "methods": [
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+    "methods": [
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.ReplacingCompositeConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BlackCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BlueCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldBlueCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldCyanCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldGreenCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.color.BoldMagentaCompositeConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldRedCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldWhiteCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.BoldYellowCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.color.CyanCompositeConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.GrayCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.pattern.color.GreenCompositeConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.MagentaCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.RedCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.WhiteCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.pattern.color.YellowCompositeConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.RollingFileAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setFile",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setRollingPolicy",
+        "parameterTypes": [
+          "ch.qos.logback.core.rolling.RollingPolicy"
+        ]
+      },
+      {
+        "name": "setTriggeringPolicy",
+        "parameterTypes": [
+          "ch.qos.logback.core.rolling.TriggeringPolicy"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.RollingPolicy",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.RollingPolicyBase",
+    "methods": [
+      {
+        "name": "setFileNamePattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.FileAppender"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setMaxFileSize",
+        "parameterTypes": [
+          "ch.qos.logback.core.util.FileSize"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setMaxFileSize",
+        "parameterTypes": [
+          "ch.qos.logback.core.util.FileSize"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.TimeBasedRollingPolicy",
+    "methods": [
+      {
+        "name": "setCleanHistoryOnStart",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setMaxHistory",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setTotalSizeCap",
+        "parameterTypes": [
+          "ch.qos.logback.core.util.FileSize"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "ch.qos.logback.core.rolling.TriggeringPolicy",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.rolling.helper.FileNamePattern"
+    },
+    "name": "ch.qos.logback.core.rolling.helper.DateTokenConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.rolling.helper.DateTokenConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.rolling.helper.FileNamePattern"
+    },
+    "name": "ch.qos.logback.core.rolling.helper.IntegerTokenConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.rolling.helper.IntegerTokenConverter",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007d00bc1874c0"
+    },
+    "name": "ch.qos.logback.core.spi.ContextAware",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+    },
+    "name": "ch.qos.logback.core.spi.ContextAware",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.core.util.FileSize",
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.joran.event.SaxEventRecorder"
+    },
+    "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.io.FilePermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.lang.RuntimePermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.net.NetPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.net.SocketPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.net.URLPermission",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.security.AllPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.security.SecurityPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "java.util.PropertyPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.Loader$1"
+    },
+    "name": "javax.smartcardio.CardPermission"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "org.slf4j.Logger"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "org.slf4j.spi.SLF4JServiceProvider"
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.security.SecureRandomParameters"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/metadata/ch.qos.logback/logback-classic/1.5.7/resource-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.5.7/resource-config.json
@@ -1,0 +1,32 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/services/org.slf4j.spi.SLF4JServiceProvider\\E",
+        "condition": {
+          "typeReachable": "org.slf4j.LoggerFactory"
+        }
+      },
+      {
+        "pattern": "\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E",
+        "condition": {
+          "typeReachable": "org.slf4j.LoggerFactory"
+        }
+      },
+      {
+        "condition": {
+          "typeReachable": "ch.qos.logback.classic.util.ClassicVersionUtil"
+        },
+        "pattern": "\\Qch/qos/logback/classic/logback-classic-version.properties\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "ch.qos.logback.core.util.VersionUtil"
+        },
+        "pattern": "\\Qch/qos/logback/core/logback-core-version.properties\\E"
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/metadata/ch.qos.logback/logback-classic/index.json
+++ b/metadata/ch.qos.logback/logback-classic/index.json
@@ -2,6 +2,14 @@
   {
     "latest" : true,
     "module" : "ch.qos.logback:logback-classic",
+    "metadata-version" : "1.5.7",
+    "test-version" : "1.4.1",
+    "tested-versions" : [
+      "1.5.7"
+    ]
+  },
+  {
+    "module" : "ch.qos.logback:logback-classic",
     "metadata-version" : "1.4.9",
     "test-version": "1.4.1",
     "tested-versions" : [


### PR DESCRIPTION
## What does this PR do?

Fixes: #744, #922 

This PR provides new metadata needed for the ch.qos.logback:logback-classic:1.5.7, addressing Native Image run failures caused by changes in the updated library version.
 
Issue #922 is also resolved because the metadata added for 1.5.7 includes the entries required by 1.5.27. Since 1.5.7 becomes the latest metadata, it is applied by default to all 1.5.7+ versions.