### PR TITLE
Implement dual-mode metadata testing for future defaults

### DIFF
--- a/.github/workflows/scripts/run-consecutive-tests.sh
+++ b/.github/workflows/scripts/run-consecutive-tests.sh
@@ -39,7 +39,11 @@ run_multiple_attempts() {
   local result=0
 
   while [ $attempt -lt "$max_attempts" ]; do
-    local cmd_str="GVM_TCK_LV=\"$VERSION\" ./gradlew clean $gradle_command -Pcoordinates=\"$TEST_COORDINATES\""
+    local native_image_mode_prefix=""
+    if [ -n "${GVM_TCK_NATIVE_IMAGE_MODE:-}" ]; then
+      native_image_mode_prefix="GVM_TCK_NATIVE_IMAGE_MODE=\"$GVM_TCK_NATIVE_IMAGE_MODE\" "
+    fi
+    local cmd_str="${native_image_mode_prefix}GVM_TCK_LV=\"$VERSION\" ./gradlew clean $gradle_command -Pcoordinates=\"$TEST_COORDINATES\""
     if [ $attempt -gt 0 ]; then
       echo "Re-running stage '$stage' (attempt $((attempt + 1))/$max_attempts)"
     fi

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -40,10 +40,12 @@ jobs:
           ./gradlew generateMatrixBatchedCoordinates -Pbatches=16
 
   test-all-metadata:
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 240
     needs: get-all-metadata
+    env:
+      GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.get-all-metadata.outputs.matrix)}}

--- a/.github/workflows/test-changed-infrastructure.yml
+++ b/.github/workflows/test-changed-infrastructure.yml
@@ -52,11 +52,13 @@ jobs:
           ./gradlew generateInfrastructureChangedCoordinatesMatrix -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.event.pull_request.head.sha }}
 
   test-changed-infrastructure:
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     if: needs.get-changed-infrastructure.outputs.relevant-files-changed == 'true' && needs.get-changed-infrastructure.result == 'success' && needs.get-changed-infrastructure.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: get-changed-infrastructure
+    env:
+      GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-changed-metadata.yml
+++ b/.github/workflows/test-changed-metadata.yml
@@ -51,11 +51,13 @@ jobs:
           echo "${{ steps.set-matrix.outputs.matrix }}"
 
   test-changed-metadata:
-    name: "🧪 ${{ matrix.coordinates }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     if: needs.get-changed-metadata.outputs.relevant-files-changed == 'true' && needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: get-changed-metadata
+    env:
+      GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-new-library-versions.yml
+++ b/.github/workflows/test-new-library-versions.yml
@@ -48,11 +48,13 @@ jobs:
           ./gradlew generateChangedTestedVersionsMatrix -PbaseCommit=${{ github.event.pull_request.base.sha }} -PnewCommit=${{ github.event.pull_request.head.sha }}
 
   test-new-library-versions:
-    name: "🧪 ${{ matrix.coordinates }} tested-version diff (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.coordinates }} tested-version diff [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     if: needs.get-changed-index-metadata.outputs.relevant-files-changed == 'true' && needs.get-changed-index-metadata.result == 'success' && needs.get-changed-index-metadata.outputs.none-found != 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: get-changed-index-metadata
+    env:
+      GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -65,13 +65,14 @@ jobs:
           git push origin "${{ steps.set-branch-name.outputs.branch }}"
 
   test-all-metadata:
-    name: "🧪 ${{ matrix.name }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+    name: "🧪 ${{ matrix.name }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
     if: needs.get-all-libraries.outputs.none-found != 'true'
     runs-on: ${{ matrix.os }}
     needs: get-all-libraries
     permissions: write-all
     env:
-      CURRENT_JOB_NAME: "🧪 ${{ matrix.name }} (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+      CURRENT_JOB_NAME: "🧪 ${{ matrix.name }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
+      GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LOG_LINES: "300"
     strategy:
@@ -99,50 +100,17 @@ jobs:
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Check for an existing issue and skip further testing if found"
-        id: check-existing-issue
-        run: |
-          GROUP_ID="$(echo "${{ matrix.name }}" | cut -d: -f1)"
-          ARTIFACT_ID="$(echo "${{ matrix.name }}" | cut -d: -f2)"
-
-          readarray -t VERSIONS < <(echo '${{ toJson(matrix.versions) }}' | jq -r '.[]')
-          ISSUE_TITLE_PREFIX="[Automation] "
-          FIRST_TESTING_VERSION="${VERSIONS[0]}"
-          GAV_COORDINATES="$GROUP_ID:$ARTIFACT_ID:$FIRST_TESTING_VERSION"
-          TITLE_END=" fails for $GAV_COORDINATES"
-
-          ISSUE_NUMBER=$(
-            gh issue list \
-              --repo "${{ github.repository }}" \
-              --state open \
-              --search "\"$TITLE_END\" in:title" \
-              --json number,title \
-              --jq ".[] | select(.title | (startswith(\"$ISSUE_TITLE_PREFIX\") and endswith(\"$TITLE_END\"))) | .number"
-          )
-
-          echo "Found the issue(s) $ISSUE_NUMBER"
-          if [[ -n "$ISSUE_NUMBER" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "There is no progress since last time for the $GAV_COORDINATES. Skipping further testing!"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: "Extract test path and library version"
-        if: steps.check-existing-issue.outputs.skip != 'true'
         id: extract-params
         run: ./gradlew extractLibraryTestParams -Pcoordinates="${{ matrix.name }}"
 
       - name: "Pull allowed docker images"
-        if: steps.check-existing-issue.outputs.skip != 'true'
         run: ./gradlew pullAllowedDockerImages -Pcoordinates="${{ env.TEST_COORDINATES }}"
 
       - name: "Disable docker networking"
-        if: steps.check-existing-issue.outputs.skip != 'true'
         run: bash ./.github/workflows/scripts/disable-docker.sh
 
       - name: "🧪 Run '${{ env.TEST_COORDINATES }}' tests"
-        if: steps.check-existing-issue.outputs.skip != 'true'
         id: runtests
         run: |
           bash ./.github/workflows/scripts/run-consecutive-tests.sh "${{ env.TEST_COORDINATES }}" '${{ toJson(matrix.versions) }}' 2>&1 | tee test_results.txt || true
@@ -176,6 +144,7 @@ jobs:
             --arg name "${{ matrix.name }}" \
             --arg os "${{ matrix.os }}" \
             --arg jdk "${{ matrix.version }}" \
+            --arg nativeImageMode "${{ matrix.nativeImageMode }}" \
             --arg latestVersion "${{ env.LATEST_VERSION }}" \
             --arg runnerLogUrl "$RUNNER_LOG_URL" \
             --arg failureType "$FAILURE_TYPE" \
@@ -188,6 +157,7 @@ jobs:
               name: $name,
               os: $os,
               version: $jdk,
+              nativeImageMode: $nativeImageMode,
               latestVersion: $latestVersion,
               runnerLogUrl: $runnerLogUrl,
               successfulVersions: $successfulVersions,
@@ -200,28 +170,13 @@ jobs:
               } end)
             }' > result.json
 
-      - name: "📝 Write skipped result"
-        if: steps.check-existing-issue.outputs.skip == 'true'
-        run: |
-          jq -n \
-            --arg name "${{ matrix.name }}" \
-            --arg os "${{ matrix.os }}" \
-            --arg jdk "${{ matrix.version }}" \
-            '{
-              name: $name,
-              os: $os,
-              version: $jdk,
-              skipped: true,
-              successfulVersions: [],
-              failure: null
-            }' > result.json
-
       - name: "📝 Compute artifact names"
         id: artifact-name
         run: |
           SAFE_NAME="$(printf '%s' '${{ matrix.name }}' | tr ':' '-')"
