### PR TITLE
Cache generateDynamicAccessReport results

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -7,6 +7,8 @@
 import groovy.json.JsonSlurper
 import org.graalvm.internal.tck.utils.DynamicAccessUtils
 
+import org.gradle.api.tasks.PathSensitivity
+
 import java.util.jar.JarFile
 
 plugins {
@@ -57,7 +59,10 @@ overrideVal = overrideVal ?: "false"
 boolean override = overrideVal.toBoolean()
 
 String generateDynamicAccessReportVal = providers.gradleProperty('tck.generateDynamicAccessReport').getOrElse("false")
-boolean generateDynamicAccessReport = generateDynamicAccessReportVal.toBoolean()
+boolean generateDynamicAccessReportTaskRequested = gradle.startParameter.taskNames.any { taskName ->
+    taskName == "generateDynamicAccessReport" || taskName.endsWith(":generateDynamicAccessReport")
+}
+boolean generateDynamicAccessReport = generateDynamicAccessReportVal.toBoolean() || generateDynamicAccessReportTaskRequested
 
 // Determine native-image build arguments from ci.json.
 def ciJsonFile = tck.repoRoot.file("ci.json").get().asFile
@@ -134,6 +139,31 @@ tasks.register("listLibraryJars") { task ->
             println file.absolutePath
         }
     }
+}
+
+Provider<Directory> dynamicAccessOutputDir = layout.buildDirectory.dir("native/nativeTestCompile/dynamic-access")
+
+tasks.register("generateDynamicAccessReport") { task ->
+    task.setDescription("Builds native tests with dynamic-access tracking and reuses Gradle up-to-date checks when inputs and classpath are unchanged")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.dependsOn(tasks.named("nativeTestCompile"))
+    // JARs resolve from the Gradle cache where filenames are content-addressed, so name-only is sufficient.
+    task.inputs.files(providers.provider { resolveTestedLibraryJars() })
+            .withPropertyName("trackedLibraryJars")
+            .withPathSensitivity(PathSensitivity.NAME_ONLY)
+    task.inputs.files(sourceSets.test.output)
+            .withPropertyName("testOutputs")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    // metadataPath is scoped to the active coordinate via GVM_TCK_MD / -Pmetadata.dir, not the repo-wide metadata root.
+    task.inputs.files(fileTree(metadataPath) { include("**/*.json") })
+            .withPropertyName("metadataFiles")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    task.inputs.file(ciJsonFile)
+            .withPropertyName("ciJsonFile")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    task.inputs.property("nativeImageArgs", providers.provider { nativeImageArgs })
+    task.outputs.dir(dynamicAccessOutputDir)
+            .withPropertyName("dynamicAccessOutputDir")
 }
 
 // Ensure detailed exception/stacktrace logging for all Test tasks, including nativeTest

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessReportInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessReportInvocationTask.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Runs `nativeTestCompile` for each matching coordinate with dynamic-access tracking enabled and
- * prints generated JSON files under `build/native/nativeTestCompile/dynamic-access`.
+ * Runs the subproject `generateDynamicAccessReport` task for each matching coordinate and prints
+ * generated JSON files under `build/native/nativeTestCompile/dynamic-access`.
  */
 @SuppressWarnings("unused")
 public abstract class GenerateDynamicAccessReportInvocationTask extends AllCoordinatesExecTask {
@@ -25,7 +25,7 @@ public abstract class GenerateDynamicAccessReportInvocationTask extends AllCoord
     public List<String> commandFor(String coordinates) {
         return List.of(
                 tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
-                "nativeTestCompile",
+                "generateDynamicAccessReport",
                 "-Ptck.generateDynamicAccessReport=true"
         );
     }


### PR DESCRIPTION
## Summary
- Adds a `generateDynamicAccessReport` task that wraps `nativeTestCompile` with declared inputs (tracked library JARs, test outputs, scoped metadata JSONs, `ci.json`, native-image args) and the dynamic-access output directory, so Gradle's UP-TO-DATE check skips rebuilding when nothing changed.
- Repoints `GenerateDynamicAccessReportInvocationTask` (per-coordinate dispatcher) at the new task.
- Auto-enables `-Ptck.generateDynamicAccessReport=true` when `generateDynamicAccessReport` is requested by name on the command line.

Closes #1729.

## Notes
- The output dir (`build/native/nativeTestCompile/dynamic-access`) lives inside `nativeTestCompile`'s output tree. Gradle should still cache correctly because the wrapper only declares this one subdirectory, but watch for "overlapping outputs" warnings under `--info` on first run.
- Task-name detection uses `gradle.startParameter.taskNames` and will not pick up abbreviated names (e.g. `gDAR`) or task-selector forms; pass `-Ptck.generateDynamicAccessReport=true` explicitly in those cases.

## Testing
- `../../gradlew test --stacktrace` (from `tests/tck-build-logic`)