### PR TITLE
Fix lambda-conditioned metadata duplicates and strict metadata checks

### DIFF
--- a/metadata/com.hazelcast/hazelcast/5.2.1/reachability-metadata.json
+++ b/metadata/com.hazelcast/hazelcast/5.2.1/reachability-metadata.json
@@ -4967,12 +4967,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1553/0x0000000800ecf330"
-      },
-      "type": "com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.map.impl.MapServiceContextImpl"
       },
       "type": "com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment"
@@ -6664,12 +6658,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsRegistryImpl$$Lambda$1635/0x0000000800f8ad98"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "java.lang.Object"
@@ -6738,12 +6726,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.map.impl.MapServiceConstructor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1553/0x0000000800ecf330"
       },
       "type": "java.lang.Object"
     },

--- a/metadata/com.hazelcast/hazelcast/5.5.0/reachability-metadata.json
+++ b/metadata/com.hazelcast/hazelcast/5.5.0/reachability-metadata.json
@@ -170,18 +170,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.client.impl.connection.ClientConnection"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.client.impl.connection.ClientConnection"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClusterConnectionMetricsProvider"
       },
       "type": "com.hazelcast.client.impl.connection.ClientConnection",
@@ -190,18 +178,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
-      },
-      "type": "com.hazelcast.client.impl.connection.tcp.TcpClientConnection"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.client.impl.connection.tcp.TcpClientConnection"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
       },
       "type": "com.hazelcast.client.impl.connection.tcp.TcpClientConnection"
     },
@@ -552,18 +528,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.collection.LocalCollectionStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.collection.LocalCollectionStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.collection.impl.list.ListService"
       },
       "type": "com.hazelcast.collection.LocalListStats",
@@ -572,18 +536,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.collection.LocalListStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.collection.LocalListStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.collection.LocalListStats"
     },
@@ -602,18 +554,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.collection.LocalQueueStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.collection.LocalQueueStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.collection.impl.set.SetService"
       },
       "type": "com.hazelcast.collection.LocalSetStats",
@@ -622,18 +562,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.collection.LocalSetStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.collection.LocalSetStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.collection.LocalSetStats"
     },
@@ -941,14 +869,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.executor.LocalExecutorStats",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
+        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "com.hazelcast.executor.LocalExecutorStats",
       "allDeclaredFields": true
@@ -1067,13 +988,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.instance.LocalInstanceStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
+        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "com.hazelcast.instance.LocalInstanceStats"
     },
@@ -1386,18 +1301,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
@@ -1411,18 +1314,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.metrics.DynamicMetricsProvider"
     },
@@ -1572,18 +1463,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.LocalFlakeIdGeneratorStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.LocalFlakeIdGeneratorStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.crdt.pncounter.PNCounterService"
       },
       "type": "com.hazelcast.internal.monitor.LocalPNCounterStats",
@@ -1592,18 +1471,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.monitor.LocalPNCounterStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.LocalPNCounterStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.monitor.LocalPNCounterStats"
     },
@@ -1629,18 +1496,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.AbstractLocalCollectionStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.AbstractLocalCollectionStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.monitor.impl.GlobalIndexesStats"
       },
       "type": "com.hazelcast.internal.monitor.impl.GlobalIndexesStats",
@@ -1655,14 +1510,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalExecutorStatsImpl",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
+        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalExecutorStatsImpl",
       "allDeclaredFields": true
@@ -1715,18 +1563,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalFlakeIdGeneratorStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalFlakeIdGeneratorStatsImpl"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.monitor.impl.LocalFlakeIdGeneratorStatsImpl"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalFlakeIdGeneratorStatsImpl",
@@ -1754,18 +1590,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalListStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalListStatsImpl"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.monitor.impl.LocalListStatsImpl"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalListStatsImpl",
@@ -1781,18 +1605,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalMapStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalMapStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalMapStatsImpl"
     },
