### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-sqlserver:10.19.0

### DIFF
--- a/metadata/org.flywaydb/flyway-sqlserver/10.19.0/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/10.19.0/reachability-metadata.json
@@ -1,0 +1,634 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "java.net.Socket",
+      "methods": [
+        {
+          "name": "setOption",
+          "parameterTypes": [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.apache.commons.logging.Log"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.clean.CleanModeCommandExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.clean.database.SQLServerCleanModePlugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBaselineMigrationPrefix",
+          "parameterTypes": []
+        },
+        {
+          "name": "setBaselineMigrationPrefix",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationTypeResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.experimental.migration.CoreMigrationTypeResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClean",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClean",
+          "parameterTypes": [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModel"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.SchemaModel"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDeployScript",
+          "parameterTypes": []
+        },
+        {
+          "name": "setDeployScript",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isPublishResult",
+          "parameterTypes": []
+        },
+        {
+          "name": "setPublishResult",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.KerberosModel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLogin",
+          "parameterTypes": []
+        },
+        {
+          "name": "setLogin",
+          "parameterTypes": [
+            "org.flywaydb.database.sqlserver.LoginModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.LoginModel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getFile",
+          "parameterTypes": []
+        },
+        {
+          "name": "setFile",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClean",
+          "parameterTypes": []
+        },
+        {
+          "name": "getKerberos",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClean",
+          "parameterTypes": [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        },
+        {
+          "name": "setKerberos",
+          "parameterTypes": [
+            "org.flywaydb.database.sqlserver.KerberosModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.slf4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type": "org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcTemplate"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.database.sqlserver.SQLServerConnection"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "glob": "META-INF/services/org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
+      },
+      "glob": "db/callback"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.scanner.Scanner"
+      },
+      "glob": "db/migration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob": "db/migration/V1__create_table.sql"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob": "db/migration/V2__alter_table.sql"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.license.VersionPrinter"
+      },
+      "glob": "org/flywaydb/core/internal/version.txt"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -1,16 +1,23 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "org.flywaydb"
+    "latest" : true,
+    "metadata-version" : "10.19.0",
+    "test-version" : "10.10.0",
+    "tested-versions" : [
+      "10.19.0"
     ],
-    "metadata-version": "10.13.0",
-    "test-version": "10.10.0",
-    "source-code-url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.13.0/flyway-sqlserver-10.13.0-sources.jar",
-    "repository-url": "https://github.com/flyway/flyway",
-    "test-code-url": "N/A",
-    "documentation-url": "https://github.com/flyway/flyway/tree/flyway-10.13.0/documentation",
-    "tested-versions": [
+    "allowed-packages" : [
+      "org.flywaydb"
+    ]
+  },
+  {
+    "metadata-version" : "10.13.0",
+    "test-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.13.0/flyway-sqlserver-10.13.0-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.13.0/documentation",
+    "tested-versions" : [
       "10.13.0",
       "10.14.0",
       "10.15.0",
@@ -23,22 +30,25 @@
       "10.18.0",
       "10.18.1",
       "10.18.2"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
     ]
   },
   {
-    "allowed-packages": [
-      "org.flywaydb"
-    ],
-    "metadata-version": "10.10.0",
-    "source-code-url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.10.0/flyway-sqlserver-10.10.0-sources.jar",
-    "repository-url": "https://github.com/flyway/flyway",
-    "test-code-url": "N/A",
-    "documentation-url": "https://github.com/flyway/flyway/tree/flyway-10.10.0/documentation",
-    "tested-versions": [
+    "metadata-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.10.0/flyway-sqlserver-10.10.0-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.10.0/documentation",
+    "tested-versions" : [
       "10.10.0",
       "10.11.0",
       "10.11.1",
       "10.12.0"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
     ]
   }
 ]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -4307,6 +4307,37 @@
               }
             }
           } ]
+        },
+        "10.19.0" : {
+          "versions" : [ {
+            "version" : "10.19.0",
+            "dynamicAccess" : {
+              "breakdown" : { },
+              "coverageRatio" : 1.0,
+              "coveredCalls" : 0,
+              "totalCalls" : 0
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 1151,
+                "missed" : 3194,
+                "ratio" : 0.264902,
+                "total" : 4345
+              },
+              "line" : {
+                "covered" : 198,
+                "missed" : 521,
+                "ratio" : 0.275382,
+                "total" : 719
+              },
+              "method" : {
+                "covered" : 79,
+                "missed" : 150,
+                "ratio" : 0.344978,
+                "total" : 229
+              }
+            }
+          } ]
         }
       }
     },


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#903

This PR provides new metadata needed for the org.flywaydb:flyway-sqlserver:10.19.0, addressing Native Image run failures caused by changes in the updated library version.