### PR TITLE
Update tested versions for org.jooq:jooq 3.20.1

### DIFF
--- a/metadata/org.jooq/jooq/index.json
+++ b/metadata/org.jooq/jooq/index.json
@@ -8,7 +8,8 @@
     "metadata-version": "3.20.0",
     "test-version": "3.18.2",
     "tested-versions": [
-      "3.20.0"
+      "3.20.0",
+      "3.20.1"
     ]
   },
   {


### PR DESCRIPTION
## What does this PR do?
Update tested versions for org.jooq:jooq and included 3.20.1