### PR TITLE
[GenAI] Add support for io.netty:netty-transport-classes-epoll:4.1.99.Final using gpt-5.4

### DIFF
--- a/metadata/io.netty/netty-transport-classes-epoll/4.1.99.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-classes-epoll/4.1.99.Final/reachability-metadata.json
@@ -1,0 +1,240 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.util.ResourceLeakDetector"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractReferenceCountedByteBuf"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.DefaultFileRegion"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.FileDescriptor"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.unix.PeerCredentials"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.AbstractReferenceCounted"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.DefaultAttributeMap"
+      },
+      "type": "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.concurrent.DefaultPromise"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.concurrent.SingleThreadEventExecutor"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader$1"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.io.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$6"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$4"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$9"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$5"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.nio.channels.FileChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$7"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.CleanerJava9$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$2"
+      },
+      "type": "sun.misc.Unsafe"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$3"
+      },
+      "type": "sun.misc.Unsafe"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll.so"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-classes-epoll/index.json
+++ b/metadata/io.netty/netty-transport-classes-epoll/index.json
@@ -1,0 +1,15 @@
+[
+  {
+    "latest": true,
+    "allowed-packages": [ "io.netty" ],
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.99.Final/netty-transport-classes-epoll-4.1.99.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.99.Final/netty-transport-classes-epoll-4.1.99.Final-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.99.Final/netty-transport-classes-epoll-4.1.99.Final-javadoc.jar",
+    "description": "Provides the Java classes for Netty's Linux epoll transport, integrating epoll-based channels and event loops with Netty's transport APIs. It is used to build high-performance non-blocking network clients and servers on Linux when paired with the corresponding native epoll artifacts.",
+    "metadata-version": "4.1.99.Final",
+    "tested-versions": [
+      "4.1.99.Final"
+    ]
+  }
+]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -2586,6 +2586,41 @@
         }
       }
     },
