### PR TITLE
Fix scheduled release cron trigger

### DIFF
--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -2,9 +2,8 @@ name: "Create scheduled release"
 
 on:
   schedule:
-    # Avoid top-of-hour scheduling because GitHub may delay or drop cron jobs there.
-    - cron: "17 2 1 * *"
-    - cron: "23 2 15 * *"
+    - cron: "0 3 1 * *"
+    - cron: "0 3 15 * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -2,8 +2,9 @@ name: "Create scheduled release"
 
 on:
   schedule:
-    - cron: "0 0 1 * *"
-    - cron: "0 0 15 * *"
+    # Avoid top-of-hour scheduling because GitHub may delay or drop cron jobs there.
+    - cron: "17 2 1 * *"
+    - cron: "23 2 15 * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- change the scheduled release workflow cron so a maintainer-owned workflow update reactivates the schedule
- run the release workflow at 3am on the 1st and 15th of each month
- leave the release logic unchanged

## Testing
- not run (workflow cron change only)

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/913