### PR TITLE
Scope nativeTestCompile cacheability to dynamic access report lane

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -29,6 +29,21 @@ tasks.withType(JavaCompile).configureEach {
     options.release = 21
 }
 
+tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach { task ->
+    if (task.name == "nativeTestCompile") {
+        // Restrict cacheability to the dynamic-access reporting lane.
+        task.outputs.cacheIf("Enabled only when generating dynamic-access reports") {
+            boolean propertyEnabled = providers.gradleProperty('tck.generateDynamicAccessReport')
+                    .map { value -> value.toBoolean() }
+                    .getOrElse(false)
+            boolean taskRequested = gradle.startParameter.taskNames.any { taskName ->
+                taskName == "generateDynamicAccessReport" || taskName.endsWith(":generateDynamicAccessReport")
+            }
+            propertyEnabled || taskRequested
+        }
+    }
+}
+
 checkstyle {
     configFile tck.repoRoot.file("gradle/checkstyle.xml").get().asFile
 }


### PR DESCRIPTION
## Summary
- gate `nativeTestCompile` build-cache enablement behind dynamic-access-report intent
- keep caching enabled only when either `-Ptck.generateDynamicAccessReport=true` is set or `generateDynamicAccessReport` task is requested

## Validation
- `clean nativeTestCompile --build-cache --info` => cache is disabled with the configured gate reason
- `clean generateDynamicAccessReport --build-cache --info` => `nativeTestCompile` gets/stores cache entries

Closes #1741
