### PR TITLE
[Automation] Generated metadata for io.opentelemetry:opentelemetry-exporter-logging:1.20.0

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/1.20.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/1.20.0/reachability-metadata.json
@@ -1,0 +1,41 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.logging.LoggingSpanExporter"
+      },
+      "type": "io.opentelemetry.exporter.logging.LoggingSpanExporter"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.logging.LoggingSpanExporter"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.resources.Resource"
+      },
+      "glob": "io/opentelemetry/sdk/common/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.logging.LoggingSpanExporter"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.logging.LoggingSpanExporter"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
@@ -1,17 +1,27 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.20.0",
+    "test-version" : "1.19.0",
+    "tested-versions" : [
+      "1.20.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-logging/1.19.0/opentelemetry-exporter-logging-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/logging/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/logging/README.md",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-logging/1.19.0/opentelemetry-exporter-logging-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/logging/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/logging/README.md",
+    "tested-versions" : [
       "1.19.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-logging/1.19.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-logging/1.19.0/build.gradle
@@ -23,3 +23,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-logging/1.19.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-logging/1.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#725

This PR provides new metadata needed for the io.opentelemetry:opentelemetry-exporter-logging:1.20.0, addressing Native Image run failures caused by changes in the updated library version.