-          echo "artifact_name=compatibility-result-$SAFE_NAME-${{ matrix.version }}-${{ matrix.os }}" >> "$GITHUB_OUTPUT"
-          echo "result_file=result-$SAFE_NAME-${{ matrix.version }}-${{ matrix.os }}.json" >> "$GITHUB_OUTPUT"
+          SAFE_MODE="$(printf '%s' '${{ matrix.nativeImageMode }}' | tr ':' '-')"
+          echo "artifact_name=compatibility-result-$SAFE_NAME-${{ matrix.version }}-${{ matrix.os }}-$SAFE_MODE" >> "$GITHUB_OUTPUT"
+          echo "result_file=result-$SAFE_NAME-${{ matrix.version }}-${{ matrix.os }}-$SAFE_MODE.json" >> "$GITHUB_OUTPUT"
 
       - name: "📝 Rename result file for merged download"
         run: mv result.json "${{ steps.artifact-name.outputs.result_file }}"
@@ -285,6 +240,7 @@ jobs:
                     map(.failure + {
                       os: .os,
                       jdk: .version,
+                      nativeImageMode: .nativeImageMode,
                       runnerLogUrl: .runnerLogUrl
                     })
                     | group_by(.failedVersion)
@@ -294,6 +250,7 @@ jobs:
                         environments: map({
                           os: .os,
                           jdk: .jdk,
+                          nativeImageMode: .nativeImageMode,
                           failureType: .failureType,
                           failedCommand: .failedCommand,
                           runnerLogUrl: .runnerLogUrl,
@@ -457,6 +414,7 @@ jobs:
               for environment in "${ENVIRONMENTS[@]}"; do
                 OS="$(printf '%s' "$environment" | jq -r '.os')"
                 JDK="$(printf '%s' "$environment" | jq -r '.jdk')"
+                NATIVE_IMAGE_MODE="$(printf '%s' "$environment" | jq -r '.nativeImageMode')"
                 COMMAND="$(printf '%s' "$environment" | jq -r '.failedCommand')"
                 RUNNER_LOG_URL="$(printf '%s' "$environment" | jq -r '.runnerLogUrl')"
                 ENV_FAILURE_TYPE="$(printf '%s' "$environment" | jq -r '.failureType')"
@@ -464,19 +422,21 @@ jobs:
                 LOG_TAIL="$(printf '%s' "$environment" | jq -r '.logTail')"
 
                 NORMAL_PREFIX="$(
-                  printf '## %s on %s / JDK %s\n\n' "$ENV_FAILURE_TYPE" "$OS" "$JDK"
+                  printf '## %s on %s / JDK %s / mode %s\n\n' "$ENV_FAILURE_TYPE" "$OS" "$JDK" "$NATIVE_IMAGE_MODE"
                   printf 'Failure kind: %s\n' "$ENV_FAILURE_TYPE"
                   printf 'OS: %s\n' "$OS"
                   printf 'JDK: %s\n' "$JDK"
+                  printf 'Native-image mode: %s\n' "$NATIVE_IMAGE_MODE"
                   printf 'Reproducer: `%s`\n' "$COMMAND"
                   printf 'Runner log: %s\n' "$RUNNER_LOG_URL"
                   printf 'Last %s lines of the log:\n' "$ENV_LOG_LINES"
                 )"
                 TRUNCATED_PREFIX="$(
-                  printf '## %s on %s / JDK %s\n\n' "$ENV_FAILURE_TYPE" "$OS" "$JDK"
+                  printf '## %s on %s / JDK %s / mode %s\n\n' "$ENV_FAILURE_TYPE" "$OS" "$JDK" "$NATIVE_IMAGE_MODE"
                   printf 'Failure kind: %s\n' "$ENV_FAILURE_TYPE"
                   printf 'OS: %s\n' "$OS"
                   printf 'JDK: %s\n' "$JDK"
+                  printf 'Native-image mode: %s\n' "$NATIVE_IMAGE_MODE"
                   printf 'Reproducer: `%s`\n' "$COMMAND"
                   printf 'Runner log: %s\n' "$RUNNER_LOG_URL"
                   printf 'Last %s lines of the log (excerpt truncated to fit the GitHub issue size limit):\n' "$ENV_LOG_LINES"

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -100,17 +100,50 @@ jobs:
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Check for an existing issue and skip further testing if found"
+        id: check-existing-issue
+        run: |
+          GROUP_ID="$(echo "${{ matrix.name }}" | cut -d: -f1)"
+          ARTIFACT_ID="$(echo "${{ matrix.name }}" | cut -d: -f2)"
+
+          readarray -t VERSIONS < <(echo '${{ toJson(matrix.versions) }}' | jq -r '.[]')
+          ISSUE_TITLE_PREFIX="[Automation] "
+          FIRST_TESTING_VERSION="${VERSIONS[0]}"
+          GAV_COORDINATES="$GROUP_ID:$ARTIFACT_ID:$FIRST_TESTING_VERSION"
+          TITLE_END=" fails for $GAV_COORDINATES"
+
+          ISSUE_NUMBER=$(
+            gh issue list \
+              --repo "${{ github.repository }}" \
+              --state open \
+              --search "\"$TITLE_END\" in:title" \
+              --json number,title \
+              --jq ".[] | select(.title | (startswith(\"$ISSUE_TITLE_PREFIX\") and endswith(\"$TITLE_END\"))) | .number"
+          )
+
+          echo "Found the issue(s) $ISSUE_NUMBER"
+          if [[ -n "$ISSUE_NUMBER" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "There is no progress since last time for the $GAV_COORDINATES. Skipping further testing!"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Extract test path and library version"
+        if: steps.check-existing-issue.outputs.skip != 'true'
         id: extract-params
         run: ./gradlew extractLibraryTestParams -Pcoordinates="${{ matrix.name }}"
 
       - name: "Pull allowed docker images"
+        if: steps.check-existing-issue.outputs.skip != 'true'
         run: ./gradlew pullAllowedDockerImages -Pcoordinates="${{ env.TEST_COORDINATES }}"
 
       - name: "Disable docker networking"
+        if: steps.check-existing-issue.outputs.skip != 'true'
         run: bash ./.github/workflows/scripts/disable-docker.sh
 
       - name: "🧪 Run '${{ env.TEST_COORDINATES }}' tests"
+        if: steps.check-existing-issue.outputs.skip != 'true'
         id: runtests
         run: |
           bash ./.github/workflows/scripts/run-consecutive-tests.sh "${{ env.TEST_COORDINATES }}" '${{ toJson(matrix.versions) }}' 2>&1 | tee test_results.txt || true
@@ -168,6 +201,24 @@ jobs:
                 logLines: $logLines,
                 logTail: ($logTail | split("\n") | .[-($logLines | tonumber):] | join("\n"))
               } end)
+            }' > result.json
+
+      - name: "📝 Write skipped result"
+        if: steps.check-existing-issue.outputs.skip == 'true'
+        run: |
+          jq -n \
+            --arg name "${{ matrix.name }}" \
+            --arg os "${{ matrix.os }}" \
+            --arg jdk "${{ matrix.version }}" \
+            --arg nativeImageMode "${{ matrix.nativeImageMode }}" \
+            '{
+              name: $name,
+              os: $os,
+              version: $jdk,
+              nativeImageMode: $nativeImageMode,
+              skipped: true,
+              successfulVersions: [],
+              failure: null
             }' > result.json
 
       - name: "📝 Compute artifact names"

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,11 @@ __pycache__/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+
+##############################
+## Agents
+##############################
+
+.codex/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
 ## One command for complete infrastructure testing
 ./gradlew testAllInfra -Pparallelism=4 --stacktrace
 
