### PR TITLE
Use latest metadata version in compatibility tests

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -464,7 +464,8 @@ tasks.register("extractLibraryTestParams", DefaultTask) { task ->
         }
 
         String testPath = "${libPath}/${testVersionFolder}"
-        String testCoordinates = testPath.replace("/", ":")
+        // Use the latest metadata version for compatibility verification.
+        String testCoordinates = "${lib}:${latestVersion}"
 
         writeGithubEnv("LATEST_VERSION", latestVersion)
         writeGithubEnv("TEST_PATH", testPath)


### PR DESCRIPTION
Fixes the issue: #1273
Fixes the second part of #1086.

## What does this PR do?
Use the latest metadata version when computing compatibility test coordinates.
It keeps test reuse through `test-version`, but resolves metadata from the latest metadata version.


## Validation
Tested locally with:

  `./gradlew extractLibraryTestParams -Pcoordinates=org.hibernate.orm:hibernate-core`

  Result after this change:
  LATEST_VERSION=7.2.0.Final
  TEST_PATH=org.hibernate.orm/hibernate-core/7.1.0.Final
  TEST_COORDINATES=org.hibernate.orm:hibernate-core:7.2.0.Final (before changes it was 7.1.0.Final)
  
  
 As you can see, we are using latest supported metadata now.