### PR TITLE
Add review-library-new-request skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -14,7 +14,12 @@ It runs the target tests, identifies missing metadata entries from the error out
 ### `review-library-bulk-update`
 
 Reviews automated pull requests with the `library-bulk-update` label.
-It encodes the historical approve/close/rerun logic for bulk tested-version updates, checks that the diff stays limited to `metadata/**/index.json`, and adds explicit verification rules for URL field changes such as `source-code-url` and `test-code-url`.
+It encodes the historical approve/close/rerun logic for bulk tested-version updates, checks that the diff stays limited to `metadata/**/index.json`, requires `REQUEST_CHANGES` whenever the review leaves a blocking comment, and approves clean PRs without merging them yet.
+
+### `review-genai-pr`
+
+Reviews pull requests with the `GenAI` label.
+It encodes the review rules that have already emerged in this repository for AI-generated metadata PRs, especially rejecting scaffold-only tests, requiring test packages to stay separate from library packages, and questioning metadata coverage claims that are not supported by the diff.
 
 ## Loading Locally
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,10 +16,10 @@ It runs the target tests, identifies missing metadata entries from the error out
 Reviews automated pull requests with the `library-bulk-update` label.
 It encodes the historical approve/close/rerun logic for bulk tested-version updates, checks that the diff stays limited to `metadata/**/index.json`, requires `REQUEST_CHANGES` whenever the review leaves a blocking comment, and approves clean PRs without merging them yet.
 
-### `review-genai-pr`
+### `review-library-new-request`
 
-Reviews pull requests with the `GenAI` label.
-It encodes the review rules that have already emerged in this repository for AI-generated metadata PRs, especially rejecting scaffold-only tests, requiring test packages to stay separate from library packages, and questioning metadata coverage claims that are not supported by the diff.
+Reviews pull requests with the `library-new-request` label.
+It covers new-library metadata PRs, including titles like `[GenAI] Add support for com.fasterxml:classmate:1.5.1 using gpt-5.4`, and encodes the review rules already used in this repository: reject scaffold-only tests, keep test packages separate from library packages, and question metadata coverage claims that are not supported by the diff.
 
 ## Loading Locally
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,7 +19,7 @@ It encodes the historical approve/close/rerun logic for bulk tested-version upda
 ### `review-library-new-request`
 
 Reviews pull requests with the `library-new-request` label.
-It covers new-library metadata PRs, including titles like `[GenAI] Add support for com.fasterxml:classmate:1.5.1 using gpt-5.4`, and encodes the review rules already used in this repository: reject scaffold-only tests, keep test packages separate from library packages, and question metadata coverage claims that are not supported by the diff.
+It covers new-library metadata PRs, including titles like `[GenAI] Add support for com.fasterxml:classmate:1.5.1 using gpt-5.4`, and encodes the review rules already used in this repository: reject scaffold-only tests, keep test packages separate from library packages so tests do not bypass visibility boundaries, and question metadata coverage claims that are not supported by the diff.
 
 ## Loading Locally
 

