### PR TITLE
[GenAI] Test fix for io.jsonwebtoken:jjwt-gson:0.12.0 using gpt-5.4

### DIFF
--- a/metadata/io.jsonwebtoken/jjwt-gson/0.12.0/reachability-metadata.json
+++ b/metadata/io.jsonwebtoken/jjwt-gson/0.12.0/reachability-metadata.json
@@ -1,0 +1,693 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultClaims"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultClaimsBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwsHeader"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtParserBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ZIP"
+      },
+      "type": "io.jsonwebtoken.impl.io.StandardCompressionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.security.KeysBridge"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ENC"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardEncryptionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$KEY"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyOperations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$SIG"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardSecureDigestAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.lang.Classes"
+      },
+      "type": "java.io.ByteArrayInputStream",
+      "fields": [
+        {
+          "name": "buf"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.SecureRandomParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.Randoms"
+      },
+      "type": "java.security.SecureRandomParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.EdECKey",
+      "methods": [
+        {
+          "name": "getParams",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.XECKey",
+      "methods": [
+        {
+          "name": "getParams",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.spec.NamedParameterSpec",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.gson.io.GsonSerializer"
+      },
+      "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "type": "java.util.LinkedHashSet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.Randoms"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$MessageDigestFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "sun.security.util.KeyUtil",
+      "methods": [
+        {
+          "name": "getKeySize",
+          "parameterTypes": [
+            "java.security.Key"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.KeysBridge"
+      },
+      "type": "sun.security.util.KeyUtil",
+      "methods": [
+        {
+          "name": "getKeySize",
+          "parameterTypes": [
+            "java.security.Key"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "glob": "META-INF/services/io.jsonwebtoken.io.Deserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtBuilder"
+      },
+      "glob": "META-INF/services/io.jsonwebtoken.io.Serializer"
+    }
+  ]
+}

--- a/metadata/io.jsonwebtoken/jjwt-gson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-gson/index.json
@@ -2,6 +2,10 @@
   {
     "latest" : true,
     "metadata-version" : "0.12.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-gson/0.12.0/jjwt-gson-0.12.0-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/gson/src/test",
+    "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
     "tested-versions" : [
       "0.12.0"
     ],

--- a/metadata/io.jsonwebtoken/jjwt-gson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-gson/index.json
@@ -1,16 +1,25 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "io.jsonwebtoken"
+    "latest" : true,
+    "metadata-version" : "0.12.0",
+    "tested-versions" : [
+      "0.12.0"
     ],
-    "metadata-version": "0.11.5",
-    "source-code-url": "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-gson/0.11.5/jjwt-gson-0.11.5-sources.jar",
-    "repository-url": "https://github.com/jwtk/jjwt",
-    "test-code-url": "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/gson/src/test",
-    "documentation-url": "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.jsonwebtoken"
+    ]
+  },
+  {
+    "metadata-version" : "0.11.5",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-gson/0.11.5/jjwt-gson-0.11.5-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/gson/src/test",
+    "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
+    "tested-versions" : [
       "0.11.5"
+    ],
+    "allowed-packages" : [
+      "io.jsonwebtoken"
     ]
   }
 ]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -1878,6 +1878,37 @@
               }
             }
           } ]
