### PR TITLE
Handle FlywaySqlException reflection

### DIFF
--- a/metadata/org.flywaydb/flyway-core/11.14.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-core/11.14.1/reachability-metadata.json
@@ -224,6 +224,30 @@
           ]
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.exception.FlywaySqlException"
+      },
+      "type": "org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlNoDriversForInteractiveAuthException",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.exception.FlywaySqlException"
+      },
+      "type": "org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlNoIntegratedAuthException",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.exception.FlywaySqlException"
+      },
+      "type": "org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlServerUntrustedCertificateSqlException",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
     }
   ],
   "resources": [

--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -8,7 +8,6 @@
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-11.14.1/documentation",
     "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
-      "10.20.1",
       "10.21.0",
       "10.22.0",
       "11.0.0",

--- a/tests/src/org.flywaydb/flyway-core/11.14.1/src/test/java/flyway/FlywayTests.java
+++ b/tests/src/org.flywaydb/flyway-core/11.14.1/src/test/java/flyway/FlywayTests.java
@@ -7,6 +7,7 @@
 package flyway;
 
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
@@ -14,10 +15,13 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.api.output.MigrateResult;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlNoDriversForInteractiveAuthException;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FlywayTests {
 
@@ -36,6 +40,24 @@ public class FlywayTests {
 
         assertThat(migration.success).isTrue();
         assertThat(migration.migrationsExecuted).isEqualTo(2);
+    }
+
+    /**
+     * Verifies that the {@link FlywaySqlException} subclasses are reflectively accessible in GraalVM native image.
+     * {@link FlywaySqlException#throwFlywayExceptionIfPossible} uses reflection to invoke {@code isFlywaySpecificVersionOf(SQLException)}
+     * on each registered subclass in order. Without the reachability metadata, this fails with {@link NoSuchMethodException}.
+     * <p>
+     * Using a {@link SQLException} that matches {@link FlywaySqlNoDriversForInteractiveAuthException}
+     * (last in the list) causes all three registered subclasses to be checked via reflection before
+     * the matching one is found and thrown.
+     */
+    @Test
+    void flywaySqlExceptionSubclassesAreReflectivelyAccessible() {
+        DataSource dataSource = getDataSource();
+        SQLException msal4jException = new SQLException("MSAL4J drivers are missing");
+
+        assertThatThrownBy(() -> FlywaySqlException.throwFlywayExceptionIfPossible(msal4jException, dataSource))
+                .isInstanceOf(FlywaySqlNoDriversForInteractiveAuthException.class);
     }
 
     private DataSource getDataSource() {


### PR DESCRIPTION
Fixes gh-1080

## What does this PR do?

Adds missing reflection metadata for Flyway 11.14.1.

## Code sections where the PR accesses files, network, docker or some external service

- N/A

## Checklist before merging
- [X] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [X] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [X] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [X] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