@@ -1942,18 +1754,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalMultiMapStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalMultiMapStatsImpl"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.multimap.impl.MultiMapService"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalMultiMapStatsImpl",
@@ -1969,18 +1769,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalPNCounterStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalPNCounterStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalPNCounterStatsImpl"
     },
@@ -2018,18 +1806,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl"
     },
@@ -2085,18 +1861,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalReplicatedMapStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalReplicatedMapStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalReplicatedMapStatsImpl"
     },
@@ -2225,18 +1989,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalSetStatsImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalSetStatsImpl"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.monitor.impl.LocalSetStatsImpl"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalSetStatsImpl",
@@ -2251,14 +2003,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
+        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl",
       "allDeclaredFields": true
@@ -2299,31 +2044,13 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.InboundPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.InboundPipeline"
     },
     {
       "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
-      },
-      "type": "com.hazelcast.internal.networking.Networking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.Networking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
       },
       "type": "com.hazelcast.internal.networking.Networking"
     },
@@ -2342,18 +2069,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.networking.Networking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.networking.Networking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.networking.Networking"
     },
@@ -2379,13 +2094,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.OutboundPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.OutboundPipeline"
     },
@@ -2415,13 +2124,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.MigratablePipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.nio.MigratablePipeline"
     },
@@ -2440,31 +2143,13 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioInboundPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.nio.NioInboundPipeline"
     },
     {
       "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioNetworking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioNetworking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
       },
       "type": "com.hazelcast.internal.networking.nio.NioNetworking"
     },
@@ -2483,18 +2168,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioNetworking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioNetworking"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.networking.nio.NioNetworking"
     },
@@ -2532,13 +2205,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioOutboundPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.nio.NioOutboundPipeline"
     },
@@ -2561,31 +2228,13 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "com.hazelcast.internal.networking.nio.NioPipeline"
     },
     {
       "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
       },
       "type": "com.hazelcast.internal.networking.nio.NioThread"
     },
@@ -2604,18 +2253,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.networking.nio.NioThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.networking.nio.NioThread"
     },
@@ -2640,18 +2277,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
@@ -2665,18 +2290,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.networking.nio.iobalancer.IOBalancer"
     },
@@ -2707,18 +2320,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.nio.Connection"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.internal.nio.Connection"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClusterConnectionMetricsProvider"
       },
       "type": "com.hazelcast.internal.nio.Connection",
@@ -2727,18 +2328,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.nio.ConnectionListenable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.nio.ConnectionListenable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.nio.ConnectionListenable"
     },
@@ -2906,18 +2495,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.server.ServerConnectionManager"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.server.ServerConnectionManager"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider"
       },
       "type": "com.hazelcast.internal.server.ServerConnectionManager"
@@ -2937,18 +2514,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider"
       },
       "type": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider",
@@ -2957,18 +2522,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerAcceptor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerAcceptor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.server.tcp.TcpServerAcceptor"
     },
@@ -2999,18 +2552,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManager"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManager"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.server.tcp.TcpServer$MetricsProvider"
       },
       "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManager"
@@ -3035,18 +2576,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManagerBase"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManagerBase"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.server.tcp.TcpServerConnectionManagerBase"
     },
@@ -3201,18 +2730,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.util.executor.CachedExecutorServiceDelegate"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.internal.util.executor.CachedExecutorServiceDelegate"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.util.executor.CachedExecutorServiceDelegate"
       },
       "type": "com.hazelcast.internal.util.executor.CachedExecutorServiceDelegate",
@@ -3248,18 +2765,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
@@ -3273,18 +2778,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.util.executor.HazelcastManagedThread"
     },
@@ -3305,18 +2798,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.util.executor.ManagedExecutorService"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.util.executor.ManagedExecutorService"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.util.executor.ManagedExecutorService"
     },
@@ -3352,18 +2833,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.internal.util.executor.NamedThreadPoolExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.internal.util.executor.NamedThreadPoolExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.internal.util.executor.NamedThreadPoolExecutor"
     },
@@ -3722,18 +3191,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.map.LocalMapStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.map.LocalMapStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.map.impl.MapService"
       },
       "type": "com.hazelcast.map.LocalMapStats",
