### PR TITLE
Handle classless JARs in dynamic access stats

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -209,20 +209,17 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
         List<Path> libraryJars = listLibraryJars(coordinates);
 
         // When library JARs contain no bytecode (no .class files), JaCoCo has nothing
-        // to instrument and produces no report. Return N/A for every stats category.
+        // to instrument and produces no report. Keep coverage as N/A, but model
+        // dynamic access as an empty fully-covered set like other empty fallbacks.
         if (!LibraryStatsSupport.containsClassFiles(libraryJars)) {
             getLogger().warn(
-                    "Library JARs for {} contain no bytecode. Writing all stats as N/A.",
+                    "Library JARs for {} contain no bytecode. Writing empty dynamic access stats and N/A coverage.",
                     coordinates
             );
             return new LibraryStatsModels.VersionStats(
                     LibraryStatsSupport.versionFromCoordinate(coordinates),
-                    LibraryStatsModels.DynamicAccessStatsValue.notAvailable(),
-                    new LibraryStatsModels.LibraryCoverage(
-                            LibraryStatsModels.CoverageMetricValue.notAvailable(),
-                            LibraryStatsModels.CoverageMetricValue.notAvailable(),
-                            LibraryStatsModels.CoverageMetricValue.notAvailable()
-                    )
+                    LibraryStatsModels.DynamicAccessStatsValue.available(LibraryStatsSupport.emptyDynamicAccessStats()),
+                    LibraryStatsSupport.unavailableLibraryCoverage()
             );
         }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -237,6 +237,13 @@ public final class LibraryStatsSupport {
             Path jacocoReport
     ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
+        if (libraryClasses.isEmpty()) {
+            return new LibraryStatsModels.VersionStats(
+                    versionFromCoordinate(coordinate),
+                    LibraryStatsModels.DynamicAccessStatsValue.available(emptyDynamicAccessStats()),
+                    unavailableLibraryCoverage()
+            );
+        }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
         ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource());
         return versionStats(
@@ -260,6 +267,9 @@ public final class LibraryStatsSupport {
 
     public static ExternalDynamicAccessSummary buildExternalDynamicAccessSummary(List<Path> libraryJars, Path dynamicAccessDir) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
+        if (libraryClasses.isEmpty()) {
+            return new ExternalDynamicAccessSummary(0L, Map.of());
+        }
         ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of());
         return new ExternalDynamicAccessSummary(
                 parsedDynamicAccess.dynamicAccessStats().totalCalls(),
@@ -274,6 +284,14 @@ public final class LibraryStatsSupport {
             Path jacocoReport
     ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
+        if (libraryClasses.isEmpty()) {
+            return new LibraryStatsModels.DynamicAccessCoverageReport(
+                    coordinate,
+                    false,
+                    new LibraryStatsModels.DynamicAccessCoverageTotals(0L, 0L),
+                    List.of()
+            );
+        }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
         ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource());
         return new LibraryStatsModels.DynamicAccessCoverageReport(
@@ -300,6 +318,23 @@ public final class LibraryStatsSupport {
                         parsedJacocoReport.instruction(),
                         parsedJacocoReport.method()
                 )
+        );
+    }
+
+    public static LibraryStatsModels.DynamicAccessStats emptyDynamicAccessStats() {
+        return new LibraryStatsModels.DynamicAccessStats(
+                0L,
+                0L,
+                fullyCoveredRatio(),
+                Map.of()
+        );
+    }
+
+    public static LibraryStatsModels.LibraryCoverage unavailableLibraryCoverage() {
+        return new LibraryStatsModels.LibraryCoverage(
+                LibraryStatsModels.CoverageMetricValue.notAvailable(),
+                LibraryStatsModels.CoverageMetricValue.notAvailable(),
+                LibraryStatsModels.CoverageMetricValue.notAvailable()
         );
     }
 
@@ -520,9 +555,6 @@ public final class LibraryStatsSupport {
                 throw new GradleException("Failed to read library JAR " + jarPath, e);
             }
         }
-        if (classes.isEmpty()) {
-            throw new GradleException("No class files were found in resolved library JARs: " + libraryJars);
-        }
         return classes;
     }
 
@@ -600,7 +632,7 @@ public final class LibraryStatsSupport {
 
     private static ParsedDynamicAccess emptyDynamicAccess() {
         return new ParsedDynamicAccess(
-                new LibraryStatsModels.DynamicAccessStats(0, 0, BigDecimal.ONE.setScale(RATIO_SCALE, RoundingMode.HALF_UP), Map.of()),
+                emptyDynamicAccessStats(),
                 List.of()
         );
     }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
@@ -141,6 +141,26 @@ class LibraryStatsSupportTests {
     }
 
     @Test
+    void buildVersionStatsTreatsLibrariesWithoutClassFilesAsEmptyDynamicAccess() throws IOException {
+        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("META-INF/MANIFEST.MF"));
+
+        LibraryStatsModels.VersionStats versionStats = LibraryStatsSupport.buildVersionStats(
+                "com.example:demo:1.0.0",
+                List.of(libraryJar),
+                tempDir.resolve("dynamic-access-missing"),
+                tempDir.resolve("jacoco-missing.xml")
+        );
+
+        assertThat(versionStats.dynamicAccess().totalCalls()).isZero();
+        assertThat(versionStats.dynamicAccess().coveredCalls()).isZero();
+        assertThat(versionStats.dynamicAccess().breakdown()).isEmpty();
+        assertThat(versionStats.dynamicAccess().coverageRatio()).isEqualByComparingTo("1.0");
+        assertThat(versionStats.libraryCoverage().line().isAvailable()).isFalse();
+        assertThat(versionStats.libraryCoverage().instruction().isAvailable()).isFalse();
+        assertThat(versionStats.libraryCoverage().method().isAvailable()).isFalse();
+    }
+
+    @Test
     void buildVersionStatsWithoutDynamicAccessPreservesCoverageAndMarksDynamicAccessAsUnavailable() throws IOException {
         Path jacocoReport = tempDir.resolve("jacoco.xml");
         Files.writeString(
@@ -387,6 +407,24 @@ class LibraryStatsSupportTests {
         assertThat(report.hasDynamicAccess()).isFalse();
         assertThat(report.totals().totalCalls()).isEqualTo(0);
         assertThat(report.totals().coveredCalls()).isEqualTo(0);
+        assertThat(report.classes()).isEmpty();
+    }
+
+    @Test
+    void buildDynamicAccessCoverageReportAllowsLibrariesWithoutClassFiles() throws IOException {
+        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("META-INF/MANIFEST.MF"));
+
+        LibraryStatsModels.DynamicAccessCoverageReport report = LibraryStatsSupport.buildDynamicAccessCoverageReport(
+                "com.example:demo:1.0.0",
+                List.of(libraryJar),
+                tempDir.resolve("dynamic-access-missing"),
+                tempDir.resolve("jacoco-missing.xml")
+        );
+
+        assertThat(report.coordinate()).isEqualTo("com.example:demo:1.0.0");
+        assertThat(report.hasDynamicAccess()).isFalse();
+        assertThat(report.totals().totalCalls()).isZero();
+        assertThat(report.totals().coveredCalls()).isZero();
         assertThat(report.classes()).isEmpty();
     }
 


### PR DESCRIPTION
Fixes #2022.

## Summary
- treat classless library JARs as empty dynamic-access input instead of reporting `N/A`
- return an empty dynamic-access coverage report for classless artifacts instead of failing
- add regression tests for both stats generation and coverage-report generation

