### PR TITLE
Fix incorrect latest flags in metadata index.json files

### DIFF
--- a/metadata/com.itextpdf/forms/index.json
+++ b/metadata/com.itextpdf/forms/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "latest": true,
     "allowed-packages": [
       "com.itextpdf"
     ],

--- a/metadata/com.itextpdf/io/index.json
+++ b/metadata/com.itextpdf/io/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "latest": true,
     "allowed-packages": [
       "com.itextpdf"
     ],

--- a/metadata/com.itextpdf/kernel/index.json
+++ b/metadata/com.itextpdf/kernel/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "latest": true,
     "allowed-packages": [
       "com.itextpdf"
     ],

--- a/metadata/com.itextpdf/layout/index.json
+++ b/metadata/com.itextpdf/layout/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "latest": true,
     "allowed-packages": [
       "com.itextpdf"
     ],

--- a/metadata/com.itextpdf/svg/index.json
+++ b/metadata/com.itextpdf/svg/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "latest": true,
     "allowed-packages": [
       "com.itextpdf"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"

--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"

--- a/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"

--- a/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
@@ -1,6 +1,6 @@
 [
   {
-    "latest": false,
+    "latest": true,
     "override": true,
     "allowed-packages": [
       "io.opentelemetry"


### PR DESCRIPTION
## What does this PR do?

Fixes: #1284

Updates `index.json` files so the newest metadata entry is consistently marked with `latest: true`.

This fixes libraries where:
- the latest entry was missing the `latest` field
- the latest entry was incorrectly marked as `latest: false`

The change keeps the metadata indexes aligned with the convention that the current default/latest metadata we ship should be explicitly marked with `latest: true`.