### PR TITLE
Add fromJar mode to generateMetadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Metadata CI currently runs both `current-defaults` and `future-defaults-all`.
 ### Generating Metadata
 - Generate metadata for a certain library version:
    - ./gradlew generateMetadata -Pcoordinates=com.hazelcast:hazelcast:5.2.1
+- Generate metadata for a certain library version and derive `user-code-filter.json` from the resolved library JAR:
+   - ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=fromJar
 - Generate metadata for a certain library version and create or update the user-code-filter.json:
    - ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,10 +45,11 @@ If you already have the test project structure in this repository and need to ge
 ./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0
 ```
 
-To change the user-code-filter used during collection, pass `--allowedPackages` with a comma-separated list of packages:
+To change the user-code-filter used during collection, pass `--agentAllowedPackages` with a comma-separated list of packages or `fromJar` to derive package roots from the resolved library JAR:
 
 ```shell
-./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0 --allowedPackages=com.example.pkg,org.acme.lib
+./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0 --agentAllowedPackages=fromJar
+./gradlew generateMetadata --coordinates=com.example:my-library:1.0.0 --agentAllowedPackages=com.example.pkg,org.acme.lib
 ```
 
 ### Checklist

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -188,14 +188,15 @@ This resolves the requested library, runs Native Image with `Preserve` and `Trac
 
 ### Generating Metadata
 
-Generates metadata for a single library coordinate. If `agentAllowedPackages` is provided, a new user-code-filter.json will be created or updated to include those packages.
+Generates metadata for a single library coordinate. If `agentAllowedPackages` is provided, a new user-code-filter.json will be created or updated from those packages or from package roots derived from the resolved library JAR.
 
 - `coordinates`: group:artifact:version (single coordinate only)
-- `agentAllowedPackages`: comma-separated package list; use `-` for none
+- `agentAllowedPackages`: comma-separated package list, `fromJar`, or `-` for none
 
 Examples:
    ```console
    ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3
+   ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=fromJar
    ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
    ```
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -610,7 +610,7 @@ tasks.register("contribute", ContributionTask.class) { task ->
     task.setGroup(METADATA_GROUP)
 }
 
