### PR TITLE
Fix stale stats directory when addTestedVersion replaces a pre-release metadata version

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -378,7 +378,7 @@ jobs:
             git restore --source=HEAD --staged --worktree gradle/libs.versions.toml || true
 
             if git status --porcelain | grep -q .; then
-              git add -A -- metadata tests/src
+              git add -A -- metadata stats tests/src
               COMMIT_BODY_FILE="$(mktemp)"
               {
                 printf 'Update tested library versions\n\n'

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
+import org.graalvm.internal.tck.stats.LibraryStatsModels;
+import org.graalvm.internal.tck.stats.LibraryStatsSupport;
 
 import org.graalvm.internal.tck.utils.CoordinateUtils;
 import org.gradle.api.DefaultTask;
@@ -26,6 +28,7 @@ import org.gradle.util.internal.VersionNumber;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.nio.file.DirectoryNotEmptyException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -160,6 +163,7 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                 if (Files.exists(oldDir)) Files.move(oldDir, newDir);
 
                 updateTests(baseDir, entry, oldMetadata, newVersion);
+                updateStats(baseDir, oldMetadata, newVersion);
                 updateDependentTestVersions(oldMetadata, newVersion, entries);
                 return new MetadataVersionsIndexEntry(
                         entry.latest(),
@@ -229,6 +233,38 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                 lines.set(i, "metadata.dir = " + group + "/" + artifact + "/" + newVersion + "/");
         }
         Files.write(gradleProps, lines);
+    }
+
+    /**
+     * Updates exploded stats when a pre-release metadata version is replaced by its full release.
+     */
+    private void updateStats(Path metadataBaseDir, String oldVersion, String newVersion) throws IOException {
+        String artifact = metadataBaseDir.getFileName().toString();
+        String group = metadataBaseDir.getParent().getFileName().toString();
+        Path repositoryRoot = metadataBaseDir.getParent().getParent().getParent();
+        Path statsRoot = repositoryRoot.resolve("stats");
+        Path oldStatsFile = LibraryStatsSupport.repositoryStatsFile(statsRoot, group, artifact, oldVersion);
+        if (!Files.exists(oldStatsFile)) return;
+
+        LibraryStatsModels.MetadataVersionStats metadataVersionStats = LibraryStatsSupport.loadMetadataVersionStats(oldStatsFile);
+        LibraryStatsModels.MetadataVersionStats updatedStats = new LibraryStatsModels.MetadataVersionStats(
+                metadataVersionStats.versions().stream()
+                        .map(versionStats -> oldVersion.equals(versionStats.version())
+                                ? new LibraryStatsModels.VersionStats(newVersion, versionStats.dynamicAccess(), versionStats.libraryCoverage())
+                                : versionStats)
+                        .toList()
+        );
+
+        Path newStatsFile = LibraryStatsSupport.repositoryStatsFile(statsRoot, group, artifact, newVersion);
+        LibraryStatsSupport.writeMetadataVersionStats(newStatsFile, updatedStats);
+        if (!oldStatsFile.equals(newStatsFile)) {
+            Files.deleteIfExists(oldStatsFile);
+            try {
+                Files.deleteIfExists(oldStatsFile.getParent());
+            } catch (DirectoryNotEmptyException ignored) {
+                // Keep the old directory when other stats artifacts still exist in it.
+            }
+        }
     }
 
     /**

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graalvm.internal.tck.stats.LibraryStatsSupport;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestedVersionUpdaterTaskTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void runReplacesPreReleaseMetadataVersionAndStatsWhenFullReleaseIsAdded() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        String oldVersion = "1.0.0-RC1";
+        String newVersion = "1.0.0";
+
+        writeIndex(group, artifact, oldVersion);
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0-RC1/reachability-metadata.json"),
+                "{}\n",
+                StandardCharsets.UTF_8
+        );
+        Files.writeString(
+                tempDir.resolve("tests/src/com.example/demo/1.0.0-RC1/gradle.properties"),
+                """
+                library.version = 1.0.0-RC1
+                library.coordinates = com.example:demo:1.0.0-RC1
+                metadata.dir = com.example/demo/1.0.0-RC1/
+                """,
+                StandardCharsets.UTF_8
+        );
+        Files.writeString(
+                tempDir.resolve("stats/com.example/demo/1.0.0-RC1/stats.json"),
+                """
+                {
+                  "versions" : [ {
+                    "version" : "1.0.0-RC1",
+                    "dynamicAccess" : "N/A",
+                    "libraryCoverage" : {
+                      "instruction" : "N/A",
+                      "line" : "N/A",
+                      "method" : "N/A"
+                    }
+                  } ]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        TestTestedVersionUpdaterTask task = createTask();
+        task.setCoordinates(group + ":" + artifact + ":" + newVersion);
+        task.getLastSupportedVersion().set(oldVersion);
+
+        task.run();
+
+        assertThat(tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json")).exists();
+        assertThat(tempDir.resolve("metadata/com.example/demo/1.0.0-RC1")).doesNotExist();
+
+        Path newTestDir = tempDir.resolve("tests/src/com.example/demo/1.0.0");
+        assertThat(newTestDir).exists();
+        assertThat(tempDir.resolve("tests/src/com.example/demo/1.0.0-RC1")).doesNotExist();
+        assertThat(Files.readString(newTestDir.resolve("gradle.properties"), StandardCharsets.UTF_8))
+                .contains("library.version = 1.0.0")
+                .contains("library.coordinates = com.example:demo:1.0.0")
+                .contains("metadata.dir = com.example/demo/1.0.0/");
+
+        Path newStatsFile = tempDir.resolve("stats/com.example/demo/1.0.0/stats.json");
+        assertThat(newStatsFile).exists();
+        assertThat(tempDir.resolve("stats/com.example/demo/1.0.0-RC1/stats.json")).doesNotExist();
+        assertThat(tempDir.resolve("stats/com.example/demo/1.0.0-RC1")).doesNotExist();
+        assertThat(LibraryStatsSupport.loadMetadataVersionStats(newStatsFile).versions())
+                .extracting(version -> version.version())
+                .containsExactly("1.0.0");
+
+        List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
+                tempDir.resolve("metadata/com.example/demo/index.json").toFile(),
+                new TypeReference<>() {
+                }
+        );
+        assertThat(indexEntries).hasSize(2);
+        assertThat(indexEntries.get(0)).containsEntry("metadata-version", "1.0.0")
+                .containsEntry("tested-versions", List.of("1.0.0"));
+        assertThat(indexEntries.get(1)).containsEntry("test-version", "1.0.0");
+    }
+
+    private TestTestedVersionUpdaterTask createTask() {
+        return ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build()
+                .getTasks()
+                .create("addTestedVersion", TestTestedVersionUpdaterTask.class);
+    }
+
+    private void writeIndex(String group, String artifact, String oldVersion) throws IOException {
+        Path indexFile = tempDir.resolve("metadata/" + group + "/" + artifact + "/index.json");
+        Files.createDirectories(indexFile.getParent());
+        Files.writeString(
+                indexFile,
+                """
+                [
+                  {
+                    "latest": true,
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "%s",
+                    "tested-versions": [
+                      "%s"
+                    ]
+                  },
+                  {
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "0.9.0",
+                    "test-version": "%s",
+                    "tested-versions": [
+                      "0.9.0"
+                    ]
+                  }
+                ]
+                """.formatted(oldVersion, oldVersion, oldVersion),
+                StandardCharsets.UTF_8
+        );
+        Files.createDirectories(tempDir.resolve("metadata/" + group + "/" + artifact + "/" + oldVersion));
+        Files.createDirectories(tempDir.resolve("tests/src/" + group + "/" + artifact + "/" + oldVersion));
+        Files.createDirectories(tempDir.resolve("stats/" + group + "/" + artifact + "/" + oldVersion));
+    }
+
+    abstract static class TestTestedVersionUpdaterTask extends TestedVersionUpdaterTask {
+        @Inject
+        public TestTestedVersionUpdaterTask() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the old exploded stats version directory after moving stats from a pre-release metadata version to the full release
- add regression coverage for the stale stats directory case
- keep the compatibility automation PR staging the stats updates

Fixes #2027
