### PR TITLE
Fix jetty-server 12.1.6 catalog resources

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-server/12.1.3/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.1.3/reachability-metadata.json
@@ -1038,7 +1038,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.eclipse.jetty.ee10.webapp.WebDescriptor"
+        "typeReached": "org.eclipse.jetty.ee10.webapp.WebDescriptor$WebDescriptorParser"
       },
       "glob": "org/eclipse/jetty/ee10/webapp/catalog-ee10.xml"
     },
@@ -1050,7 +1050,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.eclipse.jetty.ee11.webapp.WebDescriptor"
+        "typeReached": "org.eclipse.jetty.ee11.webapp.WebDescriptor$WebDescriptorParser"
       },
       "glob": "org/eclipse/jetty/ee11/webapp/catalog-ee11.xml"
     },


### PR DESCRIPTION
Fixes #980

## What does this PR do?
- Add support for `org.eclipse.jetty:jetty-server:12.1.6`
- Fix the `catalog-ee10.xml` and `catalog-ee11.xml`. Parser class is not present in the EE10/EE11  jars anymore

## Native-image result
- `7` tests found
- `7` tests successful
- `0` tests failed

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [x] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [x] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [x] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)