-// gradle generateMetadata -Pcoordinates=<maven-coordinates> [or --coordinates=<maven-coordinates>] --agentAllowedPackages=<comma-separated list of packages>
+// gradle generateMetadata -Pcoordinates=<maven-coordinates> [or --coordinates=<maven-coordinates>] --agentAllowedPackages=<comma-separated list of packages|fromJar|->
 tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
     task.setDescription("Generates metadata based on provided tests.")
     task.setGroup(METADATA_GROUP)

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
  */
 public abstract class GenerateMetadataTask extends DefaultTask {
     private static final String GRADLEW = "gradlew";
+    private static final String FROM_JAR = "fromJar";
 
     private String coordinates;
     private String agentAllowedPackages;
@@ -55,7 +56,7 @@ public abstract class GenerateMetadataTask extends DefaultTask {
         return coordinates;
     }
 
-    @Option(option = "agentAllowedPackages", description = "Comma separated allowed packages (or - for none)")
+    @Option(option = "agentAllowedPackages", description = "Comma separated allowed packages, fromJar, or - for none")
     public void setAgentAllowedPackages(String agentAllowedPackages) {
         this.agentAllowedPackages = agentAllowedPackages;
     }
@@ -71,13 +72,7 @@ public abstract class GenerateMetadataTask extends DefaultTask {
         Path testsDirectory = GeneralUtils.computeTestsDirectory(getLayout(), coordinates);
         Path gradlewPath = GeneralUtils.getPathFromProject(getLayout(), GRADLEW);
         Coordinates coordinatesValue = Coordinates.parse(coordinates);
-
-        List<String> packageList = (agentAllowedPackages == null || agentAllowedPackages.isBlank() || agentAllowedPackages.equals("-"))
-                ? List.of()
-                : Arrays.stream(agentAllowedPackages.split(","))
-                        .map(String::trim)
-                        .filter(s -> !s.isEmpty())
-                        .collect(Collectors.toList());
+        List<String> packageList = resolveAllowedPackages(coordinatesValue);
 
         if (!packageList.isEmpty()) {
             MetadataGenerationUtils.addUserCodeFilterFile(testsDirectory, packageList);
@@ -88,5 +83,25 @@ public abstract class GenerateMetadataTask extends DefaultTask {
             MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
         }
         MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
+    }
+
+    private List<String> resolveAllowedPackages(Coordinates coordinatesValue) throws IOException {
+        if (agentAllowedPackages == null || agentAllowedPackages.isBlank() || agentAllowedPackages.equals("-")) {
+            return List.of();
+        }
+
+        String normalizedValue = agentAllowedPackages.trim();
+        if (normalizedValue.equals(FROM_JAR)) {
+            return MetadataGenerationUtils.derivePackageRootsFromJar(getProject(), coordinatesValue);
+        }
+
+        List<String> packageList = Arrays.stream(agentAllowedPackages.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+        if (packageList.contains(FROM_JAR)) {
+            throw new IllegalArgumentException("--agentAllowedPackages=fromJar must be used on its own");
+        }
+        return packageList;
     }
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -14,11 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
-import org.graalvm.internal.tck.utils.JarUtils;
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
@@ -33,7 +30,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -87,7 +83,7 @@ class ScaffoldTask extends DefaultTask {
     @TaskAction
     void run() throws IOException {
         Coordinates coordinates = Coordinates.parse(this.coordinates);
-        List<String> packageRoots = derivePackageRoots(coordinates);
+        List<String> packageRoots = MetadataGenerationUtils.derivePackageRootsFromJar(getProject(), coordinates);
 
         Path coordinatesMetadataRoot = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$", coordinates)).toPath();
         Path coordinatesMetadataVersionRoot = coordinatesMetadataRoot.resolve(coordinates.version());
@@ -280,34 +276,6 @@ class ScaffoldTask extends DefaultTask {
         for (int i = 0; i < entries.size(); i++) {
             setLatest(entries, i, i == latestIndex ? true : null);
         }
-    }
-
-    /// Resolves the binary JAR for the given coordinates and derives minimal package roots.
-    private List<String> derivePackageRoots(Coordinates coordinates) throws IOException {
-        DependencyHandler dependencies = getProject().getDependencies();
-        Configuration configuration = getProject().getConfigurations().detachedConfiguration(
-                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version())
-        );
-        configuration.setTransitive(false);
-
-        List<Path> jars = configuration.resolve().stream()
-                .map(file -> file.toPath().toAbsolutePath())
-                .toList();
-
-        if (jars.isEmpty()) {
-            throw new GradleException("Failed to resolve JAR for " + coordinates);
-        }
-
-        Set<String> classNames = JarUtils.loadClassNames(jars);
-        List<String> roots = JarUtils.derivePackageRoots(classNames);
-
-        if (roots.isEmpty()) {
-            getLogger().log(LogLevel.WARN, "No packages found in JAR for {}, falling back to group ID", coordinates);
-            return List.of(coordinates.group());
-        }
-
-        getLogger().log(LogLevel.INFO, "Derived package roots for {}: {}", coordinates, roots);
-        return roots;
     }
 
     /// Builds user-code-filter.json content with an excludeClasses rule and one includeClasses per root.

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -14,6 +14,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.graalvm.internal.tck.Coordinates;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.process.ExecOperations;
 
@@ -24,13 +29,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.ArrayList;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * Static utility class for operations shared by ContributionTask and GenerateMetadataTask.
+ * Static utility class for operations shared by metadata-generation tasks.
  */
 public final class MetadataGenerationUtils {
 
@@ -40,6 +46,36 @@ public final class MetadataGenerationUtils {
     private static final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
     private MetadataGenerationUtils() {
+    }
+
+    /**
+     * Resolves the binary JAR for the given coordinates and derives minimal package roots.
+     */
+    public static List<String> derivePackageRootsFromJar(Project project, Coordinates coordinates) throws IOException {
+        DependencyHandler dependencies = project.getDependencies();
+        Configuration configuration = project.getConfigurations().detachedConfiguration(
+                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version())
+        );
+        configuration.setTransitive(false);
+
+        List<Path> jars = configuration.resolve().stream()
+                .map(file -> file.toPath().toAbsolutePath())
+                .toList();
+
+        if (jars.isEmpty()) {
+            throw new GradleException("Failed to resolve JAR for " + coordinates);
+        }
+
+        Set<String> classNames = JarUtils.loadClassNames(jars);
+        List<String> roots = JarUtils.derivePackageRoots(classNames);
+
+        if (roots.isEmpty()) {
+            project.getLogger().log(LogLevel.WARN, "No packages found in JAR for {}, falling back to group ID", coordinates);
+            return List.of(coordinates.group());
+        }
+
+        project.getLogger().log(LogLevel.INFO, "Derived package roots for {}: {}", coordinates, roots);
+        return roots;
     }
 
     /**

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GenerateMetadataTaskTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void runWithFromJarCreatesFilterFromJarRootsAndAddsAgentBlock() throws IOException {
+        Coordinates coordinates = Coordinates.parse("org.lz4:lz4-java:1.8.0");
+        installLibraryArtifact(coordinates, List.of(
+                "net/jpountz/lz4/LZ4Factory.class",
+                "net/jpountz/util/SafeUtils.class",
+                "META-INF/versions/11/net/jpountz/lz4/LZ4FrameInputStream.class",
+                "module-info.class"
+        ));
+        Project project = createProject();
+        prepareTestProject(coordinates, "plugins { id 'java' }\n");
+        TestGenerateMetadataTask task = registerGenerateMetadataTask(project, "generateMetadata", coordinates);
+        task.setAgentAllowedPackages("fromJar");
+
+        task.run();
+
+        assertGeneratedUserCodeFilter(
+                "tests/src/org.lz4/lz4-java/1.8.0/user-code-filter.json",
+                List.of("net.jpountz")
+        );
+        assertThat(readTestBuildGradle(coordinates))
+                .contains("graalvmNative")
+                .contains("agent")
+                .contains("userCodeFilterPath = \"user-code-filter.json\"");
+        assertThat(readGradlewInvocations())
+                .contains("tests/src/org.lz4/lz4-java/1.8.0|-Pagent test")
+                .contains("tests/src/org.lz4/lz4-java/1.8.0|metadataCopy --task test --dir " + tempDir.resolve("metadata/org.lz4/lz4-java/1.8.0"));
+    }
+
+    @Test
+    void runWithFromJarFallsBackToGroupIdWhenJarHasNoPackages() throws IOException {
+        Coordinates coordinates = Coordinates.parse("com.example:demo:1.0.0");
+        installLibraryArtifact(coordinates, List.of(
+                "PlainClass.class",
+                "module-info.class"
+        ));
+        Project project = createProject();
+        prepareTestProject(coordinates, "plugins { id 'java' }\n");
+        TestGenerateMetadataTask task = registerGenerateMetadataTask(project, "generateMetadata", coordinates);
+        task.setAgentAllowedPackages("fromJar");
+
+        task.run();
+
+        assertGeneratedUserCodeFilter(
+                "tests/src/com.example/demo/1.0.0/user-code-filter.json",
+                List.of("com.example")
+        );
+    }
+
+    @Test
+    void runRejectsMixedFromJarAndExplicitPackages() throws IOException {
+        Coordinates coordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
+        Project project = createProject();
+        prepareTestProject(coordinates, "plugins { id 'java' }\n");
+        TestGenerateMetadataTask task = registerGenerateMetadataTask(project, "generateMetadata", coordinates);
+        task.setAgentAllowedPackages("fromJar,org.example.app");
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--agentAllowedPackages=fromJar must be used on its own");
+        assertThat(tempDir.resolve("tests/src/org.postgresql/postgresql/42.7.3/user-code-filter.json"))
+                .doesNotExist();
+        assertThat(readGradlewInvocations()).isEmpty();
+    }
+
+    private void prepareTestProject(Coordinates coordinates, String buildGradleContent) throws IOException {
+        Path testsDirectory = tempDir.resolve("tests/src")
+                .resolve(coordinates.group())
+                .resolve(coordinates.artifact())
+                .resolve(coordinates.version());
+        Files.createDirectories(testsDirectory);
+        Files.writeString(testsDirectory.resolve("build.gradle"), buildGradleContent, StandardCharsets.UTF_8);
+        createGradlewScript();
+    }
+
+    private String readTestBuildGradle(Coordinates coordinates) throws IOException {
+        Path buildGradle = tempDir.resolve("tests/src")
+                .resolve(coordinates.group())
+                .resolve(coordinates.artifact())
+                .resolve(coordinates.version())
+                .resolve("build.gradle");
+        return Files.readString(buildGradle, StandardCharsets.UTF_8);
+    }
+
+    private String readGradlewInvocations() throws IOException {
+        Path logFile = tempDir.resolve("gradlew-invocations.log");
+        if (!Files.exists(logFile)) {
+            return "";
+        }
+        return Files.readString(logFile, StandardCharsets.UTF_8);
+    }
+
+    private void assertGeneratedUserCodeFilter(String relativePath, List<String> packageRoots) throws IOException {
+        Map<String, List<Map<String, String>>> userCodeFilter = OBJECT_MAPPER.readValue(
+                tempDir.resolve(relativePath).toFile(),
+                new TypeReference<>() {}
+        );
+        List<Map<String, String>> expectedRules = new ArrayList<>();
+        expectedRules.add(Map.of("excludeClasses", "**"));
+        for (String packageRoot : packageRoots) {
+            expectedRules.add(Map.of("includeClasses", packageRoot + ".**"));
+        }
+        assertThat(userCodeFilter).containsEntry("rules", expectedRules);
+    }
+
+    private Project createProject() throws IOException {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        Path repositoryRoot = ensureRepositoryRoot();
+        project.getRepositories().maven(repository -> repository.setUrl(repositoryRoot.toUri()));
+        return project;
+    }
+
+    private TestGenerateMetadataTask registerGenerateMetadataTask(Project project, String taskName, Coordinates coordinates) {
+        TestGenerateMetadataTask task = project.getTasks().register(taskName, TestGenerateMetadataTask.class).get();
+        task.setCoordinates(coordinates.toString());
+        return task;
+    }
+
+    private void installLibraryArtifact(Coordinates coordinates, List<String> jarEntries) throws IOException {
+        Path artifactDirectory = ensureRepositoryRoot()
+                .resolve(coordinates.group().replace('.', '/'))
+                .resolve(coordinates.artifact())
+                .resolve(coordinates.version());
+        Files.createDirectories(artifactDirectory);
+        createLibraryJar(
+                artifactDirectory.resolve(coordinates.artifact() + "-" + coordinates.version() + ".jar"),
+                jarEntries
+        );
+        Files.writeString(
+                artifactDirectory.resolve(coordinates.artifact() + "-" + coordinates.version() + ".pom"),
+                """
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>%s</groupId>
+                  <artifactId>%s</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(coordinates.group(), coordinates.artifact(), coordinates.version()),
+                StandardCharsets.UTF_8
+        );
+    }
+
+    private Path createLibraryJar(Path jarPath, List<String> entries) throws IOException {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            for (String entry : entries) {
+                jarOutputStream.putNextEntry(new JarEntry(entry));
+                jarOutputStream.write(new byte[]{0});
+                jarOutputStream.closeEntry();
+            }
+        }
+        return jarPath;
+    }
+
+    private void createGradlewScript() throws IOException {
+        Path logFile = tempDir.resolve("gradlew-invocations.log");
+        Path gradlew = tempDir.resolve("gradlew");
+        Files.writeString(
+                gradlew,
+                """
+                #!/bin/sh
+                printf '%%s|%%s\n' "$PWD" "$*" >> '%s'
+                if [ "$1" = "metadataCopy" ]; then
+                  while [ "$#" -gt 0 ]; do
+                    if [ "$1" = "--dir" ]; then
+                      mkdir -p "$2"
+                      printf '{}\n' > "$2/reachability-metadata.json"
+                      break
+                    fi
+                    shift
+                  done
+                fi
+                exit 0
+                """.formatted(logFile),
+                StandardCharsets.UTF_8
+        );
+        boolean executable = gradlew.toFile().setExecutable(true);
+        assertThat(executable).isTrue();
+    }
+
+    private Path ensureRepositoryRoot() throws IOException {
+        return Files.createDirectories(tempDir.resolve("test-maven-repo"));
+    }
+
+    abstract static class TestGenerateMetadataTask extends GenerateMetadataTask {
+        @Inject
+        public TestGenerateMetadataTask() {
+        }
+    }
+}


### PR DESCRIPTION
Closes #2025.

## What does this PR do?

- adds `--agentAllowedPackages=fromJar` to `generateMetadata`
- reuses the same JAR-derived package root calculation that `scaffold` already uses
- rejects mixed values such as `fromJar,com.acme` to keep the CLI explicit
- adds focused `GenerateMetadataTask` coverage for the `fromJar` mode, the group-ID fallback when the JAR has no packages, and invalid mixed input
- updates contributor docs and examples to show the new option