+        },
+        "0.12.0" : {
+          "versions" : [ {
+            "version" : "0.12.0",
+            "dynamicAccess" : {
+              "breakdown" : { },
+              "coverageRatio" : 1.0,
+              "coveredCalls" : 0,
+              "totalCalls" : 0
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 128,
+                "missed" : 43,
+                "ratio" : 0.748538,
+                "total" : 171
+              },
+              "line" : {
+                "covered" : 38,
+                "missed" : 4,
+                "ratio" : 0.904762,
+                "total" : 42
+              },
+              "method" : {
+                "covered" : 15,
+                "missed" : 0,
+                "ratio" : 1.0,
+                "total" : 15
+              }
+            }
+          } ]
         }
       }
     },

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/.gitignore
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.jsonwebtoken:jjwt-gson:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "io.jsonwebtoken:jjwt-api:$libraryVersion"
+    testImplementation "io.jsonwebtoken:jjwt-impl:$libraryVersion"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/io.jsonwebtoken/jjwt-gson")
+        }
+    }
+}

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation "io.jsonwebtoken:jjwt-impl:$libraryVersion"
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-exports=java.base/sun.security.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED"
+    ]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -29,6 +36,14 @@ graalvmNative {
             mergeWithExisting = true
             inputTaskNames.add("test")
             outputDirectories.add("src/test/resources/META-INF/native-image/io.jsonwebtoken/jjwt-gson")
+        }
+    }
+    binaries {
+        all {
+            buildArgs.addAll([
+                    '--add-exports=java.base/sun.security.util=ALL-UNNAMED',
+                    '--add-opens=java.base/java.io=ALL-UNNAMED'
+            ])
         }
     }
 }

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/gradle.properties
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 0.12.0
+metadata.dir = io.jsonwebtoken/jjwt-gson/0.12.0/

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/settings.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.jsonwebtoken.jjwt-gson_tests'

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_jsonwebtoken.jjwt_gson;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.CompressionCodecs;
+import io.jsonwebtoken.JwtParserBuilder;
+import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Jjwt_gsonTest {
+    @Test
+    void testSignedJWTs() {
+        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String secretString = Encoders.BASE64.encode(firstKey.getEncoded());
+        SecretKey secondKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretString));
+        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
+                Jwts.builder().setSubject("Joe").signWith(firstKey).compact()
+        ).getBody().getSubject()).isEqualTo("Joe");
+        assertThat(Jwts.parserBuilder().setSigningKey(secondKey).build().parseClaimsJws(
+                Jwts.builder().setSubject("Joe").signWith(secondKey).compact()
+        ).getBody().getSubject()).isEqualTo("Joe");
+    }
+
+    @Test
+    void testCreatingAJWS() {
+        Date firstDate = new Date();
+        Date secondDate = new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000L);
+        String uuidString = UUID.randomUUID().toString();
+        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String firstCompactJws = Jwts.builder()
+                .setSubject("Joe")
+                .setHeaderParam("kid", "myKeyId")
+                .setIssuer("Aaron")
+                .setAudience("Abel")
+                .setExpiration(secondDate)
+                .setNotBefore(firstDate)
+                .setIssuedAt(firstDate)
+                .setId(uuidString)
+                .claim("exampleClaim", "Adam")
+                .signWith(firstKey, SignatureAlgorithm.HS256)
+                .compressWith(CompressionCodecs.GZIP)
+                .compact();
+        JwtParserBuilder jwtParserBuilder = Jwts.parserBuilder().setAllowedClockSkewSeconds(3 * 60).setSigningKey(firstKey);
+        assertThat(jwtParserBuilder.build().parseClaimsJws(firstCompactJws).getBody().getSubject()).isEqualTo("Joe");
+        assertDoesNotThrow(() -> jwtParserBuilder.requireSubject("Joe").build().parseClaimsJws(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuer("Aaron").build().parseClaimsJws(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireAudience("Abel").build().parseClaimsJws(firstCompactJws));
+        // This is an error caused by GSON's own parsing
+        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireExpiration(secondDate).build().parseClaimsJws(firstCompactJws));
+        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireNotBefore(firstDate).build().parseClaimsJws(firstCompactJws));
+        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireIssuedAt(firstDate).build().parseClaimsJws(firstCompactJws));
+        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireId(uuidString).build().parseClaimsJws(firstCompactJws));
+        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.require("exampleClaim", "Adam").build().parseClaimsJws(firstCompactJws));
+    }
+
+    @Test
+    void testCompression() {
+        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
+                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.DEFLATE).compact()
+        ).getBody().getSubject()).isEqualTo("Joe");
+        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
+                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.GZIP).compact()
+        ).getBody().getSubject()).isEqualTo("Joe");
+    }
+
+    @Test
+    void testSignatureAlgorithms() {
+        Stream.of(SignatureAlgorithm.HS256, SignatureAlgorithm.HS384, SignatureAlgorithm.HS512)
+                .map(Keys::secretKeyFor)
+                .forEach(secretKey -> assertThat(Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(
+                        Jwts.builder().setSubject("Joe").signWith(secretKey).compact()
+                ).getBody().getSubject()).isEqualTo("Joe"));
+        Stream.of(SignatureAlgorithm.ES256, SignatureAlgorithm.ES384, SignatureAlgorithm.ES512,
+                        SignatureAlgorithm.RS256, SignatureAlgorithm.RS384, SignatureAlgorithm.RS512,
+                        SignatureAlgorithm.PS256, SignatureAlgorithm.PS384, SignatureAlgorithm.PS512)
+                .map(Keys::keyPairFor)
+                .forEach(keyPair -> assertThat(Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build().parseClaimsJws(
+                        Jwts.builder().setSubject("Joe").signWith(keyPair.getPrivate()).compact()
+                ).getBody().getSubject()).isEqualTo("Joe"));
+    }
+}

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
@@ -6,95 +6,186 @@
  */
 package io_jsonwebtoken.jjwt_gson;
 
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.CompressionCodecs;
 import io.jsonwebtoken.JwtParserBuilder;
