### PR TITLE
Add N/A to stats when debug info is missing from a library

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,7 +35,7 @@ Workflows testing metadata using [ci.json](../ci.json):
   - Triggers: PRs to master touching [metadata/](metadata/).
   - Uses: generateAffectedSpringTestMatrix to compute impacted Spring AOT projects and produce a matrix; runs triaged native tests via [.github/workflows/scripts/run-spring-aot-triaged-test.sh](../.github/workflows/scripts/run-spring-aot-triaged-test.sh).
 - Validate library stats ([.github/workflows/library-stats-validation.yml](../.github/workflows/library-stats-validation.yml))
-  - Triggers: PRs that touch [stats/stats.json](../stats/stats.json) or [stats/schemas/library-stats-schema-v1.0.0.json](../stats/schemas/library-stats-schema-v1.0.0.json).
+  - Triggers: PRs that touch [stats/stats.json](../stats/stats.json) or [stats/schemas/library-stats-schema-v1.0.1.json](../stats/schemas/library-stats-schema-v1.0.1.json).
   - Uses: [`validateLibraryStats`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to enforce schema compliance and normalized sorting.
 - Verify new library version compatibility ([.github/workflows/verify-new-library-version-compatibility.yml](../.github/workflows/verify-new-library-version-compatibility.yml))
   - Triggers: scheduled run and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -146,7 +146,7 @@ The root jacocoTestReport is a harness wrapper that invokes the per-project task
 - Each artifact entry can contain multiple `metadata-version` buckets
 
 Schema:
-- `stats/schemas/library-stats-schema-v1.0.0.json`
+- `stats/schemas/library-stats-schema-v1.0.1.json`
 
 ```console
 ./gradlew generateLibraryStats -Pcoordinates=[group:artifact:version|group:artifact|k/n|all]

--- a/stats/schemas/library-stats-schema-v1.0.1.json
+++ b/stats/schemas/library-stats-schema-v1.0.1.json
@@ -198,6 +198,19 @@
         }
       }
     },
+    "coverageMetricOrNa": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/coverageMetric"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "N/A"
+          ]
+        }
+      ]
+    },
     "dynamicAccessBreakdown": {
       "type": "object",
       "additionalProperties": false,
@@ -266,13 +279,13 @@
       ],
       "properties": {
         "instruction": {
-          "$ref": "#/definitions/coverageMetric"
+          "$ref": "#/definitions/coverageMetricOrNa"
         },
         "line": {
-          "$ref": "#/definitions/coverageMetric"
+          "$ref": "#/definitions/coverageMetricOrNa"
         },
         "method": {
-          "$ref": "#/definitions/coverageMetric"
+          "$ref": "#/definitions/coverageMetricOrNa"
         }
       }
     },

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -4,6 +4,7 @@
       "metadataVersions" : {
         "0.0.1" : {
           "versions" : [ {
+            "version" : "0.0.1",
             "dynamicAccess" : {
               "breakdown" : {
                 "reflection" : {
@@ -40,8 +41,7 @@
                 "ratio" : 0.416667,
                 "total" : 24
               }
-            },
-            "version" : "0.0.1"
+            }
           } ]
         }
       }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -153,7 +153,7 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
     protected Path getStatsSchemaFile() {
         return getStatsRoot()
                 .resolve("schemas")
-                .resolve("library-stats-schema-v1.0.0.json");
+                .resolve("library-stats-schema-v1.0.1.json");
     }
 
     @Internal

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsModels.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsModels.java
@@ -6,6 +6,19 @@
  */
 package org.graalvm.internal.tck.stats;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +46,11 @@ public final class LibraryStatsModels {
     ) {
     }
 
+    @JsonPropertyOrder({
+            "version",
+            "dynamicAccess",
+            "libraryCoverage"
+    })
     public record VersionStats(
             String version,
             DynamicAccessStats dynamicAccess,
@@ -56,10 +74,13 @@ public final class LibraryStatsModels {
     }
 
     public record LibraryCoverage(
-            CoverageMetric line,
-            CoverageMetric instruction,
-            CoverageMetric method
+            CoverageMetricValue line,
+            CoverageMetricValue instruction,
+            CoverageMetricValue method
     ) {
+        public LibraryCoverage(CoverageMetric line, CoverageMetric instruction, CoverageMetric method) {
+            this(CoverageMetricValue.available(line), CoverageMetricValue.available(instruction), CoverageMetricValue.available(method));
+        }
     }
 
     public record CoverageMetric(
@@ -68,5 +89,86 @@ public final class LibraryStatsModels {
             long total,
             BigDecimal ratio
     ) {
+    }
+
+    @JsonSerialize(using = CoverageMetricValueSerializer.class)
+    @JsonDeserialize(using = CoverageMetricValueDeserializer.class)
+    public record CoverageMetricValue(
+            CoverageMetric metric
+    ) {
+        private static final String NOT_AVAILABLE = "N/A";
+
+        public static CoverageMetricValue available(CoverageMetric metric) {
+            return new CoverageMetricValue(metric);
+        }
+
+        public static CoverageMetricValue notAvailable() {
+            return new CoverageMetricValue(null);
+        }
+
+        public boolean isAvailable() {
+            return metric != null;
+        }
+
+        public long covered() {
+            return requireMetric().covered();
+        }
+
+        public long missed() {
+            return requireMetric().missed();
+        }
+
+        public long total() {
+            return requireMetric().total();
+        }
+
+        public BigDecimal ratio() {
+            return requireMetric().ratio();
+        }
+
+        private CoverageMetric requireMetric() {
+            if (!isAvailable()) {
+                throw new IllegalStateException("Coverage metric is not available");
+            }
+            return metric;
+        }
+    }
+
+    public static final class CoverageMetricValueSerializer extends JsonSerializer<CoverageMetricValue> {
+
+        @Override
+        public void serialize(CoverageMetricValue value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+            if (value == null || !value.isAvailable()) {
+                generator.writeString(CoverageMetricValue.NOT_AVAILABLE);
+                return;
+            }
+            generator.writeObject(value.metric());
+        }
+    }
+
+    public static final class CoverageMetricValueDeserializer extends JsonDeserializer<CoverageMetricValue> {
+
+        @Override
+        public CoverageMetricValue deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            JsonNode node = parser.getCodec().readTree(parser);
+            if (node != null && node.isTextual() && CoverageMetricValue.NOT_AVAILABLE.equals(node.textValue())) {
+                return CoverageMetricValue.notAvailable();
+            }
+            if (node != null && node.isObject()) {
+                JsonNode coveredNode = node.get("covered");
+                JsonNode missedNode = node.get("missed");
+                JsonNode totalNode = node.get("total");
+                JsonNode ratioNode = node.get("ratio");
+                if (coveredNode != null && missedNode != null && totalNode != null && ratioNode != null) {
+                    return CoverageMetricValue.available(new CoverageMetric(
+                            coveredNode.longValue(),
+                            missedNode.longValue(),
+                            totalNode.longValue(),
+                            ratioNode.decimalValue()
+                    ));
+                }
+            }
+            throw JsonMappingException.from(parser, "Coverage metric must be an object or the string 'N/A'");
+        }
     }
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
@@ -202,7 +202,10 @@ public final class LibraryStatsSchemaValidator {
 
         for (String expectedArtifact : expectedArtifacts.keySet()) {
             if (!actualArtifacts.containsKey(expectedArtifact)) {
-                failures.add("Missing artifact entry in stats file for " + expectedArtifact + " (" + statsFile + ")");
+                Set<String> expectedArtifactMetadataVersions = expectedArtifacts.get(expectedArtifact);
+                for (String expectedMetadataVersion : expectedArtifactMetadataVersions) {
+                    failures.add("Missing metadata-version entry for " + expectedArtifact + ":" + expectedMetadataVersion + " in " + statsFile);
+                }
             }
         }
 
@@ -236,13 +239,39 @@ public final class LibraryStatsSchemaValidator {
         for (String expectedMetadataVersion : expectedMetadataVersionsForArtifact) {
             if (!actualMetadataVersions.contains(expectedMetadataVersion)) {
                 failures.add("Missing metadata-version entry for " + artifact + ":" + expectedMetadataVersion + " in " + statsFile);
+                continue;
             }
+            JsonNode metadataVersionEntry = metadataVersions.get(expectedMetadataVersion);
+            validateMetadataVersionEntry(statsFile, artifact, expectedMetadataVersion, metadataVersionEntry, failures);
         }
 
         for (String actualMetadataVersion : actualMetadataVersions) {
             if (!expectedMetadataVersionsForArtifact.contains(actualMetadataVersion)) {
                 failures.add("Orphan metadata-version entry in stats file for " + artifact + ":" + actualMetadataVersion);
             }
+        }
+    }
+
+    private static void validateMetadataVersionEntry(
+            Path statsFile,
+            String artifact,
+            String metadataVersion,
+            JsonNode metadataVersionEntry,
+            List<String> failures
+    ) {
+        if (metadataVersionEntry == null || !metadataVersionEntry.isObject()) {
+            failures.add("Stats file is missing object entry for " + artifact + ":" + metadataVersion + " in " + statsFile);
+            return;
+        }
+
+        JsonNode versions = metadataVersionEntry.get("versions");
+        if (versions == null || !versions.isArray()) {
+            failures.add("Stats file is missing array field 'versions' for " + artifact + ":" + metadataVersion + " in " + statsFile);
+            return;
+        }
+
+        if (versions.isEmpty()) {
+            failures.add("Missing version report entries in stats file for " + artifact + ":" + metadataVersion + " in " + statsFile);
         }
     }
 
@@ -326,9 +355,12 @@ public final class LibraryStatsSchemaValidator {
     private static void validateCoverageMetric(
             String locationPrefix,
             String metricName,
-            LibraryStatsModels.CoverageMetric metric,
+            LibraryStatsModels.CoverageMetricValue metric,
             List<String> failures
     ) {
+        if (metric == null || !metric.isAvailable()) {
+            return;
+        }
         long expectedTotal = metric.covered() + metric.missed();
         if (metric.total() != expectedTotal) {
             failures.add("Inconsistent totals at " + locationPrefix + ":libraryCoverage." + metricName

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -468,9 +468,9 @@ public final class LibraryStatsSupport {
             Map<String, LibraryStatsModels.CoverageMetric> rootCounters = parseRootCounters(root);
             return new ParsedJacocoReport(
                     coveredLinesBySource,
-                    requireCoverageMetric(rootCounters, "LINE"),
-                    requireCoverageMetric(rootCounters, "INSTRUCTION"),
-                    requireCoverageMetric(rootCounters, "METHOD")
+                    coverageMetricOrNa(rootCounters, "LINE"),
+                    coverageMetricOrNa(rootCounters, "INSTRUCTION"),
+                    coverageMetricOrNa(rootCounters, "METHOD")
             );
         } catch (Exception e) {
             throw new GradleException("Failed to parse JaCoCo report " + jacocoReport, e);
@@ -494,15 +494,15 @@ public final class LibraryStatsSupport {
         return counters;
     }
 
-    private static LibraryStatsModels.CoverageMetric requireCoverageMetric(
+    private static LibraryStatsModels.CoverageMetricValue coverageMetricOrNa(
             Map<String, LibraryStatsModels.CoverageMetric> counters,
             String type
     ) {
         LibraryStatsModels.CoverageMetric coverageMetric = counters.get(type);
         if (coverageMetric == null) {
-            throw new GradleException("JaCoCo report is missing root counter type " + type);
+            return LibraryStatsModels.CoverageMetricValue.notAvailable();
         }
-        return coverageMetric;
+        return LibraryStatsModels.CoverageMetricValue.available(coverageMetric);
     }
 
     private static String sourceKey(String className, String sourceFile) {
@@ -530,9 +530,9 @@ public final class LibraryStatsSupport {
 
     private record ParsedJacocoReport(
             Map<String, Set<Integer>> coveredLinesBySource,
-            LibraryStatsModels.CoverageMetric line,
-            LibraryStatsModels.CoverageMetric instruction,
-            LibraryStatsModels.CoverageMetric method
+            LibraryStatsModels.CoverageMetricValue line,
+            LibraryStatsModels.CoverageMetricValue instruction,
+            LibraryStatsModels.CoverageMetricValue method
     ) {
     }
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateLibraryStatsTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateLibraryStatsTaskTests.java
@@ -100,6 +100,83 @@ class ValidateLibraryStatsTaskTests {
     }
 
     @Test
+    void validateListsEachMissingMetadataVersionWhenArtifactEntryIsAbsent() throws IOException {
+        Project project = createProjectSkeleton();
+        createMetadataVersion("com.example", "demo", "1.0.0");
+        createMetadataVersion("com.example", "demo", "1.1.0");
+        writeStatsFile(
+                """
+                {
+                  "entries": {
+                  }
+                }
+                """
+        );
+
+        TestValidateLibraryStatsTask task = project.getTasks().create("validateLibraryStats", TestValidateLibraryStatsTask.class);
+        assertThatThrownBy(task::validate)
+                .hasMessageContaining("Missing metadata-version entry for com.example:demo:1.0.0")
+                .hasMessageContaining("Missing metadata-version entry for com.example:demo:1.1.0");
+    }
+
+    @Test
+    void validateAcceptsUnavailableCoverageMetric() throws IOException {
+        Project project = createProjectSkeleton();
+        createMetadataVersion("com.example", "demo", "1.0.0");
+        writeStatsFile(
+                """
+                {
+                  "entries": {
+                    "com.example:demo": {
+                      "metadataVersions": {
+                        "1.0.0": {
+                          "versions": [
+                            {
+                              "dynamicAccess": {
+                                "breakdown": {
+                                  "reflection": {
+                                    "coveredCalls": 0,
+                                    "coverageRatio": 0.0,
+                                    "totalCalls": 2
+                                  }
+                                },
+                                "coveredCalls": 0,
+                                "coverageRatio": 0.0,
+                                "totalCalls": 2
+                              },
+                              "libraryCoverage": {
+                                "instruction": {
+                                  "covered": 2,
+                                  "missed": 1,
+                                  "ratio": 0.666667,
+                                  "total": 3
+                                },
+                                "line": "N/A",
+                                "method": {
+                                  "covered": 3,
+                                  "missed": 0,
+                                  "ratio": 1.0,
+                                  "total": 3
+                                }
+                              },
+                              "version": "1.0.0"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                """
+        );
+        Path statsFile = tempDir.resolve("stats").resolve("stats.json");
+        LibraryStatsSupport.writeStats(statsFile, LibraryStatsSupport.loadStats(statsFile));
+
+        TestValidateLibraryStatsTask task = project.getTasks().create("validateLibraryStats", TestValidateLibraryStatsTask.class);
+        assertThatCode(task::validate).doesNotThrowAnyException();
+    }
+
+    @Test
     void validateRejectsOrphanArtifactEntry() throws IOException {
         Project project = createProjectSkeleton();
         createMetadataVersion("com.example", "demo", "1.0.0");
@@ -122,6 +199,31 @@ class ValidateLibraryStatsTaskTests {
         TestValidateLibraryStatsTask task = project.getTasks().create("validateLibraryStats", TestValidateLibraryStatsTask.class);
         assertThatThrownBy(task::validate)
                 .hasMessageContaining("Orphan artifact entry");
+    }
+
+    @Test
+    void validateRejectsMetadataVersionWithoutVersionReportEntries() throws IOException {
+        Project project = createProjectSkeleton();
+        createMetadataVersion("com.example", "demo", "1.0.0");
+        writeStatsFile(
+                """
+                {
+                  "entries": {
+                    "com.example:demo": {
+                      "metadataVersions": {
+                        "1.0.0": {
+                          "versions": []
+                        }
+                      }
+                    }
+                  }
+                }
+                """
+        );
+
+        TestValidateLibraryStatsTask task = project.getTasks().create("validateLibraryStats", TestValidateLibraryStatsTask.class);
+        assertThatThrownBy(task::validate)
+                .hasMessageContaining("Missing version report entries");
     }
 
     @Test
@@ -351,9 +453,9 @@ class ValidateLibraryStatsTaskTests {
         Files.createDirectories(tempDir.resolve("stats/schemas"));
         Files.writeString(tempDir.resolve("LICENSE"), "test", StandardCharsets.UTF_8);
         Files.writeString(
-                tempDir.resolve("stats/schemas/library-stats-schema-v1.0.0.json"),
+                tempDir.resolve("stats/schemas/library-stats-schema-v1.0.1.json"),
                 Files.readString(
-                        locateRepoFile("stats/schemas/library-stats-schema-v1.0.0.json"),
+                        locateRepoFile("stats/schemas/library-stats-schema-v1.0.1.json"),
                         StandardCharsets.UTF_8
                 ),
                 StandardCharsets.UTF_8

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
@@ -141,6 +141,65 @@ class LibraryStatsSupportTests {
     }
 
     @Test
+    void buildVersionStatsAllowsJacocoReportsWithoutLineCoverageData() throws IOException {
+        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("com/example/Foo.class"));
+
+        Path dynamicAccessDir = tempDir.resolve("dynamic-access");
+        Files.createDirectories(dynamicAccessDir.resolve("demo"));
+        Files.writeString(
+                dynamicAccessDir.resolve("demo").resolve("reflection-calls.json"),
+                """
+                {
+                  "java.lang.Class#forName(java.lang.String)": [
+                    "com.example.Foo.load(Foo.java:10)"
+                  ]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        Path jacocoReport = tempDir.resolve("jacoco.xml");
+        Files.writeString(
+                jacocoReport,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <report name="demo">
+                  <package name="com/example">
+                    <class name="com/example/Foo">
+                      <method name="load" desc="()V">
+                        <counter type="INSTRUCTION" missed="1" covered="2"/>
+                        <counter type="METHOD" missed="0" covered="1"/>
+                      </method>
+                      <counter type="INSTRUCTION" missed="1" covered="2"/>
+                      <counter type="METHOD" missed="0" covered="1"/>
+                      <counter type="CLASS" missed="0" covered="1"/>
+                    </class>
+                  </package>
+                  <counter type="INSTRUCTION" missed="1" covered="2"/>
+                  <counter type="METHOD" missed="0" covered="1"/>
+                </report>
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        LibraryStatsModels.VersionStats versionStats = LibraryStatsSupport.buildVersionStats(
+                "com.example:demo:1.0.0",
+                List.of(libraryJar),
+                dynamicAccessDir,
+                jacocoReport
+        );
+
+        assertThat(versionStats.dynamicAccess().totalCalls()).isEqualTo(1);
+        assertThat(versionStats.dynamicAccess().coveredCalls()).isEqualTo(0);
+        assertThat(versionStats.dynamicAccess().coverageRatio()).isEqualByComparingTo("0");
+        assertThat(versionStats.libraryCoverage().line().isAvailable()).isFalse();
+        assertThat(versionStats.libraryCoverage().instruction().covered()).isEqualTo(2);
+        assertThat(versionStats.libraryCoverage().instruction().missed()).isEqualTo(1);
+        assertThat(versionStats.libraryCoverage().method().covered()).isEqualTo(1);
+        assertThat(versionStats.libraryCoverage().method().missed()).isEqualTo(0);
+    }
+
+    @Test
     void mergeStatsReplacesWholeMetadataVersionWhenRequested() {
         LibraryStatsModels.VersionStats existingVersion = new LibraryStatsModels.VersionStats(
                 "1.0.0",
@@ -257,9 +316,9 @@ class LibraryStatsSupportTests {
 
     @Test
     void writeStatsProducesPayloadValidAgainstSchema() throws IOException {
-        Path schemaFile = tempDir.resolve("library-stats-schema-v1.0.0.json");
+        Path schemaFile = tempDir.resolve("library-stats-schema-v1.0.1.json");
         Files.copy(
-                locateRepoFile("stats/schemas/library-stats-schema-v1.0.0.json"),
+                locateRepoFile("stats/schemas/library-stats-schema-v1.0.1.json"),
                 schemaFile
         );
 
@@ -281,6 +340,73 @@ class LibraryStatsSupportTests {
                 statsFile,
                 schemaFile
         )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void writeStatsSerializesVersionBeforeOtherVersionFields() throws IOException {
+        LibraryStatsModels.LibraryStats libraryStats = new LibraryStatsModels.LibraryStats(Map.of(
+                "com.example:demo",
+                new LibraryStatsModels.ArtifactStats(
+                        Map.of(
+                                "1.0.0",
+                                new LibraryStatsModels.MetadataVersionStats(
+                                        List.of(createVersionStats("1.0.0", 1, 1))
+                                )
+                        )
+                )
+        ));
+        Path statsFile = tempDir.resolve("stats.json");
+
+        LibraryStatsSupport.writeStats(statsFile, libraryStats);
+
+        String content = Files.readString(statsFile, StandardCharsets.UTF_8);
+        int versionIndex = content.indexOf("\"version\"");
+        int dynamicAccessIndex = content.indexOf("\"dynamicAccess\"");
+        int libraryCoverageIndex = content.indexOf("\"libraryCoverage\"");
+
+        assertThat(versionIndex).isGreaterThanOrEqualTo(0);
+        assertThat(dynamicAccessIndex).isGreaterThanOrEqualTo(0);
+        assertThat(libraryCoverageIndex).isGreaterThanOrEqualTo(0);
+        assertThat(versionIndex).isLessThan(dynamicAccessIndex);
+        assertThat(versionIndex).isLessThan(libraryCoverageIndex);
+    }
+
+    @Test
+    void writeStatsSerializesUnavailableCoverageMetricAsNa() throws IOException {
+        LibraryStatsModels.LibraryStats libraryStats = new LibraryStatsModels.LibraryStats(Map.of(
+                "com.example:demo",
+                new LibraryStatsModels.ArtifactStats(
+                        Map.of(
+                                "1.0.0",
+                                new LibraryStatsModels.MetadataVersionStats(
+                                        List.of(new LibraryStatsModels.VersionStats(
+                                                "1.0.0",
+                                                new LibraryStatsModels.DynamicAccessStats(
+                                                        1,
+                                                        0,
+                                                        java.math.BigDecimal.ZERO,
+                                                        Map.of()
+                                                ),
+                                                new LibraryStatsModels.LibraryCoverage(
+                                                        LibraryStatsModels.CoverageMetricValue.notAvailable(),
+                                                        LibraryStatsModels.CoverageMetricValue.available(
+                                                                new LibraryStatsModels.CoverageMetric(2, 1, 3, new java.math.BigDecimal("0.666667"))
+                                                        ),
+                                                        LibraryStatsModels.CoverageMetricValue.available(
+                                                                new LibraryStatsModels.CoverageMetric(3, 0, 3, java.math.BigDecimal.ONE)
+                                                        )
+                                                )
+                                        ))
+                                )
+                        )
+                )
+        ));
+        Path statsFile = tempDir.resolve("stats.json");
+
+        LibraryStatsSupport.writeStats(statsFile, libraryStats);
+
+        String content = Files.readString(statsFile, StandardCharsets.UTF_8);
+        assertThat(content).contains("\"line\" : \"N/A\"");
     }
 
     private LibraryStatsModels.VersionStats createVersionStats(


### PR DESCRIPTION
## Summary
- represent unavailable library coverage metrics as "N/A" instead of zeroed metrics when JaCoCo omits counters
- keep stats generation running when JaCoCo succeeds but line/source data is unavailable
- tighten stats validation so it reports missing metadata-version entries explicitly and requires a report row for every metadata-version directory
- bump the library stats schema from v1.0.0 to v1.0.1

## Details
- add a typed coverage wrapper so `libraryCoverage.line`, `instruction`, and `method` can serialize as either a numeric metric object or the literal `"N/A"`
- continue to calculate instruction and method coverage when JaCoCo provides those counters, while marking line coverage as unavailable when the report has no line data
- preserve numeric dynamic-access coverage fields and continue treating uncovered-or-unmappable call sites as `coveredCalls = 0`
- require repository validation to check every `metadata/<groupId>/<artifactId>/<metadata-version>` directory, not just the artifact key, and fail when a metadata-version bucket has no version report entries
- improve validation output so missing artifacts are reported as missing metadata-version entries for the specific versions that are absent
- rename the stats schema file to `library-stats-schema-v1.0.1.json` and update task, test, and documentation references

## Testing
- `./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.stats.LibraryStatsSupportTests --tests org.graalvm.internal.tck.harness.tasks.ValidateLibraryStatsTaskTests`
- `./gradlew generateLibraryStats -Pcoordinates=org.bouncycastle:bcpkix-jdk18on:1.83`

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/1601