@@ -3772,18 +3229,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.multimap.LocalMultiMapStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "com.hazelcast.multimap.LocalMultiMapStats"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.multimap.impl.MultiMapService"
       },
       "type": "com.hazelcast.multimap.LocalMultiMapStats",
@@ -3804,18 +3249,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.replicatedmap.LocalReplicatedMapStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.replicatedmap.LocalReplicatedMapStats"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.replicatedmap.LocalReplicatedMapStats"
     },
@@ -3953,18 +3386,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1633/0x000000700136e400"
-      },
-      "type": "com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1633/0x0000008001369d78"
-      },
-      "type": "com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.map.impl.MapServiceContextImpl"
       },
       "type": "com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment"
@@ -4003,18 +3424,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
@@ -4028,18 +3437,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "com.hazelcast.spi.impl.operationexecutor.OperationHostileThread"
     },
@@ -4330,14 +3727,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "com.hazelcast.topic.LocalTopicStats",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
+        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
       },
       "type": "com.hazelcast.topic.LocalTopicStats",
       "allDeclaredFields": true
@@ -4989,18 +4379,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.client.impl.statistics.ClusterConnectionMetricsProvider"
       },
       "type": "java.lang.Object"
@@ -5055,31 +4433,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsRegistryImpl$$Lambda$1720/0x0000007001411230"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsRegistryImpl$$Lambda$1720/0x0000008001414b18"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "java.lang.Object"
     },
@@ -5141,18 +4495,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.map.impl.MapServiceConstructor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1633/0x000000700136e400"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.map.impl.MapServiceConstructor$$Lambda$1633/0x0000008001369d78"
       },
       "type": "java.lang.Object"
     },
@@ -5290,18 +4632,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "java.lang.Runnable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "java.lang.Runnable"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "java.lang.Runnable"
@@ -5315,18 +4645,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "java.lang.Runnable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.lang.Runnable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "java.lang.Runnable"
     },
@@ -5460,18 +4778,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "java.lang.Thread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
-      },
-      "type": "java.lang.Thread"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsCollectionCycle"
       },
       "type": "java.lang.Thread"
@@ -5485,18 +4791,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "java.lang.Thread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.lang.Thread"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "java.lang.Thread"
     },
@@ -5728,18 +5022,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.util.concurrent.AbstractExecutorService"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "java.util.concurrent.AbstractExecutorService"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl$MetricsProvider"
       },
       "type": "java.util.concurrent.AbstractExecutorService",
@@ -5760,18 +5042,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.util.concurrent.Executor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "java.util.concurrent.Executor"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl$MetricsProvider"
       },
       "type": "java.util.concurrent.Executor",
@@ -5780,18 +5050,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "java.util.concurrent.ExecutorService"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.util.concurrent.ExecutorService"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "java.util.concurrent.ExecutorService"
     },
@@ -5824,18 +5082,6 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.util.concurrent.ThreadPoolExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
-      },
-      "type": "java.util.concurrent.ThreadPoolExecutor"
-    },
-    {
-      "condition": {
         "typeReached": "com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl$MetricsProvider"
       },
       "type": "java.util.concurrent.ThreadPoolExecutor",
@@ -5844,18 +5090,6 @@
     {
       "condition": {
         "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService"
-      },
-      "type": "java.util.function.Consumer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000070013bc240"
-      },
-      "type": "java.util.function.Consumer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.internal.metrics.impl.MetricsService$$Lambda$1691/0x00000080013b59f0"
       },
       "type": "java.util.function.Consumer"
     },
@@ -5902,13 +5136,7 @@
     },
     {
       "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1844/0x0000008001473918"
-      },
-      "type": "java.util.function.Supplier"
-    },
-    {
-      "condition": {
-        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService$$Lambda$1846/0x0000007001479eb8"
+        "typeReached": "com.hazelcast.client.impl.statistics.ClientStatisticsService"
       },
       "type": "java.util.function.Supplier"
     },

