### PR TITLE
Bump NBT version to 1.0.0 and stop using snapshots in CI

### DIFF
--- a/.github/actions/setup-native-build-tools/action.yml
+++ b/.github/actions/setup-native-build-tools/action.yml
@@ -6,7 +6,7 @@ inputs:
   enabled-by-default:
     description: "Whether to enable this setup step even if no same-named branch is found."
     required: false
-    default: "true" # TODO: Revert to "false" once the 0.11.5 release of NBT is on the central maven repository
+    default: "false"
   java-version:
     description: "Java version to use when building native-build-tools"
     required: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Project versions
-nativeBuildTools = "0.11.5"
+nativeBuildTools = "1.0.0"
 
 # External dependencies
 junitPlatform = "1.9.2"


### PR DESCRIPTION
## What does this PR do?

In this PR we bump the NBT version used by the repo to `1.0.0` and disable using NBT SNAPSHOTs by default in the CI.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1575