-import io.jsonwebtoken.IncorrectClaimException;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.io.Encoders;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.CompressionAlgorithm;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
-import java.util.stream.Stream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class Jjwt_gsonTest {
+    private static final CompressionAlgorithm DEFLATE = new DeflateCompressionAlgorithm();
+    private static final CompressionAlgorithm GZIP = new GzipCompressionAlgorithm();
+
     @Test
-    void testSignedJWTs() {
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-        String secretString = Encoders.BASE64.encode(firstKey.getEncoded());
-        SecretKey secondKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretString));
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
-        assertThat(Jwts.parserBuilder().setSigningKey(secondKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(secondKey).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
+    void testSignedJWTs() throws GeneralSecurityException {
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
+        String secretString = Base64.getEncoder().encodeToString(firstKey.getEncoded());
+        SecretKey secondKey = new SecretKeySpec(Base64.getDecoder().decode(secretString), "HmacSHA256");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compact(), firstKey)).isEqualTo("Joe");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(secondKey).compact(), secondKey)).isEqualTo("Joe");
     }
 
     @Test
-    void testCreatingAJWS() {
+    void testCreatingAJWS() throws GeneralSecurityException {
         Date firstDate = new Date();
         Date secondDate = new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000L);
         String uuidString = UUID.randomUUID().toString();
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
         String firstCompactJws = Jwts.builder()
-                .setSubject("Joe")
-                .setHeaderParam("kid", "myKeyId")
-                .setIssuer("Aaron")
-                .setAudience("Abel")
-                .setExpiration(secondDate)
-                .setNotBefore(firstDate)
-                .setIssuedAt(firstDate)
-                .setId(uuidString)
+                .subject("Joe")
+                .header().add("kid", "myKeyId").and()
+                .issuer("Aaron")
+                .audience().add("Abel").and()
+                .expiration(secondDate)
+                .notBefore(firstDate)
+                .issuedAt(firstDate)
+                .id(uuidString)
                 .claim("exampleClaim", "Adam")
-                .signWith(firstKey, SignatureAlgorithm.HS256)
-                .compressWith(CompressionCodecs.GZIP)
+                .signWith(firstKey)
+                .compressWith(GZIP)
                 .compact();
-        JwtParserBuilder jwtParserBuilder = Jwts.parserBuilder().setAllowedClockSkewSeconds(3 * 60).setSigningKey(firstKey);
-        assertThat(jwtParserBuilder.build().parseClaimsJws(firstCompactJws).getBody().getSubject()).isEqualTo("Joe");
-        assertDoesNotThrow(() -> jwtParserBuilder.requireSubject("Joe").build().parseClaimsJws(firstCompactJws));
-        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuer("Aaron").build().parseClaimsJws(firstCompactJws));
-        assertDoesNotThrow(() -> jwtParserBuilder.requireAudience("Abel").build().parseClaimsJws(firstCompactJws));
-        // This is an error caused by GSON's own parsing
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireExpiration(secondDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireNotBefore(firstDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireIssuedAt(firstDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireId(uuidString).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.require("exampleClaim", "Adam").build().parseClaimsJws(firstCompactJws));
+        JwtParserBuilder jwtParserBuilder = Jwts.parser().clockSkewSeconds(3 * 60).verifyWith(firstKey);
+        assertThat(jwtParserBuilder.build().parseSignedClaims(firstCompactJws).getPayload().getSubject()).isEqualTo("Joe");
+        assertDoesNotThrow(() -> jwtParserBuilder.requireSubject("Joe").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuer("Aaron").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireAudience("Abel").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireExpiration(secondDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireNotBefore(firstDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuedAt(firstDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireId(uuidString).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.require("exampleClaim", "Adam").build().parseSignedClaims(firstCompactJws));
     }
 
     @Test
-    void testCompression() {
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.DEFLATE).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.GZIP).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
+    void testCompression() throws GeneralSecurityException {
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compressWith(DEFLATE).compact(), firstKey))
+                .isEqualTo("Joe");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compressWith(GZIP).compact(), firstKey))
+                .isEqualTo("Joe");
     }
 
     @Test
