### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.4-1

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.4-1/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.4-1/reachability-metadata.json
@@ -1,0 +1,170 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.AutoCloseBase"
+      },
+      "type": "com.github.luben.zstd.AutoCloseBase"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.BaseZstdBufferDecompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdCompressCtx"
+      },
+      "type": "com.github.luben.zstd.ZstdCompressCtx",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDecompressCtx"
+      },
+      "type": "com.github.luben.zstd.ZstdDecompressCtx",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictCompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictCompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictDecompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictDecompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferDecompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdInputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "org.osgi.framework.BundleEvent"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "linux/amd64/libzstd-jni-1.5.4-1.so"
+    }
+  ]
+}

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -1,16 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "com.github.luben"
+    "latest" : true,
+    "metadata-version" : "1.5.4-1",
+    "test-version" : "1.5.2-5",
+    "tested-versions" : [
+      "1.5.4-1"
     ],
-    "metadata-version": "1.5.2-5",
-    "tested-versions": [
+    "allowed-packages" : [
+      "com.github.luben"
+    ]
+  },
+  {
+    "metadata-version" : "1.5.2-5",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.2-5/zstd-jni-1.5.2-5-sources.jar",
+    "repository-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
+    "test-code-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.2-5/zstd-jni-1.5.2-5-javadoc.jar",
+    "tested-versions" : [
       "1.5.2-5"
     ],
-    "source-code-url": "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.2-5/zstd-jni-1.5.2-5-sources.jar",
-    "repository-url": "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
-    "test-code-url": "https://github.com/luben/zstd-jni/tree/c1.5.2-5/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.2-5/zstd-jni-1.5.2-5-javadoc.jar"
+    "allowed-packages" : [
+      "com.github.luben"
+    ]
   }
 ]


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#722

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.4-1, addressing Native Image run failures caused by changes in the updated library version.