### PR TITLE
[GenAI] Add support for io.netty:netty-transport-classes-epoll:4.1.99.Final using gpt-5.4

### DIFF
--- a/metadata/io.netty/netty-transport-classes-epoll/4.1.99.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-classes-epoll/4.1.99.Final/reachability-metadata.json
@@ -1,0 +1,274 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.util.ResourceLeakDetector"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.DefaultFileRegion"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.FileDescriptor"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "io.netty.channel.unix.PeerCredentials"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.AbstractReferenceCounted"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ReferenceCountUpdater"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.DefaultAttributeMap"
+      },
+      "type": "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.concurrent.DefaultPromise"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.concurrent.SingleThreadEventExecutor"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader$1"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.io.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$6"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$4"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$9"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$5"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.nio.channels.FileChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$7"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.CleanerJava9$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$2"
+      },
+      "type": "sun.misc.Unsafe"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$3"
+      },
+      "type": "sun.misc.Unsafe"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll.so"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.NativeLibraryLoader"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-classes-epoll/index.json
+++ b/metadata/io.netty/netty-transport-classes-epoll/index.json
@@ -1,0 +1,15 @@
+[
+  {
+    "latest": true,
+    "allowed-packages": [ "io.netty" ],
+    "metadata-version": "4.1.99.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.99.Final/netty-transport-classes-epoll-4.1.99.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://github.com/netty/netty/tree/netty-4.1.99.Final/transport-native-epoll/src/test/java/io/netty/channel/epoll",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/4.1.99.Final/netty-transport-classes-epoll-4.1.99.Final-javadoc.jar",
+    "description": "Provides Netty's Linux epoll transport classes for channels, event loops, socket configuration, and related epoll-specific APIs. It enables Netty applications to use epoll edge-triggered I/O and related Linux-native transport features when paired with the corresponding native epoll transport.",
+    "tested-versions": [
+      "4.1.99.Final"
+    ]
+  }
+]

--- a/stats/stats.json
+++ b/stats/stats.json
@@ -2586,6 +2586,41 @@
         }
       }
     },
