### PR TITLE
Add support for opentelemetry-exporter-logging 1.48.0

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
@@ -5,7 +5,8 @@
     "metadata-version": "1.19.0",
     "module": "io.opentelemetry:opentelemetry-exporter-logging",
     "tested-versions": [
-      "1.19.0"
+      "1.19.0",
+      "1.48.0"
     ]
   }
 ]


### PR DESCRIPTION
## What does this PR do?
Extending the existing metadata family in `metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json`. with the version 1.48.0

No new tests were added in this PR. Existing verification passed for `io.opentelemetry:opentelemetry-exporter-logging:1.48.0`.


## Checklist before merging

- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))

- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))

 No new tests were added for this change
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))

- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))

No new tests were added for this change
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))

- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)