### PR TITLE
Handle no-bytecode JARs in generateLibraryStats

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -201,9 +201,28 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
     }
 
     protected LibraryStatsModels.VersionStats computeVersionStats(String coordinates) {
+        List<Path> libraryJars = listLibraryJars(coordinates);
+
+        // When library JARs contain no bytecode (no .class files), JaCoCo has nothing
+        // to instrument and produces no report. Return N/A for every stats category.
+        if (!LibraryStatsSupport.containsClassFiles(libraryJars)) {
+            getLogger().warn(
+                    "Library JARs for {} contain no bytecode. Writing all stats as N/A.",
+                    coordinates
+            );
+            return new LibraryStatsModels.VersionStats(
+                    LibraryStatsSupport.versionFromCoordinate(coordinates),
+                    LibraryStatsModels.DynamicAccessStatsValue.notAvailable(),
+                    new LibraryStatsModels.LibraryCoverage(
+                            LibraryStatsModels.CoverageMetricValue.notAvailable(),
+                            LibraryStatsModels.CoverageMetricValue.notAvailable(),
+                            LibraryStatsModels.CoverageMetricValue.notAvailable()
+                    )
+            );
+        }
+
         boolean dynamicAccessAvailable = generateReportsForCoordinate(coordinates);
         if (dynamicAccessAvailable) {
-            List<Path> libraryJars = listLibraryJars(coordinates);
             return LibraryStatsSupport.buildVersionStats(
                     coordinates,
                     libraryJars,

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -417,6 +417,25 @@ public final class LibraryStatsSupport {
         return normalized;
     }
 
+    /// Returns true if at least one of the given JARs contains a `.class` file
+    /// (excluding `module-info.class`).
+    public static boolean containsClassFiles(List<Path> libraryJars) {
+        for (Path jarPath : libraryJars) {
+            try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+                boolean found = jarFile.stream()
+                        .map(JarEntry::getName)
+                        .filter(name -> name.endsWith(".class"))
+                        .anyMatch(name -> !name.equals("module-info.class"));
+                if (found) {
+                    return true;
+                }
+            } catch (IOException e) {
+                throw new GradleException("Failed to read library JAR " + jarPath, e);
+            }
+        }
+        return false;
+    }
+
     private static Set<String> loadLibraryClasses(List<Path> libraryJars) {
         Set<String> classes = new LinkedHashSet<>();
         for (Path jarPath : libraryJars) {


### PR DESCRIPTION
## Summary
- When library JARs contain no `.class` files, `generateLibraryStats` fails because JaCoCo has nothing to instrument and produces no report.
- Check JARs for bytecode upfront via `containsClassFiles` and return N/A for all stats categories when none is found.
- Test failures still propagate normally since the check happens before report generation.

Fixes #1795