### PR TITLE
[Automation] Generated metadata for org.apache.activemq:artemis-jms-client:2.36.0

### DIFF
--- a/metadata/org.apache.activemq/artemis-jms-client/2.36.0/reachability-metadata.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/2.36.0/reachability-metadata.json
@@ -1,0 +1,932 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "boolean[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "char[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "double[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "float[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.ChannelException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.DefaultFileRegion",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "file"
+        },
+        {
+          "name": "transferred"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+      },
+      "type": "io.netty.channel.epoll.EpollSocketChannel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.epoll.LinuxSocket",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.epoll.Native",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "count"
+        },
+        {
+          "name": "memoryAddress"
+        },
+        {
+          "name": "recipientAddr"
+        },
+        {
+          "name": "recipientAddrLen"
+        },
+        {
+          "name": "recipientPort"
+        },
+        {
+          "name": "recipientScopeId"
+        },
+        {
+          "name": "segmentSize"
+        },
+        {
+          "name": "senderAddr"
+        },
+        {
+          "name": "senderAddrLen"
+        },
+        {
+          "name": "senderPort"
+        },
+        {
+          "name": "senderScopeId"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.epoll.NativeStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.Buffer",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.DatagramSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "int",
+            "int",
+            "io.netty.channel.unix.DatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.DomainDatagramSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "io.netty.channel.unix.DomainDatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.LimitsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.PeerCredentials",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "io.netty.channel.unix.Socket",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "java.net.InetSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "type": "java.net.PortUnreachableException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "java.net.URL[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "java.sql.Date[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "java.sql.Time[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "java.sql.Timestamp[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "java.util.Calendar[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "javax.jms.ConnectionFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "javax.jms.XAConnectionFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "javax.naming.Referenceable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "long[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl"
+      },
+      "type": "org.apache.activemq.artemis.api.core.Pair[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.api.core.RefCountMessage"
+      },
+      "type": "org.apache.activemq.artemis.api.core.RefCountMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.api.core.client.ServerLocator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl"
+      },
+      "type": "org.apache.activemq.artemis.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.logs.BundleFactory"
+      },
+      "type": "org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle_impl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.slf4j.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImplBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.core.client.impl.ServerLocatorImplCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.TCPServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.core.cluster.DiscoveryListener"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.journal.impl.JournalFileImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.journal.impl.JournalFileImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.journal.impl.JournalTransaction"
+      },
+      "type": "org.apache.activemq.artemis.core.journal.impl.JournalTransaction"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.postoffice.QueueInfo"
+      },
+      "type": "org.apache.activemq.artemis.core.postoffice.QueueInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.postoffice.impl.BindingsImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.postoffice.impl.BindingsImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.postoffice.impl.CopyOnWriteBindings$BindingsAndPosition"
+      },
+      "type": "org.apache.activemq.artemis.core.postoffice.impl.CopyOnWriteBindings$BindingsAndPosition"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor$1"
+      },
+      "type": "org.apache.activemq.artemis.core.protocol.ProtocolHandler$ProtocolDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.apache.activemq.artemis.core.protocol.core.impl.CoreProtocolManagerBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.apache.activemq.artemis.core.protocol.core.impl.CoreProtocolManagerCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQClientProtocolManager"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQFrameDecoder2"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$1"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector$ActiveMQClientChannelHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactoryProvider"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultOpenSSLContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactoryProvider"
+      },
+      "type": "org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultSSLContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl"
+      },
+      "type": "org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory",
+      "methods": [
+        {
+          "name": "getCallFailoverTimeout",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCallTimeout",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClientFailureCheckPeriod",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClientID",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCompressionLevel",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConfirmationWindowSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConnectionLoadBalancingPolicyClassName",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConnectionTTL",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConsumerMaxRate",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConsumerWindowSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDeserializationAllowList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDeserializationBlackList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDeserializationDenyList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDeserializationWhiteList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDupsOKBatchSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getFactoryType",
+          "parameterTypes": []
+        },
+        {
+          "name": "getGroupID",
+          "parameterTypes": []
+        },
+        {
+          "name": "getIncomingInterceptorList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getInitialConnectAttempts",
+          "parameterTypes": []
+        },
+        {
+          "name": "getInitialMessagePacketSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxRetryInterval",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMinLargeMessageSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOutgoingInterceptorList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPassword",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPasswordCodec",
+          "parameterTypes": []
+        },
+        {
+          "name": "getProducerMaxRate",
+          "parameterTypes": []
+        },
+        {
+          "name": "getProducerWindowSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getProtocolManagerFactoryStr",
+          "parameterTypes": []
+        },
+        {
+          "name": "getReconnectAttempts",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRetryInterval",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRetryIntervalMultiplier",
+          "parameterTypes": []
+        },
+        {
+          "name": "getScheduledThreadPoolMaxSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getThreadPoolMaxSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTransactionBatchSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getUser",
+          "parameterTypes": []
+        },
+        {
+          "name": "isAutoGroup",
+          "parameterTypes": []
+        },
+        {
+          "name": "isBlockOnAcknowledge",
+          "parameterTypes": []
+        },
+        {
+          "name": "isBlockOnDurableSend",
+          "parameterTypes": []
+        },
+        {
+          "name": "isBlockOnNonDurableSend",
+          "parameterTypes": []
+        },
+        {
+          "name": "isCacheDestinations",
+          "parameterTypes": []
+        },
+        {
+          "name": "isCacheLargeMessagesClient",
+          "parameterTypes": []
+        },
+        {
+          "name": "isCompressLargeMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "isEnable1xPrefixes",
+          "parameterTypes": []
+        },
+        {
+          "name": "isEnableSharedClientID",
+          "parameterTypes": []
+        },
+        {
+          "name": "isFailoverOnInitialConnection",
+          "parameterTypes": []
+        },
+        {
+          "name": "isHA",
+          "parameterTypes": []
+        },
+        {
+          "name": "isIgnoreJTA",
+          "parameterTypes": []
+        },
+        {
+          "name": "isPreAcknowledge",
+          "parameterTypes": []
+        },
+        {
+          "name": "isUseGlobalPools",
+          "parameterTypes": []
+        },
+        {
+          "name": "isUseTopologyForLoadBalancing",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactoryBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactoryCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jms.client.ConnectionFactoryOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jndi.JNDIStorable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jndi.JNDIStorableBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.URISchema"
+      },
+      "type": "org.apache.activemq.artemis.jndi.JNDIStorableCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.logs.AuditLogger"
+      },
+      "type": "org.apache.activemq.artemis.logs.AuditLogger_impl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.slf4j.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.apache.activemq.artemis.spi.core.protocol.ProtocolManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptions",
+      "methods": [
+        {
+          "name": "setHost",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setPort",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptionsBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.uri.schema.serverLocator.AbstractServerLocatorSchema"
+      },
+      "type": "org.apache.activemq.artemis.uri.schema.serverLocator.ConnectionOptionsCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor$ThreadPoolQueue"
+      },
+      "type": "org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor$ThreadPoolQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.ReferenceCounterUtil"
+      },
+      "type": "org.apache.activemq.artemis.utils.ReferenceCounterUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.SizeAwareMetric"
+      },
+      "type": "org.apache.activemq.artemis.utils.SizeAwareMetric"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.actors.ProcessorBase"
+      },
+      "type": "org.apache.activemq.artemis.utils.actors.ProcessorBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.collections.ConcurrentLongHashMap$Section"
+      },
+      "type": "org.apache.activemq.artemis.utils.collections.ConcurrentLongHashMap$Section"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.collections.LinkedListImpl"
+      },
+      "type": "org.apache.activemq.artemis.utils.collections.LinkedListImpl$Iterator[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl"
+      },
+      "type": "org.apache.activemq.artemis.utils.collections.LinkedListImpl[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl"
+      },
+      "type": "org.apache.activemq.artemis.utils.collections.PriorityLinkedListImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.collections.UpdatableIterator"
+      },
+      "type": "org.apache.activemq.artemis.utils.collections.UpdatableIterator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.critical.CriticalMeasure"
+      },
+      "type": "org.apache.activemq.artemis.utils.critical.CriticalMeasure"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.runnables.AtomicRunnable"
+      },
+      "type": "org.apache.activemq.artemis.utils.runnables.AtomicRunnable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "org.slf4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "type": "short[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants"
+      },
+      "glob": "META-INF/io.netty.versions.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.core.remoting.impl.netty.CheckDependencies"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.commons.shaded.johnzon.core.JsonProviderImpl"
+      },
+      "glob": "META-INF/services/org.apache.activemq.artemis.commons.shaded.johnzon.core.spi.JsonPointerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.spi.core.protocol.MessagePersister"
+      },
+      "glob": "META-INF/services/org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactoryProvider"
+      },
+      "glob": "META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactoryProvider"
+      },
+      "glob": "META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.VersionLoader"
+      },
+      "glob": "activemq-version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.uri.BeanSupport"
+      },
+      "glob": "commons-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.artemis.utils.ClassloadingUtil"
+      },
+      "glob": "org.apache.activemq.artemis.api.jms.ActiveMQJMSClient.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.activemq/artemis-jms-client/index.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/index.json
@@ -1,35 +1,45 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "org.apache.activemq"
+    "latest" : true,
+    "metadata-version" : "2.36.0",
+    "test-version" : "2.28.0",
+    "tested-versions" : [
+      "2.36.0"
     ],
-    "metadata-version": "2.32.0",
-    "test-version": "2.28.0",
-    "tested-versions": [
+    "allowed-packages" : [
+      "org.apache.activemq"
+    ]
+  },
+  {
+    "metadata-version" : "2.32.0",
+    "test-version" : "2.28.0",
+    "tested-versions" : [
       "2.32.0",
       "2.33.0",
       "2.34.0",
       "2.35.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.activemq"
     ]
   },
   {
-    "allowed-packages": [
-      "org.apache.activemq"
-    ],
-    "metadata-version": "2.29.0",
-    "test-version": "2.28.0",
-    "tested-versions": [
+    "metadata-version" : "2.29.0",
+    "test-version" : "2.28.0",
+    "tested-versions" : [
       "2.29.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.activemq"
     ]
   },
   {
-    "allowed-packages": [
-      "org.apache.activemq"
-    ],
-    "metadata-version": "2.28.0",
-    "tested-versions": [
+    "metadata-version" : "2.28.0",
+    "tested-versions" : [
       "2.28.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.activemq"
     ]
   }
 ]


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#899

This PR provides new metadata needed for the org.apache.activemq:artemis-jms-client:2.36.0, addressing Native Image run failures caused by changes in the updated library version.