-    void testSignatureAlgorithms() {
-        Stream.of(SignatureAlgorithm.HS256, SignatureAlgorithm.HS384, SignatureAlgorithm.HS512)
-                .map(Keys::secretKeyFor)
-                .forEach(secretKey -> assertThat(Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(
-                        Jwts.builder().setSubject("Joe").signWith(secretKey).compact()
-                ).getBody().getSubject()).isEqualTo("Joe"));
-        Stream.of(SignatureAlgorithm.ES256, SignatureAlgorithm.ES384, SignatureAlgorithm.ES512,
-                        SignatureAlgorithm.RS256, SignatureAlgorithm.RS384, SignatureAlgorithm.RS512,
-                        SignatureAlgorithm.PS256, SignatureAlgorithm.PS384, SignatureAlgorithm.PS512)
-                .map(Keys::keyPairFor)
-                .forEach(keyPair -> assertThat(Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build().parseClaimsJws(
-                        Jwts.builder().setSubject("Joe").signWith(keyPair.getPrivate()).compact()
-                ).getBody().getSubject()).isEqualTo("Joe"));
+    void testSignatureAlgorithms() throws GeneralSecurityException {
+        assertSignedSubject("HS256", generateSecretKey("HmacSHA256"));
+        assertSignedSubject("HS384", generateSecretKey("HmacSHA384"));
+        assertSignedSubject("HS512", generateSecretKey("HmacSHA512"));
+
+        assertSignedSubject("ES256", generateEcKeyPair("secp256r1"));
+        assertSignedSubject("ES384", generateEcKeyPair("secp384r1"));
+        assertSignedSubject("ES512", generateEcKeyPair("secp521r1"));
+
+        assertSignedSubject("RS256", generateKeyPair("RSA", 2048));
+        assertSignedSubject("RS384", generateKeyPair("RSA", 3072));
+        assertSignedSubject("RS512", generateKeyPair("RSA", 4096));
+
+        assertSignedSubject("PS256", generateKeyPair("RSASSA-PSS", 2048));
+        assertSignedSubject("PS384", generateKeyPair("RSASSA-PSS", 3072));
+        assertSignedSubject("PS512", generateKeyPair("RSASSA-PSS", 4096));
+    }
+
+    private static SecretKey generateSecretKey(String algorithm) throws GeneralSecurityException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
+        return keyGenerator.generateKey();
+    }
+
+    private static KeyPair generateKeyPair(String algorithm, int keySize) throws GeneralSecurityException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
+        keyPairGenerator.initialize(keySize);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static KeyPair generateEcKeyPair(String curve) throws GeneralSecurityException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(new ECGenParameterSpec(curve));
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static void assertSignedSubject(String expectedAlgorithm, SecretKey secretKey) {
+        String compactJws = Jwts.builder().subject("Joe").signWith(secretKey).compact();
+        assertThat(readHeader(compactJws)).contains("\"alg\":\"" + expectedAlgorithm + "\"");
+        assertThat(parseSubject(compactJws, secretKey)).isEqualTo("Joe");
+    }
+
+    private static void assertSignedSubject(String expectedAlgorithm, KeyPair keyPair) {
+        String compactJws = Jwts.builder().subject("Joe").signWith(keyPair.getPrivate()).compact();
+        assertThat(readHeader(compactJws)).contains("\"alg\":\"" + expectedAlgorithm + "\"");
+        assertThat(parseSubject(compactJws, keyPair.getPublic())).isEqualTo("Joe");
+    }
+
+    private static String readHeader(String compactJws) {
+        String encodedHeader = compactJws.substring(0, compactJws.indexOf('.'));
+        return new String(Base64.getUrlDecoder().decode(encodedHeader), StandardCharsets.UTF_8);
+    }
+
+    private static String parseSubject(String compactJws, SecretKey secretKey) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(compactJws).getPayload().getSubject();
+    }
+
+    private static String parseSubject(String compactJws, PublicKey publicKey) {
+        return Jwts.parser().verifyWith(publicKey).build().parseSignedClaims(compactJws).getPayload().getSubject();
+    }
+
+    private static final class DeflateCompressionAlgorithm implements CompressionAlgorithm {
+        @Override
+        public String getId() {
+            return "DEF";
+        }
+
+        @Override
+        public OutputStream compress(OutputStream outputStream) {
+            return new DeflaterOutputStream(outputStream);
+        }
+
+        @Override
+        public InputStream decompress(InputStream inputStream) {
+            return new InflaterInputStream(inputStream);
+        }
+    }
+
+    private static final class GzipCompressionAlgorithm implements CompressionAlgorithm {
+        @Override
+        public String getId() {
+            return "GZIP";
+        }
+
+        @Override
+        public OutputStream compress(OutputStream outputStream) {
+            try {
+                return new GZIPOutputStream(outputStream);
+            } catch (java.io.IOException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
+
+        @Override
+        public InputStream decompress(InputStream inputStream) {
+            try {
+                return new GZIPInputStream(inputStream);
+            } catch (java.io.IOException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
     }
 }

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.jsonwebtoken.gson.**"
+    },
+    {
+      "includeClasses": "io.jsonwebtoken.**"
+    }
+  ]
+}

