### PR TITLE
Relax allowed-docker-images CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 metadata/*       @oracle/graalvm-reachability-maintainer
 tests/src/*      @oracle/graalvm-reachability-maintainer
 tests/tck-build-logic/* @vjovanov
-tests/tck-build-logic/src/main/resources/allowed-docker-images/* @matneu
 metadata/library-and-framework-list.json @fniephaus
 .github/* @vjovanov
 docs/*    @vjovanov

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ version: 2
 updates:
   - package-ecosystem: "docker"
     directory: "/tests/tck-build-logic/src/main/resources/allowed-docker-images"
-    reviewers:
-      - "matneu"
     assignees:
       - "jormundur00"
     schedule:


### PR DESCRIPTION
## What does this PR do?

In this PR we relax CODEOWNERs of `allowed-docker-images`. The general idea is that we shouldn't require @matneu approval for every simple docker image version bump. Simple version bumps can be simply merged, while we should add @matneu as a reviewer for more complex changes. We should keep @jormundur00 as an automated assignee and let him decide on the simplicty/severity of the Dependabot-generated PRs.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1002