--- a/metadata/org.ehcache/ehcache/3.10.8-jakarta/reachability-metadata.json
+++ b/metadata/org.ehcache/ehcache/3.10.8-jakarta/reachability-metadata.json
@@ -434,18 +434,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.ResourceConfigurationParser"
       },
       "type": "java.lang.Object"
@@ -459,54 +447,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "java.lang.Object"
     },
@@ -1078,18 +1018,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.core.internal.statistics.StatsUtils$3"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.core.internal.statistics.StatsUtils$3"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.core.util.ClassLoading$ChainedClassLoader"
       },
       "type": "org.ehcache.core.spi.service.StatisticsService"
@@ -1500,18 +1428,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$1"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$1"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.jsr107.Eh107CacheManager"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$1"
@@ -1578,18 +1494,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$2"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$2"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.jsr107.Eh107CacheManager"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$2"
@@ -1632,18 +1536,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$3"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$3"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.shadow.org.terracotta.context.query.Matchers"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$3"
@@ -1675,18 +1567,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$4"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$4"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$4"
     },
@@ -1747,18 +1627,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$5"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$5"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$5"
     },
@@ -1830,18 +1698,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$6"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$6"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.jsr107.Eh107CacheManager"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$6"
@@ -1903,18 +1759,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$8"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$8"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
       },
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$8"
     },
@@ -2062,18 +1906,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.core.internal.statistics.DefaultStatisticsService"
       },
       "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic$1"
@@ -2081,18 +1913,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic$1"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$433/0x0000000800d91a90"
-      },
-      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic$1"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.impl.store.BaseStore$BaseStoreProvider$$Lambda$436/0x0000000800d96e18"
       },
       "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic$1"
     },
@@ -2208,13 +2028,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.BaseCacheType"
     },
@@ -2245,54 +2059,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.BaseCacheType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.BaseCacheType"
@@ -2318,13 +2084,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheEntryType"
     },
@@ -2355,54 +2115,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheEntryType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheEntryType"
@@ -2428,13 +2140,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType"
     },
@@ -2465,54 +2171,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType"
@@ -2538,13 +2196,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
     },
@@ -2575,54 +2227,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind"
@@ -2648,13 +2252,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
     },
@@ -2685,54 +2283,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$Batching"
@@ -2758,13 +2308,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
     },
@@ -2795,54 +2339,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheLoaderWriterType$WriteBehind$NonBatching"
@@ -2868,13 +2364,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheTemplateType"
     },
@@ -2906,54 +2396,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheTemplateType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.CacheTemplateType"
     },
@@ -2984,13 +2426,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CacheType"
     },
@@ -3021,54 +2457,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CacheType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CacheType"
@@ -3094,13 +2482,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ConfigType"
     },
@@ -3131,54 +2513,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ConfigType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ConfigType"
@@ -3204,13 +2538,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CopierType"
     },
@@ -3241,54 +2569,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.CopierType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.CopierType"
@@ -3314,13 +2594,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.CopierType$Copier"
     },
@@ -3346,54 +2620,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.CopierType$Copier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.CopierType$Copier"
     },
@@ -3452,13 +2678,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.DiskStoreSettingsType"
     },
@@ -3484,54 +2704,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.DiskStoreSettingsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.DiskStoreSettingsType"
     },
@@ -3604,13 +2776,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ExpiryType"
     },
@@ -3641,54 +2807,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ExpiryType"
@@ -3714,13 +2832,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ExpiryType$None"
     },
@@ -3746,54 +2858,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ExpiryType$None"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.ExpiryType$None"
     },
@@ -3866,13 +2930,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ListenersType"
     },
@@ -3903,54 +2961,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ListenersType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ListenersType"
@@ -3976,13 +2986,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ListenersType$Listener"
     },
@@ -4013,54 +3017,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ListenersType$Listener"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ListenersType$Listener"
@@ -4086,13 +3042,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.MemoryType"
     },
@@ -4123,54 +3073,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.MemoryType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.MemoryType"
@@ -4196,13 +3098,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
     },
@@ -4228,54 +3124,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.MemoryTypeWithPropSubst"
     },
