### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-metrics:1.56.0 using gpt-5.4

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.api.internal.IncubatingUtil"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/reachability-metadata.json
@@ -5,6 +5,85 @@
         "typeReached": "io.opentelemetry.api.internal.IncubatingUtil"
       },
       "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.SdkMeter"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProvider",
+      "methods": [
+        {
+          "name": "resetForTest",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "addMeterConfiguratorCondition",
+          "parameterTypes": [
+            "java.util.function.Predicate",
+            "io.opentelemetry.sdk.metrics.internal.MeterConfig"
+          ]
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.ViewBuilder",
+      "methods": [
+        {
+          "name": "addAttributesProcessor",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.DoubleAdder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.context.LazyStorage"
+      },
+      "glob": "META-INF/services/io.opentelemetry.context.ContextStorageProvider"
     }
   ]
 }

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.56.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.56.0/opentelemetry-sdk-metrics-1.56.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.56.0/sdk/metrics/src/test/java",
+    "documentation-url" : "https://javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/index.html",
+    "description" : "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider, readers, views, and aggregation pipeline. Applications and instrumentation use it to configure, collect, and export metric data through OpenTelemetry.",
     "tested-versions" : [
       "1.56.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,17 +1,23 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.56.0",
+    "tested-versions" : [
+      "1.56.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
-    "description": "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
+    "description" : "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
+    "tested-versions" : [
       "1.19.0",
       "1.20.0",
       "1.20.1",
@@ -56,11 +62,14 @@
       "1.54.1",
       "1.55.0"
     ],
-    "skipped-versions": [
+    "skipped-versions" : [
       {
-        "version": "1.34.0",
-        "reason": "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
+        "version" : "1.34.0",
+        "reason" : "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
       }
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.56.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 228,
+        "missed" : 18459,
+        "ratio" : 0.012201,
+        "total" : 18687
+      },
+      "line" : {
+        "covered" : 66,
+        "missed" : 4194,
+        "ratio" : 0.015493,
+        "total" : 4260
+      },
+      "method" : {
+        "covered" : 24,
+        "missed" : 1184,
+        "ratio" : 0.019868,
+        "total" : 1208
+      }
+    }
+  } ]
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.0,
-          "coveredCalls" : 0,
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
           "totalCalls" : 5
         }
       },
-      "coverageRatio" : 0.0,
-      "coveredCalls" : 0,
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
       "totalCalls" : 5
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 228,
-        "missed" : 18459,
-        "ratio" : 0.012201,
+        "covered" : 3250,
+        "missed" : 15437,
+        "ratio" : 0.173918,
         "total" : 18687
       },
       "line" : {
-        "covered" : 66,
-        "missed" : 4194,
-        "ratio" : 0.015493,
+        "covered" : 869,
+        "missed" : 3391,
+        "ratio" : 0.203991,
         "total" : 4260
       },
       "method" : {
-        "covered" : 24,
-        "missed" : 1184,
-        "ratio" : 0.019868,
+        "covered" : 283,
+        "missed" : 925,
+        "ratio" : 0.234272,
         "total" : 1208
       }
     }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-metrics:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--allow-incomplete-classpath')
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version=1.56.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.56.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'opentelemetry-sdk-metrics-test'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+
+public class OpenTelemetrySdkMetricsTest {
+
+    @Test
+    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
+
+        Method method =
+                SdkMeterProviderBuilder.class.getDeclaredMethod(
+                        "setExemplarFilter", ExemplarFilter.class);
+        method.setAccessible(true);
+        method.invoke(sdkMeterProvider, new ExemplarFilter() {
+            @Override
+            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+                return false;
+            }
+        });
+
+        try (SdkMeterProvider provider = sdkMeterProvider.build()) {
+            provider.meterBuilder("test");
+        }
+
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,38 +6,18 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider =
+                SdkMeterProvider.builder().setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -88,7 +88,7 @@ public class SdkMeterProviderUtilTest {
     }
 
     @Test
