### PR TITLE
Fix broken kotlin tests

### DIFF
--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.1.20"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.1.20"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()


### PR DESCRIPTION
## What does this PR do?

In this PR, we bump the `org.jetbrains.kotlin.jvm` in all kotlin tests to the current latest, which fixes the currently failing incompatible versions.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1588, https://github.com/oracle/graalvm-reachability-metadata/issues/1589