### PR TITLE
Fix duplicate month labels in coverage graph X axis

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
@@ -23,6 +23,7 @@ import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -416,6 +417,7 @@ public final class ReadmeBadgeSummarySupport {
         ChartBounds bounds = calculateBounds(panel.points(), panel.percentMetric());
         List<BigDecimal> yTicks = buildYAxisTicks(bounds.minValue(), bounds.maxValue());
         List<Integer> xLabelIndexes = buildXLabelIndexes(panel.points().size());
+        List<String> xLabels = buildXLabels(panel.points(), xLabelIndexes);
 
         for (BigDecimal tick : yTicks) {
             double y = toPlotY(tick, bounds.minValue(), bounds.maxValue(), plotY, plotHeight);
@@ -437,7 +439,8 @@ public final class ReadmeBadgeSummarySupport {
                     .append("</text>\n");
         }
 
-        for (Integer pointIndex : xLabelIndexes) {
+        for (int labelIndex = 0; labelIndex < xLabelIndexes.size(); labelIndex++) {
+            int pointIndex = xLabelIndexes.get(labelIndex);
             MetricPoint point = panel.points().get(pointIndex);
             double x = toPlotX(pointIndex, panel.points().size(), plotX, plotWidth);
             boolean firstLabel = pointIndex == 0;
@@ -464,7 +467,7 @@ public final class ReadmeBadgeSummarySupport {
                     .append("\" fill=\"#6b7f95\" font-size=\"13\" text-anchor=\"")
                     .append(textAnchor)
                     .append("\">")
-                    .append(escapeXml(formatGraphDate(point.date())))
+                    .append(escapeXml(xLabels.get(labelIndex)))
                     .append("</text>\n");
         }
 
@@ -579,6 +582,35 @@ public final class ReadmeBadgeSummarySupport {
         return indexes;
     }
 
+    private static List<String> buildXLabels(List<MetricPoint> points, List<Integer> xLabelIndexes) {
+        List<LocalDate> labelDates = new ArrayList<>();
+        for (Integer pointIndex : xLabelIndexes) {
+            labelDates.add(points.get(pointIndex).date());
+        }
+
+        List<String> monthYearLabels = labelDates.stream()
+                .map(ReadmeBadgeSummarySupport::formatMonthYear)
+                .toList();
+        if (labelsAreUnique(monthYearLabels)) {
+            return monthYearLabels;
+        }
+
+        List<String> monthDayLabels = labelDates.stream()
+                .map(ReadmeBadgeSummarySupport::formatMonthDay)
+                .toList();
+        if (labelsAreUnique(monthDayLabels)) {
+            return monthDayLabels;
+        }
+
+        return labelDates.stream()
+                .map(LocalDate::toString)
+                .toList();
+    }
+
+    private static boolean labelsAreUnique(List<String> labels) {
+        return new HashSet<>(labels).size() == labels.size();
+    }
+
     private static String buildLinePath(
             List<MetricPoint> points,
             BigDecimal minValue,
@@ -653,11 +685,21 @@ public final class ReadmeBadgeSummarySupport {
         return value.divide(step, 0, RoundingMode.CEILING).multiply(step).setScale(1, RoundingMode.HALF_UP);
     }
 
-    private static String formatGraphDate(LocalDate date) {
-        return date.getMonth().name().substring(0, 1)
-                + date.getMonth().name().substring(1, 3).toLowerCase(Locale.ROOT)
+    private static String formatMonthYear(LocalDate date) {
+        return formatShortMonth(date)
                 + " "
                 + date.getYear();
+    }
+
+    private static String formatMonthDay(LocalDate date) {
+        return formatShortMonth(date)
+                + " "
+                + date.getDayOfMonth();
+    }
+
+    private static String formatShortMonth(LocalDate date) {
+        return date.getMonth().name().substring(0, 1)
+                + date.getMonth().name().substring(1, 3).toLowerCase(Locale.ROOT);
     }
 
     private static String formatTickValue(BigDecimal value, String valueFormat) {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
@@ -278,13 +278,51 @@ class ReadmeBadgeSummarySupportTests {
         assertThat(svg).contains("Covered lines reported across library coverage stats");
         assertThat(svg).contains("Updated 2026-04-07");
         assertThat(svg).contains("35.8%");
-        assertThat(svg).contains("Apr 2026");
-        assertThat(svg).contains("text-anchor=\"end\">Apr 2026</text>");
+        assertThat(svg).contains("text-anchor=\"start\">Apr 5</text>");
+        assertThat(svg).contains("text-anchor=\"middle\">Apr 6</text>");
+        assertThat(svg).contains("text-anchor=\"end\">Apr 7</text>");
         assertThat(svg).contains("<path d=\"M ");
         assertThat(svg).contains("<circle");
         assertThat(svg.indexOf("Supported libraries")).isLessThan(svg.indexOf("Tested library versions"));
         assertThat(svg.indexOf("Tested library versions")).isLessThan(svg.indexOf("Dynamic access coverage"));
         assertThat(svg.indexOf("Dynamic access coverage")).isLessThan(svg.indexOf("Tested lines of code"));
+    }
+
+    @Test
+    void writeMetricsOverviewGraphKeepsMonthYearLabelsWhenTheyAreUnique() throws IOException {
+        Path graphFile = tempDir.resolve("latest").resolve("metrics-over-time.svg");
+        ReadmeBadgeSummarySupport.ReadmeMetricsHistory history = new ReadmeBadgeSummarySupport.ReadmeMetricsHistory(
+                List.of(
+                        new ReadmeBadgeSummarySupport.HistoryEntry(
+                                "2026-04-05",
+                                new ReadmeBadgeSummarySupport.HistoryMetrics(
+                                        new ReadmeBadgeSummarySupport.MetadataIndexMetrics(4, 5, 6, 8),
+                                        new ReadmeBadgeSummarySupport.StatsMetrics(new BigDecimal("31.5"), 9, 120)
+                                )
+                        ),
+                        new ReadmeBadgeSummarySupport.HistoryEntry(
+                                "2026-05-06",
+                                new ReadmeBadgeSummarySupport.HistoryMetrics(
+                                        new ReadmeBadgeSummarySupport.MetadataIndexMetrics(4, 5, 6, 8),
+                                        new ReadmeBadgeSummarySupport.StatsMetrics(new BigDecimal("34.0"), 9, 144)
+                                )
+                        ),
+                        new ReadmeBadgeSummarySupport.HistoryEntry(
+                                "2026-06-07",
+                                new ReadmeBadgeSummarySupport.HistoryMetrics(
+                                        new ReadmeBadgeSummarySupport.MetadataIndexMetrics(4, 5, 6, 8),
+                                        new ReadmeBadgeSummarySupport.StatsMetrics(new BigDecimal("35.8"), 9, 159)
+                                )
+                        )
+                )
+        );
+
+        ReadmeBadgeSummarySupport.writeMetricsOverviewGraph(graphFile, history);
+
+        String svg = Files.readString(graphFile, StandardCharsets.UTF_8);
+        assertThat(svg).contains("text-anchor=\"start\">Apr 2026</text>");
+        assertThat(svg).contains("text-anchor=\"middle\">May 2026</text>");
+        assertThat(svg).contains("text-anchor=\"end\">Jun 2026</text>");
     }
 
     private void writeIndexFile(String groupId, String artifactId, String content) throws IOException {


### PR DESCRIPTION
## Summary
- make coverage graph X-axis labels fall back from `Mon YYYY` to `Mon D` when the selected ticks would otherwise repeat the same month-year label
- keep the existing `Mon YYYY` format when those labels are already unique
- add tests covering both the duplicate-month fallback and the unique-month case

Fixes #2107.

## Testing
- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.stats.ReadmeBadgeSummarySupportTests`

## Preview
Generated locally using the current branch data plus `origin/stats/coverage` history as the seed:

![Coverage graph preview](https://gist.githubusercontent.com/jormundur00/40cad4811bc6a9e252a19b0aa2abde17/raw/7814d9957061bd7dacd37cbc2044e766e3a50be7/metrics-over-time.svg)
