### PR TITLE
[Automation] Generated metadata for io.jsonwebtoken:jjwt-jackson:0.12.7

### DIFF
--- a/metadata/io.jsonwebtoken/jjwt-jackson/0.12.7/reachability-metadata.json
+++ b/metadata/io.jsonwebtoken/jjwt-jackson/0.12.7/reachability-metadata.json
@@ -1,0 +1,760 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.Claims"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.Header"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.Identifiable"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.JwsHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.ProtectedHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultClaims"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwsHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultProtectedHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "io.jsonwebtoken.impl.ParameterMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ZIP"
+      },
+      "type": "io.jsonwebtoken.impl.io.StandardCompressionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "io.jsonwebtoken.impl.lang.Nameable"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "io.jsonwebtoken.impl.lang.ParameterReadable"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.security.KeysBridge"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ENC"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardEncryptionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$KEY"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyOperations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$SIG"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardSecureDigestAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "type": "io.jsonwebtoken.jackson.io.JacksonDeserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.security.X509Accessor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.EdECKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.XECKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.spec.NamedParameterSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.jackson.io.JacksonSerializer"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.Randoms"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$MessageDigestFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "sun.security.rsa.RSAKeyPairGenerator$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "sun.security.rsa.RSAKeyPairGenerator$PSS",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "glob": "META-INF/services/io.jsonwebtoken.io.Deserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/io.jsonwebtoken/jjwt-jackson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-jackson/index.json
@@ -1,15 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "io.jsonwebtoken"
+    "latest" : true,
+    "metadata-version" : "0.12.7",
+    "test-version" : "0.12.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-jackson/0.12.7/jjwt-jackson-0.12.7-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.12.7/extensions/jackson/src/test",
+    "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.12.7/README.adoc",
+    "tested-versions" : [
+      "0.12.7"
     ],
-    "metadata-version": "0.12.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-jackson/0.12.0/jjwt-jackson-0.12.0-sources.jar",
-    "repository-url": "https://github.com/jwtk/jjwt",
-    "test-code-url": "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/jackson/src/test",
-    "documentation-url": "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.jsonwebtoken"
+    ]
+  },
+  {
+    "metadata-version" : "0.12.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-jackson/0.12.0/jjwt-jackson-0.12.0-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/jackson/src/test",
+    "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
+    "tested-versions" : [
       "0.12.0",
       "0.12.1",
       "0.12.2",
@@ -17,19 +28,22 @@
       "0.12.4",
       "0.12.5",
       "0.12.6"
+    ],
+    "allowed-packages" : [
+      "io.jsonwebtoken"
     ]
   },
   {
-    "allowed-packages": [
-      "io.jsonwebtoken"
-    ],
-    "metadata-version": "0.11.5",
-    "source-code-url": "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-jackson/0.11.5/jjwt-jackson-0.11.5-sources.jar",
-    "repository-url": "https://github.com/jwtk/jjwt",
-    "test-code-url": "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/jackson/src/test",
-    "documentation-url": "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
-    "tested-versions": [
+    "metadata-version" : "0.11.5",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-jackson/0.11.5/jjwt-jackson-0.11.5-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/jackson/src/test",
+    "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
+    "tested-versions" : [
       "0.11.5"
+    ],
+    "allowed-packages" : [
+      "io.jsonwebtoken"
     ]
   }
 ]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -46,6 +46,41 @@
         }
       }
     },
+    "io.jsonwebtoken:jjwt-jackson" : {
+      "metadataVersions" : {
+        "0.12.7" : {
+          "versions" : [ {
+            "version" : "0.12.7",
+            "dynamicAccess" : {
+              "breakdown" : { },
+              "coverageRatio" : 0.000000,
+              "coveredCalls" : 0,
+              "totalCalls" : 0
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 100,
+                "missed" : 95,
+                "ratio" : 0.512821,
+                "total" : 195
+              },
+              "line" : {
+                "covered" : 29,
+                "missed" : 24,
+                "ratio" : 0.547170,
+                "total" : 53
+              },
+              "method" : {
+                "covered" : 11,
+                "missed" : 5,
+                "ratio" : 0.687500,
+                "total" : 16
+              }
+            }
+          } ]
+        }
+      }
+    },
     "org.example:library" : {
       "metadataVersions" : {
         "0.0.1" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#932

This PR provides new metadata needed for the io.jsonwebtoken:jjwt-jackson:0.12.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.jsonwebtoken:jjwt-jackson:0.12.0`): 135
- Metadata entries (new `io.jsonwebtoken:jjwt-jackson:0.12.7`): 125
- Library coverage (previous): 56.00000000000001%
- Library coverage (new): 0.0%

### Stats from `stats/stats.json`

#### Dynamic access coverage

- io.jsonwebtoken:jjwt-jackson:0.12.0: N/A
- io.jsonwebtoken:jjwt-jackson:0.12.7: 0/0 covered calls (0.00%)

#### Library coverage

**Instruction:**
- io.jsonwebtoken:jjwt-jackson:0.12.0: N/A
- io.jsonwebtoken:jjwt-jackson:0.12.7: 100/195 (51.28%)

**Line:**
- io.jsonwebtoken:jjwt-jackson:0.12.0: N/A
- io.jsonwebtoken:jjwt-jackson:0.12.7: 29/53 (54.72%)

**Method:**
- io.jsonwebtoken:jjwt-jackson:0.12.0: N/A
- io.jsonwebtoken:jjwt-jackson:0.12.7: 11/16 (68.75%)
