### PR TITLE
fix: restore metadata validation

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/1.4.1/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.1/reachability-metadata.json
@@ -932,13 +932,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "org/slf4j/impl/StaticLoggerBinder.class"
     }

--- a/metadata/ch.qos.logback/logback-classic/1.4.9/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-classic/1.4.9/reachability-metadata.json
@@ -962,13 +962,13 @@
   "resources": [
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "org/slf4j/impl/StaticLoggerBinder.class"
     }

--- a/metadata/ch.qos.logback/logback-classic/1.5.7/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-classic/1.5.7/reachability-metadata.json
@@ -1253,7 +1253,7 @@
   "resources": [
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
@@ -1271,7 +1271,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.slf4j.LoggerFactory"
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
       },
       "glob": "org/slf4j/impl/StaticLoggerBinder.class"
     }

--- a/metadata/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/reachability-metadata.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/reachability-metadata.json
@@ -428,7 +428,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.coyote.AbstractProtocol"
+        "typeReached": "org.apache.tomcat.util.IntrospectionUtils"
       },
       "glob": "org/apache/coyote/mbeans-descriptors.xml"
     },

--- a/metadata/org.freemarker/freemarker/index.json
+++ b/metadata/org.freemarker/freemarker/index.json
@@ -2,7 +2,8 @@
   {
     "latest": true,
     "allowed-packages": [
-      "org.freemarker"
+      "org.freemarker",
+      "freemarker"
     ],
     "metadata-version": "2.3.31",
     "tested-versions": [

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
@@ -2,7 +2,8 @@
   {
     "latest": true,
     "allowed-packages": [
-      "org.jboss"
+      "org.jboss",
+      "javax.servlet"
     ],
     "metadata-version": "2.0.0.Final",
     "tested-versions": [

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
@@ -47,7 +47,12 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
     private final Set<String> EXPECTED_FILES = new HashSet<>(List.of(
             REACHABILITY_METADATA_FILE_NAME));
 
+    private final Set<String> ILLEGAL_TYPE_VALUES = new HashSet<>(List.of("java.lang"));
+
+    private final Set<String> PREDEFINED_ALLOWED_PACKAGES = new HashSet<>(List.of("java.lang", "java.util"));
+
     Coordinates coordinates;
+    private List<String> allowedPackages;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private JsonSchema reachabilityMetadataSchema;
 
@@ -77,6 +82,8 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
 
         File index = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$/index.json", coordinates));
         getIndexFile().set(index);
+
+        this.allowedPackages = getAllowedPackages();
     }
 
     @SuppressWarnings("unchecked")
@@ -166,6 +173,12 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
             containsErrors |= containsDuplicatedEntries(metadata.path("foreign").path("downcalls"), "foreign.downcalls", file);
             containsErrors |= containsDuplicatedEntries(metadata.path("foreign").path("upcalls"), "foreign.upcalls", file);
             containsErrors |= containsDuplicatedEntries(metadata.path("foreign").path("directUpcalls"), "foreign.directUpcalls", file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("reflection"), file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("resources"), file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("serialization"), file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("foreign").path("downcalls"), file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("foreign").path("upcalls"), file);
+            containsErrors |= containsInvalidTypeReachedEntries(metadata.path("foreign").path("directUpcalls"), file);
 
             return containsErrors;
         } catch (Exception e) {
@@ -256,6 +269,86 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
         return containsDuplicates;
     }
 
+    private boolean containsInvalidTypeReachedEntries(JsonNode entries, File file) {
+        if (!entries.isArray() || entries.isEmpty()) {
+            return false;
+        }
+
+        boolean containsErrors = false;
+        for (JsonNode entry : entries) {
+            containsErrors |= checkTypeReached(entry, file);
+            containsErrors |= containsEntriesNotFromLibrary(entry, file);
+        }
+        return containsErrors;
+    }
+
+    private boolean checkTypeReached(JsonNode entry, File file) {
+        String typeReached = getEntryTypeReached(entry);
+        if (typeReached == null) {
+            return false;
+        }
+
+        String entryDescription = describeEntry(entry);
+        if (isAllowedPredefinedEntry(typeReached, entry)) {
+            return false;
+        }
+
+        if (ILLEGAL_TYPE_VALUES.stream().anyMatch(typeReached::startsWith)) {
+            System.out.println("ERROR: In file " + file.toURI() + " entry: " + entryDescription + " contains illegal typeReached value. Field" +
+                    " typeReached cannot be any of the following values: " + ILLEGAL_TYPE_VALUES);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean containsEntriesNotFromLibrary(JsonNode entry, File file) {
+        String typeReached = getEntryTypeReached(entry);
+        if (typeReached == null) {
+            return false;
+        }
+
+        String entryDescription = describeEntry(entry);
+        if (isAllowedPredefinedEntry(typeReached, entry)) {
+            return false;
+        }
+
+        if (this.allowedPackages.stream().noneMatch(typeReached::contains)) {
+            System.out.println("ERROR: In file " + file.toURI() + "\n" +
+                    "Entry: " + entryDescription + "\n" +
+                    "TypeReached: " + typeReached + "\n" +
+                    "doesn't belong to any of the specified packages: " + this.allowedPackages + "\n");
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isAllowedPredefinedEntry(String typeReached, JsonNode entry) {
+        String entryName = getEntryName(entry);
+        return entryName != null
+                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(typeReached::contains)
+                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(entryName::contains);
+    }
+
+    private String getEntryTypeReached(JsonNode entry) {
+        JsonNode condition = entry.path("condition");
+        if (!condition.isObject() || !condition.hasNonNull("typeReached")) {
+            return null;
+        }
+        return condition.get("typeReached").asText();
+    }
+
+    private String getEntryName(JsonNode entry) {
+        if (entry.hasNonNull("name")) {
+            return entry.get("name").asText();
+        }
+        if (entry.has("type") && entry.get("type").isTextual()) {
+            return entry.get("type").asText();
+        }
+        return null;
+    }
+
     private String describeEntry(JsonNode entry) {
         if (entry == null || entry.isMissingNode() || entry.isNull()) {
             return "<missing>";
@@ -288,6 +381,75 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
             }
         }
         return entry.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getAllowedPackages() {
+        File indexFile = getIndexFile().get().getAsFile();
+        String groupId = coordinates.group();
+        String artifactId = coordinates.artifact();
+        String requestedVersion = coordinates.version();
+
+        if (!indexFile.exists()) {
+            throw new IllegalStateException("Missing artifact-level index.json: " + indexFile.toURI() + " for coordinates " + coordinates);
+        }
+
+        Object parsed = new JsonSlurper().parse(indexFile);
+        if (!(parsed instanceof List)) {
+            throw new IllegalStateException("Invalid artifact-level index.json (expected array): " + indexFile.toURI());
+        }
+
+        List<Map<String, Object>> entries = ((List<Object>) parsed).stream()
+                .map(entry -> (Map<String, Object>) entry)
+                .toList();
+
+        Optional<Map<String, Object>> byMetadataVersion = entries.stream()
+                .filter(entry -> Objects.equals(requestedVersion, entry.get("metadata-version")))
+                .findFirst();
+
+        Map<String, Object> match = byMetadataVersion.orElseGet(() ->
+                entries.stream()
+                        .filter(entry -> {
+                            Object testedVersions = entry.get("tested-versions");
+                            return testedVersions instanceof List<?> versions && versions.contains(requestedVersion);
+                        })
+                        .findFirst()
+                        .orElse(null)
+        );
+
+        if (match == null) {
+            List<String> metadataVersions = entries.stream()
+                    .map(entry -> (String) entry.get("metadata-version"))
+                    .filter(Objects::nonNull)
+                    .toList();
+            List<String> testedVersions = entries.stream()
+                    .map(entry -> {
+                        Object value = entry.get("tested-versions");
+                        if (value instanceof List<?> versions) {
+                            return versions.stream().map(Object::toString).collect(Collectors.toList());
+                        }
+                        return Collections.<String>emptyList();
+                    })
+                    .flatMap(List::stream)
+                    .distinct()
+                    .sorted()
+                    .toList();
+
+            throw new IllegalStateException(
+                    "Missing index entry for " + groupId + ":" + artifactId +
+                    " matching version=" + requestedVersion +
+                    " in " + indexFile.toURI() +
+                    ". Known metadata-versions=" + metadataVersions +
+                    ", tested-versions=" + testedVersions);
+        }
+
+        Object allowedPackagesValue = match.get("allowed-packages");
+        if (allowedPackagesValue instanceof List) {
+            return (List<String>) allowedPackagesValue;
+        }
+        throw new IllegalStateException(
+                "Missing or invalid allowed-packages for " + groupId + ":" + artifactId +
+                " (metadata-version=" + match.get("metadata-version") + ") in " + indexFile.toURI());
     }
 
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/MetadataFilesCheckerTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/MetadataFilesCheckerTaskTests.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -129,6 +131,161 @@ class MetadataFilesCheckerTaskTests {
     }
 
     @Test
+    void runFailsWhenConditionTypeReachedIsOutsideAllowedPackages() throws IOException {
+        createMetadataIndex();
+        copyReachabilitySchemaFile();
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json"),
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "org.other.Library"
+                      },
+                      "type": "com.example.Demo",
+                      "allDeclaredMethods": true
+                    }
+                  ]
+                }
+                """
+        );
+
+        TestMetadataFilesCheckerTask task = createTask();
+        task.setCoordinates("com.example:demo:1.0.1");
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Errors above found");
+    }
+
+    @Test
+    void runAllowsJavaLangTypeReachedWhenEntryAlsoTargetsJavaLang() throws IOException {
+        createMetadataIndex();
+        copyReachabilitySchemaFile();
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json"),
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "java.lang.ClassLoader"
+                      },
+                      "type": "java.lang.ClassLoader",
+                      "jniAccessible": true
+                    }
+                  ]
+                }
+                """
+        );
+
+        TestMetadataFilesCheckerTask task = createTask();
+        task.setCoordinates("com.example:demo:1.0.1");
+
+        assertThatCode(task::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void runAllowsRenamedPackageFromAllowedPackagesInResources() throws IOException {
+        createMetadataIndex(
+                "org.freemarker",
+                "freemarker",
+                "2.3.31",
+                List.of("org.freemarker", "freemarker"),
+                List.of("2.3.31", "2.3.34")
+        );
+        copyReachabilitySchemaFile();
+        Files.createDirectories(tempDir.resolve("metadata/org.freemarker/freemarker/2.3.31"));
+        Files.writeString(
+                tempDir.resolve("metadata/org.freemarker/freemarker/2.3.31/reachability-metadata.json"),
+                """
+                {
+                  "resources": [
+                    {
+                      "condition": {
+                        "typeReached": "freemarker.template.utility.ClassUtil"
+                      },
+                      "glob": "freemarker/version.properties"
+                    }
+                  ]
+                }
+                """
+        );
+
+        TestMetadataFilesCheckerTask task = createTask();
+        task.setCoordinates("org.freemarker:freemarker:2.3.34");
+
+        assertThatCode(task::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void runFailsWhenResourcesDependOnExternalTriggerPackage() throws IOException {
+        createMetadataIndex(
+                "ch.qos.logback",
+                "logback-classic",
+                "1.5.7",
+                List.of("ch.qos.logback"),
+                List.of("1.5.7", "1.5.8")
+        );
+        copyReachabilitySchemaFile();
+        Files.createDirectories(tempDir.resolve("metadata/ch.qos.logback/logback-classic/1.5.7"));
+        Files.writeString(
+                tempDir.resolve("metadata/ch.qos.logback/logback-classic/1.5.7/reachability-metadata.json"),
+                """
+                {
+                  "resources": [
+                    {
+                      "condition": {
+                        "typeReached": "org.slf4j.LoggerFactory"
+                      },
+                      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+                    }
+                  ]
+                }
+                """
+        );
+
+        TestMetadataFilesCheckerTask task = createTask();
+        task.setCoordinates("ch.qos.logback:logback-classic:1.5.8");
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Errors above found");
+    }
+
+    @Test
+    void runDoesNotApplyJavaUtilExceptionToResourceBundles() throws IOException {
+        createMetadataIndex();
+        copyReachabilitySchemaFile();
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json"),
+                """
+                {
+                  "resources": [
+                    {
+                      "condition": {
+                        "typeReached": "java.util.ServiceLoader"
+                      },
+                      "bundle": "java.util.logging"
+                    }
+                  ]
+                }
+                """
+        );
+
+        TestMetadataFilesCheckerTask task = createTask();
+        task.setCoordinates("com.example:demo:1.0.1");
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Errors above found");
+    }
+
+    @Test
     void runAllowsLegacySerializationEntriesWithRealSchema() throws IOException {
         createMetadataIndex();
         copyReachabilitySchemaFile();
@@ -194,25 +351,42 @@ class MetadataFilesCheckerTaskTests {
     }
 
     private void createMetadataIndex() throws IOException {
-        Files.createDirectories(tempDir.resolve("metadata/com.example/demo"));
+        createMetadataIndex(
+                "com.example",
+                "demo",
+                "1.0.0",
+                List.of("com.example"),
+                List.of("1.0.0", "1.0.1")
+        );
+    }
+
+    private void createMetadataIndex(
+            String group,
+            String artifact,
+            String metadataVersion,
+            List<String> allowedPackages,
+            List<String> testedVersions
+    ) throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata/" + group + "/" + artifact));
         Files.writeString(
-                tempDir.resolve("metadata/com.example/demo/index.json"),
+                tempDir.resolve("metadata/" + group + "/" + artifact + "/index.json"),
                 """
                 [
                   {
                     "latest": true,
-                    "allowed-packages": [
-                      "com.example"
-                    ],
-                    "metadata-version": "1.0.0",
-                    "tested-versions": [
-                      "1.0.0",
-                      "1.0.1"
-                    ]
+                    "allowed-packages": %s,
+                    "metadata-version": "%s",
+                    "tested-versions": %s
                   }
                 ]
-                """
+                """.formatted(toJsonArray(allowedPackages), metadataVersion, toJsonArray(testedVersions))
         );
+    }
+
+    private String toJsonArray(List<String> values) {
+        return values.stream()
+                .map(value -> "\"" + value + "\"")
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 
     private void copyReachabilitySchemaFile() throws IOException {


### PR DESCRIPTION
Fix for #1592

## What does this PR do?

- add validation for reachability-metadata.json in checkMetadataFiles
  - adapt the schema:
    a) ignore version because the validator reports Unknown keyword version
    b) support top-level serialization because the checked-in schema does not define it, while existing metadata does
  - update tests for the real schema and legacy serialization cases


## Code sections where the PR accesses files, network, docker or some external service
- N/A

## Checklist before merging
- [x] I have considered including reachability metadata directly in the library or the framework
- [x] I am the original author of all content provided in the pull request
- [x] I have properly formatted metadata files
- [x] I have added thorough tests
- [x] I have filled all places where my pull request accesses files, network, docker, or any other external service