--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
@@ -1,13 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.jsonwebtoken.gson.**"
-    },
-    {
-      "includeClasses": "io.jsonwebtoken.**"
+      "includeClasses" : "io.jsonwebtoken.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #716

This PR provides test fixes and new metadata for io.jsonwebtoken:jjwt-gson:0.12.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 188313
- Output tokens: 33848
- Entries found: 114
- Iterations: 2
- Library coverage percentage: 90.48
- Previous library version metadata entries: 98
- Previous library version coverage percentage: 75.76

### Stats from `stats/stats.json`

#### Dynamic access coverage

- io.jsonwebtoken:jjwt-gson:0.11.5: 0/0 covered calls (100.00%)
- io.jsonwebtoken:jjwt-gson:0.12.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.jsonwebtoken:jjwt-gson:0.11.5: 81/136 (59.56%)
- io.jsonwebtoken:jjwt-gson:0.12.0: 128/171 (74.85%)

**Line:**
- io.jsonwebtoken:jjwt-gson:0.11.5: 25/33 (75.76%)
- io.jsonwebtoken:jjwt-gson:0.12.0: 38/42 (90.48%)

**Method:**
- io.jsonwebtoken:jjwt-gson:0.11.5: 10/10 (100.00%)
- io.jsonwebtoken:jjwt-gson:0.12.0: 15/15 (100.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/build.gradle b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
index 7680b347..3b535947 100644
--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/build.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation "io.jsonwebtoken:jjwt-impl:$libraryVersion"
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-exports=java.base/sun.security.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED"
+    ]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -31,4 +38,12 @@ graalvmNative {
             outputDirectories.add("src/test/resources/META-INF/native-image/io.jsonwebtoken/jjwt-gson")
         }
     }
