### PR TITLE
[GenAI] Add support for org.lz4:lz4-java:1.8.0 using gpt-5.4

### DIFF
--- a/metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json
+++ b/metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json
@@ -1,0 +1,292 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JNICompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4HCJNICompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JNIFastDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JNISafeDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaSafeCompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4HCJavaSafeCompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaSafeFastDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaSafeSafeDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaUnsafeCompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4HCJavaUnsafeCompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaUnsafeFastDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.lz4.LZ4Factory"
+      },
+      "type": "net.jpountz.lz4.LZ4JavaUnsafeSafeDecompressor",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash32JNI",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash32JNI$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash64JNI",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash64JNI$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash32JavaSafe",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash32JavaSafe$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash64JavaSafe",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash64JavaSafe$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash32JavaUnsafe",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash32JavaUnsafe$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.XXHash64JavaUnsafe",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.jpountz.xxhash.XXHashFactory"
+      },
+      "type": "net.jpountz.xxhash.StreamingXXHash64JavaUnsafe$Factory",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.lz4/lz4-java/index.json
+++ b/metadata/org.lz4/lz4-java/index.json
@@ -1,0 +1,14 @@
+[
+  {
+    "latest": true,
+    "allowed-packages": [ "org.lz4" ],
+    "metadata-version": "1.8.0",
+    "source-code-url": "https://repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0-sources.jar",
+    "repository-url": "https://github.com/lz4/lz4-java",
+    "test-code-url": "https://github.com/lz4/lz4-java/tree/1.8.0/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0-javadoc.jar",
+    "tested-versions": [
+      "1.8.0"
+    ]
+  }
+]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -5989,6 +5989,52 @@
         }
       }
     },
