### PR TITLE
Fix for unblocking jetty-server 12.1.6 support

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-server/12.1.3/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-server/12.1.3/reachability-metadata.json
@@ -1038,7 +1038,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.eclipse.jetty.ee10.webapp.WebDescriptor$WebDescriptorParser"
+        "typeReached": "org.eclipse.jetty.ee10.webapp.WebDescriptor"
       },
       "glob": "org/eclipse/jetty/ee10/webapp/catalog-ee10.xml"
     },
@@ -1050,7 +1050,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.eclipse.jetty.ee11.webapp.WebDescriptor$WebDescriptorParser"
+        "typeReached": "org.eclipse.jetty.ee11.webapp.WebDescriptor"
       },
       "glob": "org/eclipse/jetty/ee11/webapp/catalog-ee11.xml"
     },


### PR DESCRIPTION
Fixes #980

## What does this PR do?
To unblock jetty-server:12.1.6 version support (buy automation script), we need to fix the Descriptor link for metadata. Parser class is not present in the EE10/EE11 jars anymore.

We changed the descriptor from:
  - org.eclipse.jetty.ee10.webapp.WebDescriptor$WebDescriptorParser
  - org.eclipse.jetty.ee11.webapp.WebDescriptor$WebDescriptorParser

  to:
  - org.eclipse.jetty.ee10.webapp.WebDescriptor
  - org.eclipse.jetty.ee11.webapp.WebDescriptor

local tests following  verify-new-library-version-compatibility.yml passed after fixes 
