### PR TITLE
Make spring aot smoke test more verbose on failure

### DIFF
--- a/.github/workflows/scripts/run-spring-aot-triaged-test.sh
+++ b/.github/workflows/scripts/run-spring-aot-triaged-test.sh
@@ -108,7 +108,6 @@ ERROR_FILE="${PROJ_DIR}/build/nativeApp/error.txt"
 
 # Print logs if they exist (we are past success exit, so build failed)
 if [ -f "$OUTPUT_FILE" ] || [ -f "$ERROR_FILE" ]; then
-  echo "::group::nativeAppTest logs for $P"
   if [ -f "$OUTPUT_FILE" ]; then
     echo "----- nativeAppTest output.txt ($OUTPUT_FILE) -----"
     cat "$OUTPUT_FILE"
@@ -117,7 +116,6 @@ if [ -f "$OUTPUT_FILE" ] || [ -f "$ERROR_FILE" ]; then
     echo "----- nativeAppTest error.txt ($ERROR_FILE) -----"
     cat "$ERROR_FILE"
   fi
-  echo "::endgroup::"
 fi
 
 echo "❌ Test $P failed. Triaging..."


### PR DESCRIPTION
## What does this PR do?

With spring aot smoke test CI workflows, we currently run two types of tests: `nativeTest` and `nativeAppTest`. `nativeTest` runs a standard native-image build/run which outputs the standard results of native image. `nativeAppTest` pipes the output to separate `output.txt` and `error.txt` files, and hides them from the standard output.

In this PR, we output these files when the test fails, so we can know what the actual error is.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1041