+    "io.netty:netty-transport-classes-epoll" : {
+      "metadataVersions" : {
+        "4.1.99.Final" : {
+          "versions" : [ {
+            "version" : "4.1.99.Final",
+            "dynamicAccess" : {
+              "breakdown" : { },
+              "coverageRatio" : 1.0,
+              "coveredCalls" : 0,
+              "totalCalls" : 0
+            },
+            "libraryCoverage" : {
+              "instruction" : {
+                "covered" : 627,
+                "missed" : 11970,
+                "ratio" : 0.049774,
+                "total" : 12597
+              },
+              "line" : {
+                "covered" : 149,
+                "missed" : 2934,
+                "ratio" : 0.04833,
+                "total" : 3083
+              },
+              "method" : {
+                "covered" : 63,
+                "missed" : 688,
+                "ratio" : 0.083888,
+                "total" : 751
+              }
+            }
+          } ]
+        }
+      }
+    },
     "io.opentelemetry:opentelemetry-exporter-jaeger" : {
       "metadataVersions" : {
         "1.19.0" : {

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-classes-epoll:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-classes-epoll:4.1.99.Final
+library.version = 4.1.99.Final
+metadata.dir = io.netty/netty-transport-classes-epoll/4.1.99.Final/

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-classes-epoll_tests'

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -96,6 +96,36 @@ class Netty_transport_classes_epollTest {
     }
 
     @Test
+    void vSockWildcardAddressesExposeSpecialEndpointConstants() {
+        VSockAddress wildcardAddress = new VSockAddress(
+                VSockAddress.VMADDR_CID_ANY,
+                VSockAddress.VMADDR_PORT_ANY);
+        VSockAddress sameWildcardAddress = new VSockAddress(
+                VSockAddress.VMADDR_CID_ANY,
+                VSockAddress.VMADDR_PORT_ANY);
+        VSockAddress hostWildcardPortAddress = new VSockAddress(
+                VSockAddress.VMADDR_CID_HOST,
+                VSockAddress.VMADDR_PORT_ANY);
+        VSockAddress wildcardCidConcretePortAddress = new VSockAddress(VSockAddress.VMADDR_CID_ANY, 9000);
+
+        assertThat(wildcardAddress).isEqualTo(sameWildcardAddress).hasSameHashCodeAs(sameWildcardAddress);
+        assertThat(wildcardAddress)
+                .isNotEqualTo(hostWildcardPortAddress)
+                .isNotEqualTo(wildcardCidConcretePortAddress)
+                .isNotEqualTo("not-an-address");
+        assertThat(wildcardAddress.getCid()).isEqualTo(VSockAddress.VMADDR_CID_ANY);
+        assertThat(wildcardAddress.getPort()).isEqualTo(VSockAddress.VMADDR_PORT_ANY);
+        assertThat(wildcardAddress.toString())
+                .contains("cid=" + VSockAddress.VMADDR_CID_ANY, "port=" + VSockAddress.VMADDR_PORT_ANY);
+        assertThat(List.of(
+                VSockAddress.VMADDR_CID_ANY,
+                VSockAddress.VMADDR_CID_HYPERVISOR,
+                VSockAddress.VMADDR_CID_LOCAL,
+                VSockAddress.VMADDR_CID_HOST))
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
     void segmentedDatagramPacketSupportAndCopiesBehaveConsistently() {
         assertThat(SegmentedDatagramPacket.isSupported())
                 .isEqualTo(EpollDatagramChannel.isSegmentedDatagramPacketSupported());

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -6,8 +6,10 @@
  */
 package io_netty.netty_transport_classes_epoll;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollChannelOption;
@@ -20,7 +22,9 @@ import io.netty.channel.epoll.EpollServerDomainSocketChannel;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.epoll.VSockAddress;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,6 +93,61 @@ class Netty_transport_classes_epollTest {
 
         EpollTcpInfo tcpInfo = new EpollTcpInfo();
         assertThat(readTcpInfo(tcpInfo)).containsOnly(0L);
+    }
+
+    @Test
+    void segmentedDatagramPacketSupportAndCopiesBehaveConsistently() {
+        assertThat(SegmentedDatagramPacket.isSupported())
+                .isEqualTo(EpollDatagramChannel.isSegmentedDatagramPacketSupported());
+
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 8081);
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 8082);
+
+        if (!SegmentedDatagramPacket.isSupported()) {
+            assertThatThrownBy(() -> new SegmentedDatagramPacket(Unpooled.EMPTY_BUFFER, 1, recipient, sender))
+                    .isInstanceOf(IllegalStateException.class);
+            return;
+        }
+
+        SegmentedDatagramPacket packet = null;
+        SegmentedDatagramPacket copiedPacket = null;
+        SegmentedDatagramPacket replacedPacket = null;
+        try {
+            packet = new SegmentedDatagramPacket(
+                    Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 }),
+                    2,
+                    recipient,
+                    sender);
+            assertThat(packet.segmentSize()).isEqualTo(2);
+            assertThat(packet.recipient()).isEqualTo(recipient);
+            assertThat(packet.sender()).isEqualTo(sender);
+            assertThat(packet.content().readableBytes()).isEqualTo(4);
+
+            copiedPacket = packet.copy();
+            assertThat(copiedPacket).isNotSameAs(packet);
+            assertThat(copiedPacket.segmentSize()).isEqualTo(packet.segmentSize());
+            assertThat(copiedPacket.recipient()).isEqualTo(recipient);
+            assertThat(copiedPacket.sender()).isEqualTo(sender);
+            assertThat(copiedPacket.content()).isNotSameAs(packet.content());
+            assertThat(copiedPacket.content().getByte(0)).isEqualTo((byte) 1);
+
+            packet.content().setByte(0, 9);
+            assertThat(packet.content().getByte(0)).isEqualTo((byte) 9);
+            assertThat(copiedPacket.content().getByte(0)).isEqualTo((byte) 1);
+
+            replacedPacket = packet.replace(Unpooled.wrappedBuffer(new byte[] { 7, 8, 9 }));
+            assertThat(replacedPacket).isNotSameAs(packet);
+            assertThat(replacedPacket.segmentSize()).isEqualTo(packet.segmentSize());
+            assertThat(replacedPacket.recipient()).isEqualTo(recipient);
+            assertThat(replacedPacket.sender()).isEqualTo(sender);
+            assertThat(replacedPacket.content().readableBytes()).isEqualTo(3);
+            assertThat(replacedPacket.content().getByte(0)).isEqualTo((byte) 7);
+            assertThat(replacedPacket.content().getByte(2)).isEqualTo((byte) 9);
+        } finally {
+            ReferenceCountUtil.safeRelease(replacedPacket);
+            ReferenceCountUtil.safeRelease(copiedPacket);
+            ReferenceCountUtil.safeRelease(packet);
+        }
     }
 
     @Test

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -6,11 +6,149 @@
  */
 package io_netty.netty_transport_classes_epoll;
 
+import java.util.List;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollDomainDatagramChannel;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollMode;
+import io.netty.channel.epoll.EpollServerDomainSocketChannel;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.epoll.VSockAddress;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 class Netty_transport_classes_epollTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void epollAvailabilityStateIsSelfConsistent() {
+        if (Epoll.isAvailable()) {
+            assertThat(Epoll.unavailabilityCause()).isNull();
+            assertThatCode(Epoll::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(Epoll.unavailabilityCause())
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining("netty_transport_native_epoll");
+        assertThatThrownBy(Epoll::ensureAvailability)
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining("failed to load the required native library");
+        assertThat(Epoll.isTcpFastOpenClientSideAvailable()).isFalse();
+        assertThat(Epoll.isTcpFastOpenServerSideAvailable()).isFalse();
+        assertThat(EpollDatagramChannel.isSegmentedDatagramPacketSupported()).isFalse();
+    }
+
+    @Test
+    void epollConstantsAndValueObjectsExposeStablePublicState() {
+        assertThat(EpollMode.values()).containsExactly(EpollMode.EDGE_TRIGGERED, EpollMode.LEVEL_TRIGGERED);
+        assertThat(EpollMode.valueOf("EDGE_TRIGGERED")).isSameAs(EpollMode.EDGE_TRIGGERED);
+        assertThat(EpollMode.valueOf("LEVEL_TRIGGERED")).isSameAs(EpollMode.LEVEL_TRIGGERED);
+
+        List<ChannelOption<?>> options = List.of(
+                EpollChannelOption.TCP_CORK,
+                EpollChannelOption.TCP_NOTSENT_LOWAT,
+                EpollChannelOption.TCP_KEEPIDLE,
+                EpollChannelOption.TCP_KEEPINTVL,
+                EpollChannelOption.TCP_KEEPCNT,
+                EpollChannelOption.TCP_USER_TIMEOUT,
+                EpollChannelOption.IP_FREEBIND,
+                EpollChannelOption.IP_TRANSPARENT,
+                EpollChannelOption.IP_RECVORIGDSTADDR,
+                EpollChannelOption.TCP_DEFER_ACCEPT,
+                EpollChannelOption.TCP_QUICKACK,
+                EpollChannelOption.SO_BUSY_POLL,
+                EpollChannelOption.EPOLL_MODE,
+                EpollChannelOption.TCP_MD5SIG,
+                EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE,
+                EpollChannelOption.UDP_GRO);
+        assertThat(options).doesNotContainNull();
+        assertThat(options).extracting(ChannelOption::name).doesNotHaveDuplicates();
+        assertThat(options).extracting(ChannelOption::name).anySatisfy(name -> assertThat(name).endsWith("TCP_CORK"));
+        assertThat(options).extracting(ChannelOption::name).anySatisfy(name -> assertThat(name).endsWith("EPOLL_MODE"));
+        assertThat(options).extracting(ChannelOption::name).contains("TCP_MD5SIG", "UDP_GRO");
+
+        VSockAddress address = new VSockAddress(VSockAddress.VMADDR_CID_HOST, 8080);
+        VSockAddress sameAddress = new VSockAddress(VSockAddress.VMADDR_CID_HOST, 8080);
+        VSockAddress differentAddress = new VSockAddress(VSockAddress.VMADDR_CID_LOCAL, 8080);
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address.getCid()).isEqualTo(VSockAddress.VMADDR_CID_HOST);
+        assertThat(address.getPort()).isEqualTo(8080);
+        assertThat(address.toString()).contains("cid=" + VSockAddress.VMADDR_CID_HOST, "port=8080");
+
+        EpollTcpInfo tcpInfo = new EpollTcpInfo();
+        assertThat(readTcpInfo(tcpInfo)).containsOnly(0L);
+    }
+
+    @Test
+    void nativeChannelConstructorsFailCleanlyWithoutTheNativeEpollArtifact() {
+        assumeFalse(Epoll.isAvailable(), "This test only applies when the native epoll library is absent");
+
+        assertNativeLibraryFailure(() -> new EpollEventLoopGroup(), "failed to load the required native library");
+        assertNativeLibraryFailure(() -> new EpollSocketChannel(), "newSocketStreamFd");
+        assertNativeLibraryFailure(() -> new EpollServerSocketChannel(), "newSocketStreamFd");
+        assertNativeLibraryFailure(() -> new EpollDatagramChannel(), "newSocketDgramFd");
+        assertNativeLibraryFailure(() -> new EpollDomainSocketChannel(), "newSocketDomainFd");
+        assertNativeLibraryFailure(() -> new EpollServerDomainSocketChannel(), "newSocketDomainFd");
+        assertNativeLibraryFailure(() -> new EpollDomainDatagramChannel(), "newSocketDomainDgramFd");
+    }
+
+    private static void assertNativeLibraryFailure(ThrowingConstructor constructor, String messageFragment) {
+        assertThatThrownBy(constructor::construct)
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining(messageFragment);
+    }
+
+    private static long[] readTcpInfo(EpollTcpInfo tcpInfo) {
+        return new long[] {
+                tcpInfo.state(),
+                tcpInfo.caState(),
+                tcpInfo.retransmits(),
+                tcpInfo.probes(),
+                tcpInfo.backoff(),
+                tcpInfo.options(),
+                tcpInfo.sndWscale(),
+                tcpInfo.rcvWscale(),
+                tcpInfo.rto(),
+                tcpInfo.ato(),
+                tcpInfo.sndMss(),
+                tcpInfo.rcvMss(),
+                tcpInfo.unacked(),
+                tcpInfo.sacked(),
+                tcpInfo.lost(),
+                tcpInfo.retrans(),
+                tcpInfo.fackets(),
+                tcpInfo.lastDataSent(),
+                tcpInfo.lastAckSent(),
+                tcpInfo.lastDataRecv(),
+                tcpInfo.lastAckRecv(),
+                tcpInfo.pmtu(),
+                tcpInfo.rcvSsthresh(),
+                tcpInfo.rtt(),
+                tcpInfo.rttvar(),
+                tcpInfo.sndSsthresh(),
+                tcpInfo.sndCwnd(),
+                tcpInfo.advmss(),
+                tcpInfo.reordering(),
+                tcpInfo.rcvRtt(),
+                tcpInfo.rcvSpace(),
+                tcpInfo.totalRetrans()
+        };
+    }
+
+    @FunctionalInterface
+    private interface ThrowingConstructor {
+        Object construct();
     }
 }

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -144,7 +144,7 @@ class Netty_transport_classes_epollTest {
         SegmentedDatagramPacket replacedPacket = null;
         try {
             packet = new SegmentedDatagramPacket(
-                    Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 }),
+                    Unpooled.wrappedBuffer(new byte[] {1, 2, 3, 4}),
                     2,
                     recipient,
                     sender);
@@ -165,7 +165,7 @@ class Netty_transport_classes_epollTest {
             assertThat(packet.content().getByte(0)).isEqualTo((byte) 9);
             assertThat(copiedPacket.content().getByte(0)).isEqualTo((byte) 1);
 
-            replacedPacket = packet.replace(Unpooled.wrappedBuffer(new byte[] { 7, 8, 9 }));
+            replacedPacket = packet.replace(Unpooled.wrappedBuffer(new byte[] {7, 8, 9}));
             assertThat(replacedPacket).isNotSameAs(packet);
             assertThat(replacedPacket.segmentSize()).isEqualTo(packet.segmentSize());
             assertThat(replacedPacket.recipient()).isEqualTo(recipient);

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/src/test/java/io_netty/netty_transport_classes_epoll/Netty_transport_classes_epollTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_classes_epoll;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_classes_epollTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-epoll/4.1.99.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.**"
+      "includeClasses" : "io.netty.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #437

This PR introduces tests and metadata for io.netty:netty-transport-classes-epoll:4.1.99.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 161166
- Cached input tokens: 2228992
- Output tokens: 35393
- Entries: 49
- Iterations: 3
- Library coverage percentage: 4.83
- Generated lines of code: 219
- Tested library lines of code: 149

Stats from `stats/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 627/12597 (4.98%)
- Line: 149/3083 (4.83%)
- Method: 63/751 (8.39%)