+    binaries {
+        all {
+            buildArgs.addAll([
+                    '--add-exports=java.base/sun.security.util=ALL-UNNAMED',
+                    '--add-opens=java.base/java.io=ALL-UNNAMED'
+            ])
+        }
+    }
 }
diff --git a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/gradle.properties b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/gradle.properties
index 1664cadd..ad4d2512 100644
--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/gradle.properties
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/gradle.properties
@@ -1,2 +1,2 @@
-library.version = 0.11.5
-metadata.dir = io.jsonwebtoken/jjwt-gson/0.11.5/
+library.version = 0.12.0
+metadata.dir = io.jsonwebtoken/jjwt-gson/0.12.0/
diff --git a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
index 1d4b6b2c..463826d8 100644
--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/src/test/java/io_jsonwebtoken/jjwt_gson/Jjwt_gsonTest.java
@@ -6,95 +6,186 @@
  */
 package io_jsonwebtoken.jjwt_gson;
 
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.CompressionCodecs;
 import io.jsonwebtoken.JwtParserBuilder;
-import io.jsonwebtoken.IncorrectClaimException;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.io.Encoders;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.CompressionAlgorithm;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
-import java.util.stream.Stream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class Jjwt_gsonTest {
+    private static final CompressionAlgorithm DEFLATE = new DeflateCompressionAlgorithm();
+    private static final CompressionAlgorithm GZIP = new GzipCompressionAlgorithm();
+
     @Test
-    void testSignedJWTs() {
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-        String secretString = Encoders.BASE64.encode(firstKey.getEncoded());
-        SecretKey secondKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretString));
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
-        assertThat(Jwts.parserBuilder().setSigningKey(secondKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(secondKey).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
+    void testSignedJWTs() throws GeneralSecurityException {
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
+        String secretString = Base64.getEncoder().encodeToString(firstKey.getEncoded());
+        SecretKey secondKey = new SecretKeySpec(Base64.getDecoder().decode(secretString), "HmacSHA256");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compact(), firstKey)).isEqualTo("Joe");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(secondKey).compact(), secondKey)).isEqualTo("Joe");
     }
 
     @Test
