### PR TITLE
Replace failing placeholder in scaffold test template

### DIFF
--- a/tests/tck-build-logic/src/main/resources/scaffold/Test.java.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/Test.java.template
@@ -8,11 +8,9 @@ package $sanitizedGroup$.$sanitizedArtifact$;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.fail;
-
 class $capitalizedSanitizedArtifact$Test {
     @Test
     void test() throws Exception {
-        fail("TODO: Add test logic here");
+        System.out.println("This is just a placeholder, implement your test");
     }
 }


### PR DESCRIPTION
Fixes #1621

Replace `fail("TODO: Add test logic here")` with a `System.out.println` placeholder so scaffolded tests pass by default. Removes the unused `Assertions.fail` import.