### PR TITLE
Add missing descriptions to metadata indexes

### DIFF
--- a/metadata/at.yawk.lz4/lz4-java/index.json
+++ b/metadata/at.yawk.lz4/lz4-java/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/yawkat/lz4-java/tree/v1.10.4",
     "test-code-url" : "https://github.com/yawkat/lz4-java/tree/v1.10.4/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/at/yawk/lz4/lz4-java/1.10.4/lz4-java-1.10.4-javadoc.jar",
+    "description" : "lz4-java provides Java bindings and pure Java implementations of the LZ4 compression algorithm and XXHash hashing algorithm. It includes compressors, decompressors, and streaming APIs for high-performance data compression in Java applications.",
     "tested-versions" : [
       "1.10.4",
       "1.11.0"

--- a/metadata/berkeleydb/je/index.json
+++ b/metadata/berkeleydb/je/index.json
@@ -8,6 +8,7 @@
     "repository-url": "https://download.oracle.com/berkeley-db/je-3.2.76.zip",
     "test-code-url": "https://download.oracle.com/berkeley-db/je-3.2.76.zip",
     "documentation-url": "https://download.oracle.com/berkeley-db/docs/je/3.2.76/index.html",
+    "description": "Berkeley DB Java Edition is a pure Java embedded database library that provides a transactional key-value store built on a B+Tree access method. It lets applications persist and query local data using direct database APIs, collections bindings, and an object persistence layer.",
     "metadata-version": "3.2.76",
     "tested-versions": [
       "3.2.76"

--- a/metadata/ch.qos.logback.contrib/logback-jackson/index.json
+++ b/metadata/ch.qos.logback.contrib/logback-jackson/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/qos-ch/logback-contrib/tree/v_0.1.5",
     "test-code-url": "https://github.com/qos-ch/logback-contrib/tree/v_0.1.5/json",
     "documentation-url": "https://repo1.maven.org/maven2/ch/qos/logback/contrib/logback-jackson/0.1.5/logback-jackson-0.1.5-javadoc.jar",
+    "description": "logback-jackson provides a Jackson-based implementation of Logback Contrib's JSON formatter API. It converts log event data maps into JSON strings and supports optional pretty-printing through Jackson.",
     "tested-versions": [
       "0.1.5"
     ]

--- a/metadata/ch.qos.logback.contrib/logback-json-classic/index.json
+++ b/metadata/ch.qos.logback.contrib/logback-json-classic/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/qos-ch/logback-contrib/tree/v_0.1.5",
     "test-code-url": "https://github.com/qos-ch/logback-contrib/tree/v_0.1.5/json/classic/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/ch/qos/logback/contrib/logback-json-classic/0.1.5/logback-json-classic-0.1.5-javadoc.jar",
+    "description": "Provides a Logback Classic JSON layout that converts logging events into JSON output. It emits standard fields such as timestamp, level, thread, MDC, message, exception, and context.",
     "tested-versions": [
       "0.1.5"
     ]

--- a/metadata/ch.qos.logback/logback-classic/index.json
+++ b/metadata/ch.qos.logback/logback-classic/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/qos-ch/logback/tree/v_1.5.7",
     "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.7/logback-classic-1.5.7-test-sources.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.7/logback-classic-1.5.7-javadoc.jar",
+    "description" : "Logback Classic is the native SLF4J implementation for the Logback logging framework in Java applications. It provides logger configuration, appenders, layouts, and filtering for routing and formatting log events.",
     "test-version" : "1.4.1",
     "tested-versions" : [
       "1.5.7",
@@ -42,6 +43,7 @@
     "repository-url" : "https://github.com/qos-ch/logback/tree/v_1.4.9",
     "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.9/logback-classic-1.4.9-test-sources.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.9/logback-classic-1.4.9-javadoc.jar",
+    "description" : "Logback Classic is the native SLF4J implementation for the Logback logging framework in Java applications. It provides logger configuration, appenders, layouts, and filtering for routing and formatting log events.",
     "test-version" : "1.4.1",
     "tested-versions" : [
       "1.4.9",
@@ -69,6 +71,7 @@
     "repository-url" : "https://github.com/qos-ch/logback/tree/v_1.4.1",
     "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.1/logback-classic-1.4.1-test-sources.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.1/logback-classic-1.4.1-javadoc.jar",
+    "description" : "Logback Classic is the native SLF4J implementation for the Logback logging framework in Java applications. It provides logger configuration, appenders, layouts, and filtering for routing and formatting log events.",
     "tested-versions" : [
       "1.4.1"
     ],
@@ -83,6 +86,7 @@
     "repository-url" : "https://github.com/qos-ch/logback/tree/v_1.2.11",
     "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.11/logback-classic-1.2.11-test-sources.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.11/logback-classic-1.2.11-javadoc.jar",
+    "description" : "Logback Classic is the native SLF4J implementation for the Logback logging framework in Java applications. It provides logger configuration, appenders, layouts, and filtering for routing and formatting log events.",
     "tested-versions" : [
       "1.2.11"
     ],

--- a/metadata/com.atomikos/transactions/index.json
+++ b/metadata/com.atomikos/transactions/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://atomikos.repositoryhosting.com/hg/atomikos/development/file/6.0.0",
     "test-code-url": "https://atomikos.repositoryhosting.com/hg/atomikos/development/file/6.0.0/public/transactions/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/atomikos/transactions/6.0.0/transactions-6.0.0-javadoc.jar",
+    "description": "Atomikos Transactions Core provides the core transaction manager and two-phase commit coordination classes used for distributed transactions. It also includes recovery and log persistence components for durable transaction state and crash recovery.",
     "tested-versions": [
       "6.0.0"
     ]

--- a/metadata/com.ecwid.consul/consul-api/index.json
+++ b/metadata/com.ecwid.consul/consul-api/index.json
@@ -11,6 +11,7 @@
     "source-code-url": "https://repo1.maven.org/maven2/com/ecwid/consul/consul-api/1.4.5/consul-api-1.4.5-sources.jar",
     "repository-url": "https://github.com/Ecwid/consul-api/tree/v1.4.5",
     "test-code-url": "https://github.com/Ecwid/consul-api/tree/v1.4.5/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/ecwid/consul/consul-api/1.4.5/consul-api-1.4.5-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/com/ecwid/consul/consul-api/1.4.5/consul-api-1.4.5-javadoc.jar",
+    "description": "This library is a Java client for the Consul HTTP API. It lets Java applications interact with Consul features such as key-value storage, service registration, health checks, and catalog queries."
   }
 ]

--- a/metadata/com.fasterxml.jackson.core/jackson-core/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-core/index.json
@@ -38,6 +38,7 @@
     ],
     "allowed-packages" : [
       "com.fasterxml.jackson.core"
-    ]
+    ],
+    "description" : "Jackson Core provides the core abstractions and streaming JSON parser and generator implementation for Jackson. It lets Java applications read and write JSON incrementally with a low-level token-based API."
   }
 ]

--- a/metadata/com.fasterxml.jackson.core/jackson-databind/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-databind/index.json
@@ -33,6 +33,7 @@
     "repository-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.15.2",
     "test-code-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.15.2/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2-javadoc.jar",
+    "description" : "Jackson Databind provides general-purpose data binding and tree-model APIs for Jackson on top of the core streaming API. It converts between JSON and Java objects and can also work with other data formats when compatible parsers and generators are available.",
     "allowed-packages" : [
       "com.fasterxml.jackson",
       "java.sql",

--- a/metadata/com.fasterxml.jackson.module/jackson-module-kotlin/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-kotlin/index.json
@@ -30,6 +30,7 @@
     ],
     "allowed-packages" : [
       "com.fasterxml.jackson.module"
-    ]
+    ],
+    "description" : "Jackson module that adds support for serializing and deserializing Kotlin classes and data classes. It lets Jackson infer constructor parameter names and work with single-constructor classes without requiring explicit property name annotations or default constructors."
   }
 ]

--- a/metadata/com.fasterxml/classmate/index.json
+++ b/metadata/com.fasterxml/classmate/index.json
@@ -16,6 +16,7 @@
     ],
     "allowed-packages" : [
       "com.fasterxml"
-    ]
+    ],
+    "description" : "ClassMate is a Java library for introspecting types with full generic information, including resolved field and method types. It is especially useful for POJO and bean introspection."
   }
 ]

--- a/metadata/com.github.ben-manes.caffeine/caffeine/index.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/index.json
@@ -8,6 +8,7 @@
     "repository-url": "https://github.com/ben-manes/caffeine/tree/v3.1.2",
     "test-code-url": "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/3.1.2/caffeine-3.1.2-test.jar",
     "documentation-url": "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/3.1.2/caffeine-3.1.2-javadoc.jar",
+    "description": "Caffeine is a high-performance Java caching library that provides an in-memory cache with a Guava-inspired API. It supports automatic loading, size-based eviction, time-based expiration, refresh, reference-based entries, removal notifications, and cache statistics.",
     "metadata-version": "3.1.2",
     "tested-versions": [
       "3.1.2",
@@ -31,6 +32,7 @@
     "repository-url": "https://github.com/ben-manes/caffeine/tree/v2.9.3",
     "test-code-url": "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3-test.jar",
     "documentation-url": "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3-javadoc.jar",
+    "description": "Caffeine is a high-performance Java caching library that provides an in-memory cache with a Guava-inspired API. It supports automatic loading, size-based eviction, time-based expiration, refresh, reference-based entries, removal notifications, and cache statistics.",
     "metadata-version": "2.9.3",
     "tested-versions": [
       "2.9.3"

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -5,6 +5,7 @@
     "repository-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
     "test-code-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.2-5/zstd-jni-1.5.2-5-javadoc.jar",
+    "description" : "zstd-jni provides Java and JVM JNI bindings for the Zstandard compression library, including APIs for compressing and decompressing byte arrays. It also includes stream-based InputStream and OutputStream implementations that transparently read and write Zstandard-compressed data.",
     "tested-versions" : [
       "1.5.2-5"
     ],
@@ -14,6 +15,11 @@
   },
   {
     "metadata-version" : "1.5.4-1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.4-1/zstd-jni-1.5.4-1-sources.jar",
+    "repository-url" : "https://github.com/luben/zstd-jni",
+    "test-code-url" : "https://github.com/luben/zstd-jni/tree/v1.5.4-1/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.4-1/zstd-jni-1.5.4-1-javadoc.jar",
+    "description" : "zstd-jni provides JNI bindings for the Zstandard compression library to Java and other JVM languages. It exposes byte-array and stream-based APIs for compressing and decompressing data using the bundled native implementation.",
     "test-version" : "1.5.2-5",
     "tested-versions" : [
       "1.5.4-1"
@@ -29,6 +35,7 @@
     "repository-url" : "https://github.com/luben/zstd-jni",
     "test-code-url" : "https://github.com/luben/zstd-jni/tree/v1.5.5-1/src/test",
     "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.5-1/zstd-jni-1.5.5-1-javadoc.jar",
+    "description" : "zstd-jni provides JNI bindings for the Zstandard compression library to Java, Android, and other JVM languages. It offers byte-array and stream-based APIs for compressing and decompressing data using bundled native binaries.",
     "tested-versions" : [
       "1.5.5-1"
     ],

--- a/metadata/com.google.auth/google-auth-library-credentials/index.json
+++ b/metadata/com.google.auth/google-auth-library-credentials/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/googleapis/google-auth-library-java",
     "test-code-url" : "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.10.0/google-auth-library-credentials-1.10.0-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.10.0/google-auth-library-credentials-1.10.0-javadoc.jar",
+    "description" : "This artifact provides the base classes and interfaces used to represent Google credentials in Java. It supports authorized identities, request metadata callbacks, and service account signing abstractions for authentication flows.",
     "tested-versions" : [
       "1.10.0",
       "1.11.0",

--- a/metadata/com.google.guava/failureaccess/index.json
+++ b/metadata/com.google.guava/failureaccess/index.json
@@ -13,6 +13,7 @@
     ],
     "allowed-packages" : [
       "com.google.guava"
-    ]
+    ],
+    "description" : "failureaccess provides Guava's internal classes for optionally exposing the cause of a failed Future through a fast path. It includes InternalFutureFailureAccess and InternalFutures for lightweight failure-cause access used by Guava concurrency utilities."
   }
 ]