@@ -4313,18 +3161,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.ResourceConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ObjectFactory"
@@ -4338,54 +3174,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ObjectFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.ObjectFactory"
     },
@@ -4444,13 +3232,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
     },
@@ -4481,54 +3263,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.PersistableMemoryTypeWithPropSubst"
@@ -4554,13 +3288,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.PersistenceType"
     },
@@ -4591,54 +3319,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.PersistenceType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.PersistenceType"
@@ -4664,13 +3344,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
     },
@@ -4702,54 +3376,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.ResourceTypeWithPropSubst"
     },
@@ -4794,13 +3420,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ResourcesType"
     },
@@ -4831,54 +3451,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ResourcesType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ResourcesType"
@@ -4904,13 +3476,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.SerializerType"
     },
@@ -4941,54 +3507,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.SerializerType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.SerializerType"
@@ -5014,13 +3532,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.SerializerType$Serializer"
     },
@@ -5051,54 +3563,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.SerializerType$Serializer"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.SerializerType$Serializer"
@@ -5124,13 +3588,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ServiceType"
     },
@@ -5161,54 +3619,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ServiceType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ServiceType"
@@ -5234,13 +3644,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.SizeofType"
     },
@@ -5271,54 +3675,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.SizeofType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.SizeofType"
@@ -5344,13 +3700,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
     },
@@ -5381,54 +3731,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.SizeofType$MaxObjectGraphSize"
@@ -5454,13 +3756,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
     },
@@ -5491,54 +3787,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ThreadPoolReferenceType"
@@ -5564,13 +3812,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ThreadPoolsType"
     },
@@ -5601,54 +3843,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ThreadPoolsType"
@@ -5674,13 +3868,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
     },
@@ -5711,54 +3899,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
-      },
-      "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
-    },
-    {
-      "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$SingleConfig"
       },
       "type": "org.ehcache.xml.model.ThreadPoolsType$ThreadPool"
@@ -5784,13 +3924,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$615/0x0000000800e52c78"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.ConfigurationParser$$Lambda$618/0x0000000800e56040"
+        "typeReached": "org.ehcache.xml.ConfigurationParser"
       },
       "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
     },
@@ -5816,54 +3950,6 @@
     {
       "condition": {
         "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8e260"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f148"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$836/0x0000000800f8f820"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$840/0x0000000800f3e880"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fadad0"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800faf688"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$849/0x0000000800fafc88"
-      },
-      "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
-    },
-    {
-      "condition": {
-        "typeReached": "org.ehcache.xml.multi.XmlMultiConfiguration$$Lambda$853/0x0000000800f96f50"
       },
       "type": "org.ehcache.xml.model.TimeTypeWithPropSubst"
     },

--- a/metadata/org.liquibase/liquibase-core/4.25.0/reachability-metadata.json
+++ b/metadata/org.liquibase/liquibase-core/4.25.0/reachability-metadata.json
@@ -56,18 +56,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "java.lang.Object"
@@ -176,18 +164,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.AbstractExtensibleObject"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.AbstractExtensibleObject"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.AbstractExtensibleObject"
@@ -224,18 +200,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.ExtensibleObject"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.ExtensibleObject"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.ExtensibleObject"
@@ -255,18 +219,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.AbstractChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.AbstractChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.AbstractChange"
     },
@@ -317,18 +269,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.AbstractSQLChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.AbstractSQLChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.AbstractSQLChange"
     },
@@ -398,18 +338,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.AbstractTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.AbstractTableChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.AbstractTableChange"
@@ -465,18 +393,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.Change"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.Change"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.Change"
@@ -508,18 +424,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.ChangeWithColumns"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.ChangeWithColumns"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.ChangeWithColumns"
     },
@@ -568,18 +472,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.DbmsTargetedChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.DbmsTargetedChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.DbmsTargetedChange"
@@ -599,18 +491,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AbstractModifyDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AbstractModifyDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AbstractModifyDataChange"
     },
@@ -657,18 +537,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AddAutoIncrementChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddAutoIncrementChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AddAutoIncrementChange"
     },
