### PR TITLE
[GenAI] Add support for org.slf4j:slf4j-api:1.5.3 using gpt-5.4

### DIFF
--- a/metadata/org.slf4j/slf4j-api/1.5.3/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-api/1.5.3/reachability-metadata.json
@@ -1,0 +1,29 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.LoggerFactory"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.LoggerFactory"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.LoggerFactory"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-api/index.json
+++ b/metadata/org.slf4j/slf4j-api/index.json
@@ -1,15 +1,31 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "org.slf4j" ],
-    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-sources.jar",
-    "repository-url": "https://github.com/qos-ch/slf4j",
-    "test-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-tests.jar",
-    "documentation-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-javadoc.jar",
-    "description": "SLF4J defines a common logging API for Java applications and libraries. It lets code route log messages to different logging implementations without changing application code.",
-    "metadata-version": "1.7.36",
-    "tested-versions": [
+    "metadata-version" : "1.5.3",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.5.3/slf4j-api-1.5.3-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.5.3/slf4j-api-1.5.3-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-site/1.5.3/slf4j-site-1.5.3-sources.jar",
+    "description" : "SLF4J defines a common logging API for Java applications and libraries. It lets code route log messages to different logging implementations without changing application code.",
+    "tested-versions" : [
+      "1.5.3"
+    ],
+    "allowed-packages" : [
+      "org.slf4j"
+    ]
+  },
+  {
+    "latest" : true,
+    "metadata-version" : "1.7.36",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-javadoc.jar",
+    "description" : "SLF4J defines a common logging API for Java applications and libraries. It lets code route log messages to different logging implementations without changing application code.",
+    "tested-versions" : [
       "1.7.36"
+    ],
+    "allowed-packages" : [
+      "org.slf4j"
     ]
   }
 ]