--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.23.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.23.0/protobuf-java-util-3.23.0-sources.jar",
+    "repository-url" : "https://github.com/protocolbuffers/protobuf",
+    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v23.0/java/util/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.23.0/protobuf-java-util-3.23.0-javadoc.jar",
+    "description" : "This library provides Java utility APIs for working with Protocol Buffers, including Proto3 JSON parsing and formatting. It also includes helpers for well-known protobuf types such as timestamps, durations, field masks, structs, and values.",
     "test-version" : "3.22.0",
     "tested-versions" : [
       "3.23.0",
@@ -18,6 +23,7 @@
     "repository-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0",
     "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.22.0/java/util/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.0/protobuf-java-util-3.22.0-javadoc.jar",
+    "description" : "This library provides Java utility APIs for working with Protocol Buffers, including JSON parsing and formatting support. It also adds helpers for common protobuf well-known types such as timestamps, durations, structs, values, and field masks.",
     "tested-versions" : [
       "3.22.0",
       "3.22.2",
@@ -41,6 +47,7 @@
     "repository-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.21.12",
     "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v3.21.12/java/util/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.12/protobuf-java-util-3.21.12-javadoc.jar",
+    "description" : "This library provides utility classes for working with Protocol Buffers in Java, including JSON formatting and helpers for timestamps, durations, structs, values, and field masks. It extends the core protobuf runtime with higher-level conversion and manipulation APIs for common protobuf types.",
     "tested-versions" : [
       "3.21.12"
     ],

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/graphql-java/graphql-java-extended-validation",
     "test-code-url": "https://github.com/graphql-java/graphql-java-extended-validation/tree/v19.1/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1/graphql-java-extended-validation-19.1-javadoc.jar",
+    "description": "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
     "tested-versions": [
       "19.1"
     ],

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/graphql-java/graphql-java",
     "test-code-url": "https://github.com/graphql-java/graphql-java/tree/v19.2/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-javadoc.jar",
+    "description": "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
     "tested-versions": [
       "19.2",
       "19.3",

--- a/metadata/com.h2database/h2/index.json
+++ b/metadata/com.h2database/h2/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/h2database/h2database",
     "test-code-url": "https://github.com/h2database/h2database/tree/version-2.1.210/h2/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/h2database/h2/2.1.210/h2-2.1.210-javadoc.jar",
+    "description": "H2 is a Java SQL relational database that can run embedded in an application or as a server-based database. It provides JDBC support and offers both disk-based and in-memory storage options.",
     "tested-versions": [
       "2.1.210",
       "2.1.212",

--- a/metadata/com.hazelcast/hazelcast/index.json
+++ b/metadata/com.hazelcast/hazelcast/index.json
@@ -8,6 +8,7 @@
     "repository-url": "https://github.com/hazelcast/hazelcast",
     "test-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-tests.jar",
     "documentation-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-javadoc.jar",
+    "description": "Hazelcast is an in-memory data grid and distributed computing platform for storing and processing data across a cluster of JVMs. It provides distributed data structures, caching, messaging, and cluster coordination for building scalable, fault-tolerant applications.",
     "tested-versions": [
       "5.2.1",
       "5.2.2",
@@ -26,6 +27,7 @@
     "repository-url": "https://github.com/hazelcast/hazelcast",
     "test-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-tests.jar",
     "documentation-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-javadoc.jar",
+    "description": "Hazelcast is a distributed computing and in-memory data platform for storing, querying, and processing data across a cluster. It provides distributed data structures, messaging, and stream processing features for building scalable, fault-tolerant applications.",
     "tested-versions": [
       "5.5.0",
       "5.6.0"

--- a/metadata/com.itextpdf/forms/index.json
+++ b/metadata/com.itextpdf/forms/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/itext/itext-java",
     "test-code-url" : "https://github.com/itext/itext-java/tree/8.0.3/forms/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/itextpdf/forms/8.0.3/forms-8.0.3-javadoc.jar",
+    "description" : "The iText forms module provides APIs for creating, reading, and modifying interactive PDF forms and their fields. It supports AcroForm and XFA processing, including field value updates, annotations, and form flattening.",
     "tested-versions" : [
       "8.0.3",
       "8.0.4",

--- a/metadata/com.itextpdf/io/index.json
+++ b/metadata/com.itextpdf/io/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/itext/itext-java",
     "test-code-url" : "https://github.com/itext/itext-java/tree/8.0.3/io/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/itextpdf/io/8.0.3/io-8.0.3-javadoc.jar",
+    "description" : "Provides iText's core input/output layer for reading and writing binary data, images, colors, and other low-level resources used in PDF processing. It also includes font parsing and encoding support plus random-access stream utilities that higher-level iText modules build on.",
     "tested-versions" : [
       "8.0.3",
       "8.0.4",

--- a/metadata/com.itextpdf/kernel/index.json
+++ b/metadata/com.itextpdf/kernel/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/itext/itext-java",
     "test-code-url" : "https://github.com/itext/itext-java/tree/8.0.3/kernel/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/itextpdf/kernel/8.0.3/kernel-8.0.3-javadoc.jar",
+    "description" : "The iText kernel module provides the core low-level PDF engine for reading, writing, and manipulating PDF documents in Java. It exposes the foundational PDF object model and processing APIs that higher-level iText modules build on.",
     "tested-versions" : [
       "8.0.3",
       "8.0.4",

--- a/metadata/com.itextpdf/layout/index.json
+++ b/metadata/com.itextpdf/layout/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/itext/itext-java",
     "test-code-url" : "https://github.com/itext/itext-java/tree/8.0.3/layout/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/itextpdf/layout/8.0.3/layout-8.0.3-javadoc.jar",
+    "description" : "iText Layout provides iText Core's high-level layout API for building PDF documents with elements such as paragraphs, tables, lists, and images. It handles page-aware composition and formatting on top of iText's lower-level PDF engine.",
     "tested-versions" : [
       "8.0.3",
       "8.0.4",

--- a/metadata/com.itextpdf/svg/index.json
+++ b/metadata/com.itextpdf/svg/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/itext/itext-java",
     "test-code-url" : "https://github.com/itext/itext-java/tree/8.0.3/svg/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/itextpdf/svg/8.0.3/svg-8.0.3-javadoc.jar",
+    "description" : "This iText module integrates SVG images into PDF creation and manipulation workflows. It parses and renders SVG content so it can be used within documents generated with iText.",
     "tested-versions" : [
       "8.0.3",
       "8.0.4",

--- a/metadata/com.microsoft.sqlserver/mssql-jdbc/index.json
+++ b/metadata/com.microsoft.sqlserver/mssql-jdbc/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/microsoft/mssql-jdbc",
     "test-code-url": "https://github.com/microsoft/mssql-jdbc/tree/v12.2.0/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.2.0.jre11/mssql-jdbc-12.2.0.jre11-javadoc.jar",
+    "description": "Microsoft JDBC Driver for SQL Server provides a Type 4 JDBC driver for connecting Java applications to Microsoft SQL Server and Azure SQL databases. It implements the JDBC API and supports SQL Server-specific connectivity features such as authentication, encryption, and data access.",
     "tested-versions": [
       "12.2.0.jre11",
       "12.3.0.jre11-preview",

--- a/metadata/com.mysql/mysql-connector-j/index.json
+++ b/metadata/com.mysql/mysql-connector-j/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/mysql/mysql-connector-j",
     "test-code-url": "https://github.com/mysql/mysql-connector-j/tree/8.0.31/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.31/mysql-connector-j-8.0.31-javadoc.jar",
+    "description": "MySQL Connector/J is the JDBC Type 4 driver for connecting Java applications to MySQL databases. It implements the JDBC API and provides connection, authentication, and data access support for MySQL servers.",
     "tested-versions": [
       "8.0.31",
       "8.0.32",

--- a/metadata/com.sun.istack/istack-commons-runtime/index.json
+++ b/metadata/com.sun.istack/istack-commons-runtime/index.json
@@ -6,6 +6,7 @@
     "tested-versions": [
       "3.0.7"
     ],
+    "description": "Provides the runtime portion of iStack Commons, a small set of shared utility classes used by JAXB and related Java XML and web-services components. It includes reusable support for annotations, localization, logging, XML and SAX helpers, and other common infrastructure.",
     "source-code-url": "https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.7/istack-commons-runtime-3.0.7-sources.jar",
     "repository-url": "https://github.com/javaee/jaxb-istack-commons",
     "test-code-url": "https://github.com/javaee/jaxb-istack-commons/tree/3.0.7-RELEASE/istack-commons/test",

--- a/metadata/com.sun.mail/jakarta.mail/index.json
+++ b/metadata/com.sun.mail/jakarta.mail/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/eclipse-ee4j/mail",
     "test-code-url": "https://github.com/eclipse-ee4j/mail/tree/2.0.1/mail/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/sun/mail/jakarta.mail/2.0.1/jakarta.mail-2.0.1-javadoc.jar",
+    "description": "Jakarta Mail provides a Java API for composing, sending, receiving, and processing email messages. It models common mail concepts and includes protocol-specific support for internet mail standards such as SMTP, POP3, IMAP, and MIME.",
     "tested-versions": [
       "2.0.1",
       "2.0.2"

--- a/metadata/com.zaxxer/HikariCP/index.json
+++ b/metadata/com.zaxxer/HikariCP/index.json
@@ -25,6 +25,7 @@
     "repository-url": "https://github.com/brettwooldridge/HikariCP",
     "test-code-url": "https://github.com/brettwooldridge/HikariCP/tree/HikariCP-6.0.0/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/com/zaxxer/HikariCP/6.0.0/HikariCP-6.0.0-javadoc.jar",
+    "description": "HikariCP is a high-performance JDBC connection pool for Java applications. It manages database connections efficiently to reduce latency and resource overhead.",
     "tested-versions": [
       "6.0.0",
       "6.1.0",

--- a/metadata/commons-cli/commons-cli/index.json
+++ b/metadata/commons-cli/commons-cli/index.json
@@ -18,6 +18,7 @@
     "allowed-packages" : [
       "org.apache.commons.cli",
       "java.util"
-    ]
+    ],
+    "description" : "Apache Commons CLI provides a simple API for defining, processing, and validating command-line options in Java applications. It helps applications parse arguments, enforce option rules, and generate usage information."
   }
 ]

--- a/metadata/commons-codec/commons-codec/index.json
+++ b/metadata/commons-codec/commons-codec/index.json
@@ -25,6 +25,7 @@
     ],
     "allowed-packages" : [
       "org.apache.commons.codec"
-    ]
+    ],
+    "description" : "Apache Commons Codec provides implementations of common encoders and decoders such as Base64, hexadecimal, phonetic, and digest utilities. It helps Java applications transform binary and text data using standard encoding, hashing, and checksum algorithms."
   }
 ]

--- a/metadata/commons-logging/commons-logging/index.json
+++ b/metadata/commons-logging/commons-logging/index.json
@@ -7,6 +7,7 @@
     "repository-url": "https://github.com/apache/commons-logging",
     "test-code-url": "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-test-sources.jar",
     "documentation-url": "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-javadoc.jar",
+    "description": "Apache Commons Logging is a thin logging bridge for Java that provides a simple wrapper API over multiple logging implementations. It lets libraries use a common logging API while deferring the choice of concrete logging backend to runtime.",
     "metadata-version": "1.2",
     "tested-versions": [
       "1.2",

--- a/metadata/dev.langchain4j/langchain4j/index.json
+++ b/metadata/dev.langchain4j/langchain4j/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/langchain4j/langchain4j",
     "test-code-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/1.9.0/langchain4j-1.9.0-test-sources.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/1.9.0/langchain4j-1.9.0-javadoc.jar",
+    "description" : "LangChain4j is an open-source Java library that simplifies integrating large language models into Java applications through a unified API. It provides abstractions and integrations for building AI features such as chat, retrieval-augmented generation, tool calling, and agents.",
     "tested-versions" : [
       "1.9.0",
       "1.9.1",

--- a/metadata/io.grpc/grpc-context/index.json
+++ b/metadata/io.grpc/grpc-context/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/grpc/grpc-java",
     "test-code-url" : "https://github.com/grpc/grpc-java/tree/v1.27.2/context/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.27.2/grpc-context-1.27.2-javadoc.jar",
+    "description" : "grpc-context provides gRPC's context propagation API for carrying scoped values and cancellation state across API boundaries and threads. It lets applications associate request-scoped data with the current execution and propagate that state through asynchronous work.",
     "tested-versions" : [
       "1.27.2",
       "1.28.0",

--- a/metadata/io.grpc/grpc-core/index.json
+++ b/metadata/io.grpc/grpc-core/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/grpc/grpc-java",
     "test-code-url" : "https://github.com/grpc/grpc-java/tree/v1.69.0/core/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.69.0/grpc-core-1.69.0-javadoc.jar",
+    "description" : "Core runtime classes for gRPC Java, including channels, calls, name resolution, load balancing, deadlines, and transport abstractions. It provides the foundational client and server behavior that higher-level gRPC Java transports and stubs build on.",
     "tested-versions" : [
       "1.69.0",
       "1.69.1",

--- a/metadata/io.grpc/grpc-netty/index.json
+++ b/metadata/io.grpc/grpc-netty/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/grpc/grpc-java",
     "test-code-url" : "https://github.com/grpc/grpc-java/tree/v1.51.0/netty/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.51.0/grpc-netty-1.51.0-javadoc.jar",
+    "description" : "grpc-netty is gRPC Java's main Netty-based transport implementation for both clients and servers. It provides HTTP/2 networking integration on top of Netty for gRPC communication.",
     "tested-versions" : [
       "1.51.0",
       "1.51.1",

--- a/metadata/io.jsonwebtoken/jjwt-gson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-gson/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/jwtk/jjwt",
     "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/gson/src/test",
     "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
+    "description" : "Provides Gson-based JSON serialization and deserialization support for the JJWT library. When present on the runtime classpath, it lets JJWT automatically use Gson to process JWT headers and claims.",
     "tested-versions" : [
       "0.12.0",
       "0.12.1",
@@ -25,6 +26,7 @@
     "repository-url" : "https://github.com/jwtk/jjwt",
     "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/gson/src/test",
     "documentation-url" : "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
+    "description" : "Provides Gson-based JSON serialization and deserialization support for the JJWT library. When present on the runtime classpath, it lets JJWT automatically use Gson to process JWT headers and claims.",
     "tested-versions" : [
       "0.11.5"
     ],

--- a/metadata/io.jsonwebtoken/jjwt-jackson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-jackson/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/jwtk/jjwt",
     "test-code-url": "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/jackson/src/test",
     "documentation-url": "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
+    "description": "jjwt-jackson provides Jackson-based JSON serializer and deserializer implementations for JJWT. It lets JJWT encode JWT headers and claims to JSON and parse them back using Jackson.",
     "tested-versions": [
       "0.12.0",
       "0.12.1",
@@ -28,6 +29,7 @@
     "repository-url": "https://github.com/jwtk/jjwt",
     "test-code-url": "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/jackson/src/test",
     "documentation-url": "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
+    "description": "jjwt-jackson provides Jackson-based JSON serializer and deserializer implementations for JJWT. It lets JJWT encode JWT headers and claims to JSON and parse them back using Jackson.",
     "tested-versions": [
       "0.11.5"
     ]

--- a/metadata/io.jsonwebtoken/jjwt-orgjson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-orgjson/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/jwtk/jjwt",
     "test-code-url": "https://github.com/jwtk/jjwt/tree/0.12.7/extensions/orgjson/src/test",
     "documentation-url": "https://github.com/jwtk/jjwt/blob/0.12.7/README.adoc",
+    "description": "The jjwt-orgjson module provides JJWT's org.json-based serializer and deserializer so JWT headers and claims can be read and written using JSON-Java. It is the recommended JSON backend for Android applications and supports simple object-to-JSON marshaling instead of POJO unmarshalling.",
     "test-version": "0.12.0",
     "tested-versions": [
       "0.12.7",
@@ -24,6 +25,7 @@
     "repository-url": "https://github.com/jwtk/jjwt",
     "test-code-url": "https://github.com/jwtk/jjwt/tree/0.12.0/extensions/orgjson/src/test",
     "documentation-url": "https://github.com/jwtk/jjwt/blob/0.12.0/README.md",
+    "description": "The jjwt-orgjson module provides JJWT's org.json-based serializer and deserializer so JWT claims and headers can be read and written using JSON-Java. It is the recommended JSON backend for Android applications and supports simple object-to-JSON marshaling rather than POJO unmarshalling.",
     "tested-versions": [
       "0.12.0",
       "0.12.1",
@@ -43,6 +45,7 @@
     "repository-url": "https://github.com/jwtk/jjwt",
     "test-code-url": "https://github.com/jwtk/jjwt/tree/0.11.5/extensions/orgjson/src/test",
     "documentation-url": "https://github.com/jwtk/jjwt/blob/0.11.5/README.md",
+    "description": "The jjwt-orgjson module provides JJWT's org.json-based JSON serializer and deserializer implementation for processing JWT content at runtime. It is the recommended JSON backend for Android use cases and supports simple claim marshaling without POJO unmarshalling.",
     "tested-versions": [
       "0.11.5"
     ]

--- a/metadata/io.nats/jnats/index.json
+++ b/metadata/io.nats/jnats/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/nats-io/nats.java",
     "test-code-url": "https://github.com/nats-io/nats.java/tree/2.16.11/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/io/nats/jnats/2.16.11/jnats-2.16.11-javadoc.jar",
+    "description": "jnats is the Java client for NATS, providing APIs to connect to NATS servers and publish, subscribe, and request messages. It also supports JetStream features such as streaming, key-value, and object store access for Java applications.",
     "tested-versions": [
       "2.16.11",
       "2.16.12",

--- a/metadata/io.netty/netty-common/index.json
+++ b/metadata/io.netty/netty-common/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/netty/netty",
     "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.115.Final/netty-common-4.1.115.Final-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.115.Final/netty-common-4.1.115.Final-javadoc.jar",
+    "description": "Provides Netty's core utility classes, concurrency abstractions, collections, timers, and internal logging infrastructure. It supplies the shared low-level building blocks that other Netty modules use for asynchronous network applications.",
     "tested-versions": [
       "4.1.115.Final",
       "4.1.116.Final",
@@ -41,6 +42,7 @@
     "repository-url": "https://github.com/netty/netty",
     "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.80.Final/netty-common-4.1.80.Final-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-common/4.1.80.Final/netty-common-4.1.80.Final-javadoc.jar",
+    "description": "Provides Netty's core utility classes, concurrency abstractions, collections, timers, and internal logging infrastructure. It supplies the shared low-level building blocks that other Netty modules use for asynchronous network applications.",
     "tested-versions": [
       "4.1.80.Final"
     ]

--- a/metadata/io.netty/netty-transport/index.json
+++ b/metadata/io.netty/netty-transport/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/netty/netty",
     "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.115.Final/netty-transport-4.1.115.Final-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.115.Final/netty-transport-4.1.115.Final-javadoc.jar",
+    "description": "Netty Transport provides the core channel and transport infrastructure used to build asynchronous event-driven network clients and servers. It supplies abstractions and implementations for I/O operations, event loops, channels, and bootstrapping within the Netty framework.",
     "tested-versions": [
       "4.1.115.Final",
       "4.1.116.Final",
@@ -41,6 +42,7 @@
     "repository-url": "https://github.com/netty/netty",
     "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.80.Final/netty-transport-4.1.80.Final-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport/4.1.80.Final/netty-transport-4.1.80.Final-javadoc.jar",
+    "description": "Netty Transport provides the core channel and transport infrastructure used to build asynchronous event-driven network clients and servers. It supplies abstractions and implementations for I/O operations, event loops, channels, and bootstrapping within the Netty framework.",
     "tested-versions": [
       "4.1.80.Final"
     ]

--- a/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.20.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-jaeger/1.20.0/opentelemetry-exporter-jaeger-1.20.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.20.0/exporters/jaeger/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-jaeger/1.20.0/opentelemetry-exporter-jaeger-1.20.0-javadoc.jar",
+    "description" : "This library exports OpenTelemetry span data to Jaeger over gRPC. It lets Java applications send collected traces to a Jaeger endpoint.",
     "test-version" : "1.19.0",
     "tested-versions" : [
       "1.20.0",
@@ -33,6 +38,7 @@
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/jaeger/src/test",
     "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/jaeger/README.md",
+    "description" : "This library exports OpenTelemetry span data to Jaeger over gRPC. It lets Java applications send collected traces to a Jaeger endpoint and supports Java 8+ and Android API level 24+.",
     "tested-versions" : [
       "1.19.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.20.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-exporter-logging/1.20.0/opentelemetry-exporter-logging-1.20.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.20.0/exporters/logging/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.20.0/exporters/logging/README.md",
+    "description" : "Provides OpenTelemetry exporters that write spans and metrics via java.util.logging and emit log records to standard output. It is intended for debugging and local inspection of telemetry rather than production export pipelines.",
     "test-version" : "1.19.0",
     "tested-versions" : [
       "1.20.0",
@@ -33,6 +38,7 @@
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/logging/src/test",
     "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/logging/README.md",
+    "description" : "Provides OpenTelemetry SDK exporters that write spans and metrics through java.util.logging and log records to standard output. It is mainly intended for local debugging and inspection of telemetry data rather than production export pipelines.",
     "tested-versions" : [
       "1.19.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/otlp/all/src/test",
     "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/otlp/all/README.md",
+    "description" : "Provides OpenTelemetry exporters that send traces and metrics to OTLP-compatible backends. This artifact packages the OTLP gRPC exporters used by Java applications to emit telemetry data to collectors and observability platforms.",
     "tested-versions" : [
       "1.19.0",
       "1.20.0",

--- a/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.20.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-zipkin/1.20.0/opentelemetry-exporter-zipkin-1.20.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.20.0/exporters/zipkin/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.20.0/exporters/zipkin/README.md",
+    "description" : "This library exports OpenTelemetry span data to a Zipkin-compatible backend using the Zipkin reporter. By default it sends spans in Zipkin JSON format over HTTP to a configured endpoint, with support for alternate encodings or custom senders.",
     "test-version" : "1.19.0",
     "tested-versions" : [
       "1.20.0",
@@ -33,6 +38,7 @@
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/exporters/zipkin/src/test",
     "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/exporters/zipkin/README.md",
+    "description" : "This library exports OpenTelemetry span data to a Zipkin-compatible backend using the Zipkin reporter. By default it sends spans in Zipkin format over HTTP and can be configured for other encodings or transports.",
     "tested-versions" : [
       "1.19.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
     "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
+    "description": "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
     "tested-versions": [
       "1.19.0",
       "1.20.0",

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
     "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/trace/src/test",
     "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/trace/README.md",
+    "description": "OpenTelemetry SDK Trace provides the Java SDK implementation for distributed tracing. It creates and manages tracers, spans, and trace processing and export pipelines for instrumented applications.",
     "tested-versions": [
       "1.19.0",
       "1.20.0",

--- a/metadata/io.undertow/undertow-core/index.json
+++ b/metadata/io.undertow/undertow-core/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/undertow-io/undertow",
     "test-code-url" : "https://repo1.maven.org/maven2/io/undertow/undertow-core/2.3.0.Final/undertow-core-2.3.0.Final-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/io/undertow/undertow-core/2.3.0.Final/undertow-core-2.3.0.Final-javadoc.jar",
+    "description" : "Undertow Core is a high-performance Java web server library built on non-blocking I/O. It provides the core HTTP server and protocol handling used to build embedded servers and web applications.",
     "tested-versions" : [
       "2.3.0.Final",
       "2.3.1.Final",
@@ -43,6 +44,7 @@
     "repository-url" : "https://github.com/undertow-io/undertow",
     "test-code-url" : "https://repo1.maven.org/maven2/io/undertow/undertow-core/2.2.19.Final/undertow-core-2.2.19.Final-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/io/undertow/undertow-core/2.2.19.Final/undertow-core-2.2.19.Final-javadoc.jar",
+    "description" : "Undertow Core is a high-performance Java web server library built on non-blocking I/O. It provides the core HTTP server and protocol handling used to build embedded servers and web applications.",
     "tested-versions" : [
       "2.2.19.Final",
       "2.2.20.Final",

--- a/metadata/jakarta.servlet/jakarta.servlet-api/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/jakartaee/servlet",
     "test-code-url": "N/A",
     "documentation-url": "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/5.0.0/jakarta.servlet-api-5.0.0-javadoc.jar",
+    "description": "Jakarta Servlet defines the standard server-side API for Java web applications to process HTTP requests and generate responses. It provides interfaces and classes for servlets, filters, listeners, sessions, and deployment descriptors in Jakarta EE 9.",
     "tested-versions": [
       "5.0.0",
       "6.0.0",

--- a/metadata/jakarta.validation/jakarta.validation-api/index.json
+++ b/metadata/jakarta.validation/jakarta.validation-api/index.json
@@ -16,6 +16,7 @@
     ],
     "allowed-packages" : [
       "jakarta.validation"
-    ]
+    ],
+    "description" : "Jakarta Validation defines a metadata model and API for JavaBean and method validation. It lets applications declare constraints on objects, method parameters, and return values and validate them through a standard Validator API."
   }
 ]

--- a/metadata/javax.cache/cache-api/index.json
+++ b/metadata/javax.cache/cache-api/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/jsr107/jsr107spec",
     "test-code-url": "N/A",
     "documentation-url": "https://repo1.maven.org/maven2/javax/cache/cache-api/1.1.1/cache-api-1.1.1-javadoc.jar",
+    "description": "JSR107 (JCache) defines the standard Java API and SPI for interacting with caches. It lets applications use a common caching abstraction while enabling providers to implement compatible cache integrations.",
     "tested-versions": [
       "1.1.1"
     ]

--- a/metadata/javax.servlet/javax.servlet-api/index.json
+++ b/metadata/javax.servlet/javax.servlet-api/index.json
@@ -13,6 +13,7 @@
     ],
     "allowed-packages" : [
       "javax.servlet"
-    ]
+    ],
+    "description" : "Defines the Java Servlet 3.1 API for handling HTTP requests and responses in Java web applications. It provides the standard interfaces, classes, annotations, and asynchronous processing contracts used by servlet containers and web components."
   }
 ]

--- a/metadata/log4j/log4j/index.json
+++ b/metadata/log4j/log4j/index.json
@@ -8,6 +8,7 @@
     "repository-url": "https://github.com/apache/logging-log4j1",
     "test-code-url": "https://github.com/apache/logging-log4j1/tree/log4j-1.2.17/tests",
     "documentation-url": "https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17-javadoc.jar",
+    "description": "Apache Log4j 1.2 is a Java logging framework that lets applications route log events to appenders such as the console, files, sockets, JDBC, and JMS. It provides hierarchical loggers plus configurable layouts, filters, and XML or properties-based configuration.",
     "metadata-version": "1.2.17",
     "tested-versions": [
       "1.2.17"

--- a/metadata/mysql/mysql-connector-java/index.json
+++ b/metadata/mysql/mysql-connector-java/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/mysql/mysql-connector-j",
     "test-code-url": "https://github.com/mysql/mysql-connector-j/tree/8.0.29/src/test",
     "documentation-url": "https://github.com/mysql/mysql-connector-j/blob/8.0.29/README.md",
+    "description": "MySQL Connector/J is a JDBC Type 4 driver that lets Java applications connect to MySQL databases. It also includes support for MySQL X DevAPI for working with MySQL as a document store.",
     "tested-versions": [
       "8.0.29",
       "8.0.30",

--- a/metadata/net.java.dev.jna/jna/index.json
+++ b/metadata/net.java.dev.jna/jna/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/java-native-access/jna",
     "test-code-url": "https://github.com/java-native-access/jna/tree/5.8.0/test",
     "documentation-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.8.0/jna-5.8.0-javadoc.jar",
+    "description": "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
     "tested-versions": [
       "5.8.0",
       "5.9.0",

--- a/metadata/org.apache.activemq/activemq-broker/index.json
+++ b/metadata/org.apache.activemq/activemq-broker/index.json
@@ -5,6 +5,7 @@
     "repository-url" : "https://github.com/apache/activemq",
     "test-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-broker/5.18.1/activemq-broker-5.18.1-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-broker/5.18.1/activemq-broker-5.18.1-javadoc.jar",
+    "description" : "ActiveMQ Broker provides the core Apache ActiveMQ Classic message broker implementation for routing, storing, and managing messages. It includes broker services such as destinations, persistence, security, transactions, and network-of-brokers support.",
     "tested-versions" : [
       "5.18.1",
       "5.18.2",
@@ -27,6 +28,7 @@
     "repository-url" : "https://github.com/apache/activemq",
     "test-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-broker/6.0.0/activemq-broker-6.0.0-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-broker/6.0.0/activemq-broker-6.0.0-javadoc.jar",
+    "description" : "ActiveMQ Broker provides the core Apache ActiveMQ Classic message broker implementation for routing, storing, and managing messages. It includes broker services such as destinations, persistence, security, transactions, and network-of-brokers support.",
     "tested-versions" : [
       "6.0.0",
       "6.0.1",

--- a/metadata/org.apache.activemq/activemq-client/index.json
+++ b/metadata/org.apache.activemq/activemq-client/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/apache/activemq",
     "test-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-client/6.0.0/activemq-client-6.0.0-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-client/6.0.0/activemq-client-6.0.0-javadoc.jar",
+    "description" : "Apache ActiveMQ Client is the Java client library for Apache ActiveMQ Classic. It provides the Jakarta Messaging (JMS) client and transport classes applications use to connect to brokers and send or receive messages.",
     "tested-versions" : [
       "6.0.0",
       "6.0.1",
@@ -34,6 +35,7 @@
     "repository-url" : "https://github.com/apache/activemq",
     "test-code-url" : "https://github.com/apache/activemq/tree/activemq-5.18.1/activemq-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-client/5.18.1/activemq-client-5.18.1-javadoc.jar",
+    "description" : "Apache ActiveMQ Client is the Java client library for Apache ActiveMQ Classic. It provides the JMS and transport classes applications use to connect to brokers and send or receive messages.",
     "tested-versions" : [
       "5.18.1",
       "5.18.2",

--- a/metadata/org.apache.activemq/artemis-jms-client/index.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/apache/artemis",
     "test-code-url" : "https://github.com/apache/artemis/tree/2.36.0/artemis-jms-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client/2.36.0/artemis-jms-client-2.36.0-javadoc.jar",
+    "description" : "ActiveMQ Artemis JMS Client provides the Jakarta Messaging client implementation for connecting Java applications to Apache ActiveMQ Artemis brokers. It lets applications create JMS connections, sessions, producers, and consumers to send and receive messages over Artemis.",
     "test-version" : "2.28.0",
     "tested-versions" : [
       "2.36.0",
@@ -32,6 +33,7 @@
     "repository-url" : "https://github.com/apache/artemis",
     "test-code-url" : "https://github.com/apache/artemis/tree/2.32.0/artemis-jms-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client/2.32.0/artemis-jms-client-2.32.0-javadoc.jar",
+    "description" : "ActiveMQ Artemis JMS Client provides the Jakarta Messaging client implementation for connecting Java applications to Apache ActiveMQ Artemis brokers. It lets applications create JMS connections, sessions, producers, and consumers to send and receive messages over Artemis.",
     "test-version" : "2.28.0",
     "tested-versions" : [
       "2.32.0",
@@ -49,6 +51,7 @@
     "repository-url" : "https://github.com/apache/artemis",
     "test-code-url" : "https://github.com/apache/artemis/tree/2.29.0/artemis-jms-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client/2.29.0/artemis-jms-client-2.29.0-javadoc.jar",
+    "description" : "ActiveMQ Artemis JMS Client provides the JMS 2.0 client implementation for connecting Java applications to Apache ActiveMQ Artemis brokers. It lets applications create JMS connections, sessions, producers, and consumers, and translates JMS interactions to the Artemis core client API.",
     "test-version" : "2.28.0",
     "tested-versions" : [
       "2.29.0"
@@ -63,6 +66,7 @@
     "repository-url" : "https://github.com/apache/artemis",
     "test-code-url" : "https://github.com/apache/artemis/tree/2.28.0/artemis-jms-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client/2.28.0/artemis-jms-client-2.28.0-javadoc.jar",
+    "description" : "ActiveMQ Artemis JMS Client provides a Jakarta JMS client implementation for connecting Java applications to Apache ActiveMQ Artemis brokers. It lets applications create JMS connections, sessions, producers, and consumers to send and receive messages over Artemis.",
     "tested-versions" : [
       "2.28.0"
     ],

--- a/metadata/org.apache.commons/commons-compress/index.json
+++ b/metadata/org.apache.commons/commons-compress/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/commons-compress",
     "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0-javadoc.jar",
+    "description": "Apache Commons Compress provides APIs for reading and writing common archive and compression formats. It supports formats such as ZIP, TAR, 7z, AR, CPIO, GZIP, BZIP2, XZ, LZ4, Brotli, and Zstandard.",
     "tested-versions": [
       "1.23.0",
       "1.24.0",

--- a/metadata/org.apache.commons/commons-dbcp2/index.json
+++ b/metadata/org.apache.commons/commons-dbcp2/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/commons-dbcp",
     "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-dbcp2/2.12.0/commons-dbcp2-2.12.0-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-dbcp2/2.12.0/commons-dbcp2-2.12.0-javadoc.jar",
+    "description": "Apache Commons DBCP implements database connection pooling for Java applications. It manages and reuses JDBC connections to improve efficiency and resource usage.",
     "tested-versions": [
       "2.12.0",
       "2.13.0",

--- a/metadata/org.apache.commons/commons-pool2/index.json
+++ b/metadata/org.apache.commons/commons-pool2/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/commons-pool",
     "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1-javadoc.jar",
+    "description": "Apache Commons Pool provides an object-pooling API and several pool implementations for managing reusable objects. It helps Java applications reduce the cost of creating expensive objects by controlling their lifecycle, validation, and reuse.",
     "tested-versions": [
       "2.11.1",
       "2.12.0",

--- a/metadata/org.apache.httpcomponents/httpclient/index.json
+++ b/metadata/org.apache.httpcomponents/httpclient/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/httpcomponents-client",
     "test-code-url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14-tests.jar",
     "documentation-url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14-javadoc.jar",
+    "description": "Apache HttpClient is a client-side HTTP library for sending requests and handling responses in Java applications. It provides APIs for connection management, authentication, cookies, redirects, and other common HTTP features.",
     "tested-versions": [
       "4.5.14"
     ]

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -7,6 +7,7 @@
     "repository-url": "https://github.com/apache/httpcomponents-core",
     "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-tests.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-javadoc.jar",
+    "description": "Apache HttpCore provides the low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
     "tested-versions": [
       "4.4.9"
     ]

--- a/metadata/org.apache.kafka/kafka-clients/index.json
+++ b/metadata/org.apache.kafka/kafka-clients/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/kafka",
     "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/3.5.1/kafka-clients-3.5.1-test-sources.jar",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/3.5.1/kafka-clients-3.5.1-javadoc.jar",
+    "description": "Apache Kafka's Java client library provides APIs for producing records to Kafka, consuming records from Kafka, and administering Kafka clusters. It lets Java applications interact with Kafka brokers through the producer, consumer, and AdminClient APIs.",
     "tested-versions": [
       "3.5.1",
       "3.5.2"

--- a/metadata/org.apache.kafka/kafka-streams/index.json
+++ b/metadata/org.apache.kafka/kafka-streams/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/apache/kafka",
     "test-code-url": "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/3.5.1/kafka-streams-3.5.1-test-sources.jar",
     "documentation-url": "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/3.5.1/kafka-streams-3.5.1-javadoc.jar",
+    "description": "Apache Kafka Streams is a client library for building applications and microservices that process data stored in Kafka clusters. It lets Java applications define stream-processing topologies to transform, join, aggregate, and materialize event streams and tables.",
     "tested-versions": [
       "3.5.1",
       "3.5.2"

--- a/metadata/org.apache.santuario/xmlsec/index.json
+++ b/metadata/org.apache.santuario/xmlsec/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/santuario-xml-security-java",
     "test-code-url": "https://github.com/apache/santuario-xml-security-java/tree/xmlsec-4.0.4/src/test",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/santuario/xmlsec/4.0.4/xmlsec-4.0.4-javadoc.jar",
+    "description": "Apache Santuario XML Security for Java implements XML Signature and XML Encryption standards for Java applications. It provides the JSR-105 API along with DOM-based and StAX-based implementations for signing, encrypting, and processing XML security data.",
     "tested-versions": [
       "4.0.4"
     ]

--- a/metadata/org.apache.tomcat.embed/tomcat-embed-core/index.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-core/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/apache/tomcat",
     "test-code-url" : "https://github.com/apache/tomcat/tree/10.1.0/test",
     "documentation-url" : "https://github.com/apache/tomcat/tree/10.1.0/webapps/docs",
+    "description" : "Apache Tomcat Embed provides the core Tomcat server implementation for embedding a servlet container in a Java application. It supplies the runtime components needed to run Jakarta Servlet-based web applications without deploying to a separate Tomcat installation.",
     "tested-versions" : [
       "10.1.0",
       "10.1.1",
@@ -85,6 +86,7 @@
     "repository-url" : "https://github.com/apache/tomcat",
     "test-code-url" : "https://github.com/apache/tomcat/tree/10.0.20/test",
     "documentation-url" : "https://github.com/apache/tomcat/tree/10.0.20/webapps/docs",
+    "description" : "Apache Tomcat Embed is a library that allows you to embed Tomcat in your application. The tomcat-embed-core artifact provides the core Tomcat server implementation for running an embedded servlet container.",
     "tested-versions" : [
       "10.0.20",
       "10.0.21",

--- a/metadata/org.apache.tomcat/tomcat-jdbc/index.json
+++ b/metadata/org.apache.tomcat/tomcat-jdbc/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/apache/tomcat",
     "test-code-url": "https://github.com/apache/tomcat/tree/10.1.7/modules/jdbc-pool/src/test",
     "documentation-url": "https://github.com/apache/tomcat/tree/10.1.7/webapps/docs",
+    "description": "Tomcat JDBC is Apache Tomcat's JDBC connection pool implementation for creating, managing, and monitoring pooled database connections. It provides a DataSource API with pooling, validation, JMX integration, and interceptors for Java applications running inside or outside Tomcat.",
     "tested-versions": [
       "10.1.7",
       "10.1.8",

--- a/metadata/org.apache.yetus/audience-annotations/index.json
+++ b/metadata/org.apache.yetus/audience-annotations/index.json
@@ -12,6 +12,7 @@
     ],
     "allowed-packages" : [
       "org.apache.yetus"
-    ]
+    ],
+    "description" : "Apache Yetus Audience Annotations provides Java annotations for marking intended API audience boundaries such as public, limited-private, and private. It also includes doclet support for generating Javadocs filtered to the intended audience."
   }
 ]

--- a/metadata/org.apache.zookeeper/zookeeper/index.json
+++ b/metadata/org.apache.zookeeper/zookeeper/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/apache/zookeeper",
     "test-code-url" : "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.8.1/zookeeper-3.8.1-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.8.1/zookeeper-3.8.1-javadoc.jar",
+    "description" : "Apache ZooKeeper is a centralized coordination service for distributed applications. It provides primitives for configuration management, naming, distributed synchronization, and group services.",
     "tested-versions" : [
       "3.8.1",
       "3.8.2",

--- a/metadata/org.bouncycastle/bcpkix-jdk15on/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk15on/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/bcgit/bc-java",
     "test-code-url": "https://github.com/bcgit/bc-java/tree/r1rv70/pkix/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15on/1.70/bcpkix-jdk15on-1.70-javadoc.jar",
+    "description": "Bouncy Castle PKIX provides Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. It supports parsing, creating, and processing PKIX- and certificate-related cryptographic structures on JDK 1.5 and later.",
     "tested-versions": [
       "1.70"
     ]

--- a/metadata/org.bouncycastle/bcpkix-jdk15to18/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk15to18/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/bcgit/bc-java",
     "test-code-url" : "https://github.com/bcgit/bc-java/tree/r1rv77/pkix/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15to18/1.77/bcpkix-jdk15to18-1.77-javadoc.jar",
+    "description" : "Provides Bouncy Castle Java APIs for PKIX, CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. It targets JDK 1.5 through JDK 1.8 and is typically used alongside a JCE/JCA provider such as Bouncy Castle's cryptography provider.",
     "tested-versions" : [
       "1.77",
       "1.78",

--- a/metadata/org.bouncycastle/bcpkix-jdk18on/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk18on/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/bcgit/bc-java",
     "test-code-url" : "https://github.com/bcgit/bc-java/tree/r1rv77/pkix/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.77/bcpkix-jdk18on-1.77-javadoc.jar",
+    "description" : "Bouncy Castle PKIX provides Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and X.509 certificate generation on JDK 1.8 and later. It is typically used with a JCE/JCA provider such as Bouncy Castle to build and process public-key infrastructure and related cryptographic message formats.",
     "tested-versions" : [
       "1.77",
       "1.78",

--- a/metadata/org.checkerframework/checker-compat-qual/index.json
+++ b/metadata/org.checkerframework/checker-compat-qual/index.json
@@ -12,6 +12,7 @@
     ],
     "allowed-packages" : [
       "org.checkerframework"
-    ]
+    ],
+    "description" : "This artifact provides compatibility annotations from the Checker Framework, including declaration-only nullness and key qualifiers such as @NullableDecl, @NonNullDecl, and @KeyForDecl, for use in Java 7 code. It lets code use these qualifiers without depending on Java 8 type-annotation classes."
   }
 ]

--- a/metadata/org.eclipse.angus/jakarta.mail/index.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/eclipse-ee4j/angus-mail",
     "test-code-url": "https://github.com/eclipse-ee4j/angus-mail/tree/1.0.0/providers/angus-mail/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/eclipse/angus/jakarta.mail/1.0.0/jakarta.mail-1.0.0-javadoc.jar",
+    "description": "Angus Mail is the Eclipse implementation of the Jakarta Mail 2.1 specification. It provides the Jakarta Mail API together with SMTP, IMAP, and POP3 providers for building Java mail and messaging applications.",
     "tested-versions": [
       "1.0.0",
       "1.1.0",

--- a/metadata/org.eclipse.jetty.alpn/alpn-api/index.json
+++ b/metadata/org.eclipse.jetty.alpn/alpn-api/index.json
@@ -7,6 +7,7 @@
     "repository-url": "https://github.com/jetty/jetty-alpn-api",
     "test-code-url": "N/A",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/alpn/alpn-api/1.1.3.v20160715/alpn-api-1.1.3.v20160715-javadoc.jar",
+    "description": "Jetty ALPN API provides interfaces for using Application-Layer Protocol Negotiation (ALPN) over TLS with SSLSocket and SSLEngine. It lets client and server applications register providers that advertise, select, and react to negotiated application protocols.",
     "tested-versions": [
       "1.1.3.v20160715"
     ]

--- a/metadata/org.eclipse.jetty/jetty-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-client/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.1.5/jetty-core/jetty-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/12.1.5/jetty-client-12.1.5-javadoc.jar",
+    "description" : "Jetty Client is an efficient, asynchronous, non-blocking HTTP client library for Java that also supports blocking request workflows through a simple API. It provides the HttpClient implementation, request and response APIs, connection pooling, and central configuration for network parameters, redirects, and cookies.",
     "tested-versions" : [
       "12.1.5",
       "12.1.6",
@@ -23,6 +24,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.0.0/jetty-core/jetty-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/12.0.0/jetty-client-12.0.0-javadoc.jar",
+    "description" : "Jetty Client is an efficient, asynchronous, non-blocking HTTP client library for Java that also supports blocking request workflows through a simple API. It provides the HttpClient implementation, request and response APIs, connection pooling, and central configuration for network settings, redirects, and cookies.",
     "tested-versions" : [
       "12.0.0",
       "12.0.1",
@@ -61,6 +63,7 @@
     "repository-url" : "https://github.com/eclipse/jetty.project",
     "test-code-url" : "https://github.com/eclipse/jetty.project/tree/jetty-11.0.12/jetty-client/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/11.0.12/jetty-client-11.0.12-javadoc.jar",
+    "description" : "Jetty Client is an asynchronous HTTP client library for Java. It provides the HttpClient implementation, request and response APIs, and connection management needed to send HTTP requests and handle responses synchronously or asynchronously.",
     "tested-versions" : [
       "11.0.12",
       "11.0.13",

--- a/metadata/org.eclipse.jetty/jetty-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.1.3/jetty-core/jetty-server/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/12.1.3/jetty-server-12.1.3-javadoc.jar",
+    "description" : "Jetty Server provides the core Eclipse Jetty server components for accepting connections, handling requests, and serving HTTP-based applications. It can be embedded in Java applications as the foundation for Jetty-based HTTP servers, handlers, and higher-level web modules.",
     "tested-versions" : [
       "12.1.3",
       "12.1.4",
@@ -25,6 +26,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.0.1/jetty-core/jetty-server/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/12.0.1/jetty-server-12.0.1-javadoc.jar",
+    "description" : "Jetty Server provides the core server components of Eclipse Jetty for handling HTTP requests in Java applications. It can be embedded as the foundation for Jetty-based HTTP servers and higher-level web application modules.",
     "tested-versions" : [
       "12.0.1",
       "12.0.2",
@@ -54,6 +56,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-11.0.12/jetty-server/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/11.0.12/jetty-server-11.0.12-javadoc.jar",
+    "description" : "Jetty Server provides the core server components of Eclipse Jetty for handling HTTP requests in Java applications. It can be embedded as the foundation for Servlet-based web applications and higher-level Jetty modules.",
     "tested-versions" : [
       "11.0.12"
     ],

--- a/metadata/org.eclipse.jetty/jetty-util/index.json
+++ b/metadata/org.eclipse.jetty/jetty-util/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/jetty/jetty.project",
     "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.0.9/jetty-core/jetty-util/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/12.0.9/jetty-util-12.0.9-javadoc.jar",
+    "description" : "Utility classes for Jetty. It provides foundational helpers for resources, security, SSL, threading, statistics, and other shared infrastructure used across Jetty components.",
     "tested-versions" : [
       "12.0.9",
       "12.0.10",

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
@@ -13,7 +13,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/7.4.0.202509020913-r/org.eclipse.jgit-7.4.0.202509020913-r-sources.jar",
     "repository-url": "https://github.com/eclipse-jgit/jgit",
     "test-code-url": "https://github.com/eclipse-jgit/jgit/tree/v7.4.0.202509020913-r/org.eclipse.jgit.test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/7.4.0.202509020913-r/org.eclipse.jgit-7.4.0.202509020913-r-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/7.4.0.202509020913-r/org.eclipse.jgit-7.4.0.202509020913-r-javadoc.jar",
+    "description": "JGit is a pure Java implementation of Git that lets Java applications read, write, and manage Git repositories and working trees. It provides APIs for repository access, object storage, transport protocols, and common Git operations without requiring native Git binaries."
   },
   {
     "allowed-packages": [
@@ -27,6 +28,7 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/6.5.0.202303070854-r/org.eclipse.jgit-6.5.0.202303070854-r-sources.jar",
     "repository-url": "https://github.com/eclipse-jgit/jgit",
     "test-code-url": "https://github.com/eclipse-jgit/jgit/tree/v6.5.0.202303070854-r/org.eclipse.jgit.test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/6.5.0.202303070854-r/org.eclipse.jgit-6.5.0.202303070854-r-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/6.5.0.202303070854-r/org.eclipse.jgit-6.5.0.202303070854-r-javadoc.jar",
+    "description": "JGit is a pure Java implementation of Git that lets applications read, write, and manage Git repositories and working trees. It provides APIs for repository access, object storage, transport protocols, and common Git operations in Java applications."
   }
 ]

--- a/metadata/org.eclipse.paho/org.eclipse.paho.client.mqttv3/index.json
+++ b/metadata/org.eclipse.paho/org.eclipse.paho.client.mqttv3/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/eclipse-paho/paho.mqtt.java",
     "test-code-url": "https://github.com/eclipse-paho/paho.mqtt.java/tree/v1.2.5/org.eclipse.paho.client.mqttv3.test",
     "documentation-url": "https://github.com/eclipse-paho/paho.mqtt.java/blob/v1.2.5/MQTTv3.md",
+    "description": "Eclipse Paho Java MQTTv3 Client is a Java library for connecting applications to MQTT brokers using the MQTT 3.x protocol. It provides synchronous and asynchronous client APIs for publishing messages, subscribing to topics, and managing MQTT connections.",
     "tested-versions": [
       "1.2.5"
     ]

--- a/metadata/org.eclipse.paho/org.eclipse.paho.mqttv5.client/index.json
+++ b/metadata/org.eclipse.paho/org.eclipse.paho.mqttv5.client/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/eclipse-paho/paho.mqtt.java",
     "test-code-url": "https://github.com/eclipse-paho/paho.mqtt.java/tree/v1.2.5/org.eclipse.paho.mqttv5.client.test/src/test",
     "documentation-url": "https://github.com/eclipse-paho/paho.mqtt.java/blob/v1.2.5/MQTTv5.md",
+    "description": "Eclipse Paho MQTT v5 Client is a Java library for connecting JVM and Android applications to MQTT brokers using the MQTT 5 protocol. It provides asynchronous and synchronous client APIs for publishing, subscribing, and managing MQTT messaging workflows.",
     "tested-versions": [
       "1.2.5"
     ]

--- a/metadata/org.ehcache/ehcache/index.json
+++ b/metadata/org.ehcache/ehcache/index.json
@@ -11,6 +11,7 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/ehcache/ehcache/3.10.8/ehcache-3.10.8-jakarta-sources.jar",
     "repository-url": "https://github.com/ehcache/ehcache3",
     "test-code-url": "https://github.com/ehcache/ehcache3/tree/v3.10.8/integration-test/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/ehcache/ehcache/3.10.8/ehcache-3.10.8-jakarta-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/ehcache/ehcache/3.10.8/ehcache-3.10.8-jakarta-javadoc.jar",
+    "description": "Ehcache is an open source, standards-based Java cache that improves performance, reduces database load, and simplifies scalability. It supports both the Ehcache API and the JSR-107 cache API, with configurations ranging from in-process caches to larger tiered deployments."
   }
 ]

--- a/metadata/org.example/library/index.json
+++ b/metadata/org.example/library/index.json
@@ -10,6 +10,7 @@
     "repository-url": "N/A",
     "test-code-url": "N/A",
     "documentation-url": "N/A",
+    "description": "N/A",
     "tested-versions": [
       "0.0.1"
     ]

--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-11.14.1/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "10.20.1",
       "10.21.0",
@@ -75,6 +76,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.20.1/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "10.20.1"
     ],
@@ -91,6 +93,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.20.0/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "10.20.0"
     ],
@@ -107,6 +110,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.15.0/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "10.15.0"
     ],
@@ -123,6 +127,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.10.0/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "10.10.0"
     ],
@@ -139,6 +144,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/9.0.1/flyway-core-9.0.1-javadoc.jar",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
     "tested-versions" : [
       "9.0.1"
     ],

--- a/metadata/org.flywaydb/flyway-database-postgresql/index.json
+++ b/metadata/org.flywaydb/flyway-database-postgresql/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/flyway/flyway",
     "test-code-url": "https://github.com/flyway/flyway/tree/flyway-10.13.0/flyway-database/flyway-database-postgresql",
     "documentation-url": "https://github.com/flyway/flyway/tree/flyway-10.13.0/documentation",
+    "description": "This Flyway module adds PostgreSQL and CockroachDB database support by providing database type detection, SQL parsing, and JDBC integration for PostgreSQL-compatible systems. It enables Flyway migrations to run with PostgreSQL-specific connection handling, schema support, table operations, and advisory locking behavior.",
     "test-version": "10.10.0",
     "tested-versions": [
       "10.13.0",

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -3,6 +3,11 @@
     "latest" : true,
     "metadata-version" : "10.19.0",
     "test-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.19.0/flyway-sqlserver-10.19.0-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/blob/flyway-10.19.0/documentation/Flyway%20CLI%20and%20API/Supported%20Databases/SQL%20Server%20Database.md",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server and Azure Synapse database-specific support to Flyway. It provides the SQL Server database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
     "tested-versions" : [
       "10.19.0",
       "10.20.0",
@@ -39,6 +44,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.13.0/documentation",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server and Azure Synapse database-specific support to Flyway. It provides the SQL Server database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
     "tested-versions" : [
       "10.13.0",
       "10.14.0",
@@ -63,6 +69,7 @@
     "repository-url" : "https://github.com/flyway/flyway",
     "test-code-url" : "N/A",
     "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-10.10.0/documentation",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server and Azure Synapse database-specific support to Flyway. It provides the SQL Server database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
     "tested-versions" : [
       "10.10.0",
       "10.11.0",

--- a/metadata/org.freemarker/freemarker/index.json
+++ b/metadata/org.freemarker/freemarker/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/apache/freemarker",
     "test-code-url": "https://github.com/apache/freemarker/tree/v2.3.31/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/freemarker/freemarker/2.3.31/freemarker-2.3.31-javadoc.jar",
+    "description": "FreeMarker is a Java template engine for generating text output such as HTML pages, emails, configuration files, and source code from templates and data models. It separates presentation templates from application logic so applications can produce dynamic content for web and non-web use cases.",
     "tested-versions": [
       "2.3.31",
       "2.3.32",

--- a/metadata/org.fusesource.hawtbuf/hawtbuf/index.json
+++ b/metadata/org.fusesource.hawtbuf/hawtbuf/index.json
@@ -7,6 +7,7 @@
     "repository-url": "https://github.com/fusesource/hawtbuf",
     "test-code-url": "https://repo1.maven.org/maven2/org/fusesource/hawtbuf/hawtbuf/1.11/hawtbuf-1.11-tests.jar",
     "documentation-url": "https://repo1.maven.org/maven2/org/fusesource/hawtbuf/hawtbuf/1.11/hawtbuf-1.11-javadoc.jar",
+    "description": "HawtBuf is a rich byte buffer library for Java. It provides buffer types, streams, and codecs for efficiently working with binary data and encoded values.",
     "tested-versions": [
       "1.11"
     ]

--- a/metadata/org.glassfish.jaxb/jaxb-runtime/index.json
+++ b/metadata/org.glassfish.jaxb/jaxb-runtime/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/eclipse-ee4j/jaxb-ri",
     "test-code-url": "https://github.com/eclipse-ee4j/jaxb-ri/tree/3.0.2-RI/jaxb-ri/runtime/impl/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/3.0.2/jaxb-runtime-3.0.2-javadoc.jar",
+    "description": "JAXB Runtime is the reference implementation of JAXB for marshalling Java objects to XML and unmarshalling XML back into Java objects. It provides the runtime binding engine and supporting infrastructure used by applications built on Jakarta XML Binding.",
     "tested-versions": [
       "3.0.2",
       "3.1.0-M1",

--- a/metadata/org.hdrhistogram/HdrHistogram/index.json
+++ b/metadata/org.hdrhistogram/HdrHistogram/index.json
@@ -13,6 +13,7 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12-sources.jar",
     "repository-url": "https://github.com/HdrHistogram/HdrHistogram",
     "test-code-url": "https://github.com/HdrHistogram/HdrHistogram/tree/HdrHistogram-2.1.12/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12-javadoc.jar",
+    "description": "HdrHistogram records and analyzes sampled value distributions across a wide integer range with configurable precision. It is commonly used for latency and performance measurements because it provides fast recording with predictable space and time costs."
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-core/index.json
+++ b/metadata/org.hibernate.orm/hibernate-core/index.json
@@ -15,7 +15,12 @@
     "test-version": "7.1.0.Final",
     "tested-versions": [
       "8.0.0.Alpha1"
-    ]
+    ],
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/8.0.0.Alpha1/hibernate-core-8.0.0.Alpha1-sources.jar",
+    "repository-url": "https://github.com/hibernate/hibernate-orm",
+    "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/8.0.0.Alpha1/hibernate-core/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/8.0.0.Alpha1/hibernate-core-8.0.0.Alpha1-javadoc.jar",
+    "description": "Hibernate ORM maps Java objects to relational database tables and provides the core runtime for persistence, querying, and transaction management. It implements Jakarta Persistence (JPA) while also exposing native Hibernate APIs and extension points for advanced ORM use cases."
   },
   {
     "latest": true,
@@ -41,7 +46,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.2.0.Final/hibernate-core-7.2.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/7.2.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.2.0.Final/hibernate-core-7.2.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.2.0.Final/hibernate-core-7.2.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides object-relational mapping for Java applications and relational databases. It implements Jakarta Persistence (JPA) and also exposes native Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "7\\.1\\..*",
@@ -74,7 +80,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.1.0.Final/hibernate-core-7.1.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/7.1.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.1.0.Final/hibernate-core-7.1.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.1.0.Final/hibernate-core-7.1.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides object-relational mapping for Java applications and relational databases. It implements Jakarta Persistence (JPA) and also exposes native Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "7\\.0\\..*",
@@ -106,7 +113,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.0.0.Final/hibernate-core-7.0.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/7.0.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.0.0.Final/hibernate-core-7.0.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/7.0.0.Final/hibernate-core-7.0.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides object-relational mapping for Java applications and relational databases. It implements Jakarta Persistence (JPA) and also exposes native Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "6\\.6\\..*",
@@ -130,7 +138,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.6.0.Final/hibernate-core-6.6.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.6.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.6.0.Final/hibernate-core-6.6.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.6.0.Final/hibernate-core-6.6.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides object-relational mapping for Java applications and relational databases. It implements Jakarta Persistence (JPA) and also exposes native Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "6\\.5\\..*",
@@ -152,7 +161,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.5.0.Final/hibernate-core-6.5.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.5.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.5.0.Final/hibernate-core-6.5.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.5.0.Final/hibernate-core-6.5.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides core object-relational mapping functionality for mapping Java objects to relational database tables. It implements Jakarta Persistence (JPA) and also exposes Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "6\\.[2-4]\\..*",
@@ -175,7 +185,8 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.2.0.Final/hibernate-core-6.2.0.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.2.0/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.2.0.Final/hibernate-core-6.2.0.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.2.0.Final/hibernate-core-6.2.0.Final-javadoc.jar",
+    "description": "Hibernate ORM provides core object-relational mapping functionality for mapping Java objects to relational database tables. It implements Jakarta Persistence (JPA) and also exposes Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "6\\.1\\..*",
@@ -197,6 +208,7 @@
     "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.1.1.Final/hibernate-core-6.1.1.Final-sources.jar",
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.1.1/hibernate-core/src/test",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.1.1.Final/hibernate-core-6.1.1.Final-javadoc.jar"
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/6.1.1.Final/hibernate-core-6.1.1.Final-javadoc.jar",
+    "description": "Hibernate ORM provides the core object-relational mapping functionality of Hibernate for mapping Java objects to relational database tables. It implements Jakarta Persistence (JPA) and also exposes Hibernate's native SessionFactory and Session APIs for querying, transactions, and entity lifecycle management."
   }
 ]

--- a/metadata/org.hibernate.orm/hibernate-envers/index.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/index.json
@@ -18,6 +18,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.1.1/hibernate-envers/src/test",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-envers/6.1.1.Final/hibernate-envers-6.1.1.Final-javadoc.jar",
+    "description": "Hibernate Envers adds auditing and history tracking to Hibernate ORM entities by recording entity revisions and changes over time. It lets applications query historical versions of audited data and inspect which properties changed in each revision.",
     "latest": true,
     "requires": [
       "org.hibernate.orm:hibernate-core"

--- a/metadata/org.hibernate.reactive/hibernate-reactive-core/index.json
+++ b/metadata/org.hibernate.reactive/hibernate-reactive-core/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-reactive",
     "test-code-url": "https://github.com/hibernate/hibernate-reactive/tree/2.0.0/hibernate-reactive-core/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/hibernate/reactive/hibernate-reactive-core/2.0.0.Final/hibernate-reactive-core-2.0.0.Final-javadoc.jar",
+    "description": "Hibernate Reactive Core is the core module of Hibernate Reactive. It adds a reactive API to Hibernate ORM for non-blocking interaction with databases using reactive drivers.",
     "tested-versions": [
       "2.0.0.Final",
       "2.0.1.Final",

--- a/metadata/org.hibernate.validator/hibernate-validator/index.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-validator",
     "test-code-url": "https://github.com/hibernate/hibernate-validator/tree/7.0.4.Final/engine/src/test",
     "documentation-url": "https://github.com/hibernate/hibernate-validator/tree/7.0.4.Final/documentation",
+    "description": "Hibernate Validator is the reference implementation of Jakarta Bean Validation and provides annotation-based and programmatic constraint validation for Java applications. It validates beans, method parameters, and return values and includes support for custom constraints and message interpolation.",
     "tested-versions": [
       "7.0.4.Final",
       "7.0.5.Final",

--- a/metadata/org.hibernate/hibernate-core/index.json
+++ b/metadata/org.hibernate/hibernate-core/index.json
@@ -17,6 +17,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.0.0/hibernate-core/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/hibernate/orm/hibernate-core/6.0.0.Final/hibernate-core-6.0.0.Final-javadoc.jar",
+    "description": "Hibernate Core is the main module of Hibernate ORM, providing object-relational mapping between Java domain models and relational databases. It implements Jakarta Persistence and adds native APIs for mapping, querying, caching, and managing persistence.",
     "tested-versions": [
       "6.0.0.Final",
       "6.0.1.Final",
@@ -40,6 +41,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/5.6.14/hibernate-core/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/hibernate/hibernate-core/5.6.14.Final/hibernate-core-5.6.14.Final-javadoc.jar",
+    "description": "Hibernate Core is the main module of Hibernate ORM, providing object-relational mapping between Java domain models and relational databases. It implements JPA and adds native APIs for mapping, querying, caching, and managing persistence.",
     "tested-versions": [
       "5.6.14.Final",
       "5.6.15.Final"

--- a/metadata/org.hibernate/hibernate-spatial/index.json
+++ b/metadata/org.hibernate/hibernate-spatial/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/7.2.0/hibernate-spatial/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/hibernate/orm/hibernate-spatial/7.2.0.Final/hibernate-spatial-7.2.0.Final-javadoc.jar",
+    "description": "Hibernate Spatial integrates Spatial/GIS data support into Hibernate ORM. It lets Hibernate map and query geospatial types and functions through supported spatial databases.",
     "tested-versions": [
       "7.2.0.Final",
       "7.2.1.Final",
@@ -27,6 +28,7 @@
     "repository-url": "https://github.com/hibernate/hibernate-orm",
     "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/6.5.0/hibernate-spatial/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/hibernate/orm/hibernate-spatial/6.5.0.Final/hibernate-spatial-6.5.0.Final-javadoc.jar",
+    "description": "Hibernate Spatial integrates Spatial/GIS data support into Hibernate ORM. It lets Hibernate map and query geospatial types and functions through supported spatial databases.",
     "tested-versions": [
       "6.5.0.Final",
       "6.5.1.Final",

--- a/metadata/org.jboss.logging/jboss-logging/index.json
+++ b/metadata/org.jboss.logging/jboss-logging/index.json
@@ -16,6 +16,7 @@
     "repository-url" : "https://github.com/jboss-logging/jboss-logging",
     "test-code-url" : "https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.5.0.Final/jboss-logging-3.5.0.Final-source-release.zip",
     "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.5.0.Final/jboss-logging-3.5.0.Final-javadoc.jar",
+    "description" : "JBoss Logging is a Java logging facade that lets applications log through a common API while remaining independent of the underlying log manager. It can bind to providers such as JBoss Log Manager, Log4j 2, SLF4J and Logback, log4j, or java.util.logging.",
     "allowed-packages" : [
       "org.jboss"
     ]

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
@@ -12,6 +12,7 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/jboss/spec/javax/servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/jboss-servlet-api_4.0_spec-2.0.0.Final-sources.jar",
     "repository-url": "https://github.com/jboss/jboss-jakarta-servlet-api_spec",
     "test-code-url": "N/A",
-    "documentation-url": "https://repo1.maven.org/maven2/org/jboss/spec/javax/servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/jboss-servlet-api_4.0_spec-2.0.0.Final-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/jboss/spec/javax/servlet/jboss-servlet-api_4.0_spec/2.0.0.Final/jboss-servlet-api_4.0_spec-2.0.0.Final-javadoc.jar",
+    "description": "Provides the Jakarta Servlet 4.0 specification API as a JBoss-packaged artifact for Java web applications. It defines the standard server-side interfaces for handling HTTP requests, responses, and related web container interactions."
   }
 ]

--- a/metadata/org.jctools/jctools-core/index.json
+++ b/metadata/org.jctools/jctools-core/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/JCTools/JCTools",
     "test-code-url": "https://github.com/JCTools/JCTools/tree/v2.1.2/jctools-core/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/jctools/jctools-core/2.1.2/jctools-core-2.1.2-javadoc.jar",
+    "description": "JCTools Core provides high-performance concurrent data structures for the JVM, especially lock-free and wait-free queues for different producer and consumer patterns. It extends the Java concurrency toolbox with queue APIs and implementations tuned for throughput, contention, allocation, and memory footprint.",
     "tested-versions": [
       "2.1.2",
       "3.0.0",

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/JetBrains/kotlin",
     "test-code-url" : "https://github.com/JetBrains/kotlin/tree/v1.7.10/compiler/testData/codegen/box/reflection",
     "documentation-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.10/kotlin-reflect-1.7.10-javadoc.jar",
+    "description" : "kotlin-reflect is Kotlin's optional JVM runtime reflection library, providing full support for the kotlin.reflect API and related reflection extensions. It lets applications inspect Kotlin classes, functions, properties, and types at runtime without requiring reflection support in deployments that do not use it.",
     "tested-versions" : [
       "1.7.10",
       "1.7.20",

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/JetBrains/kotlin",
     "test-code-url" : "https://github.com/JetBrains/kotlin/tree/v1.7.10/libraries/stdlib/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.7.10/kotlin-stdlib-1.7.10-javadoc.jar",
+    "description" : "Kotlin Standard Library for JVM provides the core runtime classes, collections, and extension APIs used by Kotlin applications on the JVM. It supports common programming tasks such as text handling, sequences, and Java interoperability required by compiled Kotlin code.",
     "tested-versions" : [
       "1.7.10",
       "1.7.20",

--- a/metadata/org.jetbrains/annotations-java5/index.json
+++ b/metadata/org.jetbrains/annotations-java5/index.json
@@ -15,6 +15,7 @@
     ],
     "allowed-packages" : [
       "org.jetbrains"
-    ]
+    ],
+    "description" : "JetBrains Java Annotations is a set of annotations for code inspection support and code documentation. It provides annotations for nullability, contracts, API status, language injection, and related metadata used by IDEs and static analysis tools."
   }
 ]

--- a/metadata/org.jline/jline/index.json
+++ b/metadata/org.jline/jline/index.json
@@ -10,6 +10,7 @@
     "repository-url": "https://github.com/jline/jline3",
     "test-code-url": "https://github.com/jline/jline3/tree/jline-parent-3.21.0",
     "documentation-url": "https://repo1.maven.org/maven2/org/jline/jline/3.21.0/jline-3.21.0-javadoc.jar",
+    "description": "JLine is a Java library for building interactive command-line applications with terminal abstraction, line editing, history, and completion support. The jline bundle packages the core JLine modules, including terminal, reader, builtins, console, style, and remote shell components.",
     "tested-versions": [
       "3.21.0",
       "3.22.0",

--- a/metadata/org.jooq/jooq/index.json
+++ b/metadata/org.jooq/jooq/index.json
@@ -7,6 +7,7 @@
     "repository-url" : "https://github.com/jOOQ/jOOQ",
     "test-code-url" : "N/A",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/jooq/jooq/3.20.0/jooq-3.20.0-javadoc.jar",
+    "description" : "jOOQ is a Java library for building and executing type-safe SQL against relational databases. It models SQL as a fluent DSL and can generate Java classes from database schemas to improve query safety and developer ergonomics.",
     "tested-versions" : [
       "3.20.0",
       "3.20.1",
@@ -36,6 +37,7 @@
     "repository-url" : "https://github.com/jOOQ/jOOQ",
     "test-code-url" : "N/A",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/jooq/jooq/3.18.2/jooq-3.18.2-javadoc.jar",
+    "description" : "jOOQ is a Java library for building and executing type-safe SQL against relational databases. It models SQL as a fluent DSL and can generate Java classes from database schemas to improve query safety and developer ergonomics.",
     "tested-versions" : [
       "3.18.2",
       "3.18.3",
@@ -111,6 +113,7 @@
     "repository-url" : "https://github.com/jOOQ/jOOQ",
     "test-code-url" : "N/A",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/jooq/jooq/3.17.7/jooq-3.17.7-javadoc.jar",
+    "description" : "jOOQ is a Java library for building and executing type-safe SQL against relational databases. It models SQL as a fluent DSL and can generate Java classes from database schemas to improve query safety and developer ergonomics.",
     "tested-versions" : [
       "3.17.7"
     ],

--- a/metadata/org.json/json/index.json
+++ b/metadata/org.json/json/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/stleary/JSON-java",
     "test-code-url" : "https://github.com/stleary/JSON-java/tree/20220320/src/test/java",
     "documentation-url" : "https://repo1.maven.org/maven2/org/json/json/20220320/json-20220320-javadoc.jar",
+    "description" : "JSON-java is a reference implementation of JSON for Java that parses JSON text into Java objects and generates JSON text from Java classes. It also provides encoders and decoders plus conversion utilities for JSON, XML, HTTP headers, cookies, and CDL.",
     "tested-versions" : [
       "20220320",
       "20220924",

--- a/metadata/org.liquibase/liquibase-core/index.json
+++ b/metadata/org.liquibase/liquibase-core/index.json
@@ -12,7 +12,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.17.0/liquibase-core-4.17.0-sources.jar",
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v4.17.0/liquibase-core/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.17.0/liquibase-core-4.17.0-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.17.0/liquibase-core-4.17.0-javadoc.jar",
+    "description": "Liquibase helps developers track, version, and deploy database schema changes. It automatically orders and applies change sets, supports rollbacks, and integrates with build and CI/CD tools."
   },
   {
     "default-for": "4\\.2(0|1|2)\\..*",
@@ -28,7 +29,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.20.0/liquibase-core-4.20.0-sources.jar",
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v4.20.0/liquibase-core/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.20.0/liquibase-core-4.20.0-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.20.0/liquibase-core-4.20.0-javadoc.jar",
+    "description": "Liquibase helps developers track, version, and deploy database schema changes. It automatically orders changes for deployment, supports rollbacks, and integrates with build and CI/CD tools."
   },
   {
     "default-for": "4\\.23\\..*",
@@ -44,7 +46,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.23.0/liquibase-core-4.23.0-sources.jar",
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v4.23.0/liquibase-standard/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.23.0/liquibase-core-4.23.0-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.23.0/liquibase-core-4.23.0-javadoc.jar",
+    "description": "Liquibase tracks, versions, and deploys database schema changes for applications. It orders change sets for deployment, supports rollbacks, and integrates with build and CI/CD tooling."
   },
   {
     "default-for": "^(4\\.25\\.(0|1)|4\\.26\\.0)$",
@@ -61,7 +64,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.25.0/liquibase-core-4.25.0-sources.jar",
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v4.25.0/liquibase-standard/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.25.0/liquibase-core-4.25.0-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.25.0/liquibase-core-4.25.0-javadoc.jar",
+    "description": "Liquibase tracks, versions, and deploys database schema changes for applications. It orders migration scripts for deployment, supports rollbacks, and integrates with build and CI/CD tools."
   },
   {
     "allowed-packages": [
@@ -83,7 +87,8 @@
     "source-code-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.27.0/liquibase-core-4.27.0-sources.jar",
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v4.27.0/liquibase-standard/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.27.0/liquibase-core-4.27.0-javadoc.jar"
+    "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.27.0/liquibase-core-4.27.0-javadoc.jar",
+    "description": "Liquibase tracks, versions, and deploys database schema changes for applications. It orders migration scripts for deployment, supports rollbacks, and integrates with build and CI/CD tools."
   },
   {
     "allowed-packages": [
@@ -99,6 +104,7 @@
     "repository-url": "https://github.com/liquibase/liquibase",
     "test-code-url": "https://github.com/liquibase/liquibase/tree/v5.0.1/liquibase-standard/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/5.0.1/liquibase-core-5.0.1-javadoc.jar",
+    "description": "Liquibase tracks, versions, and deploys database schema changes for applications. It orders database change sets for deployment, supports rollbacks, and integrates with build and CI/CD tools.",
     "latest": true
   }
 ]

--- a/metadata/org.lz4/lz4-java/index.json
+++ b/metadata/org.lz4/lz4-java/index.json
@@ -7,6 +7,7 @@
     "repository-url": "https://github.com/lz4/lz4-java",
     "test-code-url": "https://github.com/lz4/lz4-java/tree/1.8.0/src/test",
     "documentation-url": "https://repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0-javadoc.jar",
+    "description": "lz4-java provides Java ports and bindings for the LZ4 compression algorithm and the xxHash hashing algorithm. It offers JNI, pure Java, and Unsafe-based implementations for fast compression, decompression, and hashing.",
     "tested-versions": [
       "1.8.0"
     ]

--- a/metadata/org.mariadb.jdbc/mariadb-java-client/index.json
+++ b/metadata/org.mariadb.jdbc/mariadb-java-client/index.json
@@ -5,6 +5,7 @@
     "repository-url" : "https://github.com/mariadb-corporation/mariadb-connector-j",
     "test-code-url" : "https://github.com/mariadb-corporation/mariadb-connector-j/tree/3.0.6/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.0.6/mariadb-java-client-3.0.6-javadoc.jar",
+    "description" : "MariaDB Connector/J is a JDBC 4.2 compatible driver for connecting Java applications to MariaDB and MySQL databases. It provides the client library needed for standard JDBC access from Java code.",
     "tested-versions" : [
       "3.0.6",
       "3.0.7",
@@ -40,6 +41,7 @@
     "repository-url" : "https://github.com/mariadb-corporation/mariadb-connector-j",
     "test-code-url" : "https://github.com/mariadb-corporation/mariadb-connector-j/tree/3.5.2/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.5.2/mariadb-java-client-3.5.2-javadoc.jar",
+    "description" : "MariaDB Connector/J is a JDBC 4.2 compatible driver for connecting Java applications to MariaDB and MySQL databases. It provides the client library needed for standard JDBC access from Java code.",
     "tested-versions" : [
       "3.5.2",
       "3.5.3",

--- a/metadata/org.mariadb/r2dbc-mariadb/index.json
+++ b/metadata/org.mariadb/r2dbc-mariadb/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/mariadb-corporation/mariadb-connector-r2dbc",
     "test-code-url": "https://github.com/mariadb-corporation/mariadb-connector-r2dbc/tree/1.1.3/src/test",
     "documentation-url": "https://github.com/mariadb-corporation/mariadb-connector-r2dbc/blob/1.1.3/README.md",
+    "description": "MariaDB Connector/R2DBC is a non-blocking Java driver that implements the R2DBC API for MariaDB and MySQL databases. It lets reactive applications create connections and execute SQL asynchronously against those databases.",
     "tested-versions": [
       "1.1.3",
       "1.1.4",

--- a/metadata/org.mockito/mockito-core/index.json
+++ b/metadata/org.mockito/mockito-core/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/mockito/mockito",
     "test-code-url": "https://github.com/mockito/mockito/tree/v5.0.0/src/test",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.0.0/mockito-core-5.0.0-javadoc.jar",
+    "description": "Mockito Core is a Java mocking framework for creating, stubbing, and verifying mock objects in tests. It helps isolate code under test by simulating collaborators and asserting interactions.",
     "tested-versions": [
       "5.0.0",
       "5.1.0",
@@ -50,6 +51,7 @@
     "repository-url": "https://github.com/mockito/mockito",
     "test-code-url": "https://github.com/mockito/mockito/tree/v4.8.1/src/test",
     "documentation-url": "https://github.com/mockito/mockito/blob/v4.8.1/README.md",
+    "description": "Mockito Core is a Java mocking framework for creating and configuring mock objects in tests. It helps isolate code under test by stubbing behavior and verifying interactions.",
     "tested-versions": [
       "4.8.1",
       "4.9.0",

--- a/metadata/org.opengauss/opengauss-jdbc/index.json
+++ b/metadata/org.opengauss/opengauss-jdbc/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://gitee.com/opengauss/openGauss-connector-jdbc",
     "test-code-url": "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/pgjdbc/src/test",
     "documentation-url": "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/docs",
+    "description": "This artifact is the Java JDBC driver for openGauss. It enables Java applications to connect to openGauss databases and execute SQL through the standard JDBC API.",
     "tested-versions": [
       "3.1.0-og"
     ]

--- a/metadata/org.postgresql/postgresql/index.json
+++ b/metadata/org.postgresql/postgresql/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/pgjdbc/pgjdbc",
     "test-code-url": "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.3/postgresql-42.7.3-jdbc-src.tar.gz",
     "documentation-url": "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.3/postgresql-42.7.3-javadoc.jar",
+    "description": "PostgreSQL JDBC Driver lets Java applications connect to PostgreSQL databases through the standard JDBC API. It is a pure Java Type 4 driver that communicates using PostgreSQL's native network protocol.",
     "tested-versions": [
       "42.7.3",
       "42.7.4",
@@ -29,6 +30,7 @@
     "repository-url": "https://github.com/pgjdbc/pgjdbc",
     "test-code-url": "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.4/postgresql-42.3.4-jdbc-src.tar.gz",
     "documentation-url": "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.4/postgresql-42.3.4-javadoc.jar",
+    "description": "PostgreSQL JDBC Driver lets Java applications connect to PostgreSQL databases through the standard JDBC API. It is a pure Java Type 4 driver that communicates using PostgreSQL's native network protocol.",
     "tested-versions": [
       "42.3.4"
     ]

--- a/metadata/org.quartz-scheduler/quartz/index.json
+++ b/metadata/org.quartz-scheduler/quartz/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/quartz-scheduler/quartz",
     "test-code-url": "https://github.com/quartz-scheduler/quartz/tree/v2.3.2/quartz/src/test",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/quartz-scheduler/quartz/2.3.2/quartz-2.3.2-javadoc.jar",
+    "description": "Quartz is a Java job scheduling library for defining, storing, and running scheduled jobs. It supports cron-like triggers, persistence, clustering, and integration with application servers and databases.",
     "tested-versions": [
       "2.3.2",
       "2.4.0",

--- a/metadata/org.rocksdb/rocksdbjni/index.json
+++ b/metadata/org.rocksdb/rocksdbjni/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/facebook/rocksdb",
     "test-code-url": "https://github.com/facebook/rocksdb/tree/v7.9.2/java/src/test",
     "documentation-url": "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/7.9.2/rocksdbjni-7.9.2-javadoc.jar",
+    "description": "RocksDB JNI provides Java bindings for RocksDB, an embeddable persistent key-value store optimized for fast storage on flash and RAM. The rocksdbjni artifact packages the native RocksDB libraries for supported platforms so Java applications can use RocksDB without building them separately.",
     "tested-versions": [
       "7.9.2",
       "7.10.2",

--- a/metadata/org.testcontainers/testcontainers/index.json
+++ b/metadata/org.testcontainers/testcontainers/index.json
@@ -24,6 +24,7 @@
     "allowed-packages" : [
       "org.testcontainers"
     ],
+    "description" : "Testcontainers is a Java library for JUnit tests that provides lightweight, throwaway Docker containers for databases, web browsers, and other services. It helps integration tests run against real dependencies instead of mocks or in-memory substitutes.",
     "source-code-url" : "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.19.8/testcontainers-1.19.8-sources.jar",
     "repository-url" : "https://github.com/testcontainers/testcontainers-java",
     "test-code-url" : "https://github.com/testcontainers/testcontainers-java/tree/1.19.8/core/src/test",
@@ -40,6 +41,7 @@
     "source-code-url" : "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.17.6/testcontainers-1.17.6-sources.jar",
     "repository-url" : "https://github.com/testcontainers/testcontainers-java",
     "test-code-url" : "https://github.com/testcontainers/testcontainers-java/tree/1.17.6/core/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.17.6/testcontainers-1.17.6-javadoc.jar"
+    "documentation-url" : "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.17.6/testcontainers-1.17.6-javadoc.jar",
+    "description" : "Testcontainers is a Java library for tests that provides lightweight, throwaway instances of databases, web browsers, and other services running in Docker containers. It helps integration tests run against real dependencies instead of mocks or in-memory substitutes."
   }
 ]

--- a/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
+++ b/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/thymeleaf/thymeleaf",
     "test-code-url" : "https://github.com/thymeleaf/thymeleaf/tree/thymeleaf-3.1.0.RELEASE/tests/thymeleaf-tests-springsecurity6",
     "documentation-url" : "https://github.com/thymeleaf/thymeleaf/blob/thymeleaf-3.1.0.RELEASE/lib/thymeleaf-extras-springsecurity6/README.markdown",
+    "description" : "Thymeleaf Extras Spring Security 6 integrates Thymeleaf templates with Spring Security 6 by adding the SpringSecurityDialect and security expression utility objects. It lets views access authentication details and conditionally render content based on authorization expressions, URLs, and ACL permissions.",
     "tested-versions" : [
       "3.1.0.RELEASE",
       "3.1.1.RELEASE",

--- a/metadata/org.thymeleaf/thymeleaf-spring6/index.json
+++ b/metadata/org.thymeleaf/thymeleaf-spring6/index.json
@@ -6,6 +6,7 @@
     "repository-url" : "https://github.com/thymeleaf/thymeleaf",
     "test-code-url" : "https://github.com/thymeleaf/thymeleaf/tree/thymeleaf-3.1.0.RELEASE/tests/thymeleaf-tests-spring6",
     "documentation-url" : "https://www.thymeleaf.org/apidocs/thymeleaf-spring6/3.1.0.RELEASE/",
+    "description" : "Thymeleaf Spring6 integrates the Thymeleaf template engine with Spring Framework 6 for server-side view rendering in Spring MVC and WebFlux applications. It adds Spring-aware expression evaluation, data binding, form handling, and related view-layer infrastructure on top of core Thymeleaf.",
     "tested-versions" : [
       "3.1.0.RELEASE",
       "3.1.1.RELEASE",

--- a/metadata/org.thymeleaf/thymeleaf/index.json
+++ b/metadata/org.thymeleaf/thymeleaf/index.json
@@ -9,6 +9,7 @@
     "repository-url": "https://github.com/thymeleaf/thymeleaf",
     "test-code-url": "https://github.com/thymeleaf/thymeleaf/tree/thymeleaf-3.1.0.RELEASE/lib/thymeleaf/src/test",
     "documentation-url": "https://github.com/thymeleaf/thymeleaf/blob/thymeleaf-3.1.0.RELEASE/README.txt",
+    "description": "Thymeleaf is a server-side Java template engine for processing templates in web and standalone applications. It renders dynamic output through configurable template resolvers, dialects, and message resolvers.",
     "tested-versions": [
       "3.1.0.RELEASE",
       "3.1.1.RELEASE",
@@ -25,6 +26,7 @@
     "repository-url": "https://github.com/thymeleaf/thymeleaf",
     "test-code-url": "https://github.com/thymeleaf/thymeleaf/tree/thymeleaf-3.1.0.M2/lib/thymeleaf/src/test",
     "documentation-url": "https://github.com/thymeleaf/thymeleaf/blob/thymeleaf-3.1.0.M2/README.txt",
+    "description": "Thymeleaf is a server-side Java template engine for processing templates in web and standalone applications. It renders dynamic output through configurable template resolvers, dialects, and message resolvers.",
     "tested-versions": [
       "3.1.0.M2"
     ]

--- a/metadata/software.amazon.awssdk/s3/index.json
+++ b/metadata/software.amazon.awssdk/s3/index.json
@@ -41,6 +41,7 @@
     ],
     "allowed-packages" : [
       "software.amazon.awssdk"
-    ]
+    ],
+    "description" : "This module provides the AWS SDK for Java v2 client classes for Amazon S3. It lets Java applications interact with Amazon Simple Storage Service to manage buckets and objects."
   }
 ]


### PR DESCRIPTION
## What does this PR do?

- Adds missing `description` fields to existing metadata index entries.
- Backfills missing source, repository, test, and documentation links for a few incomplete entries.
- Closes #1816.

## Code sections where the PR accesses files, network, docker or some external service

- N/A. Static metadata JSON updates only.