@@ -966,18 +834,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.AddColumnChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.AddColumnChange",
@@ -1099,18 +955,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AddDefaultValueChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddDefaultValueChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AddDefaultValueChange"
     },
@@ -1450,18 +1294,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddForeignKeyConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.AddForeignKeyConstraintChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.AddForeignKeyConstraintChange",
@@ -1712,18 +1544,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddLookupTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.AddLookupTableChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.configuration.LiquibaseConfiguration"
       },
       "type": "liquibase.change.core.AddLookupTableChange",
@@ -1782,18 +1602,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AddNotNullConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddNotNullConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AddNotNullConstraintChange"
     },
@@ -2086,18 +1894,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AddPrimaryKeyChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddPrimaryKeyChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AddPrimaryKeyChange"
     },
@@ -2444,18 +2240,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.AddUniqueConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AddUniqueConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.AddUniqueConstraintChange"
     },
@@ -2857,18 +2641,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.AlterSequenceChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.AlterSequenceChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.AlterSequenceChange",
@@ -3169,18 +2941,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.CreateIndexChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.CreateIndexChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.CreateIndexChange"
@@ -3224,18 +2984,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.CreateProcedureChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.CreateProcedureChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.CreateProcedureChange"
     },
@@ -3299,13 +3047,7 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.CreateSequenceChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
+        "typeReached": "liquibase.change.ChangeFactory"
       },
       "type": "liquibase.change.core.CreateSequenceChange"
     },
@@ -3653,18 +3395,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.CreateTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.CreateTableChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.change.core.CreateTableChange"
       },
       "type": "liquibase.change.core.CreateTableChange",
@@ -3771,18 +3501,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.CreateViewChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.CreateViewChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.CreateViewChange"
     },
@@ -3998,18 +3716,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DeleteDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DeleteDataChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.DeleteDataChange"
@@ -4047,18 +3753,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropAllForeignKeyConstraintsChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropAllForeignKeyConstraintsChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropAllForeignKeyConstraintsChange"
     },
@@ -4111,18 +3805,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropColumnChange"
     },
@@ -4287,18 +3969,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropDefaultValueChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropDefaultValueChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropDefaultValueChange"
     },
@@ -4530,18 +4200,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropForeignKeyConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DropForeignKeyConstraintChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.DropForeignKeyConstraintChange",
@@ -4766,18 +4424,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropIndexChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DropIndexChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.DropIndexChange",
@@ -4981,18 +4627,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropNotNullConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropNotNullConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropNotNullConstraintChange"
     },
@@ -5250,18 +4884,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropPrimaryKeyChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DropPrimaryKeyChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.DropPrimaryKeyChange",
@@ -5474,18 +5096,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropProcedureChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DropProcedureChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.DropProcedureChange"
@@ -5529,18 +5139,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropSequenceChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropSequenceChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropSequenceChange"
     },
@@ -5735,18 +5333,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropTableChange"
     },
@@ -5959,18 +5545,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.DropUniqueConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropUniqueConstraintChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.DropUniqueConstraintChange"
     },
@@ -6202,18 +5776,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.DropViewChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.DropViewChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.DropViewChange",
@@ -6416,18 +5978,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.EmptyChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.EmptyChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.EmptyChange"
@@ -6470,18 +6020,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.ExecuteShellCommandChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.ExecuteShellCommandChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.ExecuteShellCommandChange"
@@ -6519,18 +6057,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.InsertDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.InsertDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.InsertDataChange"
     },
@@ -6584,18 +6110,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.LoadDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.LoadDataChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.LoadDataChange"
@@ -6633,18 +6147,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.LoadUpdateDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.LoadUpdateDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.LoadUpdateDataChange"
     },
@@ -6705,18 +6207,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.MergeColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.MergeColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.MergeColumnChange"
     },
