### PR TITLE
Fix for unblocking tomcat-embed-core 10.1.2 support

### DIFF
--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$libraryVersion"
 	testImplementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 	testImplementation 'org.assertj:assertj-core:3.22.0'
+	testRuntimeOnly 'org.apache.tomcat:jakartaee-migration:1.0.6'
 }
 
 graalvmNative {


### PR DESCRIPTION
Fixes #1049

## What does this PR do?
Added the required test dependency jakartaee-migration for unblocking tomcat-embed-core:10.1.2 support

tomcat 10.1.2 starts requiring EESpecProfile at runtime during Tomcat startup in the existing test setup and fails, while 10.1.1 passes 