### PR TITLE
[GenAI] Add support for ch.qos.logback:logback-core:1.1.3 using gpt-5.4

### DIFF
--- a/metadata/ch.qos.logback/logback-core/1.1.3/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-core/1.1.3/reachability-metadata.json
@@ -1,0 +1,190 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.Loader"
+      },
+      "type" : "ch.qos.logback.core.ContextBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch.qos.logback.core.spi.ContextAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch.qos.logback.core.spi.ContextAwareBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch.qos.logback.core.spi.ContextAwareBaseBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch.qos.logback.core.spi.ContextAwareBaseCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch.qos.logback.core.spi.LifeCycle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "type" : "com.ibm.icu.text.Collator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "java.beans.PropertyVetoException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.rolling.helper.FileStoreUtil"
+      },
+      "type" : "java.io.File",
+      "methods" : [
+        {
+          "name" : "toPath",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.EnvUtil"
+      },
+      "type" : "java.lang.ClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.Loader"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.rolling.helper.FileStoreUtil"
+      },
+      "type" : "java.nio.file.Files",
+      "methods" : [
+        {
+          "name" : "getFileStore",
+          "parameterTypes" : [
+            "java.nio.file.Path"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.rolling.helper.FileStoreUtil"
+      },
+      "type" : "java.nio.file.Path"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.dialect.DBUtil"
+      },
+      "type" : "java.sql.DatabaseMetaData",
+      "methods" : [
+        {
+          "name" : "supportsGetGeneratedKeys",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "type" : "java.sql.SQLException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.DriverManagerConnectionSource"
+      },
+      "type" : "org.h2.Driver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "type" : "org.h2.mvstore.MVStore$TxCounter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "type" : "org.h2.mvstore.Page"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "glob" : "META-INF/services/java.sql.Driver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.Loader"
+      },
+      "glob" : "ch_qos_logback/logback_core/LoaderTest.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.db.ConnectionSourceBase"
+      },
+      "glob" : "org/h2/util/data.zip"
+    }
+  ]
+}

--- a/metadata/ch.qos.logback/logback-core/index.json
+++ b/metadata/ch.qos.logback/logback-core/index.json
@@ -1,14 +1,30 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "ch.qos.logback" ],
-    "source-code-url": "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-sources.jar",
-    "repository-url": "https://github.com/qos-ch/logback",
-    "test-code-url": "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-test-sources.jar",
-    "documentation-url": "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-javadoc.jar",
-    "metadata-version": "1.2.12",
-    "tested-versions": [
+    "metadata-version" : "1.1.3",
+    "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/logback",
+    "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3-javadoc.jar",
+    "description" : "Logback Core is the foundational module of the Logback logging framework for Java. It provides appenders, encoders, layouts, rolling policies, filters, and support classes used by higher-level Logback modules.",
+    "tested-versions" : [
+      "1.1.3"
+    ],
+    "allowed-packages" : [
+      "ch.qos.logback.core"
+    ]
+  },
+  {
+    "latest" : true,
+    "metadata-version" : "1.2.12",
+    "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/logback",
+    "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.12/logback-core-1.2.12-javadoc.jar",
+    "tested-versions" : [
       "1.2.12"
+    ],
+    "allowed-packages" : [
+      "ch.qos.logback"
     ]
   }
 ]

