### PR TITLE
Add trailing newline to generated JSON files

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
@@ -269,7 +269,11 @@ public abstract class ContributionTask extends DefaultTask {
         }
 
         // If entries were present, 'updated' will be true. Schema requires at least one entry.
-        objectMapper.writeValue(artifactIndex, entries);
+        String json = objectMapper.writeValueAsString(entries);
+        if (!json.endsWith(System.lineSeparator())) {
+            json = json + System.lineSeparator();
+        }
+        Files.writeString(artifactIndex.toPath(), json, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     private void addTests(Path originalTestsLocation) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -221,7 +221,11 @@ class ScaffoldTask extends DefaultTask {
         }
 
         entries.sort(Comparator.comparing(e -> VersionNumber.parse(e.metadataVersion())));
-        objectMapper.writeValue(metadataIndex, entries);
+        String json = objectMapper.writeValueAsString(entries);
+        if (!json.endsWith(System.lineSeparator())) {
+            json = json + System.lineSeparator();
+        }
+        Files.writeString(metadataIndex.toPath(), json, StandardCharsets.UTF_8);
     }
 
     private void setLatest(List<MetadataVersionsIndexEntry> list, int index, Boolean newValue) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -70,8 +70,12 @@ public final class MetadataGenerationUtils {
 
         DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
         prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
-        File out = testsDirectory.resolve(USER_CODE_FILTER_FILE).toFile();
-        objectMapper.writer(prettyPrinter).writeValue(out, Map.of("rules", filterFileRules));
+        Path out = testsDirectory.resolve(USER_CODE_FILTER_FILE);
+        String json = objectMapper.writer(prettyPrinter).writeValueAsString(Map.of("rules", filterFileRules));
+        if (!json.endsWith(System.lineSeparator())) {
+            json = json + System.lineSeparator();
+        }
+        Files.writeString(out, json, StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fix `addUserCodeFilterFile`, `ContributionTask.updateAllowedPackages`, and `ScaffoldTask` to append a trailing newline when writing JSON files, matching the pattern already used elsewhere in the codebase.

Closes #1626