### PR TITLE
Support tomcat-embed-core 10.1.2

### DIFF
--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 	testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$libraryVersion"
 	testImplementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 	testImplementation 'org.assertj:assertj-core:3.22.0'
-	testRuntimeOnly 'org.apache.tomcat:jakartaee-migration:1.0.6'
 }
 
 graalvmNative {


### PR DESCRIPTION
Fixes #1049

## What does this PR do?
- Add support for `org.apache.tomcat.embed:tomcat-embed-core:10.1.2`
- Add the required test runtime dependency `org.apache.tomcat:jakartaee-migration:1.0.6`

## Why is the extra runtime dependency needed?
- `tomcat-embed-core:10.1.2` starts requiring `org.apache.tomcat.jakartaee.EESpecProfile` at runtime during Tomcat startup in the existing test setup
- `10.1.1` still passes without that dependency, while `10.1.2` fails without it


## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)