### PR TITLE
Scaffold: derive package roots from JAR instead of Maven group ID

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -14,7 +14,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
+import org.graalvm.internal.tck.utils.JarUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
@@ -29,6 +33,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Generates a scaffold for a new library.
@@ -81,6 +87,7 @@ class ScaffoldTask extends DefaultTask {
     @TaskAction
     void run() throws IOException {
         Coordinates coordinates = Coordinates.parse(this.coordinates);
+        List<String> packageRoots = derivePackageRoots(coordinates);
 
         Path coordinatesMetadataRoot = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$", coordinates)).toPath();
         Path coordinatesMetadataVersionRoot = coordinatesMetadataRoot.resolve(coordinates.version());
@@ -98,16 +105,16 @@ class ScaffoldTask extends DefaultTask {
                 if (!update) {
                     getLogger().log(LogLevel.INFO, "Artifact metadata root already exists for {}, appending new version entry", coordinates);
                 }
-                updateCoordinatesMetadataRootJson(coordinatesMetadataRoot, coordinates);
+                updateCoordinatesMetadataRootJson(coordinatesMetadataRoot, coordinates, packageRoots);
             }
         } else {
-            writeCoordinatesMetadataRootJson(coordinatesMetadataRoot, coordinates);
+            writeCoordinatesMetadataRootJson(coordinatesMetadataRoot, coordinates, packageRoots);
         }
 
         writeCoordinatesMetadataVersionJsons(coordinatesMetadataVersionRoot, coordinates);
 
         // Tests
-        writeTestScaffold(coordinatesTestRoot, coordinates);
+        writeTestScaffold(coordinatesTestRoot, coordinates, packageRoots);
 
         System.out.printf("Generated metadata and test for %s%n", coordinates);
         System.out.printf("You can now use 'gradle test -Pcoordinates=%s' to run the tests%n", coordinates);
@@ -135,7 +142,7 @@ class ScaffoldTask extends DefaultTask {
         return entries.stream().noneMatch(e -> e.metadataVersion().equalsIgnoreCase(coordinates.version()));
     }
 
-    private void writeTestScaffold(Path coordinatesTestRoot, Coordinates coordinates) throws IOException {
+    private void writeTestScaffold(Path coordinatesTestRoot, Coordinates coordinates, List<String> packageRoots) throws IOException {
         // build.gradle
         writeToFile(
                 coordinatesTestRoot.resolve("build.gradle"),
@@ -145,7 +152,7 @@ class ScaffoldTask extends DefaultTask {
         // user-code-filter.json
         writeToFile(
                 coordinatesTestRoot.resolve("user-code-filter.json"),
-                CoordinateUtils.replace(loadResource("/scaffold/user-code-filter.json.template"), coordinates)
+                buildUserCodeFilter(packageRoots)
         );
 
         // settings.gradle
@@ -185,15 +192,21 @@ class ScaffoldTask extends DefaultTask {
         );
     }
 
-    private void writeCoordinatesMetadataRootJson(Path metadataRoot, Coordinates coordinates) throws IOException {
+    private void writeCoordinatesMetadataRootJson(Path metadataRoot, Coordinates coordinates, List<String> packageRoots) throws IOException {
         // metadata/$group$/$artifact$/index.json
+        String template = loadResource("/scaffold/metadataIndex.json.template");
+        // Replace $group$ in allowed-packages with the JAR-derived roots
+        String allowedPackagesJson = packageRoots.stream()
+                .map(root -> "\"" + root + "\"")
+                .collect(Collectors.joining(", "));
+        template = template.replace("\"$group$\"", allowedPackagesJson);
         writeToFile(
                 metadataRoot.resolve("index.json"),
-                CoordinateUtils.replace(loadResource("/scaffold/metadataIndex.json.template"), coordinates)
+                CoordinateUtils.replace(template, coordinates)
         );
     }
 
-    private void updateCoordinatesMetadataRootJson(Path metadataRoot, Coordinates coordinates) throws IOException {
+    private void updateCoordinatesMetadataRootJson(Path metadataRoot, Coordinates coordinates, List<String> packageRoots) throws IOException {
         if (!shouldAddNewMetadataEntry(metadataRoot, coordinates)) {
             throw new RuntimeException("Metadata for " + coordinates + " already exists!");
         }
@@ -215,7 +228,7 @@ class ScaffoldTask extends DefaultTask {
                 null, // description
                 List.of(coordinates.version()), // tested-versions
                 null, // skipped-versions
-                List.of(coordinates.group()), // allowed-packages (default to group)
+                packageRoots, // allowed-packages (derived from JAR)
                 null // requires
         );
 
@@ -267,6 +280,52 @@ class ScaffoldTask extends DefaultTask {
         for (int i = 0; i < entries.size(); i++) {
             setLatest(entries, i, i == latestIndex ? true : null);
         }
+    }
+
+    /// Resolves the binary JAR for the given coordinates and derives minimal package roots.
+    private List<String> derivePackageRoots(Coordinates coordinates) throws IOException {
+        DependencyHandler dependencies = getProject().getDependencies();
+        Configuration configuration = getProject().getConfigurations().detachedConfiguration(
+                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version())
+        );
+        configuration.setTransitive(false);
+
+        List<Path> jars = configuration.resolve().stream()
+                .map(file -> file.toPath().toAbsolutePath())
+                .toList();
+
+        if (jars.isEmpty()) {
+            throw new GradleException("Failed to resolve JAR for " + coordinates);
+        }
+
+        Set<String> classNames = JarUtils.loadClassNames(jars);
+        List<String> roots = JarUtils.derivePackageRoots(classNames);
+
+        if (roots.isEmpty()) {
+            getLogger().log(LogLevel.WARN, "No packages found in JAR for {}, falling back to group ID", coordinates);
+            return List.of(coordinates.group());
+        }
+
+        getLogger().log(LogLevel.INFO, "Derived package roots for {}: {}", coordinates, roots);
+        return roots;
+    }
+
+    /// Builds user-code-filter.json content with an excludeClasses rule and one includeClasses per root.
+    private String buildUserCodeFilter(List<String> packageRoots) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"rules\": [\n");
+        sb.append("    {\n");
+        sb.append("      \"excludeClasses\": \"**\"\n");
+        sb.append("    }");
+        for (String root : packageRoots) {
+            sb.append(",\n    {\n");
+            sb.append("      \"includeClasses\": \"").append(root).append(".**\"\n");
+            sb.append("    }");
+        }
+        sb.append("\n  ]\n");
+        sb.append("}\n");
+        return sb.toString();
     }
 
     private String loadResource(String name) throws IOException {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/JarUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/JarUtils.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for inspecting JAR files to derive package structures.
+ */
+public abstract class JarUtils {
+
+    private static final String CLASS_SUFFIX = ".class";
+    private static final String MODULE_INFO = "module-info.class";
+    private static final String META_INF_VERSIONS = "META-INF/versions/";
+
+    /**
+     * Scans the given JARs and returns all fully-qualified class names found.
+     * Handles multi-release JARs by stripping the {@code META-INF/versions/N/} prefix.
+     * Excludes {@code module-info.class}.
+     */
+    public static Set<String> loadClassNames(List<Path> jars) throws IOException {
+        Set<String> classNames = new HashSet<>();
+        for (Path jar : jars) {
+            try (JarFile jarFile = new JarFile(jar.toFile())) {
+                Enumeration<JarEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    if (entry.isDirectory()) {
+                        continue;
+                    }
+                    String name = entry.getName();
+
+                    // Strip multi-release prefix
+                    if (name.startsWith(META_INF_VERSIONS)) {
+                        int thirdSlash = name.indexOf('/', META_INF_VERSIONS.length());
+                        if (thirdSlash >= 0) {
+                            name = name.substring(thirdSlash + 1);
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    if (!name.endsWith(CLASS_SUFFIX) || name.endsWith(MODULE_INFO)) {
+                        continue;
+                    }
+
+                    // Convert path to FQCN: replace '/' with '.' and strip .class
+                    String fqcn = name.substring(0, name.length() - CLASS_SUFFIX.length()).replace('/', '.');
+                    classNames.add(fqcn);
+                }
+            }
+        }
+        return classNames;
+    }
+
+    /**
+     * Extracts all unique packages from a set of fully-qualified class names.
+     */
+    public static Set<String> extractPackages(Set<String> classNames) {
+        Set<String> packages = new TreeSet<>();
+        for (String className : classNames) {
+            int lastDot = className.lastIndexOf('.');
+            if (lastDot > 0) {
+                packages.add(className.substring(0, lastDot));
+            }
+        }
+        return packages;
+    }
+
+    /**
+     * Derives minimal package roots from a set of class names.
+     * <p>
+     * Algorithm:
+     * 1. Extract unique packages
+     * 2. Subsumption: remove any package that has a shorter prefix already in the set
+     * 3. Sibling merge (bottom-up, iterative): if 2+ packages share the same parent
+     *    and the parent has depth > 1, replace them with the parent
+     * 4. Final subsumption after merging
+     */
+    public static List<String> derivePackageRoots(Set<String> classNames) {
+        Set<String> packages = extractPackages(classNames);
+        if (packages.isEmpty()) {
+            return List.of();
+        }
+
+        // Subsumption pass
+        packages = subsume(packages);
+
+        // Sibling merge (iterative until stable)
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            // Group by parent package
+            Map<String, List<String>> byParent = packages.stream()
+                    .filter(p -> p.contains("."))
+                    .collect(Collectors.groupingBy(p -> p.substring(0, p.lastIndexOf('.'))));
+
+            Set<String> merged = new TreeSet<>(packages);
+            for (Map.Entry<String, List<String>> entry : byParent.entrySet()) {
+                String parent = entry.getKey();
+                List<String> siblings = entry.getValue();
+                // Merge if 2+ siblings and parent has depth > 1 (contains a dot)
+                if (siblings.size() >= 2 && parent.contains(".")) {
+                    merged.removeAll(siblings);
+                    merged.add(parent);
+                    changed = true;
+                }
+            }
+            packages = merged;
+        }
+
+        // Final subsumption
+        packages = subsume(packages);
+
+        return packages.stream().sorted().toList();
+    }
+
+    /// Removes any package that is subsumed by a shorter prefix in the set.
+    private static Set<String> subsume(Set<String> packages) {
+        Set<String> result = new TreeSet<>();
+        for (String pkg : packages) {
+            boolean subsumed = false;
+            for (String other : packages) {
+                if (!other.equals(pkg) && pkg.startsWith(other + ".")) {
+                    subsumed = true;
+                    break;
+                }
+            }
+            if (!subsumed) {
+                result.add(pkg);
+            }
+        }
+        return result;
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -19,8 +19,11 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,188 +37,212 @@ class ScaffoldTaskTests {
 
     @Test
     void runCreatesCompleteScaffoldFromTemplates() throws IOException {
-        Coordinates coordinates = Coordinates.parse("com.example.lib:some-artifact:1.0.0.FINAL");
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
-        ScaffoldTask task = project.getTasks().register("scaffold", ScaffoldTask.class).get();
-        task.setCoordinates(coordinates.toString());
+        Coordinates coordinates = Coordinates.parse("org.lz4:lz4-java:1.8.0");
+        installLibraryArtifact(coordinates, List.of(
+                "net/jpountz/lz4/LZ4Factory.class",
+                "net/jpountz/util/SafeUtils.class",
+                "META-INF/versions/11/net/jpountz/lz4/LZ4FrameInputStream.class",
+                "module-info.class"
+        ));
+        Project project = createProject();
+        ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
 
         task.run();
 
         assertThat(listGeneratedFiles()).containsExactly(
-                "metadata/com.example.lib/some-artifact/1.0.0.FINAL/reachability-metadata.json",
-                "metadata/com.example.lib/some-artifact/index.json",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/.gitignore",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/build.gradle",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/gradle.properties",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/settings.gradle",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/src/test/java/com_example_lib/some_artifact/Some_artifactTest.java",
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/user-code-filter.json"
+                "metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json",
+                "metadata/org.lz4/lz4-java/index.json",
+                "tests/src/org.lz4/lz4-java/1.8.0/.gitignore",
+                "tests/src/org.lz4/lz4-java/1.8.0/build.gradle",
+                "tests/src/org.lz4/lz4-java/1.8.0/gradle.properties",
+                "tests/src/org.lz4/lz4-java/1.8.0/settings.gradle",
+                "tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java",
+                "tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json"
         );
 
-        assertGeneratedFileMatchesTemplate(
-                coordinates,
-                "metadata/com.example.lib/some-artifact/index.json",
-                "/scaffold/metadataIndex.json.template"
+        assertGeneratedMetadataIndex(
+                "metadata/org.lz4/lz4-java/index.json",
+                List.of("net.jpountz"),
+                List.of("1.8.0")
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "metadata/com.example.lib/some-artifact/1.0.0.FINAL/reachability-metadata.json",
+                "metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json",
                 "/scaffold/reachability-metadata.json.template"
         );
         assertGeneratedReachabilityMetadataIsEmptyJsonObject(
-                "metadata/com.example.lib/some-artifact/1.0.0.FINAL/reachability-metadata.json"
+                "metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json"
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/.gitignore",
+                "tests/src/org.lz4/lz4-java/1.8.0/.gitignore",
                 "/scaffold/.gitignore.template"
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/build.gradle",
+                "tests/src/org.lz4/lz4-java/1.8.0/build.gradle",
                 "/scaffold/build.gradle.template"
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/gradle.properties",
+                "tests/src/org.lz4/lz4-java/1.8.0/gradle.properties",
                 "/scaffold/gradle.properties.template"
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/settings.gradle",
+                "tests/src/org.lz4/lz4-java/1.8.0/settings.gradle",
                 "/scaffold/settings.gradle.template"
         );
-        assertGeneratedFileMatchesTemplate(
-                coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/user-code-filter.json",
-                "/scaffold/user-code-filter.json.template"
+        assertGeneratedUserCodeFilter(
+                "tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json",
+                List.of("net.jpountz")
         );
         assertGeneratedFileMatchesTemplate(
                 coordinates,
-                "tests/src/com.example.lib/some-artifact/1.0.0.FINAL/src/test/java/com_example_lib/some_artifact/Some_artifactTest.java",
+                "tests/src/org.lz4/lz4-java/1.8.0/src/test/java/org_lz4/lz4_java/Lz4_javaTest.java",
                 "/scaffold/Test.java.template"
         );
     }
 
     @Test
     void runWithSkipTestsOmitsOnlyJavaTestStub() throws IOException {
-        Coordinates coordinates = Coordinates.parse("com.example:demo:1.0.0");
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
-        ScaffoldTask task = project.getTasks().register("scaffold", ScaffoldTask.class).get();
-        task.setCoordinates(coordinates.toString());
+        Coordinates coordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        installLibraryArtifact(coordinates, List.of(
+                "org/postgresql/Driver.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        Project project = createProject();
+        ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
         task.setSkipTests(true);
 
         task.run();
 
         assertThat(listGeneratedFiles()).containsExactly(
-                "metadata/com.example/demo/1.0.0/reachability-metadata.json",
-                "metadata/com.example/demo/index.json",
-                "tests/src/com.example/demo/1.0.0/.gitignore",
-                "tests/src/com.example/demo/1.0.0/build.gradle",
-                "tests/src/com.example/demo/1.0.0/gradle.properties",
-                "tests/src/com.example/demo/1.0.0/settings.gradle",
-                "tests/src/com.example/demo/1.0.0/user-code-filter.json"
+                "metadata/org.postgresql/postgresql/42.7.3/reachability-metadata.json",
+                "metadata/org.postgresql/postgresql/index.json",
+                "tests/src/org.postgresql/postgresql/42.7.3/.gitignore",
+                "tests/src/org.postgresql/postgresql/42.7.3/build.gradle",
+                "tests/src/org.postgresql/postgresql/42.7.3/gradle.properties",
+                "tests/src/org.postgresql/postgresql/42.7.3/settings.gradle",
+                "tests/src/org.postgresql/postgresql/42.7.3/user-code-filter.json"
         );
 
-        assertThat(tempDir.resolve("tests/src/com.example/demo/1.0.0/src/test/java/com_example/demo/DemoTest.java"))
+        assertGeneratedUserCodeFilter(
+                "tests/src/org.postgresql/postgresql/42.7.3/user-code-filter.json",
+                List.of("org.postgresql")
+        );
+        assertThat(tempDir.resolve("tests/src/org.postgresql/postgresql/42.7.3/src/test/java/org_postgresql/postgresql/PostgresqlTest.java"))
                 .doesNotExist();
     }
 
     @Test
     void runWithUpdateAddsNewVersionMetadataAndTestScaffold() throws IOException {
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
+        Coordinates initialCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.2");
+        Coordinates updatedCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        installLibraryArtifact(initialCoordinates, List.of(
+                "org/postgresql/Driver.class",
+                "org/postgresql/ds/PGSimpleDataSource.class"
+        ));
+        installLibraryArtifact(updatedCoordinates, List.of(
+                "org/postgresql/jdbc/PgConnection.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        Project project = createProject();
 
-        ScaffoldTask initialTask = project.getTasks().register("scaffoldInitial", ScaffoldTask.class).get();
-        initialTask.setCoordinates("com.example:demo:1.0.0");
+        ScaffoldTask initialTask = registerScaffoldTask(project, "scaffoldInitial", initialCoordinates);
         initialTask.run();
 
-        Coordinates updatedCoordinates = Coordinates.parse("com.example:demo:2.0.0");
-        ScaffoldTask updateTask = project.getTasks().register("scaffoldUpdate", ScaffoldTask.class).get();
-        updateTask.setCoordinates(updatedCoordinates.toString());
+        ScaffoldTask updateTask = registerScaffoldTask(project, "scaffoldUpdate", updatedCoordinates);
         updateTask.setUpdate(true);
 
         updateTask.run();
 
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "metadata/com.example/demo/2.0.0/reachability-metadata.json",
+                "metadata/org.postgresql/postgresql/42.7.3/reachability-metadata.json",
                 "/scaffold/reachability-metadata.json.template"
         );
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "tests/src/com.example/demo/2.0.0/build.gradle",
+                "tests/src/org.postgresql/postgresql/42.7.3/build.gradle",
                 "/scaffold/build.gradle.template"
         );
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "tests/src/com.example/demo/2.0.0/settings.gradle",
+                "tests/src/org.postgresql/postgresql/42.7.3/settings.gradle",
                 "/scaffold/settings.gradle.template"
         );
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "tests/src/com.example/demo/2.0.0/gradle.properties",
+                "tests/src/org.postgresql/postgresql/42.7.3/gradle.properties",
                 "/scaffold/gradle.properties.template"
         );
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "tests/src/com.example/demo/2.0.0/.gitignore",
+                "tests/src/org.postgresql/postgresql/42.7.3/.gitignore",
                 "/scaffold/.gitignore.template"
         );
         assertGeneratedFileMatchesTemplate(
                 updatedCoordinates,
-                "tests/src/com.example/demo/2.0.0/src/test/java/com_example/demo/DemoTest.java",
+                "tests/src/org.postgresql/postgresql/42.7.3/src/test/java/org_postgresql/postgresql/PostgresqlTest.java",
                 "/scaffold/Test.java.template"
+        );
+        assertGeneratedUserCodeFilter(
+                "tests/src/org.postgresql/postgresql/42.7.3/user-code-filter.json",
+                List.of("org.postgresql")
         );
 
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
-                tempDir.resolve("metadata/com.example/demo/index.json").toFile(),
+                tempDir.resolve("metadata/org.postgresql/postgresql/index.json").toFile(),
                 new TypeReference<>() {}
         );
         assertThat(indexEntries).hasSize(2);
-        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "1.0.0")
-                .containsEntry("tested-versions", List.of("1.0.0"))
-                .containsEntry("allowed-packages", List.of("com.example"))
+        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "42.7.2")
+                .containsEntry("tested-versions", List.of("42.7.2"))
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .doesNotContainKey("latest");
-        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "2.0.0")
-                .containsEntry("tested-versions", List.of("2.0.0"))
-                .containsEntry("allowed-packages", List.of("com.example"))
+        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "42.7.3")
+                .containsEntry("tested-versions", List.of("42.7.3"))
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .containsEntry("latest", true);
     }
 
     @Test
     void runWithoutUpdateAddsNewVersionWhenArtifactMetadataAlreadyExists() throws IOException {
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
+        Coordinates initialCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.2");
+        Coordinates secondCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        installLibraryArtifact(initialCoordinates, List.of(
+                "org/postgresql/Driver.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        installLibraryArtifact(secondCoordinates, List.of(
+                "org/postgresql/jdbc/PgConnection.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        Project project = createProject();
 
-        ScaffoldTask initialTask = project.getTasks().register("scaffoldInitial", ScaffoldTask.class).get();
-        initialTask.setCoordinates("com.example:demo:1.0.0");
+        ScaffoldTask initialTask = registerScaffoldTask(project, "scaffoldInitial", initialCoordinates);
         initialTask.run();
 
-        ScaffoldTask secondTask = project.getTasks().register("scaffoldSecond", ScaffoldTask.class).get();
-        secondTask.setCoordinates("com.example:demo:2.0.0");
+        ScaffoldTask secondTask = registerScaffoldTask(project, "scaffoldSecond", secondCoordinates);
         secondTask.run();
 
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
-                tempDir.resolve("metadata/com.example/demo/index.json").toFile(),
+                tempDir.resolve("metadata/org.postgresql/postgresql/index.json").toFile(),
                 new TypeReference<>() {}
         );
         assertThat(indexEntries).hasSize(2);
-        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "1.0.0")
-                .containsEntry("tested-versions", List.of("1.0.0"))
+        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "42.7.2")
+                .containsEntry("tested-versions", List.of("42.7.2"))
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .doesNotContainKey("latest");
-        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "2.0.0")
-                .containsEntry("tested-versions", List.of("2.0.0"))
+        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "42.7.3")
+                .containsEntry("tested-versions", List.of("42.7.3"))
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .containsEntry("latest", true);
-        assertThat(tempDir.resolve("tests/src/com.example/demo/2.0.0/build.gradle")).exists();
-        assertThat(tempDir.resolve("metadata/com.example/demo/2.0.0/reachability-metadata.json")).exists();
-        assertThat(Files.readString(tempDir.resolve("metadata/com.example/demo/index.json"), StandardCharsets.UTF_8))
+        assertThat(tempDir.resolve("tests/src/org.postgresql/postgresql/42.7.3/build.gradle")).exists();
+        assertThat(tempDir.resolve("metadata/org.postgresql/postgresql/42.7.3/reachability-metadata.json")).exists();
+        assertThat(Files.readString(tempDir.resolve("metadata/org.postgresql/postgresql/index.json"), StandardCharsets.UTF_8))
                 .startsWith("[\n  {\n")
                 .contains("\n  },\n  {\n")
                 .doesNotContain("[ {");
@@ -223,51 +250,82 @@ class ScaffoldTaskTests {
 
     @Test
     void runWithoutUpdateKeepsLatestOnHighestVersion() throws IOException {
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
+        Coordinates highestCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        Coordinates lowerCoordinates = Coordinates.parse("org.postgresql:postgresql:42.7.2");
+        installLibraryArtifact(highestCoordinates, List.of(
+                "org/postgresql/jdbc/PgConnection.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        installLibraryArtifact(lowerCoordinates, List.of(
+                "org/postgresql/Driver.class",
+                "org/postgresql/util/PGobject.class"
+        ));
+        Project project = createProject();
 
-        ScaffoldTask initialTask = project.getTasks().register("scaffoldInitial", ScaffoldTask.class).get();
-        initialTask.setCoordinates("com.example:demo:2.0.0");
+        ScaffoldTask initialTask = registerScaffoldTask(project, "scaffoldInitial", highestCoordinates);
         initialTask.run();
 
-        ScaffoldTask secondTask = project.getTasks().register("scaffoldSecond", ScaffoldTask.class).get();
-        secondTask.setCoordinates("com.example:demo:1.5.0");
+        ScaffoldTask secondTask = registerScaffoldTask(project, "scaffoldSecond", lowerCoordinates);
         secondTask.run();
 
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
-                tempDir.resolve("metadata/com.example/demo/index.json").toFile(),
+                tempDir.resolve("metadata/org.postgresql/postgresql/index.json").toFile(),
                 new TypeReference<>() {}
         );
         assertThat(indexEntries).hasSize(2);
-        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "1.5.0")
+        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "42.7.2")
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .doesNotContainKey("latest");
-        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "2.0.0")
+        assertThat(indexEntries.get(1)).containsEntry("metadata-version", "42.7.3")
+                .containsEntry("allowed-packages", List.of("org.postgresql"))
                 .containsEntry("latest", true);
     }
 
     @Test
     void runWithoutForceFailsWhenExactVersionMetadataAlreadyExists() throws IOException {
-        Project project = ProjectBuilder.builder()
-                .withProjectDir(tempDir.toFile())
-                .build();
+        Coordinates coordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        installLibraryArtifact(coordinates, List.of("org/postgresql/Driver.class"));
+        Project project = createProject();
 
-        ScaffoldTask initialTask = project.getTasks().register("scaffoldInitial", ScaffoldTask.class).get();
-        initialTask.setCoordinates("com.example:demo:1.0.0");
+        ScaffoldTask initialTask = registerScaffoldTask(project, "scaffoldInitial", coordinates);
         initialTask.run();
 
-        ScaffoldTask secondTask = project.getTasks().register("scaffoldSecond", ScaffoldTask.class).get();
-        secondTask.setCoordinates("com.example:demo:1.0.0");
+        ScaffoldTask secondTask = registerScaffoldTask(project, "scaffoldSecond", coordinates);
 
         assertThatThrownBy(secondTask::run)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Metadata for 'com.example:demo:1.0.0' already exists");
+                .hasMessageContaining("Metadata for 'org.postgresql:postgresql:42.7.3' already exists");
     }
 
     private void assertGeneratedFileMatchesTemplate(Coordinates coordinates, String relativePath, String templateResourcePath) throws IOException {
         String expectedContent = CoordinateUtils.replace(loadResource(templateResourcePath), coordinates);
         String actualContent = Files.readString(tempDir.resolve(relativePath), StandardCharsets.UTF_8);
         assertThat(actualContent).isEqualTo(expectedContent);
+    }
+
+    private void assertGeneratedMetadataIndex(String relativePath, List<String> allowedPackages, List<String> testedVersions) throws IOException {
+        List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
+                tempDir.resolve(relativePath).toFile(),
+                new TypeReference<>() {}
+        );
+        assertThat(indexEntries).hasSize(1);
+        assertThat(indexEntries.get(0))
+                .containsEntry("allowed-packages", allowedPackages)
+                .containsEntry("tested-versions", testedVersions)
+                .containsEntry("latest", true);
+    }
+
+    private void assertGeneratedUserCodeFilter(String relativePath, List<String> packageRoots) throws IOException {
+        Map<String, List<Map<String, String>>> userCodeFilter = OBJECT_MAPPER.readValue(
+                tempDir.resolve(relativePath).toFile(),
+                new TypeReference<>() {}
+        );
+        List<Map<String, String>> expectedRules = new ArrayList<>();
+        expectedRules.add(Map.of("excludeClasses", "**"));
+        for (String packageRoot : packageRoots) {
+            expectedRules.add(Map.of("includeClasses", packageRoot + ".**"));
+        }
+        assertThat(userCodeFilter).containsEntry("rules", expectedRules);
     }
 
     private void assertGeneratedReachabilityMetadataIsEmptyJsonObject(String relativePath) throws IOException {
@@ -304,5 +362,61 @@ class ScaffoldTaskTests {
             assertThat(stream).isNotNull();
             return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private Project createProject() throws IOException {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        Path repositoryRoot = ensureRepositoryRoot();
+        project.getRepositories().maven(repository -> repository.setUrl(repositoryRoot.toUri()));
+        return project;
+    }
+
+    private ScaffoldTask registerScaffoldTask(Project project, String taskName, Coordinates coordinates) {
+        ScaffoldTask task = project.getTasks().register(taskName, ScaffoldTask.class).get();
+        task.setCoordinates(coordinates.toString());
+        return task;
+    }
+
+    private void installLibraryArtifact(Coordinates coordinates, List<String> jarEntries) throws IOException {
+        Path artifactDirectory = ensureRepositoryRoot()
+                .resolve(coordinates.group().replace('.', '/'))
+                .resolve(coordinates.artifact())
+                .resolve(coordinates.version());
+        Files.createDirectories(artifactDirectory);
+        createLibraryJar(
+                artifactDirectory.resolve(coordinates.artifact() + "-" + coordinates.version() + ".jar"),
+                jarEntries
+        );
+        Files.writeString(
+                artifactDirectory.resolve(coordinates.artifact() + "-" + coordinates.version() + ".pom"),
+                """
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>%s</groupId>
+                  <artifactId>%s</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(coordinates.group(), coordinates.artifact(), coordinates.version()),
+                StandardCharsets.UTF_8
+        );
+    }
+
+    private Path createLibraryJar(Path jarPath, List<String> entries) throws IOException {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            for (String entry : entries) {
+                jarOutputStream.putNextEntry(new JarEntry(entry));
+                jarOutputStream.write(new byte[]{0});
+                jarOutputStream.closeEntry();
+            }
+        }
+        return jarPath;
+    }
+
+    private Path ensureRepositoryRoot() throws IOException {
+        return Files.createDirectories(tempDir.resolve("test-maven-repo"));
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/JarUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/JarUtilsTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JarUtilsTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadClassNamesSkipsModuleInfoAndReadsMultiReleaseEntries() throws IOException {
+        Path jar = createLibraryJar(tempDir.resolve("library.jar"), List.of(
+                "module-info.class",
+                "com/example/Base.class",
+                "META-INF/versions/11/com/example/Versioned.class"
+        ));
+
+        assertThat(JarUtils.loadClassNames(List.of(jar)))
+                .containsExactlyInAnyOrder("com.example.Base", "com.example.Versioned");
+    }
+
+    @Test
+    void extractPackagesSkipsDefaultPackage() {
+        assertThat(JarUtils.extractPackages(Set.of(
+                "PlainClass",
+                "com.example.Foo",
+                "com.example.bar.Baz"
+        ))).containsExactly("com.example", "com.example.bar");
+    }
+
+    @Test
+    void derivePackageRootsCollapsesSiblingPackagesToParent() {
+        assertThat(JarUtils.derivePackageRoots(Set.of(
+                "net.jpountz.lz4.LZ4Factory",
+                "net.jpountz.util.SafeUtils"
+        ))).containsExactly("net.jpountz");
+    }
+
+    @Test
+    void derivePackageRootsDoesNotCollapseToSingleSegmentParent() {
+        assertThat(JarUtils.derivePackageRoots(Set.of(
+                "org.foo.alpha.Alpha",
+                "org.bar.beta.Beta"
+        ))).containsExactly("org.bar.beta", "org.foo.alpha");
+    }
+
+    private Path createLibraryJar(Path jarPath, List<String> entries) throws IOException {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            for (String entry : entries) {
+                jarOutputStream.putNextEntry(new JarEntry(entry));
+                jarOutputStream.write(new byte[]{0});
+                jarOutputStream.closeEntry();
+            }
+        }
+        return jarPath;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Closes #1957.

Scaffold currently uses the Maven group ID as a heuristic for both `user-code-filter.json` `includeClasses` rules and `metadata/.../index.json` `allowed-packages`. That breaks when the published JAR uses a different Java package root than the Maven coordinates.

This PR changes scaffold to resolve the binary JAR, scan `.class` entries, derive minimal package roots, and use those roots for:
- `user-code-filter.json` generation
- `index.json` `allowed-packages` on both fresh scaffold and metadata-root update paths

It also adds focused `JarUtils` tests plus end-to-end scaffold tests backed by a synthetic local Maven repository.

```text
┌──────────────────────────────────┬─────────────────────────┬────────────────────────────────┐
│             Library              │ Old heuristic ($group$) │        JAR-derived root        │
├──────────────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ org.lz4:lz4-java:1.8.0           │ org.lz4 (wrong)         │ net.jpountz (correct)          │
├──────────────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ org.postgresql:postgresql:42.7.3 │ org.postgresql          │ org.postgresql (same, correct) │
└──────────────────────────────────┴─────────────────────────┴────────────────────────────────┘
```

