### PR TITLE
[Automation] Generated metadata for com.google.protobuf:protobuf-java-util:3.23.0

### DIFF
--- a/metadata/com.google.protobuf/protobuf-java-util/3.23.0/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/3.23.0/reachability-metadata.json
@@ -1,0 +1,2335 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.Any",
+      "methods": [
+        {
+          "name": "getTypeUrl",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Any",
+      "methods": [
+        {
+          "name": "getTypeUrl",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.Any$Builder",
+      "methods": [
+        {
+          "name": "setTypeUrl",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.BoolValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.BoolValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.BoolValue$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.BoolValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.BytesValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.BytesValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.BytesValue$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.BytesValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.DoubleValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.DoubleValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.DoubleValue$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.DoubleValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Duration",
+      "methods": [
+        {
+          "name": "getNanos",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSeconds",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Duration$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.DurationsTest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.FieldMask",
+      "methods": [
+        {
+          "name": "getPathsList",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.FieldMask$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.FloatValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.FloatValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.FloatValue$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.FloatValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.Int32Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Int32Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.Int32Value$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Int32Value$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.Int64Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Int64Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.Int64Value$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Int64Value$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.ListValue",
+      "methods": [
+        {
+          "name": "getValuesList",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.ListValue",
+      "methods": [
+        {
+          "name": "getValuesList",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.ListValue$Builder",
+      "methods": [
+        {
+          "name": "addValues",
+          "parameterTypes": [
+            "com.google.protobuf.Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.ListValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.NullValue"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.StringValue$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.StringValue$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Struct",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Timestamp",
+      "methods": [
+        {
+          "name": "getNanos",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSeconds",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Timestamp$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.UInt32Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.UInt32Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.UInt32Value$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.UInt32Value$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.UInt64Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.UInt64Value",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.UInt64Value$Builder",
+      "methods": [
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.UInt64Value$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.Value",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type": "com.google.protobuf.Value",
+      "methods": [
+        {
+          "name": "getKindCase",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNullValueValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNumberValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl$7"
+      },
+      "type": "com.google.protobuf.Value"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Value",
+      "methods": [
+        {
+          "name": "getKindCase",
+          "parameterTypes": []
+        },
+        {
+          "name": "getListValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNullValueValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNumberValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStringValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStructValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com.google.protobuf.Value$Builder",
+      "methods": [
+        {
+          "name": "setNumberValue",
+          "parameterTypes": [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com.google.protobuf.Value$Builder",
+      "methods": [
+        {
+          "name": "setListValue",
+          "parameterTypes": [
+            "com.google.protobuf.ListValue"
+          ]
+        },
+        {
+          "name": "setStringValue",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setStructValue",
+          "parameterTypes": [
+            "com.google.protobuf.Struct"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes",
+      "methods": [
+        {
+          "name": "getOptionalAliasedEnumValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalBool",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalBytes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalDouble",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFixed32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFixed64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFloat",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalInt64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalNestedEnumValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSfixed32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSfixed64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSint32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSint64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalString",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalUint32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalUint64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedBoolList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedBytesList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedDoubleList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFixed32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFixed64List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFloatList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedInt32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedInt64List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedNestedEnumCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedNestedEnumValue",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "getRepeatedNestedMessageList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSfixed32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSfixed64List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSint32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSint64List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedStringList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedUint32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedUint64List",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalNestedMessage",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$AliasedEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$Builder",
+      "methods": [
+        {
+          "name": "addRepeatedBool",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "addRepeatedBytes",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        },
+        {
+          "name": "addRepeatedDouble",
+          "parameterTypes": [
+            "double"
+          ]
+        },
+        {
+          "name": "addRepeatedFixed32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedFixed64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "addRepeatedFloat",
+          "parameterTypes": [
+            "float"
+          ]
+        },
+        {
+          "name": "addRepeatedInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedInt64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "addRepeatedNestedEnumValue",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedNestedMessage",
+          "parameterTypes": [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name": "addRepeatedSfixed32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedSfixed64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "addRepeatedSint32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedSint64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "addRepeatedString",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "addRepeatedUint32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedUint64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "getOptionalAliasedEnumValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalBool",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalBytes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalDouble",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFixed32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFixed64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalFloat",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalInt64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalNestedEnumValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSfixed32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSfixed64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSint32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalSint64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalString",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalUint32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalUint64",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedBoolCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedBytesCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedDoubleCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFixed32Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFixed64Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedFloatCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedInt32Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedInt64Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedNestedEnumCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedNestedMessageCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSfixed32Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSfixed64Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSint32Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedSint64Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedStringCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedUint32Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedUint64Count",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "setOptionalAliasedEnumValue",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalBool",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setOptionalBytes",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        },
+        {
+          "name": "setOptionalDouble",
+          "parameterTypes": [
+            "double"
+          ]
+        },
+        {
+          "name": "setOptionalFixed32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalFixed64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "setOptionalFloat",
+          "parameterTypes": [
+            "float"
+          ]
+        },
+        {
+          "name": "setOptionalInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalInt64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "setOptionalNestedEnumValue",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalNestedMessage",
+          "parameterTypes": [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name": "setOptionalSfixed32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalSfixed64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "setOptionalSint32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalSint64",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "setOptionalString",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setOptionalUint32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalUint64",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage$Builder",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny",
+      "methods": [
+        {
+          "name": "getAnyValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasAnyValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny$Builder",
+      "methods": [
+        {
+          "name": "hasAnyValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAnyValue",
+          "parameterTypes": [
+            "com.google.protobuf.Any"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName$Builder",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration",
+      "methods": [
+        {
+          "name": "getDurationValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasDurationValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration$Builder",
+      "methods": [
+        {
+          "name": "hasDurationValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setDurationValue",
+          "parameterTypes": [
+            "com.google.protobuf.Duration"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask",
+      "methods": [
+        {
+          "name": "getFieldMaskValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasFieldMaskValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask$Builder",
+      "methods": [
+        {
+          "name": "hasFieldMaskValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setFieldMaskValue",
+          "parameterTypes": [
+            "com.google.protobuf.FieldMask"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestMap",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof",
+      "methods": [
+        {
+          "name": "getOneofFieldCase",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOneofInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOneofNullValueValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOneofInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOneofNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOneofNullValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+      "methods": [
+        {
+          "name": "getOneofFieldCase",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+      "methods": [
+        {
+          "name": "hasOneofInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOneofNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOneofNullValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setOneofInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOneofNullValueValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive$Builder",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasNested",
+          "parameterTypes": []
+        },
+        {
+          "name": "setNested",
+          "parameterTypes": [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive"
+          ]
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct",
+      "methods": [
+        {
+          "name": "getListValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStructValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasListValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasStructValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct$Builder",
+      "methods": [
+        {
+          "name": "hasListValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasStructValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setListValue",
+          "parameterTypes": [
+            "com.google.protobuf.ListValue"
+          ]
+        },
+        {
+          "name": "setStructValue",
+          "parameterTypes": [
+            "com.google.protobuf.Struct"
+          ]
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "com.google.protobuf.Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp",
+      "methods": [
+        {
+          "name": "getTimestampValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasTimestampValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp$Builder",
+      "methods": [
+        {
+          "name": "hasTimestampValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setTimestampValue",
+          "parameterTypes": [
+            "com.google.protobuf.Timestamp"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers",
+      "methods": [
+        {
+          "name": "getBoolValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBytesValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDoubleValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getFloatValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getInt32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "getInt64Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStringValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getUint32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "getUint64Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasBoolValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasBytesValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasDoubleValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasFloatValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasInt32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasInt64Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasStringValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasUint32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasUint64Value",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers$Builder",
+      "methods": [
+        {
+          "name": "hasBoolValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasBytesValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasDoubleValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasFloatValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasInt32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasInt64Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasStringValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasUint32Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasUint64Value",
+          "parameterTypes": []
+        },
+        {
+          "name": "setBoolValue",
+          "parameterTypes": [
+            "com.google.protobuf.BoolValue"
+          ]
+        },
+        {
+          "name": "setBytesValue",
+          "parameterTypes": [
+            "com.google.protobuf.BytesValue"
+          ]
+        },
+        {
+          "name": "setDoubleValue",
+          "parameterTypes": [
+            "com.google.protobuf.DoubleValue"
+          ]
+        },
+        {
+          "name": "setFloatValue",
+          "parameterTypes": [
+            "com.google.protobuf.FloatValue"
+          ]
+        },
+        {
+          "name": "setInt32Value",
+          "parameterTypes": [
+            "com.google.protobuf.Int32Value"
+          ]
+        },
+        {
+          "name": "setInt64Value",
+          "parameterTypes": [
+            "com.google.protobuf.Int64Value"
+          ]
+        },
+        {
+          "name": "setStringValue",
+          "parameterTypes": [
+            "com.google.protobuf.StringValue"
+          ]
+        },
+        {
+          "name": "setUint32Value",
+          "parameterTypes": [
+            "com.google.protobuf.UInt32Value"
+          ]
+        },
+        {
+          "name": "setUint64Value",
+          "parameterTypes": [
+            "com.google.protobuf.UInt64Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "com_google_protobuf.protobuf_java_util.UnittestImportPublic$PublicImportMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type": "java.lang.reflect.AccessibleObject"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.Timestamps"
+      },
+      "type": "java.time.Instant"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$ForeignEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$ForeignMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+      "methods": [
+        {
+          "name": "getChild",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasChild",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type": "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasPayload",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+      "methods": [
+        {
+          "name": "clearPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "getChild",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "setChild",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+          ]
+        },
+        {
+          "name": "setPayload",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$TestAllTypes"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type": "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+      "methods": [
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "setPayload",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$TestAllTypes"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes",
+      "methods": [
+        {
+          "name": "getOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedInt32List",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRepeatedNestedMessageList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalString",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasOptionalString",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$Builder",
+      "methods": [
+        {
+          "name": "addRepeatedInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "addRepeatedNestedMessage",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name": "clearOptionalInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "clearRepeatedInt32",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOptionalNestedMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "setOptionalInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalNestedMessage",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name": "setOptionalUint32",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$Builder",
+      "methods": [
+        {
+          "name": "setOptionalInt32",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setOptionalString",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage$Builder",
+      "methods": [
+        {
+          "name": "setBb",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$OptionalGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestAllTypes$RepeatedGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestRequired",
+      "methods": [
+        {
+          "name": "getA",
+          "parameterTypes": []
+        },
+        {
+          "name": "getB",
+          "parameterTypes": []
+        },
+        {
+          "name": "getC",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasA",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasB",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasC",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestRequired$Builder",
+      "methods": [
+        {
+          "name": "setA",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setB",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setC",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestRequiredMessage",
+      "methods": [
+        {
+          "name": "getRequiredMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasRequiredMessage",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "protobuf_unittest.UnittestProto$TestRequiredMessage$Builder",
+      "methods": [
+        {
+          "name": "getRequiredMessage",
+          "parameterTypes": []
+        },
+        {
+          "name": "setRequiredMessage",
+          "parameterTypes": [
+            "protobuf_unittest.UnittestProto$TestRequired"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -1,7 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.23.0",
+    "test-version" : "3.22.0",
+    "tested-versions" : [
+      "3.23.0"
+    ],
+    "allowed-packages" : [
+      "com.google.protobuf"
+    ]
+  },
+  {
     "metadata-version" : "3.22.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.0/protobuf-java-util-3.22.0-sources.jar",
+    "repository-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0",
+    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0/java/util/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.0/protobuf-java-util-3.22.0-javadoc.jar",
     "tested-versions" : [
       "3.22.0",
       "3.22.2",
@@ -9,10 +23,6 @@
       "3.22.4",
       "3.22.5"
     ],
-    "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.0/protobuf-java-util-3.22.0-sources.jar",
-    "repository-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0",
-    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0/java/util/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.0/protobuf-java-util-3.22.0-javadoc.jar",
     "skipped-versions" : [
       {
         "version" : "3.22.1",
@@ -25,13 +35,13 @@
   },
   {
     "metadata-version" : "3.21.12",
-    "tested-versions" : [
-      "3.21.12"
-    ],
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.12/protobuf-java-util-3.21.12-sources.jar",
     "repository-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.21.12",
     "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.21.12/java/util/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.12/protobuf-java-util-3.21.12-javadoc.jar",
+    "tested-versions" : [
+      "3.21.12"
+    ],
     "allowed-packages" : [
       "com.google.protobuf"
     ]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -603,6 +603,43 @@
               }
             }
           } ]
+        },
+        "3.23.0" : {
+          "versions" : [ {
+            "version" : "3.23.0",
+            "dynamicAccess" : {
+              "breakdown" : {
+                "reflection" : {
+                  "coverageRatio" : 0.25,
+                  "coveredCalls" : 1,
+                  "totalCalls" : 4
+                }
+              },
+              "coverageRatio" : 0.25,
+              "coveredCalls" : 1,
+              "totalCalls" : 4
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 5979,
+                "missed" : 472,
+                "ratio" : 0.926833,
+                "total" : 6451
+              },
+              "line" : {
+                "covered" : 1325,
+                "missed" : 91,
+                "ratio" : 0.935734,
+                "total" : 1416
+              },
+              "method" : {
+                "covered" : 251,
+                "missed" : 3,
+                "ratio" : 0.988189,
+                "total" : 254
+              }
+            }
+          } ]
         }
       }
     },


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#1587

This PR provides new metadata needed for the com.google.protobuf:protobuf-java-util:3.23.0, addressing Native Image run failures caused by changes in the updated library version.