### PR TITLE
Add the ability to run spring aot workflows with buildtools snapshots

### DIFF
--- a/.github/workflows/test-affected-spring-aot-3.5.x.yml
+++ b/.github/workflows/test-affected-spring-aot-3.5.x.yml
@@ -78,6 +78,9 @@ jobs:
           distribution: 'graalvm'
           java-version: '17.0.12'
 
+      - name: "🛠️ Setup latest native-build-tools snapshot"
+        uses: ./.github/actions/setup-native-build-tools
+
       - name: "🔧 Install GraalVM for smoke tests"
         uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/test-affected-spring-aot-4.0.x.yml
+++ b/.github/workflows/test-affected-spring-aot-4.0.x.yml
@@ -78,6 +78,9 @@ jobs:
           distribution: 'graalvm'
           java-version: '17.0.12'
 
+      - name: "🛠️ Setup latest native-build-tools snapshot"
+        uses: ./.github/actions/setup-native-build-tools
+
       - name: "🔧 Install GraalVM for smoke tests"
         uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -78,6 +78,9 @@ jobs:
           distribution: 'graalvm'
           java-version: '17.0.12'
 
+      - name: "🛠️ Setup latest native-build-tools snapshot"
+        uses: ./.github/actions/setup-native-build-tools
+
       - name: "🔧 Install GraalVM for smoke tests"
         uses: graalvm/setup-graalvm@v1
         with:


### PR DESCRIPTION
## What does this PR do?

In this PR, we introduce the ability to run the spring-aot-smoke-test workflows using native build tools snapshots. Currently, the `setup-native-build-tools` action of this repository makes all CI tests (except the spring tests) that use native build tools run:

- On the latest NBT snapshot, if enabled by default,
- On the NBT branch whose name matches the PR branches name.

This is currently not supported by the spring aot tests in our CI, as those tests call `nativeTest/nativeAppTest` from the external spring repository, making it use the given repositories native build tools setup. This will in turn lead to the inability to run/complete these tests when bigger refactoring PRs happen.

To this goal, we add the `setup-native-build-tools` action step to all spring test workflows. If the action is enabled (or a matching branch exists on the native build tools repository), the `run-spring-aot-triaged-test.sh` will also add the `mavenLocal()` repository to the required `gradle` files of the external spring repository, while also changing the version of NBT that the repository uses, so we can run the tests with the given snapshot.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1024