### PR TITLE
Add missing logback-classic metadata.

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.5.7/reflect-config.json
+++ b/metadata/ch.qos.logback/logback-classic/1.5.7/reflect-config.json
@@ -575,21 +575,7 @@
   },
   {
     "condition": {
-      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007d00bc1874c0"
-    },
-    "name": "ch.qos.logback.core.encoder.Encoder",
-    "methods": [
-      {
-        "name": "valueOf",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
     },
     "name": "ch.qos.logback.core.encoder.Encoder",
     "methods": [
@@ -631,7 +617,7 @@
   },
   {
     "condition": {
-      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
     },
     "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
     "methods": [
@@ -1150,21 +1136,7 @@
   },
   {
     "condition": {
-      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007d00bc1874c0"
-    },
-    "name": "ch.qos.logback.core.spi.ContextAware",
-    "methods": [
-      {
-        "name": "valueOf",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
-      }
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "ch.qos.logback.core.model.processor.DefaultProcessor$$Lambda/0x00007dff1019a570"
+      "typeReachable": "ch.qos.logback.core.util.OptionHelper"
     },
     "name": "ch.qos.logback.core.spi.ContextAware",
     "methods": [
@@ -1306,6 +1278,18 @@
       "typeReachable": "ch.qos.logback.core.util.OptionHelper"
     },
     "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "ch.qos.logback.classic.BasicConfigurator",
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.util.ContextInitializer"
+    },
     "methods": [
       {
         "name": "<init>",


### PR DESCRIPTION
## What does this PR do?

Fixes: #1006 

After adding metadata for the `ch.qos.logback:logback-classic:1.5.7`, [LayeredApplicationFunctionalTest](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy) on native build tools fails when using logback-classic version 1.5.7 or later.  This PR corrects the recently added metadata so the test passes.
