### PR TITLE
Fix splitTestOnlyMetadata proxy detection

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
@@ -238,13 +238,16 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
             if (!(proxyNode instanceof ArrayNode proxyArray) || proxyArray.isEmpty()) {
                 return false;
             }
+            boolean referencesAnyTestPackage = false;
             for (JsonNode proxyType : proxyArray) {
-                if (!proxyType.isTextual()
-                        || testPackages.stream().noneMatch(testPackage -> referencesTestPackage(proxyType.asText(), testPackage))) {
+                if (!proxyType.isTextual()) {
                     return false;
                 }
+                if (testPackages.stream().anyMatch(testPackage -> referencesTestPackage(proxyType.asText(), testPackage))) {
+                    referencesAnyTestPackage = true;
+                }
             }
-            return true;
+            return referencesAnyTestPackage;
         }
         return false;
     }


### PR DESCRIPTION
Fixes #1814

### What does this PR do?
`splitTestOnlyMetadata` currently treats proxy reflection metadata as test-only only when all proxy interfaces belong to discovered test packages. This change updates that behavior so the proxy metadata is moved when at least one proxy interface belongs to a test package, which matches the intended handling for mixed proxy entries. The task still rejects malformed proxy entries that contain non-textual interface names.