@@ -7030,18 +6520,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.ModifyDataTypeChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.ModifyDataTypeChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.changelog.ChangeSet"
       },
       "type": "liquibase.change.core.ModifyDataTypeChange",
@@ -7262,18 +6740,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.OutputChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.OutputChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.OutputChange"
@@ -7328,13 +6794,7 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.RawSQLChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
+        "typeReached": "liquibase.change.ChangeFactory"
       },
       "type": "liquibase.change.core.RawSQLChange"
     },
@@ -7403,18 +6863,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.RenameColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.RenameColumnChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.RenameColumnChange"
     },
@@ -7684,18 +7132,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.RenameSequenceChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.RenameSequenceChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.RenameSequenceChange"
@@ -7743,18 +7179,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.RenameTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.RenameTableChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.RenameTableChange"
     },
@@ -7958,18 +7382,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.RenameViewChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.RenameViewChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.RenameViewChange"
@@ -8022,18 +7434,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.SQLFileChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.SQLFileChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.SQLFileChange"
@@ -8071,18 +7471,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.SetColumnRemarksChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.SetColumnRemarksChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.SetColumnRemarksChange"
     },
@@ -8130,18 +7518,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.SetTableRemarksChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.SetTableRemarksChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.SetTableRemarksChange"
@@ -8179,18 +7555,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.core.StopChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.StopChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.core.StopChange"
     },
@@ -8238,18 +7602,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.TagDatabaseChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.TagDatabaseChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.TagDatabaseChange"
@@ -8292,18 +7644,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.core.UpdateDataChange"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.change.core.UpdateDataChange"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.change.core.UpdateDataChange"
@@ -8341,18 +7681,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.change.custom.CustomChangeWrapper"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.change.custom.CustomChangeWrapper"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.change.custom.CustomChangeWrapper"
     },
@@ -9048,18 +8376,6 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.plugin.AbstractPlugin"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
-      },
-      "type": "liquibase.plugin.AbstractPlugin"
-    },
-    {
-      "condition": {
         "typeReached": "liquibase.util.ObjectUtil"
       },
       "type": "liquibase.plugin.AbstractPlugin"
@@ -9091,18 +8407,6 @@
     {
       "condition": {
         "typeReached": "liquibase.change.ChangeFactory"
-      },
-      "type": "liquibase.plugin.Plugin"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x00000070012425c8"
-      },
-      "type": "liquibase.plugin.Plugin"
-    },
-    {
-      "condition": {
-        "typeReached": "liquibase.change.ChangeFactory$$Lambda$510/0x0000007001243818"
       },
       "type": "liquibase.plugin.Plugin"
     },
@@ -9302,7 +8606,7 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.command.core.helpers.DatabaseChangelogCommandStep$$Lambda$506/0x0000007001211230"
+        "typeReached": "liquibase.command.core.helpers.DatabaseChangelogCommandStep"
       },
       "type": "liquibase.precondition.core.PreconditionContainer",
       "methods": [
@@ -9316,7 +8620,7 @@
     },
     {
       "condition": {
-        "typeReached": "liquibase.command.core.helpers.DatabaseChangelogCommandStep$$Lambda$506/0x0000007001214000"
+        "typeReached": "liquibase.command.core.helpers.DatabaseChangelogCommandStep"
       },
       "type": "liquibase.precondition.core.PreconditionContainer",
       "methods": [

--- a/metadata/org.testcontainers/testcontainers/1.17.6/reachability-metadata.json
+++ b/metadata/org.testcontainers/testcontainers/1.17.6/reachability-metadata.json
@@ -3098,12 +3098,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$421/0x0000000100311e88"
-      },
-      "type": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory"
       },
       "type": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"

--- a/metadata/org.testcontainers/testcontainers/1.19.8/reachability-metadata.json
+++ b/metadata/org.testcontainers/testcontainers/1.19.8/reachability-metadata.json
@@ -30,12 +30,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.command.CreateContainerResponse"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
       },
       "type": "com.github.dockerjava.api.command.CreateContainerResponse"