-    void testCreatingAJWS() {
+    void testCreatingAJWS() throws GeneralSecurityException {
         Date firstDate = new Date();
         Date secondDate = new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000L);
         String uuidString = UUID.randomUUID().toString();
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
         String firstCompactJws = Jwts.builder()
-                .setSubject("Joe")
-                .setHeaderParam("kid", "myKeyId")
-                .setIssuer("Aaron")
-                .setAudience("Abel")
-                .setExpiration(secondDate)
-                .setNotBefore(firstDate)
-                .setIssuedAt(firstDate)
-                .setId(uuidString)
+                .subject("Joe")
+                .header().add("kid", "myKeyId").and()
+                .issuer("Aaron")
+                .audience().add("Abel").and()
+                .expiration(secondDate)
+                .notBefore(firstDate)
+                .issuedAt(firstDate)
+                .id(uuidString)
                 .claim("exampleClaim", "Adam")
-                .signWith(firstKey, SignatureAlgorithm.HS256)
-                .compressWith(CompressionCodecs.GZIP)
+                .signWith(firstKey)
+                .compressWith(GZIP)
                 .compact();
-        JwtParserBuilder jwtParserBuilder = Jwts.parserBuilder().setAllowedClockSkewSeconds(3 * 60).setSigningKey(firstKey);
-        assertThat(jwtParserBuilder.build().parseClaimsJws(firstCompactJws).getBody().getSubject()).isEqualTo("Joe");
-        assertDoesNotThrow(() -> jwtParserBuilder.requireSubject("Joe").build().parseClaimsJws(firstCompactJws));
-        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuer("Aaron").build().parseClaimsJws(firstCompactJws));
-        assertDoesNotThrow(() -> jwtParserBuilder.requireAudience("Abel").build().parseClaimsJws(firstCompactJws));
-        // This is an error caused by GSON's own parsing
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireExpiration(secondDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireNotBefore(firstDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireIssuedAt(firstDate).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.requireId(uuidString).build().parseClaimsJws(firstCompactJws));
-        assertThrows(IncorrectClaimException.class, () -> jwtParserBuilder.require("exampleClaim", "Adam").build().parseClaimsJws(firstCompactJws));
+        JwtParserBuilder jwtParserBuilder = Jwts.parser().clockSkewSeconds(3 * 60).verifyWith(firstKey);
+        assertThat(jwtParserBuilder.build().parseSignedClaims(firstCompactJws).getPayload().getSubject()).isEqualTo("Joe");
+        assertDoesNotThrow(() -> jwtParserBuilder.requireSubject("Joe").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuer("Aaron").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireAudience("Abel").build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireExpiration(secondDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireNotBefore(firstDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireIssuedAt(firstDate).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.requireId(uuidString).build().parseSignedClaims(firstCompactJws));
+        assertDoesNotThrow(() -> jwtParserBuilder.require("exampleClaim", "Adam").build().parseSignedClaims(firstCompactJws));
     }
 
     @Test
-    void testCompression() {
-        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.DEFLATE).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
-        assertThat(Jwts.parserBuilder().setSigningKey(firstKey).build().parseClaimsJws(
-                Jwts.builder().setSubject("Joe").signWith(firstKey).compressWith(CompressionCodecs.GZIP).compact()
-        ).getBody().getSubject()).isEqualTo("Joe");
+    void testCompression() throws GeneralSecurityException {
+        SecretKey firstKey = generateSecretKey("HmacSHA256");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compressWith(DEFLATE).compact(), firstKey))
+                .isEqualTo("Joe");
+        assertThat(parseSubject(Jwts.builder().subject("Joe").signWith(firstKey).compressWith(GZIP).compact(), firstKey))
+                .isEqualTo("Joe");
     }
 
     @Test
