### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-trace:1.55.0 using gpt-5.4

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/reachability-metadata.json
@@ -2,6 +2,12 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "io.opentelemetry.sdk.trace.SdkTracer"
+      },
+      "type": "io.opentelemetry.api.incubator.trace.ExtendedDefaultTracerProvider"
+    },
+    {
+      "condition": {
         "typeReached": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField"
       },
       "type": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField"
@@ -17,6 +23,47 @@
         "typeReached": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField"
       },
       "type": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.trace.SdkTracerProvider",
+      "methods": [
+        {
+          "name": "setTracerConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.trace.SdkTracerProviderBuilder",
+      "methods": [
+        {
+          "name": "addTracerConfiguratorCondition",
+          "parameterTypes": [
+            "java.util.function.Predicate",
+            "io.opentelemetry.sdk.trace.internal.TracerConfig"
+          ]
+        },
+        {
+          "name": "setExceptionAttributeResolver",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.internal.ExceptionAttributeResolver"
+          ]
+        },
+        {
+          "name": "setTracerConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.internal.ScopeConfigurator"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerIndexField"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.55.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.55.0/opentelemetry-sdk-trace-1.55.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.55.0/sdk/trace/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.55.0/opentelemetry-sdk-trace-1.55.0-javadoc.jar",
+    "description" : "OpenTelemetry SDK Trace provides the Java SDK implementation for distributed tracing. It creates and manages tracers, spans, and trace processing and export pipelines for instrumented applications.",
     "tested-versions" : [
       "1.55.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
@@ -1,17 +1,23 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.55.0",
+    "tested-versions" : [
+      "1.55.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.19.0/opentelemetry-sdk-trace-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/trace/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/trace/README.md",
-    "description": "OpenTelemetry SDK Trace provides the Java SDK implementation for distributed tracing. It creates and manages tracers, spans, and trace processing and export pipelines for instrumented applications.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.19.0/opentelemetry-sdk-trace-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/trace/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/trace/README.md",
+    "description" : "OpenTelemetry SDK Trace provides the Java SDK implementation for distributed tracing. It creates and manages tracers, spans, and trace processing and export pipelines for instrumented applications.",
+    "tested-versions" : [
       "1.19.0",
       "1.20.0",
       "1.20.1",
@@ -55,11 +61,14 @@
       "1.54.0",
       "1.54.1"
     ],
-    "skipped-versions": [
+    "skipped-versions" : [
       {
-        "version": "1.34.0",
-        "reason": "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
+        "version" : "1.34.0",
+        "reason" : "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
       }
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/stats/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.55.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 191,
+        "missed" : 7473,
+        "ratio" : 0.024922,
+        "total" : 7664
+      },
+      "line" : {
+        "covered" : 59,
+        "missed" : 1841,
+        "ratio" : 0.031053,
+        "total" : 1900
+      },
+      "method" : {
+        "covered" : 25,
+        "missed" : 513,
+        "ratio" : 0.046468,
+        "total" : 538
+      }
+    }
+  } ]
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.0,
-          "coveredCalls" : 0,
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
           "totalCalls" : 4
         }
       },
-      "coverageRatio" : 0.0,
-      "coveredCalls" : 0,
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
       "totalCalls" : 4
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 191,
-        "missed" : 7473,
-        "ratio" : 0.024922,
+        "covered" : 1740,
+        "missed" : 5924,
+        "ratio" : 0.227035,
         "total" : 7664
       },
       "line" : {
-        "covered" : 59,
-        "missed" : 1841,
-        "ratio" : 0.031053,
+        "covered" : 486,
+        "missed" : 1414,
+        "ratio" : 0.255789,
         "total" : 1900
       },
       "method" : {
-        "covered" : 25,
-        "missed" : 513,
-        "ratio" : 0.046468,
+        "covered" : 154,
+        "missed" : 384,
+        "ratio" : 0.286245,
         "total" : 538
       }
     }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-trace:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--allow-incomplete-classpath')
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version=1.55.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.55.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'opentelemetry-sdk-trace-test'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class OpenTelemetrySdkTraceTest {
+
+    @Test
+    public void sdkTracingTest() {
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField", "consumerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField", "producerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField", "producerLimit"));
+
+        MpscArrayQueue<String> q = new MpscArrayQueue<>(10);
+        q.offer("test");
+        Assertions.assertEquals(q.lvProducerIndex(), 1);
+        Assertions.assertEquals(q.lvConsumerIndex(), 0);
+        Assertions.assertEquals(q.relaxedPoll(), "test");
+    }
+
+    private boolean isFieldAccessible(String className, String fieldName) {
+        try {
+            Class<?> aClass = Class.forName(className);
+            aClass.getDeclaredField(fieldName);
+            return true;
+        } catch (ClassNotFoundException | NoSuchFieldException ex) {
+            return false;
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
@@ -6,7 +6,7 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueue;
+import io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +15,11 @@ public class OpenTelemetrySdkTraceTest {
 
     @Test
     public void sdkTracingTest() {
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField", "consumerIndex"));
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField", "producerIndex"));
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField", "producerLimit"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField", "consumerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerIndexField", "producerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField", "producerLimit"));
 
-        MpscArrayQueue<String> q = new MpscArrayQueue<>(10);
+        MpscAtomicArrayQueue<String> q = new MpscAtomicArrayQueue<>(10);
         q.offer("test");
         Assertions.assertEquals(q.lvProducerIndex(), 1);
         Assertions.assertEquals(q.lvConsumerIndex(), 0);

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/SdkTracerProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/SdkTracerProviderUtilTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.internal.ExceptionAttributeResolver;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil;
+import io.opentelemetry.sdk.trace.internal.TracerConfig;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SdkTracerProviderUtilTest {
+
+    @Test
+    public void setTracerConfiguratorOnBuilderAppliesConfiguredTracerBehavior() {
+        try (
+            SdkTracerProvider tracerProvider = createProviderWithBuilderConfigurator("disabled-by-builder")
+        ) {
+            Assertions.assertFalse(isRecording(tracerProvider.get("disabled-by-builder")));
+            Assertions.assertTrue(isRecording(tracerProvider.get("enabled-by-builder")));
+        }
+    }
+
+    @Test
+    public void addTracerConfiguratorConditionAppliesOnlyToMatchingScope() {
+        try (SdkTracerProvider tracerProvider = createProviderWithConditionalConfigurator()) {
+            Assertions.assertFalse(isRecording(tracerProvider.get("conditional-disabled")));
+            Assertions.assertTrue(isRecording(tracerProvider.get("conditional-enabled")));
+        }
+    }
+
+    @Test
+    public void setTracerConfiguratorOnProviderUpdatesExistingTracer() {
+        try (SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build()) {
+            Tracer tracer = tracerProvider.get("mutable-scope");
+            Assertions.assertTrue(isRecording(tracer));
+
+            SdkTracerProviderUtil.setTracerConfigurator(
+                tracerProvider,
+                scopeInfo -> scopeInfo.getName().equals("mutable-scope")
+                    ? TracerConfig.disabled()
+                    : TracerConfig.enabled());
+
+            Assertions.assertFalse(isRecording(tracer));
+            Assertions.assertTrue(isRecording(tracerProvider.get("other-scope")));
+        }
+    }
+
+    @Test
+    public void setExceptionAttributeResolverOverridesRecordedExceptionAttributes() {
+        CapturingSpanProcessor spanProcessor = new CapturingSpanProcessor();
+        try (SdkTracerProvider tracerProvider = createProviderWithExceptionResolver(spanProcessor)) {
+            Span span =
+                tracerProvider.get("exception-scope").spanBuilder("exception-span").startSpan();
+            span.recordException(new IllegalStateException("boom"));
+            span.end();
+        }
+
+        SpanData spanData = spanProcessor.getOnlyEndedSpan();
+        Assertions.assertEquals(1, spanData.getEvents().size());
+
+        EventData exceptionEvent = spanData.getEvents().get(0);
+        Assertions.assertEquals("exception", exceptionEvent.getName());
+        Assertions.assertEquals(
+            "custom.exception.type",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_TYPE));
+        Assertions.assertEquals(
+            "custom.exception.message",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_MESSAGE));
+        Assertions.assertEquals(
+            "custom.exception.stacktrace",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_STACKTRACE));
+    }
+
+    private static SdkTracerProvider createProviderWithBuilderConfigurator(
+        String disabledScopeName
+    ) {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
+        SdkTracerProviderUtil.setTracerConfigurator(
+            tracerProviderBuilder,
+            scopeInfo -> scopeInfo.getName().equals(disabledScopeName)
+                ? TracerConfig.disabled()
+                : TracerConfig.enabled());
+        return tracerProviderBuilder.build();
+    }
+
+    private static SdkTracerProvider createProviderWithConditionalConfigurator() {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
+        SdkTracerProviderUtil.addTracerConfiguratorCondition(
+            tracerProviderBuilder,
+            scopeInfo -> scopeInfo.getName().equals("conditional-disabled"),
+            TracerConfig.disabled());
+        return tracerProviderBuilder.build();
+    }
+
+    private static SdkTracerProvider createProviderWithExceptionResolver(
+        CapturingSpanProcessor spanProcessor
+    ) {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
+            .addSpanProcessor(spanProcessor);
+        SdkTracerProviderUtil.setExceptionAttributeResolver(
+            tracerProviderBuilder,
+            (attributeSetter, exception, maxAttributeLength) -> {
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_TYPE, "custom.exception.type"
+                );
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_MESSAGE, "custom.exception.message"
+                );
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_STACKTRACE,
+                    "custom.exception.stacktrace"
+                );
+            });
+        return tracerProviderBuilder.build();
+    }
+
+    private static boolean isRecording(Tracer tracer) {
+        Span span = tracer.spanBuilder("coverage-span").startSpan();
+        try {
+            return span.isRecording();
+        } finally {
+            span.end();
+        }
+    }
+
+    private static final class CapturingSpanProcessor implements SpanProcessor {
+        private final List<SpanData> endedSpans = new ArrayList<>();
+
+        @Override
+        public void onStart(Context parentContext, ReadWriteSpan span) {
+        }
+
+        @Override
+        public boolean isStartRequired() {
+            return false;
+        }
+
+        @Override
+        public void onEnd(ReadableSpan span) {
+            endedSpans.add(span.toSpanData());
+        }
+
+        @Override
+        public boolean isEndRequired() {
+            return true;
+        }
+
+        private SpanData getOnlyEndedSpan() {
+            Assertions.assertEquals(1, endedSpans.size());
+            return endedSpans.get(0);
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.internal.shaded.jctools.**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.sdk.trace.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #809

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-trace:1.55.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 81386
- Cached input tokens: 1324416
- Output tokens: 15266
- Entries found: 10
- Iterations: 2
- Library coverage percentage: 25.58
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 4.7

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-trace:1.19.0: 2/3 covered calls (66.67%)
- io.opentelemetry:opentelemetry-sdk-trace:1.55.0: 4/4 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-trace:1.19.0: 2/3 covered calls (66.67%)
- io.opentelemetry:opentelemetry-sdk-trace:1.55.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-trace:1.19.0: 288/6861 (4.20%)
- io.opentelemetry:opentelemetry-sdk-trace:1.55.0: 1740/7664 (22.70%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-trace:1.19.0: 80/1701 (4.70%)
- io.opentelemetry:opentelemetry-sdk-trace:1.55.0: 486/1900 (25.58%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-trace:1.19.0: 33/470 (7.02%)
- io.opentelemetry:opentelemetry-sdk-trace:1.55.0: 154/538 (28.62%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/build.gradle b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
index 975e9334..eceffe8e 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/gradle.properties b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/gradle.properties
index d0710188..dbf5306b 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/gradle.properties
@@ -1,2 +1,2 @@
-library.version=1.19.0
-metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.19.0/
+library.version=1.55.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.55.0/
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
index cb9db608..5f571c48 100644
--- a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/OpenTelemetrySdkTraceTest.java
@@ -6,7 +6,7 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueue;
+import io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +15,11 @@ public class OpenTelemetrySdkTraceTest {
 
     @Test
     public void sdkTracingTest() {
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField", "consumerIndex"));
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField", "producerIndex"));
-        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField", "producerLimit"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueConsumerIndexField", "consumerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerIndexField", "producerIndex"));
+        Assertions.assertTrue(isFieldAccessible("io.opentelemetry.internal.shaded.jctools.queues.atomic.MpscAtomicArrayQueueProducerLimitField", "producerLimit"));
 
-        MpscArrayQueue<String> q = new MpscArrayQueue<>(10);
+        MpscAtomicArrayQueue<String> q = new MpscAtomicArrayQueue<>(10);
         q.offer("test");
         Assertions.assertEquals(q.lvProducerIndex(), 1);
         Assertions.assertEquals(q.lvConsumerIndex(), 0);
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/SdkTracerProviderUtilTest.java b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/SdkTracerProviderUtilTest.java
new file mode 100644
index 00000000..63d23ead
--- /dev/null
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/src/test/java/opentelemetry/SdkTracerProviderUtilTest.java
@@ -0,0 +1,169 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.internal.ExceptionAttributeResolver;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil;
+import io.opentelemetry.sdk.trace.internal.TracerConfig;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SdkTracerProviderUtilTest {
+
+    @Test
+    public void setTracerConfiguratorOnBuilderAppliesConfiguredTracerBehavior() {
+        try (
+            SdkTracerProvider tracerProvider = createProviderWithBuilderConfigurator("disabled-by-builder")
+        ) {
+            Assertions.assertFalse(isRecording(tracerProvider.get("disabled-by-builder")));
+            Assertions.assertTrue(isRecording(tracerProvider.get("enabled-by-builder")));
+        }
+    }
+
+    @Test
+    public void addTracerConfiguratorConditionAppliesOnlyToMatchingScope() {
+        try (SdkTracerProvider tracerProvider = createProviderWithConditionalConfigurator()) {
+            Assertions.assertFalse(isRecording(tracerProvider.get("conditional-disabled")));
+            Assertions.assertTrue(isRecording(tracerProvider.get("conditional-enabled")));
+        }
+    }
+
+    @Test
+    public void setTracerConfiguratorOnProviderUpdatesExistingTracer() {
+        try (SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build()) {
+            Tracer tracer = tracerProvider.get("mutable-scope");
+            Assertions.assertTrue(isRecording(tracer));
+
+            SdkTracerProviderUtil.setTracerConfigurator(
+                tracerProvider,
+                scopeInfo -> scopeInfo.getName().equals("mutable-scope")
+                    ? TracerConfig.disabled()
+                    : TracerConfig.enabled());
+
+            Assertions.assertFalse(isRecording(tracer));
+            Assertions.assertTrue(isRecording(tracerProvider.get("other-scope")));
+        }
+    }
+
+    @Test
+    public void setExceptionAttributeResolverOverridesRecordedExceptionAttributes() {
+        CapturingSpanProcessor spanProcessor = new CapturingSpanProcessor();
+        try (SdkTracerProvider tracerProvider = createProviderWithExceptionResolver(spanProcessor)) {
+            Span span =
+                tracerProvider.get("exception-scope").spanBuilder("exception-span").startSpan();
+            span.recordException(new IllegalStateException("boom"));
+            span.end();
+        }
+
+        SpanData spanData = spanProcessor.getOnlyEndedSpan();
+        Assertions.assertEquals(1, spanData.getEvents().size());
+
+        EventData exceptionEvent = spanData.getEvents().get(0);
+        Assertions.assertEquals("exception", exceptionEvent.getName());
+        Assertions.assertEquals(
+            "custom.exception.type",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_TYPE));
+        Assertions.assertEquals(
+            "custom.exception.message",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_MESSAGE));
+        Assertions.assertEquals(
+            "custom.exception.stacktrace",
+            exceptionEvent.getAttributes().get(ExceptionAttributeResolver.EXCEPTION_STACKTRACE));
+    }
+
+    private static SdkTracerProvider createProviderWithBuilderConfigurator(
+        String disabledScopeName
+    ) {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
+        SdkTracerProviderUtil.setTracerConfigurator(
+            tracerProviderBuilder,
+            scopeInfo -> scopeInfo.getName().equals(disabledScopeName)
+                ? TracerConfig.disabled()
+                : TracerConfig.enabled());
+        return tracerProviderBuilder.build();
+    }
+
+    private static SdkTracerProvider createProviderWithConditionalConfigurator() {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
+        SdkTracerProviderUtil.addTracerConfiguratorCondition(
+            tracerProviderBuilder,
+            scopeInfo -> scopeInfo.getName().equals("conditional-disabled"),
+            TracerConfig.disabled());
+        return tracerProviderBuilder.build();
+    }
+
+    private static SdkTracerProvider createProviderWithExceptionResolver(
+        CapturingSpanProcessor spanProcessor
+    ) {
+        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
+            .addSpanProcessor(spanProcessor);
+        SdkTracerProviderUtil.setExceptionAttributeResolver(
+            tracerProviderBuilder,
+            (attributeSetter, exception, maxAttributeLength) -> {
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_TYPE, "custom.exception.type"
+                );
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_MESSAGE, "custom.exception.message"
+                );
+                attributeSetter.setAttribute(
+                    ExceptionAttributeResolver.EXCEPTION_STACKTRACE,
+                    "custom.exception.stacktrace"
+                );
+            });
+        return tracerProviderBuilder.build();
+    }
+
+    private static boolean isRecording(Tracer tracer) {
+        Span span = tracer.spanBuilder("coverage-span").startSpan();
+        try {
+            return span.isRecording();
+        } finally {
+            span.end();
+        }
+    }
+
+    private static final class CapturingSpanProcessor implements SpanProcessor {
+        private final List<SpanData> endedSpans = new ArrayList<>();
+
+        @Override
+        public void onStart(Context parentContext, ReadWriteSpan span) {
+        }
+
+        @Override
+        public boolean isStartRequired() {
+            return false;
+        }
+
+        @Override
+        public void onEnd(ReadableSpan span) {
+            endedSpans.add(span.toSpanData());
+        }
+
+        @Override
+        public boolean isEndRequired() {
+            return true;
+        }
+
+        private SpanData getOnlyEndedSpan() {
+            Assertions.assertEquals(1, endedSpans.size());
+            return endedSpans.get(0);
+        }
+    }
+}
diff --git a/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/user-code-filter.json b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/user-code-filter.json
new file mode 100644
index 00000000..74464d65
--- /dev/null
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-trace/1.55.0/user-code-filter.json
@@ -0,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.internal.shaded.jctools.**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.sdk.trace.**"
+    }
+  ]
+}

```