+    "org.lz4:lz4-java" : {
+      "metadataVersions" : {
+        "1.8.0" : {
+          "versions" : [ {
+            "version" : "1.8.0",
+            "dynamicAccess" : {
+              "breakdown" : {
+                "reflection" : {
+                  "coverageRatio" : 1.0,
+                  "coveredCalls" : 9,
+                  "totalCalls" : 9
+                },
+                "resources" : {
+                  "coverageRatio" : 1.0,
+                  "coveredCalls" : 1,
+                  "totalCalls" : 1
+                }
+              },
+              "coverageRatio" : 1.0,
+              "coveredCalls" : 10,
+              "totalCalls" : 10
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 5398,
+                "missed" : 14059,
+                "ratio" : 0.277432,
+                "total" : 19457
+              },
+              "line" : {
+                "covered" : 1106,
+                "missed" : 2828,
+                "ratio" : 0.281139,
+                "total" : 3934
+              },
+              "method" : {
+                "covered" : 185,
+                "missed" : 300,
+                "ratio" : 0.381443,
+                "total" : 485
+              }
+            }
+          } ]
+        }
+      }
+    },
     "org.mariadb.jdbc:mariadb-java-client" : {
       "metadataVersions" : {
         "3.0.6" : {

--- a/tests/src/org.lz4/lz4-java/1.8.0/.gitignore
+++ b/tests/src/org.lz4/lz4-java/1.8.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.lz4/lz4-java/1.8.0/build.gradle
+++ b/tests/src/org.lz4/lz4-java/1.8.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.lz4:lz4-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/gradle.properties
+++ b/tests/src/org.lz4/lz4-java/1.8.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.lz4:lz4-java:1.8.0
+library.version = 1.8.0
+metadata.dir = org.lz4/lz4-java/1.8.0/

--- a/tests/src/org.lz4/lz4-java/1.8.0/settings.gradle
+++ b/tests/src/org.lz4/lz4-java/1.8.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.lz4.lz4-java_tests'

--- a/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java
+++ b/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java
@@ -6,11 +6,55 @@
  */
 package org_lz4.lz4_java;
 
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
 import org.junit.jupiter.api.Test;
 
-class Lz4_javaTest {
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LZ4FactoryTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void shouldCreateSafeFactoryAndRoundTripData() {
+        LZ4Factory factory = LZ4Factory.safeInstance();
+        byte[] input = "lz4 factory safe instance round trip".getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = new byte[factory.fastCompressor().maxCompressedLength(input.length)];
+
+        int compressedLength = factory.fastCompressor().compress(input, 0, input.length, compressed, 0, compressed.length);
+
+        byte[] restored = new byte[input.length];
+        int decompressedLength = factory.safeDecompressor().decompress(compressed, 0, compressedLength, restored, 0);
+
+        assertThat(decompressedLength).isEqualTo(input.length);
+        assertThat(restored).isEqualTo(input);
+        assertThat(factory.toString()).contains("JavaSafe");
+    }
+
+    @Test
+    void shouldSupportConstructedHighCompressionLevels() {
+        LZ4Factory factory = LZ4Factory.safeInstance();
+        byte[] input = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                + "cccccccccccccccccccccccccccccccc"
+                + "lz4 factory high compression levels")
+                .getBytes(StandardCharsets.UTF_8);
+
+        assertThat(factory.highCompressor(-1)).isSameAs(factory.highCompressor());
+        assertThat(factory.highCompressor(99)).isSameAs(factory.highCompressor(17));
+
+        assertRoundTrip(factory.highCompressor(1), factory, input);
+        assertRoundTrip(factory.highCompressor(17), factory, input);
+    }
+
+    private static void assertRoundTrip(LZ4Compressor compressor, LZ4Factory factory, byte[] input) {
+        byte[] compressed = new byte[compressor.maxCompressedLength(input.length)];
+        int compressedLength = compressor.compress(input, 0, input.length, compressed, 0, compressed.length);
+        byte[] restored = new byte[input.length];
+
+        int decompressedLength = factory.safeDecompressor().decompress(compressed, 0, compressedLength, restored, 0);
+
+        assertThat(decompressedLength).isEqualTo(input.length);
+        assertThat(restored).isEqualTo(input);
     }
 }

--- a/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java
+++ b/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_lz4.lz4_java;
+
+import org.junit.jupiter.api.Test;
+
+class Lz4_javaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/NativeTest.java
+++ b/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/NativeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_lz4.lz4_java;
+
+import net.jpountz.lz4.LZ4Factory;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NativeTest {
+    @Test
+    void shouldReachBundledNativeLibraryLookupWhenCreatingNativeFactory() {
+        LZ4Factory factory = nativeFactoryOrSafeFallback();
+        byte[] input = ("native loading should look up the bundled lz4 resource"
+                + " before the test falls back to the safe implementation")
+                .getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = new byte[factory.fastCompressor().maxCompressedLength(input.length)];
+
+        int compressedLength = factory.fastCompressor().compress(input, 0, input.length, compressed, 0, compressed.length);
+
+        byte[] restored = new byte[input.length];
+        int restoredLength = factory.safeDecompressor().decompress(compressed, 0, compressedLength, restored, 0);
+
+        assertThat(restoredLength).isEqualTo(input.length);
+        assertThat(restored).isEqualTo(input);
+        assertThat(factory.toString()).startsWith("LZ4Factory:");
+    }
+
+    private static LZ4Factory nativeFactoryOrSafeFallback() {
+        try {
+            return LZ4Factory.nativeInstance();
+        } catch (Throwable throwable) {
+            return LZ4Factory.safeInstance();
+        }
+    }
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/UnsafeUtilsTest.java
+++ b/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/UnsafeUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_lz4.lz4_java;
+
+import net.jpountz.lz4.LZ4Factory;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnsafeUtilsTest {
+    @Test
+    void shouldLoadUnsafeUtilsWhenCreatingUnsafeFactoryAndRoundTripData() {
+        LZ4Factory factory = LZ4Factory.unsafeInstance();
+        byte[] input = ("unsafe lz4 factory initialization should exercise the unsafe utils"
+                + " path and preserve the original payload after decompression")
+                .getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = new byte[factory.fastCompressor().maxCompressedLength(input.length)];
+
+        int compressedLength = factory.fastCompressor().compress(input, 0, input.length, compressed, 0, compressed.length);
+
+        byte[] restored = new byte[input.length];
+        int restoredLength = factory.safeDecompressor().decompress(compressed, 0, compressedLength, restored, 0);
+
+        assertThat(restoredLength).isEqualTo(input.length);
+        assertThat(restored).isEqualTo(input);
+        assertThat(factory.toString()).contains("JavaUnsafe");
+    }
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/XXHashFactoryTest.java
+++ b/tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/XXHashFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_lz4.lz4_java;
+
+import net.jpountz.xxhash.StreamingXXHash32;
+import net.jpountz.xxhash.StreamingXXHash64;
+import net.jpountz.xxhash.XXHashFactory;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class XXHashFactoryTest {
+    @Test
+    void shouldCreateSafeFactoryAndMatchStreaming32BitHash() {
+        XXHashFactory factory = XXHashFactory.safeInstance();
+        byte[] input = "xxhash factory safe instance".getBytes(StandardCharsets.UTF_8);
+        int seed = 0x9E3779B1;
+
+        int blockHash = factory.hash32().hash(input, 0, input.length, seed);
+        StreamingXXHash32 streamingHash = factory.newStreamingHash32(seed);
+        streamingHash.update(input, 0, 7);
+        streamingHash.update(input, 7, input.length - 7);
+
+        assertThat(streamingHash.getValue()).isEqualTo(blockHash);
+        assertThat(factory.hash32().hash(ByteBuffer.wrap(input), seed)).isEqualTo(blockHash);
+        assertThat(factory.toString()).contains("JavaSafe");
+    }
+
+    @Test
+    void shouldCreateSafeFactoryAndMatchStreaming64BitHash() {
+        XXHashFactory factory = XXHashFactory.safeInstance();
+        byte[] input = "xxhash factory 64-bit verification".getBytes(StandardCharsets.UTF_8);
+        long seed = 0x1234ABCDL;
+
+        long blockHash = factory.hash64().hash(input, 0, input.length, seed);
+        StreamingXXHash64 streamingHash = factory.newStreamingHash64(seed);
+        streamingHash.update(input, 0, 11);
+        streamingHash.update(input, 11, input.length - 11);
+
+        assertThat(streamingHash.getValue()).isEqualTo(blockHash);
+        assertThat(factory.hash64().hash(ByteBuffer.wrap(input), seed)).isEqualTo(blockHash);
+        assertThat(streamingHash.toString()).contains("seed=").contains(Long.toString(seed));
+    }
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json
+++ b/tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.lz4.**"
+    }
+  ]
+}

--- a/tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json
+++ b/tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.lz4.**"
+      "includeClasses" : "org.lz4.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1551

This PR introduces tests and metadata for org.lz4:lz4-java:1.8.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 141244
- Cached input tokens: 1990144
- Output tokens: 21415
- Entries: 51
- Iterations: 4
- Library coverage percentage: 28.12
- Generated lines of code: 150
- Tested library lines of code: 5532

Stats from `stats/stats.json`:

Dynamic access coverage:
- Overall: 10/10 covered calls (100.00%)
- Reflection: 9/9 covered calls (100.00%)
- Resources: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 5398/19457 (27.74%)
- Line: 1106/3934 (28.11%)
- Method: 185/485 (38.14%)
