### PR TITLE
[Automation] Generated metadata for io.opentelemetry:opentelemetry-exporter-zipkin:1.20.0

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/1.20.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/1.20.0/reachability-metadata.json
@@ -1,0 +1,418 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporter"
+      },
+      "type": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporter"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "java.lang.Throwable"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "javax.net.ssl.SSLParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "javax.net.ssl.SSLSocket"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.NetscapeCertTypeExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.PrivateKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.internal.ThrottlingLogger"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.resources.Resource"
+      },
+      "glob": "io/opentelemetry/sdk/common/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.internal.ThrottlingLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.internal.ThrottlingLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
@@ -1,17 +1,27 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.20.0",
+    "test-version" : "1.19.0",
+    "tested-versions" : [
+      "1.20.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-zipkin/1.19.0/opentelemetry-exporter-zipkin-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/zipkin/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/zipkin/README.md",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-zipkin/1.19.0/opentelemetry-exporter-zipkin-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/zipkin/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/zipkin/README.md",
+    "tested-versions" : [
       "1.19.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0/build.gradle
@@ -24,3 +24,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-zipkin/1.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#724

This PR provides new metadata needed for the io.opentelemetry:opentelemetry-exporter-zipkin:1.20.0, addressing Native Image run failures caused by changes in the updated library version.