### PR TITLE
Do not auto-assign library support issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_support_new_library.yml
+++ b/.github/ISSUE_TEMPLATE/01_support_new_library.yml
@@ -4,8 +4,6 @@ title: "Support for {maven_coordinates}"
 labels:
   - library-new-request
   - priority
-assignees:
-  - kimeta
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_update_existing_library.yml
+++ b/.github/ISSUE_TEMPLATE/02_update_existing_library.yml
@@ -4,8 +4,6 @@ title: "Update existing library: {maven_coordinates}"
 labels:
   - library-update-request
   - priority
-assignees:
-  - vjovanov
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
Remove the default assignees from the two library-support issue templates so new tickets stay unassigned by default.

## Testing
- not run (issue template change only)

Closes #1950