--- a/stats/ch.qos.logback/logback-core/1.1.3/stats.json
+++ b/stats/ch.qos.logback/logback-core/1.1.3/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.1.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 26,
+          "totalCalls" : 26
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 29,
+      "totalCalls" : 29
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3032,
+        "missed" : 27828,
+        "ratio" : 0.09825,
+        "total" : 30860
+      },
+      "line" : {
+        "covered" : 817,
+        "missed" : 7032,
+        "ratio" : 0.10409,
+        "total" : 7849
+      },
+      "method" : {
+        "covered" : 204,
+        "missed" : 1654,
+        "ratio" : 0.109795,
+        "total" : 1858
+      }
+    }
+  } ]
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/.gitignore
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/build.gradle
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "ch.qos.logback:logback-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/build.gradle
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "ch.qos.logback:logback-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'com.h2database:h2:2.1.214'
 }
 
 graalvmNative {

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/gradle.properties
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = ch.qos.logback:logback-core:1.1.3
+library.version = 1.1.3
+metadata.dir = ch.qos.logback/logback-core/1.1.3/

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/settings.gradle
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'ch.qos.logback.logback-core_tests'

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/AutoFlushingObjectWriterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/AutoFlushingObjectWriterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.net.AutoFlushingObjectWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class AutoFlushingObjectWriterTest {
+
+    @Test
+    void writesObjectsFlushesTheStreamAndResetsAtTheConfiguredFrequency() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        RecordingObjectOutputStream objectOutputStream = new RecordingObjectOutputStream(outputStream);
+        AutoFlushingObjectWriter writer = new AutoFlushingObjectWriter(objectOutputStream, 1);
+        ArrayList<String> payload = new ArrayList<>(List.of("first"));
+
+        writer.write(payload);
+        payload.add("second");
+        writer.write(payload);
+
+        assertThat(objectOutputStream.getFlushCalls()).isEqualTo(2);
+        assertThat(objectOutputStream.getResetCalls()).isEqualTo(2);
+
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
+            @SuppressWarnings("unchecked")
+            ArrayList<String> firstCopy = (ArrayList<String>) objectInputStream.readObject();
+            @SuppressWarnings("unchecked")
+            ArrayList<String> secondCopy = (ArrayList<String>) objectInputStream.readObject();
+
+            assertThat(firstCopy).containsExactly("first");
+            assertThat(secondCopy).containsExactly("first", "second");
+            assertThat(secondCopy).isNotSameAs(firstCopy);
+        }
+    }
+
+    private static final class RecordingObjectOutputStream extends ObjectOutputStream {
+
+        private int flushCalls;
+        private int resetCalls;
+
+        private RecordingObjectOutputStream(ByteArrayOutputStream outputStream) throws IOException {
+            super(outputStream);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushCalls++;
+            super.flush();
+        }
+
+        @Override
+        public void reset() throws IOException {
+            resetCalls++;
+            super.reset();
+        }
+
+        private int getFlushCalls() {
+            return flushCalls;
+        }
+
+        private int getResetCalls() {
+            return resetCalls;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/DriverManagerConnectionSourceTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/DriverManagerConnectionSourceTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.db.DriverManagerConnectionSource;
+import ch.qos.logback.core.db.dialect.SQLDialectCode;
+import java.sql.Connection;
+import org.junit.jupiter.api.Test;
+
+public class DriverManagerConnectionSourceTest {
+
+    private static final String JDBC_URL =
+            "jdbc:h2:mem:logback_core_driver_manager_connection_source;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE";
+
+    @Test
+    void loadsTheConfiguredDriverClassAndDiscoversJdbcCapabilities() throws Exception {
+        DriverManagerConnectionSource connectionSource = new DriverManagerConnectionSource();
+        connectionSource.setContext(new ContextBase());
+        connectionSource.setDriverClass("org.h2.Driver");
+        connectionSource.setUrl(JDBC_URL);
+
+        connectionSource.start();
+
+        try (Connection connection = connectionSource.getConnection()) {
+            assertThat(connection).isNotNull();
+        }
+
+        assertThat(connectionSource.getSQLDialectCode()).isEqualTo(SQLDialectCode.H2_DIALECT);
+        assertThat(connectionSource.supportsBatchUpdates()).isTrue();
+        assertThat(connectionSource.supportsGetGeneratedKeys()).isTrue();
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/EnvUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/EnvUtilTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.util.EnvUtil;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.ServiceLoader;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+
+public class EnvUtilTest {
+
+    private static final String ISOLATED_PROVIDER_PACKAGE = "ch_qos_logback.logback_core.isolated.";
+    private static final String JANINO_PACKAGE = "org.codehaus.janino.";
+    private static final String LOGBACK_PACKAGE = "ch.qos.logback.";
+
+    @Test
+    void reportsJaninoAvailabilityWhenJaninoIsResolvableFromTheEnvUtilClassLoader() throws Exception {
+        try (ChildFirstClassLoader classLoader = new ChildFirstClassLoader(new URL[] {
+                codeSourceUrl(EnvUtilTest.class),
+                codeSourceUrl(EnvUtil.class)
+        }, EnvUtilTest.class.getClassLoader())) {
+            BooleanSupplier action = ServiceLoader.load(BooleanSupplier.class, classLoader)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected an isolated EnvUtil provider"));
+
+            assertThat(action.getAsBoolean()).isTrue();
+        }
+    }
+
+    private static URL codeSourceUrl(Class<?> type) {
+        CodeSource codeSource = type.getProtectionDomain().getCodeSource();
+
+        assertThat(codeSource).isNotNull();
+        return codeSource.getLocation();
+    }
+
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+
+        private ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    if (isChildFirst(name)) {
+                        try {
+                            loadedClass = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loadedClass = super.loadClass(name, false);
+                        }
+                    } else {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private boolean isChildFirst(String className) {
+            return className.startsWith(LOGBACK_PACKAGE)
+                    || className.startsWith(ISOLATED_PROVIDER_PACKAGE)
+                    || className.startsWith(JANINO_PACKAGE);
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/EventObjectInputStreamTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/EventObjectInputStreamTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.encoder.EventObjectInputStream;
+import ch.qos.logback.core.encoder.ObjectStreamEncoder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.Test;
+
+public class EventObjectInputStreamTest {
+
+    @Test
+    void readsSerializedEventsFromAnObjectStreamEncoderPayload() throws Exception {
+        SerializablePayload firstEvent = new SerializablePayload("first-event");
+        SerializablePayload secondEvent = new SerializablePayload("second-event");
+        byte[] encodedEvents = encode(firstEvent, secondEvent);
+
+        try (EventObjectInputStream<SerializablePayload> inputStream = newEventObjectInputStream(
+                new ByteArrayInputStream(encodedEvents))) {
+            SerializablePayload restoredFirstEvent = inputStream.readEvent();
+            SerializablePayload restoredSecondEvent = inputStream.readEvent();
+            SerializablePayload endOfStream = inputStream.readEvent();
+
+            assertThat(restoredFirstEvent).isNotNull();
+            assertThat(restoredFirstEvent.getValue()).isEqualTo(firstEvent.getValue());
+            assertThat(restoredSecondEvent).isNotNull();
+            assertThat(restoredSecondEvent.getValue()).isEqualTo(secondEvent.getValue());
+            assertThat(endOfStream).isNull();
+        }
+    }
+
+    private static byte[] encode(SerializablePayload... events) throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ObjectStreamEncoder<SerializablePayload> encoder = new ObjectStreamEncoder<>();
+        encoder.init(outputStream);
+
+        for (SerializablePayload event : events) {
+            encoder.doEncode(event);
+        }
+
+        encoder.close();
+        return outputStream.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static EventObjectInputStream<SerializablePayload> newEventObjectInputStream(InputStream inputStream)
+            throws Exception {
+        Constructor<EventObjectInputStream> constructor = EventObjectInputStream.class.getDeclaredConstructor(
+                InputStream.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(inputStream);
+    }
+
+    private static final class SerializablePayload implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        private SerializablePayload(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/FileStoreUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/FileStoreUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.core.rolling.helper.FileStoreUtil;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FileStoreUtilTest {
+
+    @Test
+    void reportsSiblingFilesOnTheSameFileStore(@TempDir Path tempDir) throws Exception {
+        Path firstFile = Files.createFile(tempDir.resolve("first.log"));
+        Path secondFile = Files.createFile(tempDir.resolve("second.log"));
+
+        boolean areOnSameFileStore = FileStoreUtil.areOnSameFileStore(firstFile.toFile(), secondFile.toFile());
+
+        assertThat(areOnSameFileStore)
+                .isEqualTo(Files.getFileStore(firstFile).equals(Files.getFileStore(secondFile)));
+    }
+
+    @Test
+    void rejectsMissingFiles(@TempDir Path tempDir) throws Exception {
+        Path existingFile = Files.createFile(tempDir.resolve("existing.log"));
+        Path missingFile = tempDir.resolve("missing.log");
+
+        assertThatThrownBy(() -> FileStoreUtil.areOnSameFileStore(existingFile.toFile(), missingFile.toFile()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist");
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/FileUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/FileUtilTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.util.FileUtil;
+import org.junit.jupiter.api.Test;
+
+public class FileUtilTest {
+
+    private static final String RESOURCE_NAME = "ch_qos_logback/logback_core/file-util-resource.txt";
+
+    @Test
+    void readsResourceFromProvidedClassLoader() {
+        FileUtil fileUtil = new FileUtil(new ContextBase());
+
+        String resourceContents = fileUtil.resourceAsString(FileUtilTest.class.getClassLoader(), RESOURCE_NAME);
+
+        assertThat(resourceContents.trim()).isEqualTo("file util resource");
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/IsolatedLoaderAction.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/IsolatedLoaderAction.java
@@ -6,11 +6,7 @@
  */
 package ch_qos_logback.logback_core;
 
-import org.junit.jupiter.api.Test;
+public interface IsolatedLoaderAction {
 
-class Logback_coreTest {
-    @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
-    }
+    String loadStringClass();
 }

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/LoaderTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/LoaderTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.util.Loader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.LinkedHashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LoaderTest {
+
+    private static final String TEST_CLASS_RESOURCE = LoaderTest.class.getName().replace('.', '/') + ".class";
+    private static final String IGNORE_TCL_PROPERTY_NAME = "logback.ignoreTCL";
+    private static final String LOGBACK_PACKAGE = "ch.qos.logback.";
+    private static final String ISOLATED_PROVIDER_PACKAGE = "ch_qos_logback.logback_core.isolated.";
+
+    @BeforeAll
+    static void clearIgnoreThreadContextClassLoaderProperty() {
+        System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+    }
+
+    @AfterEach
+    void clearIgnoreThreadContextClassLoaderPropertyAfterEachTest() {
+        System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+    }
+
+    @Test
+    void loadsResourcesFromProvidedClassLoader() throws Exception {
+        ClassLoader classLoader = LoaderTest.class.getClassLoader();
+        Set<URL> resources = Loader.getResourceOccurrenceCount(TEST_CLASS_RESOURCE, classLoader);
+        URL resource = Loader.getResource(TEST_CLASS_RESOURCE, classLoader);
+
+        assertThat(resources).isNotEmpty();
+        assertThat(resource).isNotNull();
+        assertThat(resources).contains(resource);
+    }
+
+    @Test
+    void loadsClassesFromContextAndProvidedClassLoaders() throws Exception {
+        assertThat(Loader.loadClass(ContextBase.class.getName(), new ContextBase())).isEqualTo(ContextBase.class);
+
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        TrackingClassLoader trackingClassLoader = new TrackingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(ContextBase.class.getName())
+        );
+        thread.setContextClassLoader(trackingClassLoader);
+
+        try {
+            assertThat(Loader.loadClass(ContextBase.class.getName())).isEqualTo(ContextBase.class);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(trackingClassLoader.getDelegatedLoads()).contains(ContextBase.class.getName());
+    }
+
+    @Test
+    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadTheClass() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        RejectingClassLoader rejectingClassLoader = new RejectingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(ContextBase.class.getName())
+        );
+        thread.setContextClassLoader(rejectingClassLoader);
+
+        try {
+            assertThat(Loader.loadClass(ContextBase.class.getName())).isEqualTo(ContextBase.class);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(rejectingClassLoader.getRejectedLoads()).contains(ContextBase.class.getName());
+    }
+
+    @Test
+    void canIgnoreTheThreadContextClassLoaderWhenConfiguredBeforeLoaderInitialization() throws Exception {
+        System.setProperty(IGNORE_TCL_PROPERTY_NAME, Boolean.TRUE.toString());
+
+        try (ChildFirstClassLoader classLoader = new ChildFirstClassLoader(new URL[] {
+                codeSourceUrl(LoaderTest.class),
+                codeSourceUrl(ContextBase.class)
+        }, LoaderTest.class.getClassLoader())) {
+            IsolatedLoaderAction action = ServiceLoader.load(IsolatedLoaderAction.class, classLoader)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected an isolated Loader action"));
+
+            assertThat(action.loadStringClass()).isEqualTo(String.class.getName());
+        }
+    }
+
+    private static URL codeSourceUrl(Class<?> type) {
+        CodeSource codeSource = type.getProtectionDomain().getCodeSource();
+
+        assertThat(codeSource).isNotNull();
+        return codeSource.getLocation();
+    }
+
+    private static final class TrackingClassLoader extends ClassLoader {
+
+        private final Set<String> delegatedLoads = new LinkedHashSet<>();
+        private final Set<String> trackedClassNames;
+
+        private TrackingClassLoader(ClassLoader parent, Set<String> trackedClassNames) {
+            super(parent);
+            this.trackedClassNames = trackedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (trackedClassNames.contains(name)) {
+                delegatedLoads.add(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getDelegatedLoads() {
+            return delegatedLoads;
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+
+        private final Set<String> rejectedLoads = new LinkedHashSet<>();
+        private final Set<String> rejectedClassNames;
+
+        private RejectingClassLoader(ClassLoader parent, Set<String> rejectedClassNames) {
+            super(parent);
+            this.rejectedClassNames = rejectedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (rejectedClassNames.contains(name)) {
+                rejectedLoads.add(name);
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getRejectedLoads() {
+            return rejectedLoads;
+        }
+    }
+
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+
+        private ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    if (isChildFirst(name)) {
+                        try {
+                            loadedClass = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loadedClass = super.loadClass(name, false);
+                        }
+                    } else {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private boolean isChildFirst(String className) {
+            return className.startsWith(LOGBACK_PACKAGE) || className.startsWith(ISOLATED_PROVIDER_PACKAGE);
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/Logback_coreTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/Logback_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import org.junit.jupiter.api.Test;
+
+class Logback_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/NestedComplexPropertyIATest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/NestedComplexPropertyIATest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.joran.action.NestedComplexPropertyIA;
+import ch.qos.logback.core.joran.spi.ElementPath;
+import ch.qos.logback.core.joran.spi.InterpretationContext;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.spi.LifeCycle;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class NestedComplexPropertyIATest {
+
+    @Test
+    void instantiatesImplicitNestedComponentAndAttachesItToParent() {
+        ContextBase context = new ContextBase();
+        NestedComplexPropertyIA action = new NestedComplexPropertyIA();
+        InterpretationContext interpretationContext = new InterpretationContext(context, null);
+        ParentTarget parent = new ParentTarget();
+        ElementPath elementPath = new ElementPath("component");
+        AttributesImpl attributes = new AttributesImpl();
+
+        action.setContext(context);
+        interpretationContext.pushObject(parent);
+
+        assertThat(action.isApplicable(elementPath, attributes, interpretationContext)).isTrue();
+
+        action.begin(interpretationContext, "component", attributes);
+
+        assertThat(interpretationContext.peekObject()).isInstanceOf(NestedComponent.class);
+
+        action.end(interpretationContext, "component");
+
+        assertThat(parent.getComponent()).isNotNull();
+        assertThat(parent.getComponent().getParent()).isSameAs(parent);
+        assertThat(parent.getComponent().getContext()).isSameAs(context);
+        assertThat(parent.getComponent().isStarted()).isTrue();
+        assertThat(interpretationContext.peekObject()).isSameAs(parent);
+    }
+
+    public static final class ParentTarget {
+
+        private NestedComponent component;
+
+        public NestedComponent getComponent() {
+            return component;
+        }
+
+        public void setComponent(NestedComponent component) {
+            this.component = component;
+        }
+    }
+
+    public static final class NestedComponent extends ContextAwareBase implements LifeCycle {
+
+        private ParentTarget parent;
+        private boolean started;
+
+        public NestedComponent() {
+        }
+
+        public ParentTarget getParent() {
+            return parent;
+        }
+
+        public void setParent(ParentTarget parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void start() {
+            started = true;
+        }
+
+        @Override
+        public void stop() {
+            started = false;
+        }
+
+        @Override
+        public boolean isStarted() {
+            return started;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/OptionHelperTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/OptionHelperTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.util.OptionHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+public class OptionHelperTest {
+
+    @Test
+    void instantiatesClassWithDefaultConstructorFromItsName() throws Exception {
+        Object instance = OptionHelper.instantiateByClassNameAndParameter(
+                DefaultConstructorInstantiable.class.getName(),
+                TestInstantiable.class,
+                OptionHelperTest.class.getClassLoader(),
+                null,
+                null);
+
+        assertThat(instance)
+                .isInstanceOf(DefaultConstructorInstantiable.class)
+                .isInstanceOf(TestInstantiable.class);
+    }
+
+    @Test
+    void instantiatesClassWithMatchingConstructorParameterFromItsName() throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        ParameterizedInstantiable instance = (ParameterizedInstantiable) OptionHelper.instantiateByClassNameAndParameter(
+                ParameterizedInstantiable.class.getName(),
+                TestInstantiable.class,
+                OptionHelperTest.class.getClassLoader(),
+                OutputStream.class,
+                stream);
+
+        assertThat(instance.getOutputStream()).isSameAs(stream);
+    }
+
+    public interface TestInstantiable {
+    }
+
+    public static final class DefaultConstructorInstantiable implements TestInstantiable {
+
+        public DefaultConstructorInstantiable() {
+        }
+    }
+
+    public static final class ParameterizedInstantiable implements TestInstantiable {
+
+        private final OutputStream outputStream;
+
+        public ParameterizedInstantiable(OutputStream outputStream) {
+            this.outputStream = outputStream;
+        }
+
+        public OutputStream getOutputStream() {
+            return outputStream;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/PropertySetterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/PropertySetterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.joran.spi.DefaultNestedComponentRegistry;
+import ch.qos.logback.core.joran.util.PropertySetter;
+import ch.qos.logback.core.util.AggregationType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PropertySetterTest {
+
+    @Test
+    void invokesSetterWhenAssigningAStringProperty() {
+        PropertyTarget target = new PropertyTarget();
+        PropertySetter propertySetter = new PropertySetter(target);
+
+        propertySetter.setProperty("name", "test-name");
+
+        assertThat(target.getName()).isEqualTo("test-name");
+    }
+
+    @Test
+    void invokesAdderWhenAddingAComplexProperty() {
+        PropertyTarget target = new PropertyTarget();
+        PropertySetter propertySetter = new PropertySetter(target);
+        NestedComponent component = new NestedComponent();
+
+        propertySetter.addComplexProperty("component", component);
+
+        assertThat(target.getComponents()).containsExactly(component);
+    }
+
+    @Test
+    void resolvesConcreteNestedComponentTypeViaImplicitRules() {
+        PropertySetter propertySetter = new PropertySetter(new PropertyTarget());
+
+        Class<?> componentType = propertySetter.getClassNameViaImplicitRules(
+                "component",
+                AggregationType.AS_COMPLEX_PROPERTY,
+                new DefaultNestedComponentRegistry());
+
+        assertThat(componentType).isEqualTo(NestedComponent.class);
+    }
+
+    public static final class PropertyTarget {
+
+        private String name;
+        private NestedComponent component;
+        private final List<NestedComponent> components = new ArrayList<>();
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public NestedComponent getComponent() {
+            return component;
+        }
+
+        public void setComponent(NestedComponent component) {
+            this.component = component;
+        }
+
+        public List<NestedComponent> getComponents() {
+            return components;
+        }
+
+        public void addComponent(NestedComponent component) {
+            components.add(component);
+        }
+    }
+
+    public static final class NestedComponent {
+
+        public NestedComponent() {
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.net.server.AbstractServerSocketAppender;
+import ch.qos.logback.core.spi.PreSerializationTransformer;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import javax.net.ServerSocketFactory;
+import org.junit.jupiter.api.Test;
+
+public class RemoteReceiverStreamClientTest {
+
+    @Test
+    void writesQueuedEventsToConnectedReceiverClient() throws Exception {
+        ContextBase context = new ContextBase();
+        context.start();
+
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            TestServerSocketAppender appender = new TestServerSocketAppender(serverSocket);
+            appender.setContext(context);
+            appender.setName("remoteReceiver");
+            appender.start();
+
+            try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), serverSocket.getLocalPort())) {
+                socket.setSoTimeout(5_000);
+
+                try (ObjectInputStream inputStream = new ObjectInputStream(socket.getInputStream())) {
+                    appender.doAppend("logback-core remote receiver event");
+
+                    assertThat(inputStream.readObject()).isEqualTo("logback-core remote receiver event");
+                }
+            } finally {
+                appender.stop();
+            }
+        } finally {
+            context.stop();
+        }
+    }
+
+    private static final class TestServerSocketAppender extends AbstractServerSocketAppender<Serializable> {
+
+        private final ServerSocketFactory serverSocketFactory;
+
+        private TestServerSocketAppender(ServerSocket serverSocket) {
+            this.serverSocketFactory = new PreparedServerSocketFactory(serverSocket);
+        }
+
+        @Override
+        protected void postProcessEvent(Serializable event) {
+        }
+
+        @Override
+        protected PreSerializationTransformer<Serializable> getPST() {
+            return event -> event;
+        }
+
+        @Override
+        protected ServerSocketFactory getServerSocketFactory() {
+            return serverSocketFactory;
+        }
+    }
+
+    private static final class PreparedServerSocketFactory extends ServerSocketFactory {
+
+        private final ServerSocket serverSocket;
+        private boolean used;
+
+        private PreparedServerSocketFactory(ServerSocket serverSocket) {
+            this.serverSocket = serverSocket;
+        }
+
+        @Override
+        public ServerSocket createServerSocket(int port) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServerSocket createServerSocket(int port, int backlog) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress) throws IOException {
+            if (used) {
+                throw new IllegalStateException("Server socket already created");
+            }
+            used = true;
+            return serverSocket;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/StringToObjectConverterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/StringToObjectConverterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.joran.util.StringToObjectConverter;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import org.junit.jupiter.api.Test;
+
+public class StringToObjectConverterTest {
+
+    @Test
+    void recognizesTypesThatFollowTheStaticValueOfConvention() {
+        assertThat(StringToObjectConverter.canBeBuiltFromSimpleString(ValueOfTarget.class)).isTrue();
+    }
+
+    @Test
+    void convertsValuesUsingTheStaticValueOfConvention() {
+        ContextAwareBase contextAware = new ContextAwareBase();
+
+        Object converted = StringToObjectConverter.convertArg(contextAware, "  trimmed value  ", ValueOfTarget.class);
+
+        assertThat(converted).isInstanceOf(ValueOfTarget.class);
+        assertThat(((ValueOfTarget) converted).getValue()).isEqualTo("trimmed value");
+    }
+
+    public static final class ValueOfTarget {
+
+        private final String value;
+
+        private ValueOfTarget(String value) {
+            this.value = value;
+        }
+
+        public static ValueOfTarget valueOf(String value) {
+            return new ValueOfTarget(value);
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/isolated/EnvUtilJaninoAvailabilityProvider.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/isolated/EnvUtilJaninoAvailabilityProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core.isolated;
+
+import ch.qos.logback.core.util.EnvUtil;
+import java.util.function.BooleanSupplier;
+
+public class EnvUtilJaninoAvailabilityProvider implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return EnvUtil.isJaninoAvailable();
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/isolated/IsolatedLoaderActionProvider.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/ch_qos_logback/logback_core/isolated/IsolatedLoaderActionProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core.isolated;
+
+import ch.qos.logback.core.util.Loader;
+import ch_qos_logback.logback_core.IsolatedLoaderAction;
+
+public class IsolatedLoaderActionProvider implements IsolatedLoaderAction {
+
+    @Override
+    public String loadStringClass() {
+        try {
+            return Loader.loadClass(String.class.getName()).getName();
+        } catch (ClassNotFoundException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/org/codehaus/janino/ScriptEvaluator.java
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/java/org/codehaus/janino/ScriptEvaluator.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.codehaus.janino;
+
+public class ScriptEvaluator {
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -57,6 +57,20 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type" : "ch_qos_logback.logback_core.StringToObjectConverterTest$ValueOfTarget",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -23,6 +23,52 @@
     },
     {
       "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$NestedComponent",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$NestedComponent",
+      "methods" : [
+        {
+          "name" : "setParent",
+          "parameterTypes" : [
+            "ch_qos_logback.logback_core.NestedComplexPropertyIATest$ParentTarget"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$ParentTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$ParentTarget",
+      "methods" : [
+        {
+          "name" : "setComponent",
+          "parameterTypes" : [
+            "ch_qos_logback.logback_core.NestedComplexPropertyIATest$NestedComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "ch.qos.logback.core.util.OptionHelper"
       },
       "type" : "ch_qos_logback.logback_core.OptionHelperTest$DefaultConstructorInstantiable",

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -138,6 +138,12 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.EnvUtil"
+      },
+      "type" : "org.codehaus.janino.ScriptEvaluator"
     }
   ]
 }

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,20 +4,6 @@
       "condition" : {
         "typeReached" : "ch.qos.logback.core.encoder.EventObjectInputStream"
       },
-      "type" : "ch.qos.logback.core.encoder.EventObjectInputStream",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [
-            "java.io.InputStream"
-          ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "ch.qos.logback.core.encoder.EventObjectInputStream"
-      },
       "type" : "ch_qos_logback.logback_core.EventObjectInputStreamTest$SerializablePayload",
       "serializable" : true
     },
@@ -144,6 +130,57 @@
         "typeReached" : "ch.qos.logback.core.util.EnvUtil"
       },
       "type" : "org.codehaus.janino.ScriptEvaluator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.encoder.ObjectStreamEncoder"
+      },
+      "type" : "ch_qos_logback.logback_core.EventObjectInputStreamTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$NestedComponentBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$NestedComponentCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$ParentTargetBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.action.NestedComplexPropertyIA"
+      },
+      "type" : "ch_qos_logback.logback_core.NestedComplexPropertyIATest$ParentTargetCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.PropertySetterTest$PropertyTargetBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.PropertySetterTest$PropertyTargetCustomizer"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.FileUtil"
+      },
+      "glob" : "ch_qos_logback/logback_core/file-util-resource.txt"
     }
   ]
 }

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,27 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "ch.qos.logback.core.encoder.EventObjectInputStream"
+      },
+      "type" : "ch.qos.logback.core.encoder.EventObjectInputStream",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.io.InputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.encoder.EventObjectInputStream"
+      },
+      "type" : "ch_qos_logback.logback_core.EventObjectInputStreamTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "ch.qos.logback.core.util.OptionHelper"
       },
       "type" : "ch_qos_logback.logback_core.OptionHelperTest$DefaultConstructorInstantiable",

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type" : "ch_qos_logback.logback_core.OptionHelperTest$DefaultConstructorInstantiable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type" : "ch_qos_logback.logback_core.OptionHelperTest$ParameterizedInstantiable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.io.OutputStream"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -25,6 +25,38 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.PropertySetterTest$NestedComponent",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.PropertySetter"
+      },
+      "type" : "ch_qos_logback.logback_core.PropertySetterTest$PropertyTarget",
+      "methods" : [
+        {
+          "name" : "addComponent",
+          "parameterTypes" : [
+            "ch_qos_logback.logback_core.PropertySetterTest$NestedComponent"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/services/ch_qos_logback.logback_core.IsolatedLoaderAction
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/services/ch_qos_logback.logback_core.IsolatedLoaderAction
@@ -1,0 +1,1 @@
+ch_qos_logback.logback_core.isolated.IsolatedLoaderActionProvider

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/services/java.util.function.BooleanSupplier
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/META-INF/services/java.util.function.BooleanSupplier
@@ -1,0 +1,1 @@
+ch_qos_logback.logback_core.isolated.EnvUtilJaninoAvailabilityProvider

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/ch_qos_logback/logback_core/file-util-resource.txt
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/src/test/resources/ch_qos_logback/logback_core/file-util-resource.txt
@@ -1,0 +1,1 @@
+file util resource

--- a/tests/src/ch.qos.logback/logback-core/1.1.3/user-code-filter.json
+++ b/tests/src/ch.qos.logback/logback-core/1.1.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "ch.qos.logback.core.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1301

This PR introduces tests and metadata for ch.qos.logback:logback-core:1.1.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 369231
- Cached input tokens: 4919936
- Output tokens: 59730
- Entries: 32
- Iterations: 12
- Library coverage percentage: 10.41
- Generated lines of code: 798
- Tested library lines of code: 817

Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 29/29 covered calls (100.00%)
- Reflection: 26/26 covered calls (100.00%)
- Resources: 3/3 covered calls (100.00%)

Library coverage:
- Instruction: 3032/30860 (9.83%)
- Line: 817/7849 (10.41%)
- Method: 204/1858 (10.98%)