@@ -362,12 +356,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.command.InspectImageResponse"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectImageCmdImpl"
       },
       "type": "com.github.dockerjava.api.command.InspectImageResponse"
@@ -416,12 +404,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.command.RootFS"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.command.InspectImageCmdImpl"
       },
       "type": "com.github.dockerjava.api.command.RootFS"
@@ -463,12 +445,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.containers.GenericContainer"
-      },
-      "type": "com.github.dockerjava.api.model.AuthConfig"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
       },
       "type": "com.github.dockerjava.api.model.AuthConfig"
     },
@@ -603,12 +579,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.containers.GenericContainer"
-      },
-      "type": "com.github.dockerjava.api.model.Binds"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
       },
       "type": "com.github.dockerjava.api.model.Binds"
     },
@@ -953,12 +923,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.model.DockerObject"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.dockerclient.DockerClientProviderStrategy"
       },
       "type": "com.github.dockerjava.api.model.DockerObject"
@@ -1174,12 +1138,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.model.ExposedPorts"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerBase"
       },
       "type": "com.github.dockerjava.api.model.ExposedPorts",
@@ -1259,12 +1217,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.containers.GenericContainer"
-      },
-      "type": "com.github.dockerjava.api.model.HostConfig"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
       },
       "type": "com.github.dockerjava.api.model.HostConfig"
     },
@@ -1692,12 +1644,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.model.Links"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
       },
       "type": "com.github.dockerjava.api.model.Links"
@@ -1933,12 +1879,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.containers.GenericContainer"
-      },
-      "type": "com.github.dockerjava.api.model.Ports"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
       },
       "type": "com.github.dockerjava.api.model.Ports"
     },
@@ -2627,12 +2567,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
-      },
-      "type": "com.github.dockerjava.api.model.Volumes"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"
       },
       "type": "com.github.dockerjava.api.model.Volumes"
@@ -2798,12 +2732,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
-      },
-      "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
       },
       "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile",
@@ -2823,12 +2751,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
-      },
-      "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints"
-    },
-    {
-      "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile"
       },
       "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints",
@@ -2843,12 +2765,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"
-      },
-      "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints$Docker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder$$Lambda$432/0x000000e8011c3200"
       },
       "type": "org.testcontainers.shaded.com.github.dockerjava.core.DockerContextMetaFile$Endpoints$Docker"
     },
@@ -3392,12 +3308,6 @@
     {
       "condition": {
         "typeReached": "org.testcontainers.containers.GenericContainer"
-      },
-      "type": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
-    },
-    {
-      "condition": {
-        "typeReached": "org.testcontainers.containers.GenericContainer$$Lambda$478/0x000000e80123bd50"
       },
       "type": "org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
     },

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckMetadataFilesAllTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CheckMetadataFilesAllTask.java
@@ -9,6 +9,7 @@ package org.graalvm.internal.tck.harness.tasks;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 import org.graalvm.internal.tck.MetadataFilesCheckerTask;
+import org.graalvm.internal.tck.utils.CoordinateUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,16 @@ import java.util.List;
  */
 @SuppressWarnings("unused")
 public abstract class CheckMetadataFilesAllTask extends CoordinatesAwareTask {
+
+    @Override
+    protected List<String> computeMatchingCoordinates(String filter) {
+        if (CoordinateUtils.isFractionalBatch(filter)) {
+            int[] frac = CoordinateUtils.parseFraction(filter);
+            List<String> all = tckExtension.getMatchingCoordinatesStrict("all");
+            return CoordinateUtils.computeBatchedCoordinates(all, frac[0], frac[1]);
+        }
+        return tckExtension.getMatchingCoordinatesStrict(filter);
+    }
 
     @TaskAction
     public void runAll() {


### PR DESCRIPTION
## Summary
- normalize unstable lambda-based `condition.typeReached` values in the affected metadata files to stable enclosing classes
- remove duplicate metadata entries created by that normalization in the ehcache, testcontainers, hazelcast, and liquibase metadata
- make `checkMetadataFiles` resolve coordinates strictly so `tested-versions` that reuse another metadata directory are not checked repeatedly

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/2007