### PR TITLE
Set enabled-by-default to true in setup-native-build-tools

### DIFF
--- a/.github/actions/setup-native-build-tools/action.yml
+++ b/.github/actions/setup-native-build-tools/action.yml
@@ -6,7 +6,7 @@ inputs:
   enabled-by-default:
     description: "Whether to enable this setup step even if no same-named branch is found."
     required: false
-    default: "false"
+    default: "true" # TODO: Revert to "false" once spring-smoke-tests have NBT updated
   java-version:
     description: "Java version to use when building native-build-tools"
     required: false


### PR DESCRIPTION
## What does this PR do?

Fixes: #1579

Spring smoke tests in CI fail without the NBT snapshot setup running. Set `enabled-by-default` to `"true"` as a workaround until spring-smoke-tests have NBT updated.