+Run the future-defaults lane locally with:
+GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew testAllInfra -Pparallelism=4 --stacktrace
+
 ## Code Style
 - Always try to reuse existing code.
 - Be assertive in code.
@@ -44,10 +47,13 @@
   - ./gradlew pullAllowedDockerImages -Pcoordinates=group:artifact:version
   - ./gradlew checkMetadataFiles -Pcoordinates=group:artifact:version
   - ./gradlew test -Pcoordinates=group:artifact:version
+  - GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=group:artifact:version
 - Sharded example (1/64):
   - ./gradlew pullAllowedDockerImages -Pcoordinates=1/64
   - ./gradlew checkMetadataFiles -Pcoordinates=1/64
   - ./gradlew test -Pcoordinates=1/64
+
+Metadata CI currently runs both `current-defaults` and `future-defaults-all`.
 
 ### Generating Metadata
 - Generate metadata for a certain library version:

--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,11 @@ tasks.register('testAllInfra') { t ->
                     def jsonStr = line.substring("matrix=".length())
                     def parsed = new JsonSlurper().parseText(jsonStr)
                     def coords = (parsed["coordinates"] as List) ?: []
+                    if (coords.isEmpty()) {
+                        coords = ((parsed["include"] as List) ?: [])
+                                .collect { it instanceof Map ? it["coordinates"] : null }
+                                .findAll { it != null }
+                    }
                     if (!coords.isEmpty()) {
                         artifactCoordinate = coords[0].toString()
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,11 @@
  */
 import groovy.json.JsonSlurper
 
+import org.graalvm.internal.tck.utils.CoordinateUtils
+
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import groovy.json.JsonSlurper
 
 plugins {
     id 'base'
@@ -138,6 +139,32 @@ static List<Map> testInfraCommands(String gradleCmd, String target) {
     }
 }
 
+List<String> resolveConcreteCoordinates(String coordinateFilter) {
+    List<String> matchingCoordinates
+    if (CoordinateUtils.isFractionalBatch(coordinateFilter)) {
+        int[] fraction = CoordinateUtils.parseFraction(coordinateFilter)
+        List<String> allCoordinates = tck.getMatchingCoordinatesStrict("all")
+        matchingCoordinates = CoordinateUtils.computeBatchedCoordinates(allCoordinates, fraction[0], fraction[1])
+    } else {
+        matchingCoordinates = tck.getMatchingCoordinates(coordinateFilter)
+    }
+    return matchingCoordinates.findAll { !it.startsWith("samples:") }
+}
+
+void printTestInfraReproducer(String gradleCmd, String coordinate, int parallelism) {
+    String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE")
+    String command = "${gradleCmd} testInfra -Pcoordinates=${coordinate} -Pparallelism=${parallelism} --stacktrace"
+    if (nativeImageMode != null && !nativeImageMode.trim().isEmpty()) {
+        command = "GVM_TCK_NATIVE_IMAGE_MODE=${nativeImageMode} ${command}"
+    }
+
+    String delimiter = "========================================================================"
+    println(delimiter)
+    println("REPRODUCER ${coordinate}")
+    println(command)
+    println(delimiter)
+}
+
 tasks.register('testInfra') { t ->
     t.group = "verification"
     t.setDescription("""Runs clean and pullAllowedDockerImages, then runs (${testInfraCommands('', '').collect { it.name }.join(', ')}) concurrently with isolated logs for a single coordinate.
@@ -152,6 +179,14 @@ tasks.register('testInfra') { t ->
         def gradleCmd = System.getProperty("os.name").toLowerCase().contains("windows") ? "gradlew.bat" : "./gradlew"
         int parallelism = parsePositiveIntProp('parallelism', 4)
         println("Using parallelism=${parallelism} for testInfra.")
+
+        List<String> concreteCoordinates = resolveConcreteCoordinates(coordinateProp)
+        if (concreteCoordinates.isEmpty()) {
+            throw new GradleException("No matching coordinates found for '${coordinateProp}'.")
+        }
+        concreteCoordinates.each { coordinate ->
+            printTestInfraReproducer(gradleCmd, coordinate, parallelism)
+        }
 
         def logsDir = layout.buildDirectory.dir("command-logs").get().asFile
         logsDir.mkdirs()

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 import groovy.json.JsonSlurper
 
 import org.graalvm.internal.tck.utils.CoordinateUtils
+import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -151,11 +152,19 @@ List<String> resolveConcreteCoordinates(String coordinateFilter) {
     return matchingCoordinates.findAll { !it.startsWith("samples:") }
 }
 
+String resolveSelectedNativeImageMode() {
+    return NativeImageConfigUtils.resolveSelectedMode(
+            System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"),
+            project.findProperty("tck.nativeImageMode")?.toString()
+    )
+}
+
 void printTestInfraReproducer(String gradleCmd, String coordinate, int parallelism) {
-    String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE")
+    String nativeImageMode = resolveSelectedNativeImageMode()
     String command = "${gradleCmd} testInfra -Pcoordinates=${coordinate} -Pparallelism=${parallelism} --stacktrace"
-    if (nativeImageMode != null && !nativeImageMode.trim().isEmpty()) {
-        command = "GVM_TCK_NATIVE_IMAGE_MODE=${nativeImageMode} ${command}"
+    if (nativeImageMode != null && !nativeImageMode.trim().isEmpty()
+            && nativeImageMode != NativeImageConfigUtils.DEFAULT_MODE) {
+        command = "GVM_TCK_NATIVE_IMAGE_MODE='${nativeImageMode}' ${command}"
     }
 
     String delimiter = "========================================================================"
@@ -359,7 +368,7 @@ def runLoggedCommand(List<String> args, String label, File logFile, File working
 
     def pb = new ProcessBuilder(args as String[])
     pb.directory(workingDir)
-    String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE")
+    String nativeImageMode = resolveSelectedNativeImageMode()
     if (nativeImageMode != null && !nativeImageMode.trim().isEmpty()) {
         pb.environment().put("GVM_TCK_NATIVE_IMAGE_MODE", nativeImageMode)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -319,6 +319,10 @@ def runLoggedCommand(List<String> args, String label, File logFile, File working
 
     def pb = new ProcessBuilder(args as String[])
     pb.directory(workingDir)
+    String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE")
+    if (nativeImageMode != null && !nativeImageMode.trim().isEmpty()) {
+        pb.environment().put("GVM_TCK_NATIVE_IMAGE_MODE", nativeImageMode)
+    }
     pb.redirectErrorStream(true)
     pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
     def proc = pb.start()

--- a/ci.json
+++ b/ci.json
@@ -1,5 +1,9 @@
 {
   "buildArgs": ["--verbose", "-Ob", "-H:+ReportExceptionStackTraces"],
+  "nativeImageModes": {
+    "current-defaults": [],
+    "future-defaults-all": ["--future-defaults=all"]
+  },
   "generateMatrixBatchedCoordinates": {
     "java": ["25", "latest-ea"],
     "os": ["ubuntu-latest"]

--- a/ci.json
+++ b/ci.json
@@ -4,6 +4,9 @@
     "current-defaults": [],
     "future-defaults-all": ["--future-defaults=all"]
   },
+  "nativeImageModeJavaVersions": {
+    "future-defaults-all": ["latest-ea"]
+  },
   "generateMatrixBatchedCoordinates": {
     "java": ["25", "latest-ea"],
     "os": ["ubuntu-latest"]

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -15,6 +15,7 @@ The release is made every two weeks if there are metadata changes: [.github/work
 
 The test matrix definition starts with [ci.json](../ci.json):
 - A single source of truth for which Java versions and OS runners to test on.
+- Supports optional per-native-image-mode Java overrides via `nativeImageModeJavaVersions` when a mode should run on only a subset of the configured JDKs.
 - Gradle tasks read it to generate GitHub Actions matrices consumed by the workflows below.
 - Way to define build arguments for the build. If this file is changed everything is re-run.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -26,6 +26,11 @@ Tip: When debugging locally, add `--stacktrace` for better error output.
 ./gradlew testAllInfra --stacktrace
 ```
 
+To run the same coverage with future defaults enabled:
+```console
+GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew testAllInfra --stacktrace
+```
+
 ### Style and formatting
 
 1. To check style use
@@ -63,6 +68,11 @@ For a single coordinate, CI runs three steps in this order:
     ```console
    ./gradlew test -Pcoordinates=org.postgresql:postgresql:42.7.3
    ```
+
+To run the same coordinate with future defaults enabled:
+```console
+GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=org.postgresql:postgresql:42.7.3
+```
 
 ### Testing libraries in bulk
 
@@ -139,6 +149,16 @@ Report format: XML only.
 ./gradlew jacocoTestReport -Pcoordinates=[group:artifact:version|k/n|all]
  ```
 The root jacocoTestReport is a harness wrapper that invokes the per-project task across matching coordinates.
+
+### Native-image modes
+
+Local runs default to `current-defaults`.
+
+During the transition period, metadata CI runs both:
+- `current-defaults`
+- `future-defaults-all`
+
+Select the future lane locally with `GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all`.
 
 ### Library stats
 

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -267,6 +267,45 @@
         },
         "1.5.7" : {
           "versions" : [ {
+            "version" : "1.5.29",
+            "dynamicAccess" : {
+              "breakdown" : {
+                "reflection" : {
+                  "coverageRatio" : 0.2,
+                  "coveredCalls" : 3,
+                  "totalCalls" : 15
+                },
+                "resources" : {
+                  "coverageRatio" : 1.0,
+                  "coveredCalls" : 1,
+                  "totalCalls" : 1
+                }
+              },
+              "coverageRatio" : 0.25,
+              "coveredCalls" : 4,
+              "totalCalls" : 16
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 4064,
+                "missed" : 14469,
+                "ratio" : 0.219285,
+                "total" : 18533
+              },
+              "line" : {
+                "covered" : 1094,
+                "missed" : 4021,
+                "ratio" : 0.213881,
+                "total" : 5115
+              },
+              "method" : {
+                "covered" : 284,
+                "missed" : 841,
+                "ratio" : 0.252444,
+                "total" : 1125
+              }
+            }
+          }, {
             "version" : "1.5.7",
             "dynamicAccess" : {
               "breakdown" : {

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -267,45 +267,6 @@
         },
         "1.5.7" : {
           "versions" : [ {
-            "version" : "1.5.29",
-            "dynamicAccess" : {
-              "breakdown" : {
-                "reflection" : {
-                  "coverageRatio" : 0.2,
-                  "coveredCalls" : 3,
-                  "totalCalls" : 15
-                },
-                "resources" : {
-                  "coverageRatio" : 1.0,
-                  "coveredCalls" : 1,
-                  "totalCalls" : 1
-                }
-              },
-              "coverageRatio" : 0.25,
-              "coveredCalls" : 4,
-              "totalCalls" : 16
-            },
-            "libraryCoverage" : {
-              "instruction" : {
-                "covered" : 4064,
-                "missed" : 14469,
-                "ratio" : 0.219285,
-                "total" : 18533
-              },
-              "line" : {
-                "covered" : 1094,
-                "missed" : 4021,
-                "ratio" : 0.213881,
-                "total" : 5115
-              },
-              "method" : {
-                "covered" : 284,
-                "missed" : 841,
-                "ratio" : 0.252444,
-                "total" : 1125
-              }
-            }
-          }, {
             "version" : "1.5.7",
             "dynamicAccess" : {
               "breakdown" : {

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -43,6 +43,7 @@ import org.graalvm.internal.tck.harness.tasks.ValidateLibraryStatsTask
 import org.graalvm.internal.tck.harness.tasks.AnalyzeExternalLibraryDynamicAccessTask
 import org.graalvm.internal.tck.harness.tasks.GenerateReadmeBadgeSummaryTask
 import org.graalvm.internal.tck.harness.tasks.SplitTestOnlyMetadataTask
+import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 
 import static org.graalvm.internal.tck.Utils.generateTaskName
@@ -277,6 +278,20 @@ Map<String, List<String>> matrixDefaultsFor(String section) {
     ]
 }
 
+List<String> nativeImageModesForMatrix() {
+    NativeImageConfigUtils.modeNames(loadCi())
+}
+
+List<Map<String, Object>> expandMatrixEntries(List<Map<String, Object>> entries, String section) {
+    def defaults = matrixDefaultsFor(section)
+    NativeImageConfigUtils.expandMatrixEntries(
+            entries,
+            defaults["version"],
+            defaults["os"],
+            nativeImageModesForMatrix()
+    )
+}
+
 Map<String, Object> springAotMatrixConfig() {
     def ci = loadCi()
     def sec = ci["generateAffectedSpringTestMatrix"]
@@ -288,48 +303,26 @@ Map<String, Object> springAotMatrixConfig() {
 }
 
 List<Map<String, Object>> expandNewLibraryVersionCompatibilityMatrix(List<Map<String, Object>> libraries) {
-    def defaults = matrixDefaultsFor("generateNewLibraryVersionCompatibilityMatrix")
-    List<String> javaVersions = defaults["version"]
-    List<String> operatingSystems = defaults["os"]
-
-    List<Map<String, Object>> include = []
-    libraries.each { Map<String, Object> library ->
-        javaVersions.each { String javaVersion ->
-            operatingSystems.each { String operatingSystem ->
-                include.add([
-                        "name": library["name"],
-                        "versions": library["versions"],
-                        "version": javaVersion,
-                        "os": operatingSystem
-                ])
-            }
-        }
-    }
-    include
+    expandMatrixEntries(libraries.collect { Map<String, Object> library ->
+        [
+                "name"    : library["name"],
+                "versions": library["versions"]
+        ]
+    }, "generateNewLibraryVersionCompatibilityMatrix")
 }
 
 List<Map<String, Object>> expandChangedTestedVersionsMatrix(List<Map<String, Object>> entries) {
-    def defaults = matrixDefaultsFor("generateChangedTestedVersionsMatrix")
-    List<String> javaVersions = defaults["version"]
-    List<String> operatingSystems = defaults["os"]
-
     List<Map<String, Object>> include = []
     entries.each { Map<String, Object> entry ->
         List<Map<String, Object>> matrixEntries = entry.containsKey("entries")
                 ? (entry["entries"] as List<Map<String, Object>>)
                 : [entry]
-        matrixEntries.each { Map<String, Object> matrixEntry ->
-            javaVersions.each { String javaVersion ->
-                operatingSystems.each { String operatingSystem ->
-                    include.add([
-                            "coordinates": matrixEntry["coordinates"],
-                            "versions": matrixEntry["versions"],
-                            "version": javaVersion,
-                            "os": operatingSystem
-                    ])
-                }
-            }
-        }
+        include.addAll(expandMatrixEntries(matrixEntries.collect { Map<String, Object> matrixEntry ->
+            [
+                    "coordinates": matrixEntry["coordinates"],
+                    "versions"   : matrixEntry["versions"]
+            ]
+        }, "generateChangedTestedVersionsMatrix"))
     }
     include
 }
@@ -356,11 +349,12 @@ Provider<Task> generateMatrixBatchedCoordinates = tasks.register("generateMatrix
         if (batches <= 0) {
             throw new GradleException("Invalid 'batches' value: ${batches}")
         }
-        List<String> coords = (1..batches).collect { i -> "${i}/${batches}" }
         def matrix = [
-                "coordinates": coords
+                "include": expandMatrixEntries(
+                        (1..batches).collect { i -> ["coordinates": "${i}/${batches}"] },
+                        "generateMatrixBatchedCoordinates"
+                )
         ]
-        matrix.putAll(matrixDefaultsFor("generateMatrixBatchedCoordinates"))
         writeGithubOutput("matrix", JsonOutput.toJson(matrix))
     }
 }
@@ -376,9 +370,13 @@ Provider<Task> generateChangedCoordinatesMatrix = tasks.register("generateChange
 
         boolean noneFound = diffCoordinates.isEmpty()
         def matrix = [
-                "coordinates": noneFound ? [] : diffCoordinates
+                "include": noneFound
+                        ? []
+                        : expandMatrixEntries(
+                                diffCoordinates.collect { coordinate -> ["coordinates": coordinate] },
+                                "generateChangedCoordinatesMatrix"
+                        )
         ]
-        matrix.putAll(matrixDefaultsFor("generateChangedCoordinatesMatrix"))
         if (noneFound) {
             println "No changed coordinates were found!"
         }
@@ -495,11 +493,11 @@ Provider<Task> generateInfrastructureChangedCoordinatesMatrix = tasks.register("
         }
 
         def matrix = [
-                "coordinates": selected
+                "include": expandMatrixEntries(
+                        selected.collect { coordinate -> ["coordinates": coordinate] },
+                        "generateInfrastructureChangedCoordinatesMatrix"
+                )
         ]
-        matrix.putAll(matrixDefaultsFor("generateInfrastructureChangedCoordinatesMatrix"))
-
-
         writeGithubOutput("matrix", JsonOutput.toJson(matrix))
         writeGithubOutput("none-found", "false")
     }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -495,8 +495,7 @@ Provider<Task> generateInfrastructureChangedCoordinatesMatrix = tasks.register("
         }
 
         def matrix = [
-                "coordinates": selected,
-                "include"    : expandMatrixEntries(
+                "include": expandMatrixEntries(
                         selected.collect { coordinate -> ["coordinates": coordinate] },
                         "generateInfrastructureChangedCoordinatesMatrix"
                 )

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -284,11 +284,13 @@ List<String> nativeImageModesForMatrix() {
 
 List<Map<String, Object>> expandMatrixEntries(List<Map<String, Object>> entries, String section) {
     def defaults = matrixDefaultsFor(section)
+    List<String> nativeImageModes = nativeImageModesForMatrix()
     NativeImageConfigUtils.expandMatrixEntries(
             entries,
             defaults["version"],
             defaults["os"],
-            nativeImageModesForMatrix()
+            nativeImageModes,
+            NativeImageConfigUtils.javaVersionsByMode(loadCi(), defaults["version"], nativeImageModes)
     )
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -493,7 +493,8 @@ Provider<Task> generateInfrastructureChangedCoordinatesMatrix = tasks.register("
         }
 
         def matrix = [
-                "include": expandMatrixEntries(
+                "coordinates": selected,
+                "include"    : expandMatrixEntries(
                         selected.collect { coordinate -> ["coordinates": coordinate] },
                         "generateInfrastructureChangedCoordinatesMatrix"
                 )

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -6,6 +6,7 @@
  */
 import groovy.json.JsonSlurper
 import org.graalvm.internal.tck.utils.DynamicAccessUtils
+import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 import java.util.jar.JarFile
 
@@ -65,17 +66,22 @@ def nativeImageArgs = []
 if (ciJsonFile.exists()) {
     try {
         def parsed = new JsonSlurper().parse(ciJsonFile)
-        def argsFromCi = parsed?.buildArgs
-        if (argsFromCi instanceof Collection && !argsFromCi.isEmpty()) {
-            nativeImageArgs = argsFromCi.collect { it.toString() }
-            // Post-process placeholders in args
-            nativeImageArgs = nativeImageArgs.collect { arg ->
-                arg.replace('{{library.version}}', libraryVersion)
-                   .replace('{{library.coordinates}}', libraryGAV)
-            }
-        }
-    } catch (Exception ignored) {
-        throw new GradleException("ci.json must contain the buildArgs")
+        String selectedNativeImageMode = NativeImageConfigUtils.resolveSelectedMode(
+                System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"),
+                providers.gradleProperty("tck.nativeImageMode").getOrElse(null)
+        )
+        nativeImageArgs = NativeImageConfigUtils.resolvedBuildArgs(
+                parsed as Map<String, Object>,
+                selectedNativeImageMode,
+                [
+                        "{{library.version}}"    : libraryVersion,
+                        "{{library.coordinates}}": libraryGAV
+                ]
+        )
+    } catch (GradleException e) {
+        throw e
+    } catch (Exception e) {
+        throw new GradleException("Failed to resolve native-image args from ci.json", e)
     }
 } else {
     throw new GradleException("Required configuration file ci.json not found at expected path: ${ciJsonFile.absolutePath}\"")

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
@@ -113,8 +113,9 @@ public abstract class AbstractSubprojectTask extends DefaultTask {
             // we only set this env variable if user didn't specify it manually
             env.put("GVM_TCK_LV", version);
         }
-        if (System.getenv("GVM_TCK_NATIVE_IMAGE_MODE") != null) {
-            env.put("GVM_TCK_NATIVE_IMAGE_MODE", System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"));
+        String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE");
+        if (nativeImageMode != null) {
+            env.put("GVM_TCK_NATIVE_IMAGE_MODE", nativeImageMode);
         }
         env.put("GVM_TCK_MD", metadataDir.toAbsolutePath().toString());
         env.put("GVM_TCK_TCKDIR", tckExtension.getTckRoot().get().getAsFile().toPath().toAbsolutePath().toString());

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
@@ -113,6 +113,9 @@ public abstract class AbstractSubprojectTask extends DefaultTask {
             // we only set this env variable if user didn't specify it manually
             env.put("GVM_TCK_LV", version);
         }
+        if (System.getenv("GVM_TCK_NATIVE_IMAGE_MODE") != null) {
+            env.put("GVM_TCK_NATIVE_IMAGE_MODE", System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"));
+        }
         env.put("GVM_TCK_MD", metadataDir.toAbsolutePath().toString());
         env.put("GVM_TCK_TCKDIR", tckExtension.getTckRoot().get().getAsFile().toPath().toAbsolutePath().toString());
         spec.environment(env);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
@@ -170,8 +170,9 @@ public abstract class AllCoordinatesExecTask extends CoordinatesAwareTask {
         if (System.getenv("GVM_TCK_LV") == null) {
             env.put("GVM_TCK_LV", version);
         }
-        if (System.getenv("GVM_TCK_NATIVE_IMAGE_MODE") != null) {
-            env.put("GVM_TCK_NATIVE_IMAGE_MODE", System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"));
+        String nativeImageMode = System.getenv("GVM_TCK_NATIVE_IMAGE_MODE");
+        if (nativeImageMode != null) {
+            env.put("GVM_TCK_NATIVE_IMAGE_MODE", nativeImageMode);
         }
         env.put("GVM_TCK_MD", metadataDir.toAbsolutePath().toString());
         env.put("GVM_TCK_TCKDIR", tckExtension.getTckRoot().get().getAsFile().toPath().toAbsolutePath().toString());

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
@@ -170,6 +170,9 @@ public abstract class AllCoordinatesExecTask extends CoordinatesAwareTask {
         if (System.getenv("GVM_TCK_LV") == null) {
             env.put("GVM_TCK_LV", version);
         }
+        if (System.getenv("GVM_TCK_NATIVE_IMAGE_MODE") != null) {
+            env.put("GVM_TCK_NATIVE_IMAGE_MODE", System.getenv("GVM_TCK_NATIVE_IMAGE_MODE"));
+        }
         env.put("GVM_TCK_MD", metadataDir.toAbsolutePath().toString());
         env.put("GVM_TCK_TCKDIR", tckExtension.getTckRoot().get().getAsFile().toPath().toAbsolutePath().toString());
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/NativeImageConfigUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/NativeImageConfigUtils.java
@@ -94,19 +94,71 @@ public final class NativeImageConfigUtils {
     }
 
     /**
+     * Returns the Java versions allowed for each native-image mode, falling back to the matrix defaults.
+     */
+    public static Map<String, List<String>> javaVersionsByMode(
+            Map<String, Object> ci,
+            List<String> defaultJavaVersions,
+            List<String> nativeImageModes
+    ) {
+        Object overridesValue = ci.get("nativeImageModeJavaVersions");
+        Map<String, List<String>> overrides = new LinkedHashMap<>();
+        if (overridesValue != null) {
+            if (!(overridesValue instanceof Map<?, ?> rawOverrides)) {
+                throw new GradleException("ci.json field 'nativeImageModeJavaVersions' must be an object when present");
+            }
+            for (Map.Entry<?, ?> entry : rawOverrides.entrySet()) {
+                if (!(entry.getKey() instanceof String modeName) || modeName.isBlank()) {
+                    throw new GradleException("ci.json nativeImageModeJavaVersions must use non-empty string keys");
+                }
+                if (!nativeImageModes.contains(modeName)) {
+                    throw new GradleException("ci.json nativeImageModeJavaVersions contains unknown mode '" + modeName + "'");
+                }
+                List<String> versions = requireStringList(rawOverrides, modeName, "ci.json nativeImageModeJavaVersions");
+                if (versions.isEmpty()) {
+                    throw new GradleException("ci.json nativeImageModeJavaVersions for mode '" + modeName + "' must not be empty");
+                }
+                overrides.put(modeName, new ArrayList<>(new LinkedHashSet<>(versions)));
+            }
+        }
+
+        List<String> normalizedDefaultJavaVersions = new ArrayList<>(new LinkedHashSet<>(defaultJavaVersions));
+        if (normalizedDefaultJavaVersions.isEmpty()) {
+            throw new GradleException("Matrix Java versions must not be empty");
+        }
+
+        Map<String, List<String>> javaVersionsByMode = new LinkedHashMap<>();
+        for (String nativeImageMode : new LinkedHashSet<>(nativeImageModes)) {
+            javaVersionsByMode.put(
+                    nativeImageMode,
+                    overrides.getOrDefault(nativeImageMode, normalizedDefaultJavaVersions)
+            );
+        }
+        return javaVersionsByMode;
+    }
+
+    /**
      * Expands a matrix include list with Java, OS, and native-image mode dimensions.
      */
     public static List<Map<String, Object>> expandMatrixEntries(
             List<Map<String, Object>> entries,
             List<String> javaVersions,
             List<String> operatingSystems,
-            List<String> nativeImageModes
+            List<String> nativeImageModes,
+            Map<String, List<String>> javaVersionsByMode
     ) {
         List<Map<String, Object>> include = new ArrayList<>();
+        List<String> normalizedJavaVersions = new ArrayList<>(new LinkedHashSet<>(javaVersions));
+        List<String> normalizedOperatingSystems = new ArrayList<>(new LinkedHashSet<>(operatingSystems));
+        List<String> normalizedNativeImageModes = new ArrayList<>(new LinkedHashSet<>(nativeImageModes));
         for (Map<String, Object> entry : entries) {
-            for (String javaVersion : new LinkedHashSet<>(javaVersions)) {
-                for (String operatingSystem : new LinkedHashSet<>(operatingSystems)) {
-                    for (String nativeImageMode : new LinkedHashSet<>(nativeImageModes)) {
+            for (String javaVersion : normalizedJavaVersions) {
+                for (String operatingSystem : normalizedOperatingSystems) {
+                    for (String nativeImageMode : normalizedNativeImageModes) {
+                        List<String> versionsForMode = javaVersionsByMode.get(nativeImageMode);
+                        if (versionsForMode == null || !versionsForMode.contains(javaVersion)) {
+                            continue;
+                        }
                         Map<String, Object> matrixEntry = new LinkedHashMap<>(entry);
                         matrixEntry.put("version", javaVersion);
                         matrixEntry.put("os", operatingSystem);

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/NativeImageConfigUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/NativeImageConfigUtils.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import org.gradle.api.GradleException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for reading and expanding native-image CI configuration.
+ */
+public final class NativeImageConfigUtils {
+
+    public static final String DEFAULT_MODE = "current-defaults";
+
+    private NativeImageConfigUtils() {
+    }
+
+    /**
+     * Resolves the active native-image mode, preferring the environment override over the Gradle property.
+     */
+    public static String resolveSelectedMode(String environmentMode, String propertyMode) {
+        if (environmentMode != null && !environmentMode.isBlank()) {
+            return environmentMode;
+        }
+        if (propertyMode != null && !propertyMode.isBlank()) {
+            return propertyMode;
+        }
+        return DEFAULT_MODE;
+    }
+
+    /**
+     * Returns the ordered common native-image build arguments.
+     */
+    public static List<String> baseBuildArgs(Map<String, Object> ci) {
+        return requireStringList(ci, "buildArgs", "ci.json");
+    }
+
+    /**
+     * Returns the ordered native-image modes and their additional build arguments.
+     */
+    public static Map<String, List<String>> nativeImageModes(Map<String, Object> ci) {
+        Object modesValue = ci.get("nativeImageModes");
+        if (!(modesValue instanceof Map<?, ?> rawModes) || rawModes.isEmpty()) {
+            throw new GradleException("ci.json must contain a non-empty nativeImageModes object");
+        }
+
+        Map<String, List<String>> modes = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : rawModes.entrySet()) {
+            if (!(entry.getKey() instanceof String modeName) || modeName.isBlank()) {
+                throw new GradleException("ci.json nativeImageModes must use non-empty string keys");
+            }
+            if (modes.containsKey(modeName)) {
+                throw new GradleException("ci.json nativeImageModes must not contain duplicate mode '" + modeName + "'");
+            }
+            modes.put(modeName, requireStringList(rawModes, modeName, "ci.json nativeImageModes"));
+        }
+        return modes;
+    }
+
+    /**
+     * Returns the resolved native-image arguments for the selected mode with placeholders expanded.
+     */
+    public static List<String> resolvedBuildArgs(
+            Map<String, Object> ci,
+            String selectedMode,
+            Map<String, String> placeholders
+    ) {
+        Map<String, List<String>> modes = nativeImageModes(ci);
+        List<String> modeArgs = modes.get(selectedMode);
+        if (modeArgs == null) {
+            throw new GradleException("Unknown native-image mode '" + selectedMode + "'. Available modes: " + modes.keySet());
+        }
+
+        List<String> args = new ArrayList<>(baseBuildArgs(ci).size() + modeArgs.size());
+        args.addAll(baseBuildArgs(ci));
+        args.addAll(modeArgs);
+        return applyPlaceholders(args, placeholders);
+    }
+
+    /**
+     * Returns the ordered mode names defined in the CI configuration.
+     */
+    public static List<String> modeNames(Map<String, Object> ci) {
+        return new ArrayList<>(nativeImageModes(ci).keySet());
+    }
+
+    /**
+     * Expands a matrix include list with Java, OS, and native-image mode dimensions.
+     */
+    public static List<Map<String, Object>> expandMatrixEntries(
+            List<Map<String, Object>> entries,
+            List<String> javaVersions,
+            List<String> operatingSystems,
+            List<String> nativeImageModes
+    ) {
+        List<Map<String, Object>> include = new ArrayList<>();
+        for (Map<String, Object> entry : entries) {
+            for (String javaVersion : new LinkedHashSet<>(javaVersions)) {
+                for (String operatingSystem : new LinkedHashSet<>(operatingSystems)) {
+                    for (String nativeImageMode : new LinkedHashSet<>(nativeImageModes)) {
+                        Map<String, Object> matrixEntry = new LinkedHashMap<>(entry);
+                        matrixEntry.put("version", javaVersion);
+                        matrixEntry.put("os", operatingSystem);
+                        matrixEntry.put("nativeImageMode", nativeImageMode);
+                        include.add(matrixEntry);
+                    }
+                }
+            }
+        }
+        return include;
+    }
+
+    private static List<String> applyPlaceholders(List<String> args, Map<String, String> placeholders) {
+        List<String> resolvedArgs = new ArrayList<>(args.size());
+        for (String arg : args) {
+            String resolvedArg = arg;
+            for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {
+                resolvedArg = resolvedArg.replace(placeholder.getKey(), placeholder.getValue());
+            }
+            resolvedArgs.add(resolvedArg);
+        }
+        return resolvedArgs;
+    }
+
+    private static List<String> requireStringList(Map<?, ?> container, String fieldName, String owner) {
+        Object value = container.get(fieldName);
+        if (!(value instanceof List<?> values)) {
+            throw new GradleException(owner + " must contain " + fieldName);
+        }
+
+        List<String> stringValues = new ArrayList<>();
+        for (Object element : values) {
+            if (element == null) {
+                throw new GradleException(owner + " field '" + fieldName + "' must not contain null values");
+            }
+            stringValues.add(element.toString());
+        }
+        return stringValues;
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/NativeImageConfigUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/NativeImageConfigUtilsTests.java
@@ -82,12 +82,38 @@ class NativeImageConfigUtilsTests {
     }
 
     @Test
+    void javaVersionsByModeUsesOverridesWhenPresent() {
+        Map<String, Object> ci = new LinkedHashMap<>();
+        ci.put("buildArgs", List.of("--verbose"));
+        Map<String, Object> nativeImageModes = new LinkedHashMap<>();
+        nativeImageModes.put("current-defaults", List.of());
+        nativeImageModes.put("future-defaults-all", List.of("--future-defaults=all"));
+        ci.put("nativeImageModes", nativeImageModes);
+        ci.put("nativeImageModeJavaVersions", Map.of(
+                "future-defaults-all", List.of("latest-ea")
+        ));
+
+        assertThat(NativeImageConfigUtils.javaVersionsByMode(
+                ci,
+                List.of("25", "latest-ea"),
+                List.of("current-defaults", "future-defaults-all")
+        )).containsExactly(
+                Map.entry("current-defaults", List.of("25", "latest-ea")),
+                Map.entry("future-defaults-all", List.of("latest-ea"))
+        );
+    }
+
+    @Test
     void expandMatrixEntriesAddsNativeImageModeToEveryEnvironmentCombination() {
         List<Map<String, Object>> include = NativeImageConfigUtils.expandMatrixEntries(
                 List.of(Map.of("coordinates", "1/2")),
                 List.of("25"),
                 List.of("ubuntu-latest", "macos-latest"),
-                List.of("current-defaults", "future-defaults-all")
+                List.of("current-defaults", "future-defaults-all"),
+                Map.of(
+                        "current-defaults", List.of("25"),
+                        "future-defaults-all", List.of("25")
+                )
         );
 
         assertThat(include).containsExactly(
@@ -113,6 +139,41 @@ class NativeImageConfigUtilsTests {
                         "coordinates", "1/2",
                         "version", "25",
                         "os", "macos-latest",
+                        "nativeImageMode", "future-defaults-all"
+                )
+        );
+    }
+
+    @Test
+    void expandMatrixEntriesSkipsJavaVersionsDisallowedForNativeImageMode() {
+        List<Map<String, Object>> include = NativeImageConfigUtils.expandMatrixEntries(
+                List.of(Map.of("coordinates", "1/2")),
+                List.of("25", "latest-ea"),
+                List.of("ubuntu-latest"),
+                List.of("current-defaults", "future-defaults-all"),
+                Map.of(
+                        "current-defaults", List.of("25", "latest-ea"),
+                        "future-defaults-all", List.of("latest-ea")
+                )
+        );
+
+        assertThat(include).containsExactly(
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "25",
+                        "os", "ubuntu-latest",
+                        "nativeImageMode", "current-defaults"
+                ),
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "latest-ea",
+                        "os", "ubuntu-latest",
+                        "nativeImageMode", "current-defaults"
+                ),
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "latest-ea",
+                        "os", "ubuntu-latest",
                         "nativeImageMode", "future-defaults-all"
                 )
         );

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/NativeImageConfigUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/NativeImageConfigUtilsTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import org.gradle.api.GradleException;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NativeImageConfigUtilsTests {
+
+    @Test
+    void resolveSelectedModePrefersEnvironmentOverride() {
+        assertThat(NativeImageConfigUtils.resolveSelectedMode("future-defaults-all", "current-defaults"))
+                .isEqualTo("future-defaults-all");
+    }
+
+    @Test
+    void resolveSelectedModeFallsBackToDefault() {
+        assertThat(NativeImageConfigUtils.resolveSelectedMode(null, null))
+                .isEqualTo(NativeImageConfigUtils.DEFAULT_MODE);
+    }
+
+    @Test
+    void resolvedBuildArgsMergesBaseAndModeArgsAndExpandsPlaceholders() {
+        Map<String, Object> ci = new LinkedHashMap<>();
+        ci.put("buildArgs", List.of("--verbose", "--library={{library.version}}"));
+        ci.put("nativeImageModes", new LinkedHashMap<>(Map.of(
+                "current-defaults", List.of(),
+                "future-defaults-all", List.of("--future-defaults=all", "--for={{library.coordinates}}")
+        )));
+
+        assertThat(NativeImageConfigUtils.resolvedBuildArgs(
+                ci,
+                "future-defaults-all",
+                Map.of(
+                        "{{library.version}}", "1.2.3",
+                        "{{library.coordinates}}", "g:a:1.2.3"
+                )
+        )).containsExactly(
+                "--verbose",
+                "--library=1.2.3",
+                "--future-defaults=all",
+                "--for=g:a:1.2.3"
+        );
+    }
+
+    @Test
+    void resolvedBuildArgsRejectsUnknownMode() {
+        Map<String, Object> ci = new LinkedHashMap<>();
+        ci.put("buildArgs", List.of("--verbose"));
+        ci.put("nativeImageModes", new LinkedHashMap<>(Map.of(
+                "current-defaults", List.of(),
+                "future-defaults-all", List.of("--future-defaults=all")
+        )));
+
+        assertThatThrownBy(() -> NativeImageConfigUtils.resolvedBuildArgs(ci, "missing-mode", Map.of()))
+                .isInstanceOf(GradleException.class)
+                .hasMessageContaining("Unknown native-image mode 'missing-mode'");
+    }
+
+    @Test
+    void modeNamesPreserveCiOrder() {
+        Map<String, Object> ci = new LinkedHashMap<>();
+        ci.put("buildArgs", List.of("--verbose"));
+        Map<String, Object> modes = new LinkedHashMap<>();
+        modes.put("current-defaults", List.of());
+        modes.put("future-defaults-all", List.of("--future-defaults=all"));
+        ci.put("nativeImageModes", modes);
+
+        assertThat(NativeImageConfigUtils.modeNames(ci))
+                .containsExactly("current-defaults", "future-defaults-all");
+    }
+
+    @Test
+    void expandMatrixEntriesAddsNativeImageModeToEveryEnvironmentCombination() {
+        List<Map<String, Object>> include = NativeImageConfigUtils.expandMatrixEntries(
+                List.of(Map.of("coordinates", "1/2")),
+                List.of("25"),
+                List.of("ubuntu-latest", "macos-latest"),
+                List.of("current-defaults", "future-defaults-all")
+        );
+
+        assertThat(include).containsExactly(
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "25",
+                        "os", "ubuntu-latest",
+                        "nativeImageMode", "current-defaults"
+                ),
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "25",
+                        "os", "ubuntu-latest",
+                        "nativeImageMode", "future-defaults-all"
+                ),
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "25",
+                        "os", "macos-latest",
+                        "nativeImageMode", "current-defaults"
+                ),
+                Map.of(
+                        "coordinates", "1/2",
+                        "version", "25",
+                        "os", "macos-latest",
+                        "nativeImageMode", "future-defaults-all"
+                )
+        );
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Implements issue #1709 by introducing a first-class native-image mode dimension for metadata testing and compatibility reporting.

Key changes:
- add nativeImageModes to ci.json and resolve the active mode from GVM_TCK_NATIVE_IMAGE_MODE, then tck.nativeImageMode, then current-defaults
- share native-image mode parsing and matrix expansion through NativeImageConfigUtils, including ordered mode handling and mode-specific native-image args
- expand metadata workflow matrices to include nativeImageMode and forward GVM_TCK_NATIVE_IMAGE_MODE through Gradle, harness tasks, and the consecutive test runner
- make scheduled compatibility reporting mode-aware in job names, result payloads, artifact names, and aggregate reporting
- remove the early open-issue skip in compatibility verification so one failing mode does not suppress the other
- document the default mode and the local future-defaults opt-in command in AGENTS.md and docs/DEVELOPING.md

Tests: not run locally as part of opening this PR.

Fixes #1709

## Code sections where the PR accesses files, network, docker or some external service

- tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle: reads ci.json and resolves mode-specific native-image args
- tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle: reads CI configuration to expand workflow matrices with nativeImageMode
- build.gradle, tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java, tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java, and .github/workflows/scripts/run-consecutive-tests.sh: forward GVM_TCK_NATIVE_IMAGE_MODE into subprocess Gradle invocations
- .github/workflows/verify-new-library-version-compatibility.yml: uses GitHub Actions workflow steps and uploads mode-specific result artifacts