-    public void setMeterConfiguratorOnProviderAndResetForTestAffectExistingMeters() {
+    public void setMeterConfiguratorOnProviderAndResetForTestDisableExistingMeters() {
         CapturingMetricReader reader = new CapturingMetricReader();
 
         try (SdkMeterProvider provider =
@@ -101,7 +101,8 @@ public class SdkMeterProviderUtilTest {
             SdkMeterProviderUtil.setMeterConfigurator(provider, disableMeterNamed("runtime-meter"));
             counter.add(8);
 
-            assertThat(sumValue(reader.collectAllMetrics(), "runtime.counter")).isEqualTo(5);
+            assertThat(reader.collectAllMetrics()).extracting(MetricData::getName)
+                    .doesNotContain("runtime.counter");
 
             SdkMeterProviderUtil.resetForTest(provider);
 

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.MeterConfig;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SdkMeterProviderUtilTest {
+
+    @Test
+    public void setMeterConfiguratorOnBuilderDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.setMeterConfigurator(
+                builder, disableMeterNamed("builder-disabled-meter"));
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter =
+                    createCounter(provider, "builder-enabled-meter", "builder.enabled.counter");
+            LongCounter disabledCounter =
+                    createCounter(provider, "builder-disabled-meter", "builder.disabled.counter");
+
+            enabledCounter.add(2);
+            disabledCounter.add(4);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("builder.enabled.counter")
+                    .doesNotContain("builder.disabled.counter");
+            assertThat(sumValue(metrics, "builder.enabled.counter")).isEqualTo(2);
+        }
+    }
+
+    @Test
+    public void addMeterConfiguratorConditionDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.addMeterConfiguratorCondition(
+                builder,
+                scopeInfo -> scopeInfo.getName().startsWith("conditional-disabled"),
+                MeterConfig.disabled());
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter = createCounter(
+                    provider, "conditional-enabled-meter", "conditional.enabled.counter");
+            LongCounter disabledCounter = createCounter(
+                    provider, "conditional-disabled-meter", "conditional.disabled.counter");
+
+            enabledCounter.add(3);
+            disabledCounter.add(6);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("conditional.enabled.counter")
+                    .doesNotContain("conditional.disabled.counter");
+            assertThat(sumValue(metrics, "conditional.enabled.counter")).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void setMeterConfiguratorOnProviderAndResetForTestAffectExistingMeters() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+
+        try (SdkMeterProvider provider =
+                SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+            LongCounter counter = createCounter(provider, "runtime-meter", "runtime.counter");
+            counter.add(5);
+
+            assertThat(sumValue(reader.collectAllMetrics(), "runtime.counter")).isEqualTo(5);
+
+            SdkMeterProviderUtil.setMeterConfigurator(provider, disableMeterNamed("runtime-meter"));
+            counter.add(8);
+
+            assertThat(sumValue(reader.collectAllMetrics(), "runtime.counter")).isEqualTo(5);
+
+            SdkMeterProviderUtil.resetForTest(provider);
+
+            assertThat(reader.collectAllMetrics()).isEmpty();
+        }
+    }
+
+    @Test
+    public void appendFilteredBaggageAttributesAddsMatchingBaggageAfterAttributeFiltering() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        ViewBuilder viewBuilder = View.builder().setAttributeFilter(Set.of("existing"));
+        SdkMeterProviderUtil.appendFilteredBaggageAttributes(
+                viewBuilder, key -> key.equals("tenant"));
+
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .registerView(
+                        InstrumentSelector.builder()
+                                .setName("baggage.counter")
+                                .setType(InstrumentType.COUNTER)
+                                .build(),
+                        viewBuilder.build())
+                .build()) {
+            LongCounter counter = createCounter(provider, "baggage-meter", "baggage.counter");
+            Context context = Baggage.builder()
+                    .put("tenant", "alpha")
+                    .put("ignored", "beta")
+                    .build()
+                    .storeInContext(Context.root());
+
+            counter.add(7, Attributes.of(AttributeKey.stringKey("existing"), "kept"), context);
+
+            LongPointData point = getOnlyPoint(reader.collectAllMetrics(), "baggage.counter");
+            assertThat(point.getValue()).isEqualTo(7);
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("existing")))
+                    .isEqualTo("kept");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("tenant")))
+                    .isEqualTo("alpha");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("ignored"))).isNull();
+        }
+    }
+
+    private static ScopeConfigurator<MeterConfig> disableMeterNamed(String meterName) {
+        return scopeInfo -> scopeInfo.getName().equals(meterName)
+                ? MeterConfig.disabled()
+                : MeterConfig.enabled();
+    }
+
+    private static LongCounter createCounter(
+            SdkMeterProvider provider, String meterName, String counterName) {
+        return provider.meterBuilder(meterName).build().counterBuilder(counterName).build();
+    }
+
+    private static long sumValue(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        return metric.getLongSumData().getPoints().stream()
+                .mapToLong(LongPointData::getValue)
+                .sum();
+    }
+
+    private static LongPointData getOnlyPoint(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        assertThat(metric.getLongSumData().getPoints()).hasSize(1);
+        return metric.getLongSumData().getPoints().iterator().next();
+    }
+
+    private static final class CapturingMetricReader implements MetricReader {
+
+        private CollectionRegistration registration = CollectionRegistration.noop();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            this.registration = registration;
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        Collection<MetricData> collectAllMetrics() {
+            return registration.collectAllMetrics();
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #810

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-metrics:1.56.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 111628
- Cached input tokens: 1767168
- Output tokens: 16756
- Entries found: 13
- Iterations: 3
- Library coverage percentage: 20.4
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 1.29

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 5/5 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 165/15046 (1.10%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 3250/18687 (17.39%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 45/3480 (1.29%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 869/4260 (20.40%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 15/999 (1.50%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 283/1208 (23.43%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
index 399b536e..b5ab7616 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/gradle.properties b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
index d0710188..1fc6342c 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/gradle.properties
@@ -1,2 +1,2 @@
-library.version=1.19.0
-metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.19.0/
+library.version=1.56.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.56.0/
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
index c50a968c..2b5d3144 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,38 +6,18 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider =
+                SdkMeterProvider.builder().setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
new file mode 100644
index 00000000..b5c6a0ee
--- /dev/null
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -0,0 +1,206 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.MeterConfig;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SdkMeterProviderUtilTest {
+
+    @Test
+    public void setMeterConfiguratorOnBuilderDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.setMeterConfigurator(
+                builder, disableMeterNamed("builder-disabled-meter"));
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter =
+                    createCounter(provider, "builder-enabled-meter", "builder.enabled.counter");
+            LongCounter disabledCounter =
+                    createCounter(provider, "builder-disabled-meter", "builder.disabled.counter");
+
+            enabledCounter.add(2);
+            disabledCounter.add(4);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("builder.enabled.counter")
+                    .doesNotContain("builder.disabled.counter");
+            assertThat(sumValue(metrics, "builder.enabled.counter")).isEqualTo(2);
+        }
+    }
+
+    @Test
+    public void addMeterConfiguratorConditionDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.addMeterConfiguratorCondition(
+                builder,
+                scopeInfo -> scopeInfo.getName().startsWith("conditional-disabled"),
+                MeterConfig.disabled());
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter = createCounter(
+                    provider, "conditional-enabled-meter", "conditional.enabled.counter");
+            LongCounter disabledCounter = createCounter(
+                    provider, "conditional-disabled-meter", "conditional.disabled.counter");
+
+            enabledCounter.add(3);
+            disabledCounter.add(6);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("conditional.enabled.counter")
+                    .doesNotContain("conditional.disabled.counter");
+            assertThat(sumValue(metrics, "conditional.enabled.counter")).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void setMeterConfiguratorOnProviderAndResetForTestDisableExistingMeters() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+
+        try (SdkMeterProvider provider =
+                SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+            LongCounter counter = createCounter(provider, "runtime-meter", "runtime.counter");
+            counter.add(5);
+
+            assertThat(sumValue(reader.collectAllMetrics(), "runtime.counter")).isEqualTo(5);
+
+            SdkMeterProviderUtil.setMeterConfigurator(provider, disableMeterNamed("runtime-meter"));
+            counter.add(8);
+
+            assertThat(reader.collectAllMetrics()).extracting(MetricData::getName)
+                    .doesNotContain("runtime.counter");
+
+            SdkMeterProviderUtil.resetForTest(provider);
+
+            assertThat(reader.collectAllMetrics()).isEmpty();
+        }
+    }
+
+    @Test
+    public void appendFilteredBaggageAttributesAddsMatchingBaggageAfterAttributeFiltering() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        ViewBuilder viewBuilder = View.builder().setAttributeFilter(Set.of("existing"));
+        SdkMeterProviderUtil.appendFilteredBaggageAttributes(
+                viewBuilder, key -> key.equals("tenant"));
+
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .registerView(
+                        InstrumentSelector.builder()
+                                .setName("baggage.counter")
+                                .setType(InstrumentType.COUNTER)
+                                .build(),
+                        viewBuilder.build())
+                .build()) {
+            LongCounter counter = createCounter(provider, "baggage-meter", "baggage.counter");
+            Context context = Baggage.builder()
+                    .put("tenant", "alpha")
+                    .put("ignored", "beta")
+                    .build()
+                    .storeInContext(Context.root());
+
+            counter.add(7, Attributes.of(AttributeKey.stringKey("existing"), "kept"), context);
+
+            LongPointData point = getOnlyPoint(reader.collectAllMetrics(), "baggage.counter");
+            assertThat(point.getValue()).isEqualTo(7);
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("existing")))
+                    .isEqualTo("kept");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("tenant")))
+                    .isEqualTo("alpha");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("ignored"))).isNull();
+        }
+    }
+
+    private static ScopeConfigurator<MeterConfig> disableMeterNamed(String meterName) {
+        return scopeInfo -> scopeInfo.getName().equals(meterName)
+                ? MeterConfig.disabled()
+                : MeterConfig.enabled();
+    }
+
+    private static LongCounter createCounter(
+            SdkMeterProvider provider, String meterName, String counterName) {
+        return provider.meterBuilder(meterName).build().counterBuilder(counterName).build();
+    }
+
+    private static long sumValue(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        return metric.getLongSumData().getPoints().stream()
+                .mapToLong(LongPointData::getValue)
+                .sum();
+    }
+
+    private static LongPointData getOnlyPoint(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        assertThat(metric.getLongSumData().getPoints()).hasSize(1);
+        return metric.getLongSumData().getPoints().iterator().next();
+    }
+
+    private static final class CapturingMetricReader implements MetricReader {
+
+        private CollectionRegistration registration = CollectionRegistration.noop();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            this.registration = registration;
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        Collection<MetricData> collectAllMetrics() {
+            return registration.collectAllMetrics();
+        }
+    }
+}
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
new file mode 100644
index 00000000..91784540
--- /dev/null
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}

```
