### PR TITLE
Stop testing com.google.protobuf:protobuf-java-util:3.22.1 as it has a malformed POM

### DIFF
--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -7,6 +7,12 @@
     "metadata-version": "3.22.0",
     "tested-versions": [
       "3.22.0"
+    ],
+    "skipped-versions": [
+      {
+        "version": "3.22.1",
+        "reason": "Published POM for com.google.protobuf:protobuf-java-util:3.22.1 is malformed: dependency com.google.protobuf:protobuf-java uses invalid groupId '$com.google.protobuf' and omits the version."
+      }
     ]
   },
   {


### PR DESCRIPTION
## What does this PR do?

The testing of `com.google.protobuf:protobuf-java-util:3.22.1` should be skipped, as it has a malformed POM file, with this entry:
```
<dependencies>
<dependency>
<groupId>$com.google.protobuf</groupId>
<artifactId>protobuf-java</artifactId>
</dependency>
```

Version `3.22.2` has this issue fixed, while the previous `3.22.0` version never had this issue in the first place.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/824