### PR TITLE
Add missing metadata entries to tomcat-embed-core:10.1.0

### DIFF
--- a/metadata/org.apache.tomcat.embed/tomcat-embed-core/10.1.0/reachability-metadata.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-core/10.1.0/reachability-metadata.json
@@ -715,6 +715,66 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.catalina.connector.Connector"
+      },
+      "type": "org.apache.catalina.mbeans.ConnectorMBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.catalina.core.StandardEngine"
+      },
+      "type": "org.apache.catalina.mbeans.ContainerMBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.catalina.core.StandardContext"
+      },
+      "type": "org.apache.catalina.mbeans.ContextMBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.catalina.deploy.NamingResourcesImpl"
+      },
+      "type": "org.apache.catalina.mbeans.NamingResourcesMBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.catalina.core.StandardService"
+      },
+      "type": "org.apache.catalina.mbeans.ServiceMBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.tomcat.util.IntrospectionUtils"
       },
       "type": "org.apache.coyote.AbstractProtocol",
@@ -922,6 +982,32 @@
         {
           "name": "<init>",
           "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.util.digester.Digester"
+      },
+      "type": "org.apache.tomcat.util.modeler.ParameterInfo",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.util.digester.Digester"
+      },
+      "type": "org.apache.tomcat.util.modeler.OperationInfo",
+      "methods": [
+        {
+          "name": "addParameter",
+          "parameterTypes": [
+            "org.apache.tomcat.util.modeler.ParameterInfo"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## What does this PR do?

In this PR we add the missing `org.apache.tomcat.embed:tomcat-embed-core:10.1.0` metadata entries that somehow got lost from the move from `10.0.20` to `10.1.0`. With these entries added, the tests no longer fail with errors such as:
```
java.lang.NoSuchMethodException: org.apache.tomcat.util.modeler.ParameterInfo.<init>()
	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1356)
	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1565)
	at java.base@25.0.2/java.lang.Class.getConstructor(DynamicHub.java:2199)
	at org.apache.tomcat.util.digester.ObjectCreateRule.begin(ObjectCreateRule.java:103)
	at org.apache.tomcat.util.digester.Digester.startElement(Digester.java:1264)
	at java.xml@25.0.2/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:519)
	at java.xml@25.0.2/com.sun.org.apache.xerces.internal.parsers.AbstractXMLDocumentParser.emptyElement(AbstractXMLDocumentParser.java:183)
```
and
```
javax.management.MBeanException: Cannot load ModelMBean class [org.apache.catalina.mbeans.ConnectorMBean]
        at org.apache.tomcat.util.modeler.ManagedBean.createMBean(ManagedBean.java:318)
        at org.apache.tomcat.util.modeler.Registry.registerComponent(Registry.java:642)
        at org.apache.catalina.util.LifecycleMBeanBase.register(LifecycleMBeanBase.java:152)
```

These entries already exist in the older metadata, but were omitted from the `10.1.0` version for some reason.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1049