-    void testSignatureAlgorithms() {
-        Stream.of(SignatureAlgorithm.HS256, SignatureAlgorithm.HS384, SignatureAlgorithm.HS512)
-                .map(Keys::secretKeyFor)
-                .forEach(secretKey -> assertThat(Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(
-                        Jwts.builder().setSubject("Joe").signWith(secretKey).compact()
-                ).getBody().getSubject()).isEqualTo("Joe"));
-        Stream.of(SignatureAlgorithm.ES256, SignatureAlgorithm.ES384, SignatureAlgorithm.ES512,
-                        SignatureAlgorithm.RS256, SignatureAlgorithm.RS384, SignatureAlgorithm.RS512,
-                        SignatureAlgorithm.PS256, SignatureAlgorithm.PS384, SignatureAlgorithm.PS512)
-                .map(Keys::keyPairFor)
-                .forEach(keyPair -> assertThat(Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build().parseClaimsJws(
-                        Jwts.builder().setSubject("Joe").signWith(keyPair.getPrivate()).compact()
-                ).getBody().getSubject()).isEqualTo("Joe"));
+    void testSignatureAlgorithms() throws GeneralSecurityException {
+        assertSignedSubject("HS256", generateSecretKey("HmacSHA256"));
+        assertSignedSubject("HS384", generateSecretKey("HmacSHA384"));
+        assertSignedSubject("HS512", generateSecretKey("HmacSHA512"));
+
+        assertSignedSubject("ES256", generateEcKeyPair("secp256r1"));
+        assertSignedSubject("ES384", generateEcKeyPair("secp384r1"));
+        assertSignedSubject("ES512", generateEcKeyPair("secp521r1"));
+
+        assertSignedSubject("RS256", generateKeyPair("RSA", 2048));
+        assertSignedSubject("RS384", generateKeyPair("RSA", 3072));
+        assertSignedSubject("RS512", generateKeyPair("RSA", 4096));
+
+        assertSignedSubject("PS256", generateKeyPair("RSASSA-PSS", 2048));
+        assertSignedSubject("PS384", generateKeyPair("RSASSA-PSS", 3072));
+        assertSignedSubject("PS512", generateKeyPair("RSASSA-PSS", 4096));
+    }
+
+    private static SecretKey generateSecretKey(String algorithm) throws GeneralSecurityException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
+        return keyGenerator.generateKey();
+    }
+
+    private static KeyPair generateKeyPair(String algorithm, int keySize) throws GeneralSecurityException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
+        keyPairGenerator.initialize(keySize);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static KeyPair generateEcKeyPair(String curve) throws GeneralSecurityException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(new ECGenParameterSpec(curve));
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static void assertSignedSubject(String expectedAlgorithm, SecretKey secretKey) {
+        String compactJws = Jwts.builder().subject("Joe").signWith(secretKey).compact();
+        assertThat(readHeader(compactJws)).contains("\"alg\":\"" + expectedAlgorithm + "\"");
+        assertThat(parseSubject(compactJws, secretKey)).isEqualTo("Joe");
+    }
+
+    private static void assertSignedSubject(String expectedAlgorithm, KeyPair keyPair) {
+        String compactJws = Jwts.builder().subject("Joe").signWith(keyPair.getPrivate()).compact();
+        assertThat(readHeader(compactJws)).contains("\"alg\":\"" + expectedAlgorithm + "\"");
+        assertThat(parseSubject(compactJws, keyPair.getPublic())).isEqualTo("Joe");
+    }
+
+    private static String readHeader(String compactJws) {
+        String encodedHeader = compactJws.substring(0, compactJws.indexOf('.'));
+        return new String(Base64.getUrlDecoder().decode(encodedHeader), StandardCharsets.UTF_8);
+    }
+
+    private static String parseSubject(String compactJws, SecretKey secretKey) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(compactJws).getPayload().getSubject();
+    }
+
+    private static String parseSubject(String compactJws, PublicKey publicKey) {
+        return Jwts.parser().verifyWith(publicKey).build().parseSignedClaims(compactJws).getPayload().getSubject();
+    }
+
+    private static final class DeflateCompressionAlgorithm implements CompressionAlgorithm {
+        @Override
+        public String getId() {
+            return "DEF";
+        }
+
+        @Override
+        public OutputStream compress(OutputStream outputStream) {
+            return new DeflaterOutputStream(outputStream);
+        }
+
+        @Override
+        public InputStream decompress(InputStream inputStream) {
+            return new InflaterInputStream(inputStream);
+        }
+    }
+
+    private static final class GzipCompressionAlgorithm implements CompressionAlgorithm {
+        @Override
+        public String getId() {
+            return "GZIP";
+        }
+
+        @Override
+        public OutputStream compress(OutputStream outputStream) {
+            try {
+                return new GZIPOutputStream(outputStream);
+            } catch (java.io.IOException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
+
+        @Override
+        public InputStream decompress(InputStream inputStream) {
+            try {
+                return new GZIPInputStream(inputStream);
+            } catch (java.io.IOException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
     }
 }
diff --git a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/user-code-filter.json b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
index a40f1176..1d5aa4fd 100644
--- a/tests/src/io.jsonwebtoken/jjwt-gson/0.11.5/user-code-filter.json
+++ b/tests/src/io.jsonwebtoken/jjwt-gson/0.12.0/user-code-filter.json
@@ -1,13 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.jsonwebtoken.gson.**"
-    },
-    {
-      "includeClasses": "io.jsonwebtoken.**"
+      "includeClasses" : "io.jsonwebtoken.**"
     }
   ]
 }

```