--- a/stats/org.slf4j/slf4j-api/1.5.3/stats.json
+++ b/stats/org.slf4j/slf4j-api/1.5.3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.5.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 697,
+        "missed" : 821,
+        "ratio" : 0.459157,
+        "total" : 1518
+      },
+      "line" : {
+        "covered" : 201,
+        "missed" : 246,
+        "ratio" : 0.449664,
+        "total" : 447
+      },
+      "method" : {
+        "covered" : 60,
+        "missed" : 75,
+        "ratio" : 0.444444,
+        "total" : 135
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/.gitignore
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/build.gradle
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:slf4j-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/build.gradle
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.slf4j:slf4j-api:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly "org.slf4j:slf4j-simple:$libraryVersion"
 }
 
 graalvmNative {

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:slf4j-api:1.5.3
+library.version = 1.5.3
+metadata.dir = org.slf4j/slf4j-api/1.5.3/

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/settings.gradle
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.slf4j-api_tests'

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_api;
+
+import org.junit.jupiter.api.Test;
+
+class Slf4j_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
@@ -121,6 +121,34 @@ public class Slf4j_apiTest {
     }
 
     @Test
+    void markersSupportRecursiveContainmentEqualityAndCyclePrevention() {
+        Marker parentMarker = MarkerFactory.getDetachedMarker("PARENT");
+        Marker childMarker = MarkerFactory.getDetachedMarker("CHILD");
+        Marker sameNamedChildMarker = MarkerFactory.getDetachedMarker("CHILD");
+        Marker grandchildMarker = MarkerFactory.getDetachedMarker("GRANDCHILD");
+
+        childMarker.add(grandchildMarker);
+        parentMarker.add(childMarker);
+        parentMarker.add(sameNamedChildMarker);
+        grandchildMarker.add(parentMarker);
+
+        List<String> directChildNames = new ArrayList<>();
+        for (Iterator<?> iterator = parentMarker.iterator(); iterator.hasNext(); ) {
+            Marker nextMarker = (Marker) iterator.next();
+            directChildNames.add(nextMarker.getName());
+        }
+
+        assertThat(parentMarker.hasChildren()).isTrue();
+        assertThat(childMarker.hasChildren()).isTrue();
+        assertThat(parentMarker.contains(grandchildMarker)).isTrue();
+        assertThat(parentMarker.contains("GRANDCHILD")).isTrue();
+        assertThat(childMarker).isEqualTo(sameNamedChildMarker);
+        assertThat(childMarker.hashCode()).isEqualTo(sameNamedChildMarker.hashCode());
+        assertThat(directChildNames).containsExactly("CHILD");
+        assertThat(grandchildMarker.contains(parentMarker)).isFalse();
+    }
+
+    @Test
     void mdcAcceptsContextOperationsAndRejectsNullKeys() {
         Map<String, String> replacementContext = new LinkedHashMap<>();
 

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
@@ -189,6 +189,20 @@ public class Slf4j_apiTest {
         assertThat(primitiveArrayArgument).isEqualTo("Array [1, 2]");
     }
 
+    @Test
+    void messageFormatterRecursivelyFormatsNestedAndSelfReferentialObjectArrays() {
+        Object[] selfReferentialArray = new Object[1];
+        Object[] nestedArray = new Object[]{new Object[]{"alpha", new int[]{1, 2}}, "omega"};
+
+        selfReferentialArray[0] = selfReferentialArray;
+
+        String nestedArrayMessage = MessageFormatter.arrayFormat("Nested {}", new Object[]{nestedArray});
+        String selfReferentialArrayMessage = MessageFormatter.arrayFormat("Self {}", new Object[]{selfReferentialArray});
+
+        assertThat(nestedArrayMessage).isEqualTo("Nested [[alpha, [1, 2]], omega]");
+        assertThat(selfReferentialArrayMessage).isEqualTo("Self [[...]]");
+    }
+
     private static final class RecordingLogger extends MarkerIgnoringBase {
 
         private final List<LogEntry> entries = new ArrayList<>();

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
@@ -102,7 +102,7 @@ public class Slf4j_apiTest {
         managedMarker.add(childMarker);
 
         List<String> childNames = new ArrayList<>();
-        for (Iterator<?> iterator = managedMarker.iterator(); iterator.hasNext(); ) {
+        for (Iterator<?> iterator = managedMarker.iterator(); iterator.hasNext();) {
             Marker nextMarker = (Marker) iterator.next();
             childNames.add(nextMarker.getName());
         }
@@ -133,7 +133,7 @@ public class Slf4j_apiTest {
         grandchildMarker.add(parentMarker);
 
         List<String> directChildNames = new ArrayList<>();
-        for (Iterator<?> iterator = parentMarker.iterator(); iterator.hasNext(); ) {
+        for (Iterator<?> iterator = parentMarker.iterator(); iterator.hasNext();) {
             Marker nextMarker = (Marker) iterator.next();
             directChildNames.add(nextMarker.getName());
         }

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/src/test/java/org_slf4j/slf4j_api/Slf4j_apiTest.java
@@ -6,11 +6,342 @@
  */
 package org_slf4j.slf4j_api;
 
-import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-class Slf4j_apiTest {
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.helpers.MessageFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Slf4j_apiTest {
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void loggerFactoryProvidesStableNamedAndClassLoggers() {
+        ILoggerFactory firstFactory = LoggerFactory.getILoggerFactory();
+        ILoggerFactory secondFactory = LoggerFactory.getILoggerFactory();
+        Logger namedLogger = LoggerFactory.getLogger("structured-logger");
+        Logger sameNamedLogger = LoggerFactory.getLogger("structured-logger");
+        Logger classLogger = LoggerFactory.getLogger(Slf4j_apiTest.class);
+        Marker marker = MarkerFactory.getMarker("AUDIT");
+
+        assertThat(firstFactory).isSameAs(secondFactory);
+        assertThat(namedLogger).isSameAs(sameNamedLogger);
+        assertThat(namedLogger.getName()).isEqualTo("structured-logger");
+        assertThat(classLogger.getName()).isEqualTo(Slf4j_apiTest.class.getName());
+
+        namedLogger.trace("trace {}", "value");
+        namedLogger.debug("debug {} {}", "left", "right");
+        namedLogger.info("info {} {}", new Object[]{"first", "second"});
+        namedLogger.warn("warn message");
+        namedLogger.error(marker, "error {}", "value");
+    }
+
+    @Test
+    void markerIgnoringBaseDelegatesMarkerOverloadsToConcreteLoggerMethods() {
+        RecordingLogger logger = new RecordingLogger("delegating-logger");
+        Marker marker = MarkerFactory.getMarker("SECURITY");
+        IllegalStateException failure = new IllegalStateException("boom");
+
+        assertThat(logger.isTraceEnabled(marker)).isTrue();
+        assertThat(logger.isDebugEnabled(marker)).isTrue();
+        assertThat(logger.isInfoEnabled(marker)).isTrue();
+        assertThat(logger.isWarnEnabled(marker)).isTrue();
+        assertThat(logger.isErrorEnabled(marker)).isTrue();
+
+        logger.trace(marker, "trace {}", "value");
+        logger.debug(marker, "debug {} {}", "left", "right");
+        logger.info(marker, "info {} {}", new Object[]{"first", "second"});
+        logger.warn(marker, "warn message", failure);
+        logger.error(marker, "error {}", "value");
+
+        List<LogEntry> entries = logger.getEntries();
+
+        assertThat(entries).hasSize(5);
+        assertThat(entries.get(0).level).isEqualTo("TRACE");
+        assertThat(entries.get(0).formattedMessage).isEqualTo("trace value");
+        assertThat(entries.get(1).level).isEqualTo("DEBUG");
+        assertThat(entries.get(1).formattedMessage).isEqualTo("debug left right");
+        assertThat(entries.get(2).level).isEqualTo("INFO");
+        assertThat(entries.get(2).formattedMessage).isEqualTo("info first second");
+        assertThat(entries.get(3).level).isEqualTo("WARN");
+        assertThat(entries.get(3).formattedMessage).isEqualTo("warn message");
+        assertThat(entries.get(3).throwable).isSameAs(failure);
+        assertThat(entries.get(4).level).isEqualTo("ERROR");
+        assertThat(entries.get(4).formattedMessage).isEqualTo("error value");
+        assertThat(logger.toString()).contains("delegating-logger");
+    }
+
+    @Test
+    void markerFactorySupportsManagedAndDetachedMarkers() {
+        IMarkerFactory markerFactory = MarkerFactory.getIMarkerFactory();
+        Marker managedMarker = MarkerFactory.getMarker("HTTP");
+        Marker sameManagedMarker = MarkerFactory.getMarker("HTTP");
+        Marker detachedMarker = MarkerFactory.getDetachedMarker("DETACHED");
+        Marker childMarker = MarkerFactory.getDetachedMarker("CHILD");
+
+        managedMarker.add(childMarker);
+
+        List<String> childNames = new ArrayList<>();
+        for (Iterator<?> iterator = managedMarker.iterator(); iterator.hasNext(); ) {
+            Marker nextMarker = (Marker) iterator.next();
+            childNames.add(nextMarker.getName());
+        }
+
+        assertThat(managedMarker).isSameAs(sameManagedMarker);
+        assertThat(detachedMarker.getName()).isEqualTo("DETACHED");
+        assertThat(markerFactory.exists("HTTP")).isTrue();
+        assertThat(markerFactory.exists("DETACHED")).isFalse();
+        assertThat(managedMarker.contains(childMarker)).isTrue();
+        assertThat(managedMarker.contains("CHILD")).isTrue();
+        assertThat(childNames).containsExactly("CHILD");
+        assertThat(managedMarker.remove(childMarker)).isTrue();
+        assertThat(managedMarker.contains("CHILD")).isFalse();
+        assertThat(markerFactory.detachMarker("HTTP")).isTrue();
+        assertThat(markerFactory.exists("HTTP")).isFalse();
+    }
+
+    @Test
+    void mdcAcceptsContextOperationsAndRejectsNullKeys() {
+        Map<String, String> replacementContext = new LinkedHashMap<>();
+
+        MDC.put("requestId", "42");
+        MDC.put("route", "/health");
+
+        replacementContext.put("requestId", "84");
+        replacementContext.put("user", "tester");
+        MDC.setContextMap(replacementContext);
+        MDC.remove("user");
+        MDC.clear();
+
+        assertThat(MDC.get("requestId")).isNull();
+        assertThat(MDC.getCopyOfContextMap()).isNull();
+        assertThatThrownBy(() -> MDC.put(null, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("key parameter cannot be null");
+        assertThatThrownBy(() -> MDC.get(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("key parameter cannot be null");
+        assertThatThrownBy(() -> MDC.remove(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("key parameter cannot be null");
+    }
+
+    @Test
+    void messageFormatterHandlesArraysEscapingAndNullValues() {
+        String singleArgument = MessageFormatter.format("Hello {}", "world");
+        String twoArguments = MessageFormatter.format("{} {}", "alpha", "beta");
+        String escapedDelimiter = MessageFormatter.arrayFormat("Escaped \\{} and {}", new Object[]{"value"});
+        String nullArgument = MessageFormatter.arrayFormat("Null {}", new Object[]{null});
+        String primitiveArrayArgument = MessageFormatter.arrayFormat("Array {}", new Object[]{new int[]{1, 2}});
+
+        assertThat(singleArgument).isEqualTo("Hello world");
+        assertThat(twoArguments).isEqualTo("alpha beta");
+        assertThat(escapedDelimiter).isEqualTo("Escaped {} and value");
+        assertThat(nullArgument).isEqualTo("Null null");
+        assertThat(primitiveArrayArgument).isEqualTo("Array [1, 2]");
+    }
+
+    private static final class RecordingLogger extends MarkerIgnoringBase {
+
+        private final List<LogEntry> entries = new ArrayList<>();
+
+        private RecordingLogger(String name) {
+            this.name = name;
+        }
+
+        private List<LogEntry> getEntries() {
+            return Collections.unmodifiableList(this.entries);
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return true;
+        }
+
+        @Override
+        public void trace(String msg) {
+            recordPlain("TRACE", msg, null);
+        }
+
+        @Override
+        public void trace(String format, Object arg) {
+            recordFormatted("TRACE", MessageFormatter.format(format, arg), null);
+        }
+
+        @Override
+        public void trace(String format, Object arg1, Object arg2) {
+            recordFormatted("TRACE", MessageFormatter.format(format, arg1, arg2), null);
+        }
+
+        @Override
+        public void trace(String format, Object[] arguments) {
+            recordFormatted("TRACE", MessageFormatter.arrayFormat(format, arguments), null);
+        }
+
+        @Override
+        public void trace(String msg, Throwable t) {
+            recordPlain("TRACE", msg, t);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(String msg) {
+            recordPlain("DEBUG", msg, null);
+        }
+
+        @Override
+        public void debug(String format, Object arg) {
+            recordFormatted("DEBUG", MessageFormatter.format(format, arg), null);
+        }
+
+        @Override
+        public void debug(String format, Object arg1, Object arg2) {
+            recordFormatted("DEBUG", MessageFormatter.format(format, arg1, arg2), null);
+        }
+
+        @Override
+        public void debug(String format, Object[] arguments) {
+            recordFormatted("DEBUG", MessageFormatter.arrayFormat(format, arguments), null);
+        }
+
+        @Override
+        public void debug(String msg, Throwable t) {
+            recordPlain("DEBUG", msg, t);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(String msg) {
+            recordPlain("INFO", msg, null);
+        }
+
+        @Override
+        public void info(String format, Object arg) {
+            recordFormatted("INFO", MessageFormatter.format(format, arg), null);
+        }
+
+        @Override
+        public void info(String format, Object arg1, Object arg2) {
+            recordFormatted("INFO", MessageFormatter.format(format, arg1, arg2), null);
+        }
+
+        @Override
+        public void info(String format, Object[] arguments) {
+            recordFormatted("INFO", MessageFormatter.arrayFormat(format, arguments), null);
+        }
+
+        @Override
+        public void info(String msg, Throwable t) {
+            recordPlain("INFO", msg, t);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(String msg) {
+            recordPlain("WARN", msg, null);
+        }
+
+        @Override
+        public void warn(String format, Object arg) {
+            recordFormatted("WARN", MessageFormatter.format(format, arg), null);
+        }
+
+        @Override
+        public void warn(String format, Object[] arguments) {
+            recordFormatted("WARN", MessageFormatter.arrayFormat(format, arguments), null);
+        }
+
+        @Override
+        public void warn(String format, Object arg1, Object arg2) {
+            recordFormatted("WARN", MessageFormatter.format(format, arg1, arg2), null);
+        }
+
+        @Override
+        public void warn(String msg, Throwable t) {
+            recordPlain("WARN", msg, t);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public void error(String msg) {
+            recordPlain("ERROR", msg, null);
+        }
+
+        @Override
+        public void error(String format, Object arg) {
+            recordFormatted("ERROR", MessageFormatter.format(format, arg), null);
+        }
+
+        @Override
+        public void error(String format, Object arg1, Object arg2) {
+            recordFormatted("ERROR", MessageFormatter.format(format, arg1, arg2), null);
+        }
+
+        @Override
+        public void error(String format, Object[] arguments) {
+            recordFormatted("ERROR", MessageFormatter.arrayFormat(format, arguments), null);
+        }
+
+        @Override
+        public void error(String msg, Throwable t) {
+            recordPlain("ERROR", msg, t);
+        }
+
+        private void recordPlain(String level, String message, Throwable throwable) {
+            this.entries.add(new LogEntry(level, message, throwable));
+        }
+
+        private void recordFormatted(String level, String formattedMessage, Throwable throwable) {
+            this.entries.add(new LogEntry(level, formattedMessage, throwable));
+        }
+    }
+
+    private static final class LogEntry {
+
+        private final String level;
+        private final String formattedMessage;
+        private final Throwable throwable;
+
+        private LogEntry(String level, String formattedMessage, Throwable throwable) {
+            this.level = level;
+            this.formattedMessage = formattedMessage;
+            this.throwable = throwable;
+        }
     }
 }

--- a/tests/src/org.slf4j/slf4j-api/1.5.3/user-code-filter.json
+++ b/tests/src/org.slf4j/slf4j-api/1.5.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.slf4j.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #942

This PR introduces tests and metadata for org.slf4j:slf4j-api:1.5.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 169189
- Cached input tokens: 2660096
- Output tokens: 41447
- Entries: 4
- Iterations: 3
- Library coverage percentage: 44.97
- Generated lines of code: 319
- Tested library lines of code: 201

Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 697/1518 (45.92%)
- Line: 201/447 (44.97%)
- Method: 60/135 (44.44%)