--- a/skills/review-genai-pr/SKILL.md
+++ b/skills/review-genai-pr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: review-genai-pr
+description: Review pull requests with the `GenAI` label in graalvm-reachability-metadata. Use when asked to review or triage an AI-generated PR that adds metadata and tests for a library, especially to catch scaffold-only tests, suspicious package names in test sources, metadata that is not justified by the exercised code path, and PRs that push more than one library.
+---
+
+# Review `GenAI` PRs
+
+These PRs usually add reachability metadata and tests for one library version. Review them with extra scrutiny. The historical review comments in this repository show that the main failure mode is not formatting, but weak or unjustified content.
+
+## Historical Review Signals
+
+Treat the following as hard review rules unless the PR provides a strong reason otherwise:
+
+- Do not accept PRs that push more than one library. A `GenAI` PR must stay scoped to one target library version plus its supporting test files.
+- Do not accept scaffold-only tests. Generated tests must be changed into library-specific tests that exercise the behavior that requires the metadata.
+- Do not accept test packages that match the library package directly. This makes `allowed-packages` harder to reason about and can hide bad test structure. Prefer a `test` prefix in the package path.
+- Investigate any inconsistency between metadata coverage numbers and the actual metadata present in the diff. If the PR claims covered entries but the metadata file is empty or nearly empty, the test likely does not justify the result.
+
+## Workflow
+
+1. Inspect the PR summary.
+   - Confirm the PR has label `GenAI`.
+   - Read the title and body to identify the target coordinates.
+   - Gather files, reviews, inline comments, and CI checks.
+
+2. Validate the diff shape first.
+   - Confirm there is exactly one target coordinate in the PR. Reject the PR if it adds metadata or tests for multiple libraries, even if the extra libraries look valid on their own.
+   - Expected files are usually limited to:
+     - `metadata/<group>/<artifact>/<version>/reachability-metadata.json`
+     - `metadata/<group>/<artifact>/index.json`
+     - `tests/src/<group>/<artifact>/<version>/**`
+   - Be suspicious of changes to build logic, workflows, unrelated libraries, generated sources outside the target test directory, or wide refactors.
+   - Treat extra `metadata/**` or `tests/src/**` trees for other coordinates as a blocking scope violation, not as a minor cleanup issue.
+
+3. Review the test source before reading the metadata.
+   - The test must be library-specific, not a lightly edited scaffold.
+   - Reject tests that only instantiate the obvious type, mirror the generated skeleton, or fail to exercise the code path that would need metadata.
+   - Check package names carefully. Tests should not live in the same package as the library under test unless there is a strong technical reason.
+   - Prefer test packages prefixed with `test` so `allowed-packages` stays explicit and easy to audit.
+
+4. Review the metadata with the test in mind.
+   - Every metadata entry should be explainable from the exercised code path.
+   - Be suspicious when the metadata is empty, trivial, or obviously smaller than what the PR claims to cover.
+   - Ask where a metadata requirement comes from if the test does not appear to trigger it.
+   - Do not approve speculative metadata added “just in case”.
+
+5. Compare the metadata file, test, and reported coverage as one unit.
+   - If covered-entry counts and the actual metadata do not line up, ask for investigation.
+   - If the test would pass without the metadata, the PR has not proven the metadata is needed.
+   - If the metadata would be needed but the test does not assert the relevant behavior, the PR is incomplete.
+
+6. Check validation status.
+   - Expected minimum: metadata validation and library test jobs for the target coordinates are green.
+   - If the PR is small and the review concerns correctness rather than infra noise, prefer asking for code changes over rerunning CI.
+   - If CI is flaky but the content is otherwise solid, ask for a rerun after the review issues are resolved.
+
+## Review Heuristics
+
+- Strong PR:
+  - Test names and assertions are specific to the library behavior.
+  - The test would fail meaningfully without the submitted metadata.
+  - Test packages are clearly separated from the library namespace.
+  - `reachability-metadata.json` contains only entries justified by the test.
+
+- Weak PR:
+  - PR pushes metadata or tests for more than one library.
+  - Test class still looks like the scaffold.
+  - Package name copies the library package.
+  - Metadata appears without a demonstrated trigger path.
+  - Claimed coverage is not credible from the diff.
+
+## Output Style
+
+Match the concise review style already used in this repository:
+
+- For scaffold-only tests: say that tests must differ from the scaffold and should not be accepted as-is.
+- For multiple-library PRs: say that `GenAI` PRs must push only one library and ask for the unrelated library additions to be removed.
+- For bad test packaging: say that tests should not use the library package and ask for a `test` prefix.
+- For metadata/coverage mismatch: ask where the metadata is and why the test would not fail without it.
+
+Keep comments short, factual, and blocking. Focus on the concrete defect, not a long explanation.

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -1,25 +1,28 @@
 ---
-name: review-genai-pr
-description: Review pull requests with the `GenAI` label in graalvm-reachability-metadata. Use when asked to review or triage an AI-generated PR that adds metadata and tests for a library, especially to catch scaffold-only tests, suspicious package names in test sources, metadata that is not justified by the exercised code path, and PRs that push more than one library.
+name: review-library-new-request
+description: Review pull requests with the `library-new-request` label in graalvm-reachability-metadata. Use when asked to review or triage a PR that adds metadata and tests for a new library, including PRs titled like `[GenAI] Add support for com.fasterxml:classmate:1.5.1 using gpt-5.4`. Focus on catching scaffold-only tests, metadata that is not justified by the exercised code path, and PRs that push more than one library.
+argument-hint: "[pr-number-or-url]"
 ---
 
-# Review `GenAI` PRs
+# Review `library-new-request` PRs
 
