### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-metrics:1.56.0 using gpt-5.4

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.api.internal.IncubatingUtil"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -2,6 +2,10 @@
   {
     "latest" : true,
     "metadata-version" : "1.56.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.56.0/opentelemetry-sdk-metrics-1.56.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.56.0/sdk/metrics/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.56.0/opentelemetry-sdk-metrics-1.56.0-javadoc.jar",
     "tested-versions" : [
       "1.56.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,16 +1,22 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.56.0",
+    "tested-versions" : [
+      "1.56.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
+    "tested-versions" : [
       "1.19.0",
       "1.20.0",
       "1.20.1",
@@ -55,11 +61,14 @@
       "1.54.1",
       "1.55.0"
     ],
-    "skipped-versions": [
+    "skipped-versions" : [
       {
-        "version": "1.34.0",
-        "reason": "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
+        "version" : "1.34.0",
+        "reason" : "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
       }
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -2522,6 +2522,43 @@
               }
             }
           } ]
+        },
+        "1.56.0" : {
+          "versions" : [ {
+            "version" : "1.56.0",
+            "dynamicAccess" : {
+              "breakdown" : {
+                "reflection" : {
+                  "coverageRatio" : 0.0,
+                  "coveredCalls" : 0,
+                  "totalCalls" : 5
+                }
+              },
+              "coverageRatio" : 0.0,
+              "coveredCalls" : 0,
+              "totalCalls" : 5
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 228,
+                "missed" : 18459,
+                "ratio" : 0.012201,
+                "total" : 18687
+              },
+              "line" : {
+                "covered" : 66,
+                "missed" : 4194,
+                "ratio" : 0.015493,
+                "total" : 4260
+              },
+              "method" : {
+                "covered" : 24,
+                "missed" : 1184,
+                "ratio" : 0.019868,
+                "total" : 1208
+              }
+            }
+          } ]
         }
       }
     },

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-metrics:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--allow-incomplete-classpath')
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version=1.56.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.56.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'opentelemetry-sdk-metrics-test'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+
+public class OpenTelemetrySdkMetricsTest {
+
+    @Test
+    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
+
+        Method method =
+                SdkMeterProviderBuilder.class.getDeclaredMethod(
+                        "setExemplarFilter", ExemplarFilter.class);
+        method.setAccessible(true);
+        method.invoke(sdkMeterProvider, new ExemplarFilter() {
+            @Override
+            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+                return false;
+            }
+        });
+
+        try (SdkMeterProvider provider = sdkMeterProvider.build()) {
+            provider.meterBuilder("test");
+        }
+
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,42 +6,20 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider =
+                SdkMeterProvider.builder().setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");
         }
-
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #810

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-metrics:1.56.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 41389
- Cached input tokens: 0
- Output tokens: 3149
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 1.55
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 1.29

### Stats from `stats/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 0/5 covered calls (0.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 0/5 covered calls (0.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 165/15046 (1.10%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 228/18687 (1.22%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 45/3480 (1.29%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 66/4260 (1.55%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 15/999 (1.50%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 24/1208 (1.99%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
index 399b536e..b5ab7616 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/gradle.properties b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
index d0710188..1fc6342c 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
@@ -1,2 +1,2 @@
-library.version=1.19.0
-metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.19.0/
+library.version=1.56.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.56.0/
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
index c50a968c..651e723b 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,42 +6,20 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider =
+                SdkMeterProvider.builder().setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");
         }
-
     }
 }
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
new file mode 100644
index 00000000..91784540
--- /dev/null
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}

```