+    "io.netty:netty-transport-classes-epoll" : {
+      "metadataVersions" : {
+        "4.1.99.Final" : {
+          "versions" : [ {
+            "version" : "4.1.99.Final",
+            "dynamicAccess" : {
+              "breakdown" : { },
+              "coverageRatio" : 1.0,
+              "coveredCalls" : 0,
+              "totalCalls" : 0
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 583,
+                "missed" : 12014,
+                "ratio" : 0.046281,
+                "total" : 12597
+              },
+              "line" : {
+                "covered" : 140,
+                "missed" : 2943,
+                "ratio" : 0.04541,
+                "total" : 3083
+              },
+              "method" : {
+                "covered" : 61,
+                "missed" : 690,
+                "ratio" : 0.081225,
+                "total" : 751
+              }
+            }
+          } ]
+        }
+      }
+    },
     "io.opentelemetry:opentelemetry-exporter-jaeger" : {
       "metadataVersions" : {
         "1.19.0" : {

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-classes-epoll:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-classes-epoll:4.1.99.Final
+library.version = 4.1.99.Final
+metadata.dir = io.netty/netty-transport-classes-epoll/4.1.99.Final/

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-classes-epoll_tests'

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -6,11 +6,185 @@
  */
 package io_netty.netty_transport_classes_epoll;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollMode;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.epoll.VSockAddress;
+import io.netty.channel.socket.InternetProtocolFamily;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class Netty_transport_classes_epollTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void epollAvailabilityContractIsSelfConsistent() {
+        boolean available = Epoll.isAvailable();
+        Throwable cause = Epoll.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(Epoll::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(Epoll.isTcpFastOpenClientSideAvailable()).isFalse();
+        assertThat(Epoll.isTcpFastOpenServerSideAvailable()).isFalse();
+        assertThat(EpollDatagramChannel.isSegmentedDatagramPacketSupported()).isFalse();
+
+        Throwable thrown = catchThrowable(Epoll::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+        assertThat(rootCauseMessage(thrown)).contains("netty_transport_native_epoll");
+    }
+
+    @Test
+    void epollPublicTypesRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(EpollSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollDatagramChannel::new);
+        assertEventLoopGroupConstructorMatchesAvailability(EpollEventLoopGroup::new);
+    }
+
+    @Test
+    void epollChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                EpollChannelOption.TCP_CORK,
+                EpollChannelOption.TCP_NOTSENT_LOWAT,
+                EpollChannelOption.TCP_KEEPIDLE,
+                EpollChannelOption.TCP_KEEPINTVL,
+                EpollChannelOption.TCP_KEEPCNT,
+                EpollChannelOption.TCP_USER_TIMEOUT,
+                EpollChannelOption.IP_FREEBIND,
+                EpollChannelOption.IP_TRANSPARENT,
+                EpollChannelOption.IP_RECVORIGDSTADDR,
+                EpollChannelOption.TCP_DEFER_ACCEPT,
+                EpollChannelOption.TCP_QUICKACK,
+                EpollChannelOption.SO_BUSY_POLL,
+                EpollChannelOption.EPOLL_MODE,
+                EpollChannelOption.TCP_MD5SIG,
+                EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE,
+                EpollChannelOption.UDP_GRO
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void epollProtocolFamilyConstructorsRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(() -> new EpollSocketChannel(InternetProtocolFamily.IPv4));
+        assertChannelConstructorMatchesAvailability(() -> new EpollServerSocketChannel(InternetProtocolFamily.IPv4));
+        assertChannelConstructorMatchesAvailability(() -> new EpollDatagramChannel(InternetProtocolFamily.IPv4));
+    }
+
+    @Test
+    void epollValueObjectsExposeStableStateWithoutNativeTransport() {
+        assertThat(EpollMode.values()).containsExactly(EpollMode.EDGE_TRIGGERED, EpollMode.LEVEL_TRIGGERED);
+        assertThat(EpollMode.valueOf("EDGE_TRIGGERED")).isSameAs(EpollMode.EDGE_TRIGGERED);
+        assertThat(EpollMode.valueOf("LEVEL_TRIGGERED")).isSameAs(EpollMode.LEVEL_TRIGGERED);
+
+        EpollTcpInfo tcpInfo = new EpollTcpInfo();
+        assertThat(new long[] {
+                tcpInfo.state(),
+                tcpInfo.caState(),
+                tcpInfo.retransmits(),
+                tcpInfo.probes(),
+                tcpInfo.backoff(),
+                tcpInfo.options(),
+                tcpInfo.sndWscale(),
+                tcpInfo.rcvWscale(),
+                tcpInfo.rto(),
+                tcpInfo.ato(),
+                tcpInfo.sndMss(),
+                tcpInfo.rcvMss(),
+                tcpInfo.unacked(),
+                tcpInfo.sacked(),
+                tcpInfo.lost(),
+                tcpInfo.retrans(),
+                tcpInfo.fackets(),
+                tcpInfo.lastDataSent(),
+                tcpInfo.lastAckSent(),
+                tcpInfo.lastDataRecv(),
+                tcpInfo.lastAckRecv(),
+                tcpInfo.pmtu(),
+                tcpInfo.rcvSsthresh(),
+                tcpInfo.rtt(),
+                tcpInfo.rttvar(),
+                tcpInfo.sndSsthresh(),
+                tcpInfo.sndCwnd(),
+                tcpInfo.advmss(),
+                tcpInfo.reordering(),
+                tcpInfo.rcvRtt(),
+                tcpInfo.rcvSpace(),
+                tcpInfo.totalRetrans()
+        }).containsOnly(0L);
+
+        VSockAddress address = new VSockAddress(3, 7);
+        VSockAddress sameAddress = new VSockAddress(3, 7);
+        VSockAddress differentAddress = new VSockAddress(3, 8);
+
+        assertThat(address.getCid()).isEqualTo(3);
+        assertThat(address.getPort()).isEqualTo(7);
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address).hasToString("VSockAddress{cid=3, port=7}");
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (Epoll.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(Supplier<? extends EventLoopGroup> constructor) {
+        if (Epoll.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage() == null ? current.getClass().getName() : current.getMessage();
     }
 }

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -96,6 +96,23 @@ class Netty_transport_classes_epollTest {
     }
 
     @Test
+    void epollFastOpenOptionsReuseTheSharedChannelOptionInstances() {
+        assertThat(EpollChannelOption.TCP_FASTOPEN).isSameAs(ChannelOption.TCP_FASTOPEN);
+        assertThat(EpollChannelOption.TCP_FASTOPEN.name())
+                .isEqualTo(ChannelOption.TCP_FASTOPEN.name())
+                .contains("TCP_FASTOPEN");
+
+        assertThat(EpollChannelOption.TCP_FASTOPEN_CONNECT).isSameAs(ChannelOption.TCP_FASTOPEN_CONNECT);
+        assertThat(EpollChannelOption.TCP_FASTOPEN_CONNECT.name())
+                .isEqualTo(ChannelOption.TCP_FASTOPEN_CONNECT.name())
+                .contains("TCP_FASTOPEN_CONNECT");
+
+        assertThat(ChannelOption.valueOf(EpollChannelOption.TCP_FASTOPEN.name())).isSameAs(EpollChannelOption.TCP_FASTOPEN);
+        assertThat(ChannelOption.valueOf(EpollChannelOption.TCP_FASTOPEN_CONNECT.name()))
+                .isSameAs(EpollChannelOption.TCP_FASTOPEN_CONNECT);
+    }
+
+    @Test
     void epollProtocolFamilyConstructorsRespectTransportAvailability() {
         assertChannelConstructorMatchesAvailability(() -> new EpollSocketChannel(InternetProtocolFamily.IPv4));
         assertChannelConstructorMatchesAvailability(() -> new EpollServerSocketChannel(InternetProtocolFamily.IPv4));

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -6,10 +6,12 @@
  */
 package io_netty.netty_transport_classes_epoll;
 
+import java.net.InetSocketAddress;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.Supplier;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -21,6 +23,7 @@ import io.netty.channel.epoll.EpollMode;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.epoll.VSockAddress;
 import io.netty.channel.socket.InternetProtocolFamily;
 import org.junit.jupiter.api.Test;
@@ -150,6 +153,67 @@ class Netty_transport_classes_epollTest {
         assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
         assertThat(address).isNotEqualTo(differentAddress);
         assertThat(address).hasToString("VSockAddress{cid=3, port=7}");
+    }
+
+    @Test
+    void segmentedDatagramPacketBufferOperationsPreserveSegmentMetadata() {
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 8080);
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 8081);
+
+        if (!SegmentedDatagramPacket.isSupported()) {
+            assertThatThrownBy(() -> new SegmentedDatagramPacket(
+                    Unpooled.wrappedBuffer(new byte[] {1, 2, 3, 4}),
+                    2,
+                    recipient,
+                    sender
+            )).isInstanceOf(IllegalStateException.class);
+            return;
+        }
+
+        SegmentedDatagramPacket packet = new SegmentedDatagramPacket(
+                Unpooled.wrappedBuffer(new byte[] {1, 2, 3, 4}),
+                2,
+                recipient,
+                sender
+        );
+        SegmentedDatagramPacket copied = packet.copy();
+        SegmentedDatagramPacket retainedDuplicate = packet.retainedDuplicate();
+        SegmentedDatagramPacket replaced = packet.replace(Unpooled.wrappedBuffer(new byte[] {9, 8}));
+
+        try {
+            assertThat(packet.segmentSize()).isEqualTo(2);
+            assertThat(packet.recipient()).isEqualTo(recipient);
+            assertThat(packet.sender()).isEqualTo(sender);
+            assertThat(packet.content().getByte(0)).isEqualTo((byte) 1);
+
+            assertThat(copied.segmentSize()).isEqualTo(2);
+            assertThat(copied.recipient()).isEqualTo(recipient);
+            assertThat(copied.sender()).isEqualTo(sender);
+            assertThat(copied.content()).isNotSameAs(packet.content());
+
+            packet.content().setByte(0, 7);
+            assertThat(copied.content().getByte(0)).isEqualTo((byte) 1);
+
+            assertThat(retainedDuplicate.segmentSize()).isEqualTo(2);
+            assertThat(retainedDuplicate.recipient()).isEqualTo(recipient);
+            assertThat(retainedDuplicate.sender()).isEqualTo(sender);
+            assertThat(retainedDuplicate.content()).isNotSameAs(packet.content());
+            assertThat(retainedDuplicate.content().getByte(0)).isEqualTo((byte) 7);
+
+            packet.content().setByte(1, 6);
+            assertThat(retainedDuplicate.content().getByte(1)).isEqualTo((byte) 6);
+
+            assertThat(replaced.segmentSize()).isEqualTo(2);
+            assertThat(replaced.recipient()).isEqualTo(recipient);
+            assertThat(replaced.sender()).isEqualTo(sender);
+            assertThat(replaced.content().getByte(0)).isEqualTo((byte) 9);
+            assertThat(replaced.content()).isNotSameAs(packet.content());
+        } finally {
+            replaced.release();
+            retainedDuplicate.release();
+            copied.release();
+            packet.release();
+        }
     }
 
     private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_classes_epoll;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_classes_epollTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.**"
+      "includeClasses" : "io.netty.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #437

This PR introduces tests and metadata for io.netty:netty-transport-classes-epoll:4.1.99.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 153819
- Cached input tokens: 3021312
- Output tokens: 38248
- Entries: 39
- Iterations: 3
- Library coverage percentage: 4.52
- Generated lines of code: 238
- Tested library lines of code: 700

Stats from `stats/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 583/12597 (4.63%)
- Line: 140/3083 (4.54%)
- Method: 61/751 (8.12%)
