### PR TITLE
[GenAI] Add support for com.baomidou:mybatis-plus:3.5.3 using gpt-5.4

### DIFF
--- a/metadata/com.baomidou/mybatis-plus/3.5.3/reachability-metadata.json
+++ b/metadata/com.baomidou/mybatis-plus/3.5.3/reachability-metadata.json
@@ -1,9 +1,6 @@
 {
   "reflection" : [
     {
-      "condition" : {
-        "typeReached" : "com.baomidou.mybatisplus.core.toolkit.Sequence"
-      },
       "type" : "sun.management.VMManagementImpl",
       "jniAccessible" : true,
       "fields" : [

--- a/metadata/com.baomidou/mybatis-plus/3.5.3/reachability-metadata.json
+++ b/metadata/com.baomidou/mybatis-plus/3.5.3/reachability-metadata.json
@@ -1,0 +1,37 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.baomidou.mybatisplus.core.toolkit.Sequence"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.baomidou/mybatis-plus/index.json
+++ b/metadata/com.baomidou/mybatis-plus/index.json
@@ -1,0 +1,15 @@
+[
+  {
+    "latest": true,
+    "allowed-packages": [ "com.baomidou" ],
+    "metadata-version": "3.5.3",
+    "source-code-url": "https://github.com/baomidou/mybatis-plus/tree/v3.5.3/mybatis-plus",
+    "repository-url": "https://github.com/baomidou/mybatis-plus",
+    "test-code-url": "https://github.com/baomidou/mybatis-plus/tree/v3.5.3/mybatis-plus/src/test",
+    "documentation-url": "https://github.com/baomidou/mybatis-plus/blob/v3.5.3/README.md",
+    "description": "MyBatis-Plus is an enhancement toolkit for MyBatis that simplifies Java persistence development without changing core MyBatis behavior. It provides ready-to-use CRUD APIs, query wrappers, pagination, and other extensions that reduce boilerplate when working with relational databases.",
+    "tested-versions": [
+      "3.5.3"
+    ]
+  }
+]

--- a/stats/com.baomidou/mybatis-plus/3.5.3/stats.json
+++ b/stats/com.baomidou/mybatis-plus/3.5.3/stats.json
@@ -1,0 +1,16 @@
+{
+  "versions" : [ {
+    "version" : "3.5.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : "N/A",
+      "line" : "N/A",
+      "method" : "N/A"
+    }
+  } ]
+}

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/.gitignore
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/build.gradle
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.baomidou:mybatis-plus:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/gradle.properties
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.baomidou:mybatis-plus:3.5.3
+library.version = 3.5.3
+metadata.dir = com.baomidou/mybatis-plus/3.5.3/

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/settings.gradle
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.baomidou.mybatis-plus_tests'

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
@@ -6,11 +6,124 @@
  */
 package com_baomidou.mybatis_plus;
 
+import com.baomidou.mybatisplus.core.MybatisPlusVersion;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.baomidou.mybatisplus.core.enums.SqlLike;
+import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
+import com.baomidou.mybatisplus.core.toolkit.TableNameParser;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlUtils;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 class Mybatis_plusTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void queryWrapperBuildsComplexPredicatesAndCanBeCleared() {
+        QueryWrapper<Object> queryWrapper = Wrappers.<Object>query()
+                .select("id", "name")
+                .eq("status", "ACTIVE")
+                .nested(wrapper -> wrapper.ge("age", 18).lt("age", 65))
+                .groupBy("role")
+                .having("count(*) > {0}", 1)
+                .orderByDesc("created_at")
+                .last("limit 5");
+
+        assertThat(queryWrapper.getSqlSelect()).isEqualTo("id,name");
+        assertThat(normalizeSql(queryWrapper.getCustomSqlSegment()))
+                .isEqualTo("WHERE (status = #{ew.paramNameValuePairs.MPGENVAL1} AND (age >= #{ew.paramNameValuePairs.MPGENVAL2} AND age < #{ew.paramNameValuePairs.MPGENVAL3})) GROUP BY role HAVING count(*) > #{ew.paramNameValuePairs.MPGENVAL4} ORDER BY created_at DESC limit 5");
+        assertThat(normalizeSql(queryWrapper.getTargetSql()))
+                .isEqualTo("(status = ? AND (age >= ? AND age < ?)) GROUP BY role HAVING count(*) > ? ORDER BY created_at DESC limit 5");
+        assertThat(queryWrapper.getParamNameValuePairs().values())
+                .containsExactlyInAnyOrder("ACTIVE", 18, 65, 1);
+
+        queryWrapper.clear();
+
+        assertThat(queryWrapper.getSqlSelect()).isNull();
+        assertThat(queryWrapper.getTargetSql()).isEmpty();
+        assertThat(queryWrapper.getParamNameValuePairs()).isEmpty();
+        assertThat(Wrappers.emptyWrapper().isEmptyOfWhere()).isTrue();
+    }
+
+    @Test
+    void updateWrapperTracksAssignmentsAndPredicateParameters() {
+        UpdateWrapper<Object> updateWrapper = Wrappers.<Object>update()
+                .set("name", "Neo")
+                .setSql("updated_at = CURRENT_TIMESTAMP")
+                .eq("id", 7)
+                .in("status", List.of("ACTIVE", "LOCKED"));
+
+        assertThat(updateWrapper.getSqlSet())
+                .isEqualTo("name=#{ew.paramNameValuePairs.MPGENVAL1},updated_at = CURRENT_TIMESTAMP");
+        assertThat(normalizeSql(updateWrapper.getCustomSqlSegment()))
+                .isEqualTo("WHERE (id = #{ew.paramNameValuePairs.MPGENVAL2} AND status IN (#{ew.paramNameValuePairs.MPGENVAL3},#{ew.paramNameValuePairs.MPGENVAL4}))");
+        assertThat(normalizeSql(updateWrapper.getTargetSql()))
+                .isEqualTo("(id = ? AND status IN (?,?))");
+        assertThat(updateWrapper.getParamNameValuePairs().values())
+                .containsExactlyInAnyOrder("Neo", 7, "ACTIVE", "LOCKED");
+    }
+
+    @Test
+    void pageAndOrderFactoriesRetainPaginationState() {
+        Page<String> page = Page.<String>of(2, 3, 8)
+                .setRecords(List.of("alpha", "beta"))
+                .addOrder(OrderItem.asc("name"), OrderItem.desc("created_at"));
+
+        assertThat(page.getCurrent()).isEqualTo(2);
+        assertThat(page.getSize()).isEqualTo(3);
+        assertThat(page.getTotal()).isEqualTo(8);
+        assertThat(page.getPages()).isEqualTo(3);
+        assertThat(page.hasPrevious()).isTrue();
+        assertThat(page.hasNext()).isTrue();
+        assertThat(page.getRecords()).containsExactly("alpha", "beta");
+        assertThat(page.orders())
+                .extracting(OrderItem::getColumn, OrderItem::isAsc)
+                .containsExactly(
+                        tuple("name", true),
+                        tuple("created_at", false)
+                );
+        assertThat(OrderItem.ascs("first_name", "last_name"))
+                .extracting(OrderItem::getColumn, OrderItem::isAsc)
+                .containsExactly(
+                        tuple("first_name", true),
+                        tuple("last_name", true)
+                );
+        assertThat(OrderItem.descs("updated_at"))
+                .extracting(OrderItem::getColumn, OrderItem::isAsc)
+                .containsExactly(tuple("updated_at", false));
+    }
+
+    @Test
+    void sqlUtilitiesAndStringHelpersCoverCommonPublicHelpers() {
+        assertThat(SqlScriptUtils.safeParam("name")).isEqualTo("#{name}");
+        assertThat(SqlScriptUtils.unSafeParam("name")).isEqualTo("${name}");
+        assertThat(normalizeSql(SqlScriptUtils.convertIf("name=#{name}", "name != null", true)))
+                .isEqualTo("<if test=\"name != null\"> name=#{name} </if>");
+        assertThat(normalizeSql(SqlScriptUtils.convertWhere(" AND name=#{name}")))
+                .isEqualTo("<where> AND name=#{name} </where>");
+        assertThat(normalizeSql(SqlScriptUtils.convertTrim("name=#{name},", "SET", null, null, ",")))
+                .isEqualTo("<trim prefix=\"SET\" suffixOverrides=\",\"> name=#{name}, </trim>");
+        assertThat(normalizeSql(SqlScriptUtils.convertForeach("#{item}", "items", null, "item", ",")))
+                .isEqualTo("<foreach collection=\"items\" item=\"item\" separator=\",\"> #{item} </foreach>");
+        assertThat(SqlUtils.concatLike("neo", SqlLike.DEFAULT)).isEqualTo("%neo%");
+        assertThat(new TableNameParser("SELECT u.id, o.id FROM users u JOIN orders o ON u.id = o.user_id WHERE u.status = 1").tables())
+                .containsExactlyInAnyOrder("users", "orders");
+        assertThat(MybatisPlusVersion.getVersion()).matches("\\d+\\.\\d+\\.\\d+(?:[-.][A-Za-z0-9]+)?");
+        assertThat(StringUtils.camelToUnderline("createdAt")).isEqualTo("created_at");
+        assertThat(StringUtils.underlineToCamel("created_at")).isEqualTo("createdAt");
+        assertThat(StringUtils.sqlArgsFill("name={0}, state={1}", "Neo", "ACTIVE"))
+                .isEqualTo("name='Neo', state='ACTIVE'");
+        assertThat(StringUtils.quotaMarkList(List.of("neo", 7))).isEqualTo("('neo',7)");
+    }
+
+    private static String normalizeSql(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
     }
 }

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
@@ -10,14 +10,18 @@ import com.baomidou.mybatisplus.core.MybatisPlusVersion;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.enums.SqlLike;
+import com.baomidou.mybatisplus.core.incrementer.DefaultIdentifierGenerator;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.toolkit.IdWorker;
+import com.baomidou.mybatisplus.core.toolkit.Sequence;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.core.toolkit.TableNameParser;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlUtils;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.ibatis.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -145,6 +149,26 @@ class Mybatis_plusTest {
     }
 
     @Test
+    void identifierGeneratorsProduceMonotonicIdsAndParsableTimestamps() {
+        configureMybatisLogging();
+        long beforeGeneration = System.currentTimeMillis();
+        Sequence sequence = new Sequence(1L, 1L);
+        long firstId = sequence.nextId();
+        long secondId = sequence.nextId();
+        long afterGeneration = System.currentTimeMillis();
+        DefaultIdentifierGenerator identifierGenerator = new DefaultIdentifierGenerator(1L, 1L);
+        long generatedId = identifierGenerator.nextId(new Object());
+
+        assertThat(firstId).isPositive();
+        assertThat(secondId).isGreaterThan(firstId);
+        assertThat(Sequence.parseIdTimestamp(firstId))
+                .isBetween(beforeGeneration - 1_000L, afterGeneration + 1_000L);
+        assertThat(generatedId).isPositive();
+        assertThat(IdWorker.getIdStr()).matches("\\d+");
+        assertThat(IdWorker.get32UUID()).matches("[0-9a-f]{32}");
+    }
+
+    @Test
     void sqlUtilitiesAndStringHelpersCoverCommonPublicHelpers() {
         assertThat(SqlScriptUtils.safeParam("name")).isEqualTo("#{name}");
         assertThat(SqlScriptUtils.unSafeParam("name")).isEqualTo("${name}");
@@ -167,7 +191,47 @@ class Mybatis_plusTest {
         assertThat(StringUtils.quotaMarkList(List.of("neo", 7))).isEqualTo("('neo',7)");
     }
 
+    private static void configureMybatisLogging() {
+        new NativeImageFriendlyLog(Mybatis_plusTest.class.getName());
+        LogFactory.useCustomLogging(NativeImageFriendlyLog.class);
+    }
+
     private static String normalizeSql(String sql) {
         return sql.replaceAll("\\s+", " ").trim();
+    }
+
+    public static final class NativeImageFriendlyLog implements org.apache.ibatis.logging.Log {
+        public NativeImageFriendlyLog(String loggerName) {
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void error(String message) {
+        }
+
+        @Override
+        public void debug(String message) {
+        }
+
+        @Override
+        public void trace(String message) {
+        }
+
+        @Override
+        public void warn(String message) {
+        }
     }
 }

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_baomidou.mybatis_plus;
+
+import org.junit.jupiter.api.Test;
+
+class Mybatis_plusTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
@@ -10,6 +10,7 @@ import com.baomidou.mybatisplus.core.MybatisPlusVersion;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.enums.SqlLike;
+import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.core.toolkit.TableNameParser;
@@ -20,6 +21,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -68,6 +70,48 @@ class Mybatis_plusTest {
                 .isEqualTo("(id = ? AND status IN (?,?))");
         assertThat(updateWrapper.getParamNameValuePairs().values())
                 .containsExactlyInAnyOrder("Neo", 7, "ACTIVE", "LOCKED");
+    }
+
+    @Test
+    void pageConvertMutatesRecordsAndPreservesPagingConfiguration() {
+        Page<String> page = Page.<String>of(3, 2, 5, false)
+                .setRecords(List.of("neo", "trinity"))
+                .setSearchCount(false)
+                .setOptimizeCountSql(false)
+                .addOrder(OrderItem.desc("created_at"));
+        page.setOptimizeJoinOfCountSql(false);
+        page.setMaxLimit(50L);
+        page.setCountId("customCount");
+
+        IPage<Integer> convertedPage = page.convert(String::length);
+
+        assertThat((Object) convertedPage).isSameAs(page);
+        assertThat(convertedPage.getRecords()).containsExactly(3, 7);
+        assertThat(convertedPage.searchCount()).isFalse();
+        assertThat(convertedPage.optimizeCountSql()).isFalse();
+        assertThat(convertedPage.optimizeJoinOfCountSql()).isFalse();
+        assertThat(convertedPage.maxLimit()).isEqualTo(50L);
+        assertThat(convertedPage.countId()).isEqualTo("customCount");
+        assertThat(convertedPage.offset()).isEqualTo(4);
+        assertThat(convertedPage.orders())
+                .extracting(OrderItem::getColumn, OrderItem::isAsc)
+                .containsExactly(tuple("created_at", false));
+    }
+
+    @Test
+    void pageConvertSkipsMapperInvocationWhenNoRecordsArePresent() {
+        Page<String> page = Page.<String>of(1, 5)
+                .setRecords(List.of());
+        AtomicInteger mappingCount = new AtomicInteger();
+
+        IPage<Integer> convertedPage = page.convert(value -> {
+            mappingCount.incrementAndGet();
+            return value.length();
+        });
+
+        assertThat((Object) convertedPage).isSameAs(page);
+        assertThat(convertedPage.getRecords()).isEmpty();
+        assertThat(mappingCount).hasValue(0);
     }
 
     @Test

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/java/com_baomidou/mybatis_plus/Mybatis_plusTest.java
@@ -44,7 +44,13 @@ class Mybatis_plusTest {
 
         assertThat(queryWrapper.getSqlSelect()).isEqualTo("id,name");
         assertThat(normalizeSql(queryWrapper.getCustomSqlSegment()))
-                .isEqualTo("WHERE (status = #{ew.paramNameValuePairs.MPGENVAL1} AND (age >= #{ew.paramNameValuePairs.MPGENVAL2} AND age < #{ew.paramNameValuePairs.MPGENVAL3})) GROUP BY role HAVING count(*) > #{ew.paramNameValuePairs.MPGENVAL4} ORDER BY created_at DESC limit 5");
+                .isEqualTo(
+                        "WHERE (status = #{ew.paramNameValuePairs.MPGENVAL1}"
+                                + " AND (age >= #{ew.paramNameValuePairs.MPGENVAL2}"
+                                + " AND age < #{ew.paramNameValuePairs.MPGENVAL3}))"
+                                + " GROUP BY role HAVING count(*) > #{ew.paramNameValuePairs.MPGENVAL4}"
+                                + " ORDER BY created_at DESC limit 5"
+                );
         assertThat(normalizeSql(queryWrapper.getTargetSql()))
                 .isEqualTo("(status = ? AND (age >= ? AND age < ?)) GROUP BY role HAVING count(*) > ? ORDER BY created_at DESC limit 5");
         assertThat(queryWrapper.getParamNameValuePairs().values())
@@ -201,7 +207,7 @@ class Mybatis_plusTest {
     }
 
     public static final class NativeImageFriendlyLog implements org.apache.ibatis.logging.Log {
-        public NativeImageFriendlyLog(String loggerName) {
+        NativeImageFriendlyLog(String loggerName) {
         }
 
         @Override

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.baomidou.mybatisplus.core.toolkit.Sequence"
+      },
+      "type" : "com_baomidou.mybatis_plus.Mybatis_plusTest$NativeImageFriendlyLog",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,9 +1,6 @@
 {
   "reflection" : [
     {
-      "condition" : {
-        "typeReached" : "com.baomidou.mybatisplus.core.toolkit.Sequence"
-      },
       "type" : "com_baomidou.mybatis_plus.Mybatis_plusTest$NativeImageFriendlyLog",
       "methods" : [
         {

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/user-code-filter.json
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.baomidou.**"
+    }
+  ]
+}

--- a/tests/src/com.baomidou/mybatis-plus/3.5.3/user-code-filter.json
+++ b/tests/src/com.baomidou/mybatis-plus/3.5.3/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.baomidou.**"
+      "includeClasses" : "com.baomidou.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #157

This PR introduces tests and metadata for com.baomidou:mybatis-plus:3.5.3, enabling support for this library.

Summary:
- Strategy: optimistic_dynamic_access_iterative_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 359340
- Cached input tokens: 7306112
- Output tokens: 78741
- Entries: 10
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 213
- Tested library lines of code: 0

Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: N/A
- Line: N/A
- Method: N/A
