### PR TITLE
Avoid consulting library-and-framework-list during triage

### DIFF
--- a/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
+++ b/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
@@ -423,23 +423,6 @@ function parseCreateTSV(createTSV) {
 }
 
 /**
- * Loads the curated list of artifacts already tracked by the repository.
- */
-function loadListedArtifacts(workspaceDir) {
-  const listedArtifactsPath = path.join(
-    workspaceDir,
-    'metadata',
-    'library-and-framework-list.json'
-  );
-  const listedArtifacts = JSON.parse(fs.readFileSync(listedArtifactsPath, 'utf8'));
-  return new Set(
-    listedArtifacts
-      .map((entry) => entry?.artifact)
-      .filter((artifact) => typeof artifact === 'string' && artifact.length > 0)
-  );
-}
-
-/**
  * Checks whether repository automation already supports the given coordinates.
  */
 function isRepositorySupported(workspaceDir, gav) {
@@ -464,17 +447,11 @@ function prepareCreationInputs(plan, workspaceDir) {
   const supportedGA = new Set();
   const excludedGA = new Set();
   const toCreate = new Map();
-  const listedArtifacts = loadListedArtifacts(workspaceDir);
 
   for (const node of Array.isArray(plan.nodes) ? plan.nodes : []) {
     const ga = node?.ga;
     const version = node?.version;
     if (!ga || !version) {
-      continue;
-    }
-
-    if (listedArtifacts.has(ga)) {
-      supportedGA.add(ga);
       continue;
     }
 
@@ -1026,7 +1003,7 @@ module.exports = async function openDependencyIssuesAndLinkBlockers({ github, co
     const diagnosticComment = [
       'Automation: No dependency issues were created by the triage workflow.',
       '',
-      'This typically means every dependency in the deps.dev expansion is already supported by the repository or listed in metadata/library-and-framework-list.json.',
+      'This typically means every dependency in the deps.dev expansion is already supported by the repository.',
       '',
       'Plan nodes:',
       '```',

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -177,48 +177,8 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
-      - name: "Derive group:artifact"
-        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
-        id: derive
-        run: |
-          set -Eeuo pipefail
-          IFS=':' read -r G A V <<< "${{ steps.extract.outputs.coords }}"
-          GA="$G:$A"
-          echo "ga=$GA" >> "$GITHUB_OUTPUT"
-
-      - name: "Check if listed in library-and-framework-list.json"
-        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
-        id: listed
-        run: |
-          set -Eeuo pipefail
-          GA="${{ steps.derive.outputs.ga }}"
-          if jq -e --arg ga "$GA" 'map(.artifact == $ga) | any' metadata/library-and-framework-list.json >/dev/null; then
-            echo "listed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "listed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: "Close issue - library listed as supported in library-and-framework-list.json"
-        if: ${{ steps.listed.outputs.listed == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = context.issue.number;
-            const coords = "${{ steps.extract.outputs.coords }}";
-            const ga = "${{ steps.derive.outputs.ga }}";
-            const body = [
-              `Automated triage: The library (${ga}) is listed as supported in metadata/library-and-framework-list.json.`,
-              "",
-              "Closing this issue. If you believe this is not correct for the requested coordinates (" + coords + "), please reopen with additional context.",
-              "Note: Reopening will not re-run automation; maintainers will review manually."
-            ].join("\n");
-            await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
-
       - name: "Mark issue eligible for dependency graph expansion"
-        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' && steps.listed.outputs.listed != 'true' }}
+        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
         id: expand
         run: |
           set -Eeuo pipefail


### PR DESCRIPTION
## Summary

This PR removes `metadata/library-and-framework-list.json` from the automation paths involved in new library issue triage.

## What changed

- In `.github/workflows/triage-new-issues.yml`, removed the `group:artifact` derivation, the lookup against `metadata/library-and-framework-list.json`, and the close path that treated list membership as repository support.
- The triage workflow now uses `check-library-support.sh` as the only automated check for whether the requested coordinates are already supported, and otherwise continues to dependency graph expansion.
- In `.github/workflows/scripts/open-dependency-issues-and-link-blockers.js`, removed the `loadListedArtifacts()` path and the early filtering that added listed artifacts to `supportedGA`.
- That means listed artifacts are no longer suppressed from `toCreate`, so dependency issue creation is decided by `check-library-support.sh` and the existing exclusion rules rather than by presence in the library list.
- Updated the diagnostic comment emitted when no dependency issues are created so it no longer claims that list membership is a reason for suppression.

## Verification

- Parsed `.github/workflows/triage-new-issues.yml` successfully with Ruby YAML loading.
- Ran `node --check .github/workflows/scripts/open-dependency-issues-and-link-blockers.js` successfully.

Fixes: #1723