-These PRs usually add reachability metadata and tests for one library version. Review them with extra scrutiny. The historical review comments in this repository show that the main failure mode is not formatting, but weak or unjustified content.
+These PRs usually add reachability metadata and tests for one library version. Review them with extra scrutiny.
+
+The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation (for example, an open review tab, a PR URL mentioned earlier, or the current branch's PR from `gh pr status`); only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Historical Review Signals
 
 Treat the following as hard review rules unless the PR provides a strong reason otherwise:
 
-- Do not accept PRs that push more than one library. A `GenAI` PR must stay scoped to one target library version plus its supporting test files.
+- Do not accept PRs that push more than one library. A `library-new-request` PR must stay scoped to one target library version plus its supporting test files.
 - Do not accept scaffold-only tests. Generated tests must be changed into library-specific tests that exercise the behavior that requires the metadata.
-- Do not accept test packages that match the library package directly. This makes `allowed-packages` harder to reason about and can hide bad test structure. Prefer a `test` prefix in the package path.
-- Investigate any inconsistency between metadata coverage numbers and the actual metadata present in the diff. If the PR claims covered entries but the metadata file is empty or nearly empty, the test likely does not justify the result.
+- Investigate any inconsistency between metadata coverage numbers and the actual metadata present in the diff. If the PR claims covered entries but the metadata file is empty or nearly empty, the test likely does not justify the result. A `reachability-metadata.json` file containing `{}` is acceptable when the PR also shows no dynamic-access calls and no metadata entries are needed.
 
 ## Workflow
 
 1. Inspect the PR summary.
-   - Confirm the PR has label `GenAI`.
+   - Resolve the target PR from the optional argument, or infer it from context when the user just says "review this PR". Ask the user only if it cannot be inferred.
+   - Confirm the PR has label `library-new-request`.
    - Read the title and body to identify the target coordinates.
    - Gather files, reviews, inline comments, and CI checks.
 
@@ -35,18 +38,17 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 3. Review the test source before reading the metadata.
    - The test must be library-specific, not a lightly edited scaffold.
    - Reject tests that only instantiate the obvious type, mirror the generated skeleton, or fail to exercise the code path that would need metadata.
-   - Check package names carefully. Tests should not live in the same package as the library under test unless there is a strong technical reason.
-   - Prefer test packages prefixed with `test` so `allowed-packages` stays explicit and easy to audit.
 
 4. Review the metadata with the test in mind.
    - Every metadata entry should be explainable from the exercised code path.
-   - Be suspicious when the metadata is empty, trivial, or obviously smaller than what the PR claims to cover.
+   - Be suspicious when the metadata is obviously smaller than what the PR claims to cover.
+   - Treat `reachability-metadata.json` containing `{}` as valid when the PR shows no dynamic-access calls and the review confirms the test is not relying on metadata.
    - Ask where a metadata requirement comes from if the test does not appear to trigger it.
    - Do not approve speculative metadata added “just in case”.
 
 5. Compare the metadata file, test, and reported coverage as one unit.
    - If covered-entry counts and the actual metadata do not line up, ask for investigation.
-   - If the test would pass without the metadata, the PR has not proven the metadata is needed.
+   - If the PR reports zero dynamic-access calls and `reachability-metadata.json` is `{}`, that is acceptable as long as the test is library-specific and the scope is otherwise correct.
    - If the metadata would be needed but the test does not assert the relevant behavior, the PR is incomplete.
 
 6. Check validation status.
@@ -59,13 +61,11 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 - Strong PR:
   - Test names and assertions are specific to the library behavior.
   - The test would fail meaningfully without the submitted metadata.
-  - Test packages are clearly separated from the library namespace.
   - `reachability-metadata.json` contains only entries justified by the test.
 
 - Weak PR:
   - PR pushes metadata or tests for more than one library.
   - Test class still looks like the scaffold.
-  - Package name copies the library package.
   - Metadata appears without a demonstrated trigger path.
   - Claimed coverage is not credible from the diff.
 
@@ -74,8 +74,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 Match the concise review style already used in this repository:
 
 - For scaffold-only tests: say that tests must differ from the scaffold and should not be accepted as-is.
-- For multiple-library PRs: say that `GenAI` PRs must push only one library and ask for the unrelated library additions to be removed.
-- For bad test packaging: say that tests should not use the library package and ask for a `test` prefix.
-- For metadata/coverage mismatch: ask where the metadata is and why the test would not fail without it.
+- For multiple-library PRs: say that `library-new-request` PRs must push only one library and ask for the unrelated library additions to be removed.
+- For metadata/coverage mismatch: ask where the metadata is and why the numbers do not match the diff. Do not use this comment when the PR reports zero dynamic-access calls and `reachability-metadata.json` is `{}`.
 
 Keep comments short, factual, and blocking. Focus on the concrete defect, not a long explanation.

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -37,6 +37,8 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 
 3. Review the test source before reading the metadata.
    - The test must be library-specific, not a lightly edited scaffold.
+   - Keep test packages separate from library packages. Reject tests that live under the target library's package unless the PR clearly needs that package placement to exercise the library.
+   - Separate packages matter because tests placed inside the library package can bypass visibility boundaries and produce false confidence about what user code can access.
    - Reject tests that only instantiate the obvious type, mirror the generated skeleton, or fail to exercise the code path that would need metadata.
 
 4. Review the metadata with the test in mind.
@@ -66,6 +68,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 - Weak PR:
   - PR pushes metadata or tests for more than one library.
   - Test class still looks like the scaffold.
+  - Test sources are placed in the library package without a demonstrated need.
   - Metadata appears without a demonstrated trigger path.
   - Claimed coverage is not credible from the diff.
 


### PR DESCRIPTION
## Summary
- add a repo-local skill for reviewing `library-new-request` PRs
- encode the review signals already seen in recent review comments for new-library submissions
- document the new skill in the skills index

## Commented Examples
- #1727

## Merged Examples
- #1696

Closes #1732

