### PR TITLE
fix: shared-version resolution during batching execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ List<String> resolveConcreteCoordinates(String coordinateFilter) {
     List<String> matchingCoordinates
     if (CoordinateUtils.isFractionalBatch(coordinateFilter)) {
         int[] fraction = CoordinateUtils.parseFraction(coordinateFilter)
-        List<String> allCoordinates = tck.getMatchingCoordinatesStrict("all")
+        List<String> allCoordinates = tck.getMatchingCoordinates("all")
         matchingCoordinates = CoordinateUtils.computeBatchedCoordinates(allCoordinates, fraction[0], fraction[1])
     } else {
         matchingCoordinates = tck.getMatchingCoordinates(coordinateFilter)

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTask.java
@@ -67,22 +67,23 @@ public abstract class ComputeAndPullAllowedDockerImagesTask extends DefaultTask 
         return prop == null ? "" : prop.toString();
     }
 
+    protected List<String> resolveMatchingCoordinates(TckExtension tck, String filter) {
+        if (CoordinateUtils.isFractionalBatch(filter)) {
+            int[] frac = CoordinateUtils.parseFraction(filter);
+            assert frac != null : "Already checked";
+            List<String> all = tck.getMatchingCoordinates("all");
+            return CoordinateUtils.computeBatchedCoordinates(all, frac[0], frac[1]);
+        }
+        return tck.getMatchingCoordinates(filter);
+    }
+
     @TaskAction
     public void run() throws IOException {
         TckExtension tck = Objects.requireNonNull(getProject().getExtensions().findByType(TckExtension.class));
 
         // Resolve coordinates
         String filter = effectiveCoordinateFilter();
-
-        List<String> matching;
-        if (CoordinateUtils.isFractionalBatch(filter)) {
-            int[] frac = CoordinateUtils.parseFraction(filter);
-            assert frac != null : "Already checked";
-            List<String> all = tck.getMatchingCoordinatesStrict("all");
-            matching = CoordinateUtils.computeBatchedCoordinates(all, frac[0], frac[1]);
-        } else {
-            matching = tck.getMatchingCoordinates(filter);
-        }
+        List<String> matching = resolveMatchingCoordinates(tck, filter);
 
         if (matching == null || matching.isEmpty()) {
             throw new GradleException("No matching coordinates found. Provide --coordinates=<filter> (preferred) or -Pcoordinates=<filter>, or a fractional batch 'k/n'.");

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTask.java
@@ -77,6 +77,37 @@ public abstract class ComputeAndPullAllowedDockerImagesTask extends DefaultTask 
         return tck.getMatchingCoordinates(filter);
     }
 
+    protected String resolveTestVersion(List<MetadataVersionsIndexEntry> entries, String coordinateVersion) {
+        if (entries == null || coordinateVersion == null) {
+            return null;
+        }
+
+        // 1) Primary: when a tested-version is provided, find the entry whose tested-versions contains it
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (entry == null) {
+                continue;
+            }
+            List<String> testedVersions = entry.testedVersions();
+            if (testedVersions != null && testedVersions.contains(coordinateVersion)) {
+                return effectiveTestVersion(entry);
+            }
+        }
+
+        // 2) Fallback: if the coordinate version is actually a metadata-version, match it directly
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (entry != null && coordinateVersion.equals(entry.metadataVersion())) {
+                return effectiveTestVersion(entry);
+            }
+        }
+
+        return null;
+    }
+
+    private static String effectiveTestVersion(MetadataVersionsIndexEntry entry) {
+        String testVersion = entry.testVersion();
+        return (testVersion != null && !testVersion.isBlank()) ? testVersion : entry.metadataVersion();
+    }
+
     @TaskAction
     public void run() throws IOException {
         TckExtension tck = Objects.requireNonNull(getProject().getExtensions().findByType(TckExtension.class));
@@ -115,27 +146,7 @@ public abstract class ComputeAndPullAllowedDockerImagesTask extends DefaultTask 
 
             List<MetadataVersionsIndexEntry> entries = mapper.readValue(indexPath.toFile(), new TypeReference<>() {});
  
-            String testVersion = null;
-            // 1) Primary: when a tested-version is provided, find the entry whose tested-versions contains it
-            for (MetadataVersionsIndexEntry entry : entries) {
-                List<String> tvs = entry.testedVersions();
-                if (tvs != null && tvs.contains(version)) {
-                    // Priority: 1. test-version (if present), 2. metadata-version
-                    String tv = entry.testVersion();
-                    testVersion = (tv != null && !tv.isBlank()) ? tv : entry.metadataVersion();
-                    break;
-                }
-            }
-            // 2) Fallback: if the coordinate version is actually a metadata-version, match it directly
-            if (testVersion == null) {
-                for (MetadataVersionsIndexEntry entry : entries) {
-                    if (version.equals(entry.metadataVersion())) {
-                        String tv = entry.testVersion();
-                        testVersion = (tv != null && !tv.isBlank()) ? tv : entry.metadataVersion();
-                        break;
-                    }
-                }
-            }
+            String testVersion = resolveTestVersion(entries, version);
             if (testVersion != null) {
                 Path dockerImagesPath = getProject().getProjectDir().toPath()
                         .resolve("tests/src")

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTask.java
@@ -68,7 +68,7 @@ public abstract class CoordinatesAwareTask extends DefaultTask {
     protected List<String> computeMatchingCoordinates(String filter) {
         if (CoordinateUtils.isFractionalBatch(filter)) {
             int[] frac = CoordinateUtils.parseFraction(filter);
-            List<String> all = tckExtension.getMatchingCoordinatesStrict("all");
+            List<String> all = tckExtension.getMatchingCoordinates("all");
             return CoordinateUtils.computeBatchedCoordinates(all, frac[0], frac[1]);
         } else {
             return tckExtension.getMatchingCoordinates(filter);

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/TckExtensionTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/TckExtensionTests.java
@@ -11,6 +11,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -145,12 +146,57 @@ class TckExtensionTests {
                 );
     }
 
+    @Test
+    void diffCoordinatesKeepsStrictMatchingForSharedVersionMetadataChanges() throws IOException, InterruptedException {
+        createRepoFixture(
+                """
+                [
+                  {
+                    "latest": true,
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "1.0.0",
+                    "test-version": "0.9.0",
+                    "tested-versions": [
+                      "1.0.0",
+                      "1.0.1"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        runGit("init");
+        runGit("config", "user.name", "Test User");
+        runGit("config", "user.email", "test@example.com");
+        runGit("add", ".");
+        runGit("commit", "-m", "base");
+        String baseCommit = runGit("rev-parse", "HEAD").trim();
+
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json"),
+                """
+                {
+                  "reflection": []
+                }
+                """
+        );
+        runGit("add", ".");
+        runGit("commit", "-m", "change shared metadata");
+        String headCommit = runGit("rev-parse", "HEAD").trim();
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        TckExtension extension = project.getExtensions().create("tck", TckExtension.class, project);
+
+        assertThat(extension.diffCoordinates(baseCommit, headCommit))
+                .containsExactly("com.example:demo:1.0.0");
+    }
+
     private TckExtension createExtension(String metadataIndexJson) throws IOException {
-        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
-        Files.writeString(tempDir.resolve("metadata/com.example/demo/index.json"), metadataIndexJson);
-        Files.createDirectories(tempDir.resolve("tests/src/com.example/demo/0.9.0"));
-        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
-        Files.writeString(tempDir.resolve("LICENSE"), "test");
+        createRepoFixture(metadataIndexJson);
 
         Project project = ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
@@ -158,10 +204,94 @@ class TckExtensionTests {
         return project.getExtensions().create("tck", TckExtension.class, project);
     }
 
+    @Test
+    void diffCoordinatesKeepsStrictMatchingForSharedVersionTestChanges() throws IOException, InterruptedException {
+        createRepoFixture(
+                """
+                [
+                  {
+                    "latest": true,
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "1.0.0",
+                    "test-version": "0.9.0",
+                    "tested-versions": [
+                      "1.0.0",
+                      "1.0.1"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        runGit("init");
+        runGit("config", "user.name", "Test User");
+        runGit("config", "user.email", "test@example.com");
+        runGit("add", ".");
+        runGit("commit", "-m", "base");
+        String baseCommit = runGit("rev-parse", "HEAD").trim();
+
+        Files.writeString(
+                tempDir.resolve("tests/src/com.example/demo/0.9.0/SharedTest.java"),
+                "class SharedTest { int value() { return 2; } }"
+        );
+        runGit("add", ".");
+        runGit("commit", "-m", "change shared tests");
+        String headCommit = runGit("rev-parse", "HEAD").trim();
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        TckExtension extension = project.getExtensions().create("tck", TckExtension.class, project);
+
+        assertThat(extension.diffCoordinates(baseCommit, headCommit))
+                .containsExactly("com.example:demo:1.0.0");
+    }
+
     private static String toJsonArray(List<String> values) {
         return values.stream()
                 .map(value -> "\"" + value + "\"")
                 .toList()
                 .toString();
+    }
+
+    private void createRepoFixture(String metadataIndexJson) throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(tempDir.resolve("metadata/com.example/demo/index.json"), metadataIndexJson);
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/1.0.0/reachability-metadata.json"),
+                "{}"
+        );
+        Files.createDirectories(tempDir.resolve("tests/src/com.example/demo/0.9.0"));
+        Files.writeString(
+                tempDir.resolve("tests/src/com.example/demo/0.9.0/SharedTest.java"),
+                "class SharedTest { int value() { return 1; } }"
+        );
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+    }
+
+    private String runGit(String... command) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder()
+                .command(commandWithGit(command))
+                .directory(tempDir.toFile())
+                .redirectErrorStream(true)
+                .start();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        process.getInputStream().transferTo(output);
+        int exitCode = process.waitFor();
+        String text = output.toString();
+        assertThat(exitCode)
+                .withFailMessage("git %s failed: %s", String.join(" ", command), text)
+                .isZero();
+        return text;
+    }
+
+    private String[] commandWithGit(String... command) {
+        String[] fullCommand = new String[command.length + 1];
+        fullCommand[0] = "git";
+        System.arraycopy(command, 0, fullCommand, 1, command.length);
+        return fullCommand;
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
@@ -132,6 +132,7 @@ class ComputeAndPullAllowedDockerImagesTaskTests {
                 null,
                 null,
                 null,
+                null,
                 testedVersions,
                 null,
                 List.of("com.example"),

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
@@ -9,6 +9,7 @@ package org.graalvm.internal.tck.harness.tasks;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.graalvm.internal.tck.harness.TckExtension;
+import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,6 +39,51 @@ class ComputeAndPullAllowedDockerImagesTaskTests {
                 .containsExactly("com.example:demo:1.0.0");
         assertThat(task.exposedResolveMatchingCoordinates(extension, "2/2"))
                 .containsExactly("com.example:demo:1.0.1");
+    }
+
+    @Test
+    void resolveTestVersionUsesTestVersionFromTestedVersionsMatch() throws IOException {
+        Project project = createProject();
+        TestComputeAndPullAllowedDockerImagesTask task = project.getTasks().create(
+                "pullAllowedDockerImages",
+                TestComputeAndPullAllowedDockerImagesTask.class
+        );
+
+        List<MetadataVersionsIndexEntry> entries = List.of(
+                entry("1.0.0", "0.9.0", List.of("1.0.0", "1.0.1"))
+        );
+
+        assertThat(task.exposedResolveTestVersion(entries, "1.0.1")).isEqualTo("0.9.0");
+    }
+
+    @Test
+    void resolveTestVersionFallsBackToMetadataVersionMatch() throws IOException {
+        Project project = createProject();
+        TestComputeAndPullAllowedDockerImagesTask task = project.getTasks().create(
+                "pullAllowedDockerImages",
+                TestComputeAndPullAllowedDockerImagesTask.class
+        );
+
+        List<MetadataVersionsIndexEntry> entries = List.of(
+                entry("2.0.0", "1.9.0", List.of("1.9.1", "1.9.2"))
+        );
+
+        assertThat(task.exposedResolveTestVersion(entries, "2.0.0")).isEqualTo("1.9.0");
+    }
+
+    @Test
+    void resolveTestVersionUsesMetadataVersionWhenTestVersionBlank() throws IOException {
+        Project project = createProject();
+        TestComputeAndPullAllowedDockerImagesTask task = project.getTasks().create(
+                "pullAllowedDockerImages",
+                TestComputeAndPullAllowedDockerImagesTask.class
+        );
+
+        List<MetadataVersionsIndexEntry> entries = List.of(
+                entry("3.0.0", "  ", List.of("3.0.1"))
+        );
+
+        assertThat(task.exposedResolveTestVersion(entries, "3.0.1")).isEqualTo("3.0.0");
     }
 
     private Project createProject() throws IOException {
@@ -75,6 +121,24 @@ class ComputeAndPullAllowedDockerImagesTaskTests {
         Files.writeString(tempDir.resolve("LICENSE"), "test");
     }
 
+    private MetadataVersionsIndexEntry entry(String metadataVersion, String testVersion, List<String> testedVersions) {
+        return new MetadataVersionsIndexEntry(
+                null,
+                null,
+                null,
+                metadataVersion,
+                testVersion,
+                null,
+                null,
+                null,
+                null,
+                testedVersions,
+                null,
+                List.of("com.example"),
+                null
+        );
+    }
+
     abstract static class TestComputeAndPullAllowedDockerImagesTask extends ComputeAndPullAllowedDockerImagesTask {
         @Inject
         public TestComputeAndPullAllowedDockerImagesTask() {
@@ -82,6 +146,10 @@ class ComputeAndPullAllowedDockerImagesTaskTests {
 
         List<String> exposedResolveMatchingCoordinates(TckExtension tck, String filter) {
             return resolveMatchingCoordinates(tck, filter);
+        }
+
+        String exposedResolveTestVersion(List<MetadataVersionsIndexEntry> entries, String coordinateVersion) {
+            return resolveTestVersion(entries, coordinateVersion);
         }
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ComputeAndPullAllowedDockerImagesTaskTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.graalvm.internal.tck.harness.TckExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ComputeAndPullAllowedDockerImagesTaskTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolveMatchingCoordinatesSupportsFractionalBatchForSharedTestVersions() throws IOException {
+        Project project = createProject();
+        TestComputeAndPullAllowedDockerImagesTask task = project.getTasks().create(
+                "pullAllowedDockerImages",
+                TestComputeAndPullAllowedDockerImagesTask.class
+        );
+        TckExtension extension = project.getExtensions().getByType(TckExtension.class);
+
+        assertThat(task.exposedResolveMatchingCoordinates(extension, "1/2"))
+                .containsExactly("com.example:demo:1.0.0");
+        assertThat(task.exposedResolveMatchingCoordinates(extension, "2/2"))
+                .containsExactly("com.example:demo:1.0.1");
+    }
+
+    private Project createProject() throws IOException {
+        createSharedVersionFixture();
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        project.getExtensions().create("tck", TckExtension.class, project);
+        return project;
+    }
+
+    private void createSharedVersionFixture() throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/index.json"),
+                """
+                [
+                  {
+                    "latest": true,
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "1.0.0",
+                    "test-version": "0.9.0",
+                    "tested-versions": [
+                      "1.0.0",
+                      "1.0.1"
+                    ]
+                  }
+                ]
+                """
+        );
+        Files.createDirectories(tempDir.resolve("tests/src/com.example/demo/0.9.0"));
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+    }
+
+    abstract static class TestComputeAndPullAllowedDockerImagesTask extends ComputeAndPullAllowedDockerImagesTask {
+        @Inject
+        public TestComputeAndPullAllowedDockerImagesTask() {
+        }
+
+        List<String> exposedResolveMatchingCoordinates(TckExtension tck, String filter) {
+            return resolveMatchingCoordinates(tck, filter);
+        }
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTaskTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.graalvm.internal.tck.harness.TckExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoordinatesAwareTaskTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void computeMatchingCoordinatesIncludesSharedVersionsInFractionalBatches() throws IOException {
+        Project project = createProject();
+        ExposedCoordinatesAwareTask task = project.getTasks().create("coords", ExposedCoordinatesAwareTask.class);
+
+        assertThat(task.exposedComputeMatchingCoordinates("1/2"))
+                .containsExactly("com.example:demo:1.0.0");
+        assertThat(task.exposedComputeMatchingCoordinates("2/2"))
+                .containsExactly("com.example:demo:1.0.1");
+    }
+
+    private Project createProject() throws IOException {
+        createSharedVersionFixture();
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        project.getExtensions().create("tck", TckExtension.class, project);
+        return project;
+    }
+
+    private void createSharedVersionFixture() throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata/com.example/demo/1.0.0"));
+        Files.writeString(
+                tempDir.resolve("metadata/com.example/demo/index.json"),
+                """
+                [
+                  {
+                    "latest": true,
+                    "allowed-packages": [
+                      "com.example"
+                    ],
+                    "metadata-version": "1.0.0",
+                    "test-version": "0.9.0",
+                    "tested-versions": [
+                      "1.0.0",
+                      "1.0.1"
+                    ]
+                  }
+                ]
+                """
+        );
+        Files.createDirectories(tempDir.resolve("tests/src/com.example/demo/0.9.0"));
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+    }
+
+    abstract static class ExposedCoordinatesAwareTask extends CoordinatesAwareTask {
+        @Inject
+        public ExposedCoordinatesAwareTask() {
+        }
+
+        List<String> exposedComputeMatchingCoordinates(String filter) {
+            return computeMatchingCoordinates(filter);
+        }
+    }
+}


### PR DESCRIPTION
Relates to #2037

## Problem

The repository already supports library versions that reuse a shared metadata directory through `metadata/<group>/<artifact>/index.json`.

Execution batching was not fully aligned with that model. Some `k/n` batching paths still expanded work from physical metadata directories only, so shared-only supported versions were skipped from batched execution.

Example:
- `org.slf4j:slf4j-api:2.0.17` is a supported version in `metadata/org.slf4j/slf4j-api/index.json`
- it reuses metadata directory `1.7.36`
- strict directory-based batching can skip it because there is no physical `metadata/org.slf4j/slf4j-api/2.0.17/` directory

## What this PR changes

- makes `CoordinatesAwareTask` resolve fractional batches from `tck.getMatchingCoordinates("all")`
- makes `ComputeAndPullAllowedDockerImagesTask` use the same shared-version-aware coordinate set
- aligns root `testInfra` / `testAllInfra` batch expansion with the same coordinate model

## Why this matters

- `k/n` execution batching now matches the repository's supported-coordinate model
- shared-only supported versions are included in batched execution
- batched execution is consistent with single-coordinate execution paths that already honor `index.json`

## Out of scope

- changed-coordinate / `diffCoordinates` behavior remains strict

## Validation

- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.harness.TckExtensionTests --tests org.graalvm.internal.tck.harness.tasks.CoordinatesAwareTaskTests --tests org.graalvm.internal.tck.harness.tasks.ComputeAndPullAllowedDockerImagesTaskTests --console=plain`
- `./gradlew help --quiet`
- sampled `./gradlew testInfra -Pcoordinate=1/64 -Pparallelism=1` and verified that the expanded reproducer list includes shared-only supported versions before interrupting the full run
