### PR TITLE
[GenAI] Add support for org.rnorth.duct-tape:duct-tape:1.0.8 using gpt-5.4

### DIFF
--- a/metadata/org.rnorth.duct-tape/duct-tape/1.0.8/reachability-metadata.json
+++ b/metadata/org.rnorth.duct-tape/duct-tape/1.0.8/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.rnorth.ducttape.unreliables.Unreliables"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.rnorth.duct-tape/duct-tape/index.json
+++ b/metadata/org.rnorth.duct-tape/duct-tape/index.json
@@ -1,0 +1,15 @@
+[
+  {
+    "latest": true,
+    "allowed-packages": [ "org.rnorth.ducttape" ],
+    "metadata-version": "1.0.8",
+    "source-code-url": "https://repo1.maven.org/maven2/org/rnorth/duct-tape/duct-tape/1.0.8/duct-tape-1.0.8-sources.jar",
+    "repository-url": "https://github.com/rnorth/duct-tape",
+    "test-code-url": "https://github.com/rnorth/duct-tape/tree/1.0.8/src/test/java",
+    "documentation-url": "https://github.com/rnorth/duct-tape/blob/1.0.8/docs/index.md",
+    "description": "Duct Tape is a Java 8 fault-tolerance library for code that calls external APIs and other unreliable components. It provides resilience utilities such as circuit breakers, retries, timeouts, rate limiters, and handling for inconsistent results.",
+    "tested-versions": [
+      "1.0.8"
+    ]
+  }
+]

--- a/stats/org.rnorth.duct-tape/duct-tape/1.0.8/stats.json
+++ b/stats/org.rnorth.duct-tape/duct-tape/1.0.8/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.8",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 923,
+        "missed" : 52,
+        "ratio" : 0.946667,
+        "total" : 975
+      },
+      "line" : {
+        "covered" : 214,
+        "missed" : 15,
+        "ratio" : 0.934498,
+        "total" : 229
+      },
+      "method" : {
+        "covered" : 68,
+        "missed" : 9,
+        "ratio" : 0.883117,
+        "total" : 77
+      }
+    }
+  } ]
+}

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/.gitignore
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/build.gradle
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.rnorth.duct-tape:duct-tape:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.slf4j:slf4j-api:1.7.7'
 }
 
 graalvmNative {

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/build.gradle
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.rnorth.duct-tape:duct-tape:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/gradle.properties
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.rnorth.duct-tape:duct-tape:1.0.8
+library.version = 1.0.8
+metadata.dir = org.rnorth.duct-tape/duct-tape/1.0.8/

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/settings.gradle
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.rnorth.duct-tape.duct-tape_tests'

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
@@ -7,10 +7,258 @@
 package org_rnorth_duct_tape.duct_tape;
 
 import org.junit.jupiter.api.Test;
+import org.rnorth.ducttape.RetryCountExceededException;
+import org.rnorth.ducttape.TimeoutException;
+import org.rnorth.ducttape.circuitbreakers.Breaker;
+import org.rnorth.ducttape.circuitbreakers.BreakerBuilder;
+import org.rnorth.ducttape.circuitbreakers.State;
+import org.rnorth.ducttape.inconsistents.InconsistentResultsException;
+import org.rnorth.ducttape.inconsistents.Inconsistents;
+import org.rnorth.ducttape.inconsistents.ResultsNeverConsistentException;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.rnorth.ducttape.timeouts.Timeouts;
+import org.rnorth.ducttape.unreliables.Unreliables;
 
-class Duct_tapeTest {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Duct_tapeTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void timeoutsExecuteWorkAndWrapFailures() {
+        AtomicBoolean executed = new AtomicBoolean();
+
+        Timeouts.doWithTimeout(1, TimeUnit.SECONDS, () -> executed.set(true));
+        String value = Timeouts.getWithTimeout(1, TimeUnit.SECONDS, () -> "value");
+
+        RuntimeException executionFailure = assertThrows(RuntimeException.class,
+                () -> Timeouts.getWithTimeout(1, TimeUnit.SECONDS, () -> {
+                    throw new IllegalStateException("boom");
+                }));
+
+        assertThat(executed.get()).isTrue();
+        assertThat(value).isEqualTo("value");
+        assertThat(executionFailure).hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(executionFailure.getCause()).hasMessage("boom");
+    }
+
+    @Test
+    void timeoutsRejectInvalidTimeoutsAndInterruptLongRunningCalls() {
+        assertThatThrownBy(() -> Timeouts.doWithTimeout(0, TimeUnit.MILLISECONDS, () -> {
+        })).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timeout must be greater than zero");
+
+        TimeoutException timeoutException = assertThrows(TimeoutException.class,
+                () -> Timeouts.getWithTimeout(50, TimeUnit.MILLISECONDS, () -> {
+                    Thread.sleep(200);
+                    return "late";
+                }));
+
+        assertThat(timeoutException).hasCauseInstanceOf(Exception.class);
+    }
+
+    @Test
+    void unreliablesRetryUntilSuccessAndTrueAcrossTimeoutBasedAndCountBasedApis() {
+        AtomicInteger successAttempts = new AtomicInteger();
+        String successValue = Unreliables.retryUntilSuccess(1, TimeUnit.SECONDS, () -> {
+            if (successAttempts.getAndIncrement() < 2) {
+                throw new IllegalStateException("not yet");
+            }
+            return "ready";
+        });
+
+        AtomicInteger trueAttempts = new AtomicInteger();
+        Unreliables.retryUntilTrue(1, TimeUnit.SECONDS, () -> trueAttempts.incrementAndGet() >= 3);
+
+        AtomicInteger countedSuccessAttempts = new AtomicInteger();
+        Integer countedValue = Unreliables.retryUntilSuccess(3, () -> {
+            if (countedSuccessAttempts.getAndIncrement() == 0) {
+                throw new IllegalStateException("retry once");
+            }
+            return 42;
+        });
+
+        AtomicInteger countedTrueAttempts = new AtomicInteger();
+        Unreliables.retryUntilTrue(3, () -> countedTrueAttempts.incrementAndGet() >= 2);
+
+        assertThat(successValue).isEqualTo("ready");
+        assertThat(successAttempts.get()).isEqualTo(3);
+        assertThat(trueAttempts.get()).isGreaterThanOrEqualTo(3);
+        assertThat(countedValue).isEqualTo(42);
+        assertThat(countedSuccessAttempts.get()).isEqualTo(2);
+        assertThat(countedTrueAttempts.get()).isEqualTo(2);
+    }
+
+    @Test
+    void unreliablesSurfaceTheLastFailureWhenRetriesAreExhausted() {
+        TimeoutException timeoutFailure = assertThrows(TimeoutException.class,
+                () -> Unreliables.retryUntilSuccess(100, TimeUnit.MILLISECONDS, () -> {
+                    throw new IllegalStateException("still failing");
+                }));
+
+        TimeoutException timeoutFromBoolean = assertThrows(TimeoutException.class,
+                () -> Unreliables.retryUntilTrue(50, TimeUnit.MILLISECONDS, () -> {
+                    Thread.sleep(100);
+                    return true;
+                }));
+
+        RetryCountExceededException countFailure = assertThrows(RetryCountExceededException.class,
+                () -> Unreliables.retryUntilSuccess(2, () -> {
+                    throw new IllegalStateException("always failing");
+                }));
+
+        RetryCountExceededException falseCountFailure = assertThrows(RetryCountExceededException.class,
+                () -> Unreliables.retryUntilTrue(2, () -> false));
+
+        assertThat(timeoutFailure).hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(timeoutFailure.getCause()).hasMessage("still failing");
+        assertThat(timeoutFromBoolean).hasCauseInstanceOf(Exception.class);
+        assertThat(countFailure).hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(countFailure.getCause()).hasMessage("always failing");
+        assertThat(falseCountFailure.getCause()).isInstanceOf(RuntimeException.class);
+        assertThat(falseCountFailure.getCause()).hasMessage("Not ready yet");
+    }
+
+    @Test
+    void inconsistentsReturnOnceAValueStaysStableLongEnough() {
+        AtomicInteger attempt = new AtomicInteger();
+
+        Integer result = Inconsistents.retryUntilConsistent(30, 500, TimeUnit.MILLISECONDS, () -> {
+            Thread.sleep(20);
+            return attempt.incrementAndGet() < 3 ? 1 : 2;
+        });
+
+        assertThat(result).isEqualTo(2);
+        assertThat(attempt.get()).isGreaterThanOrEqualTo(5);
+    }
+
+    @Test
+    void inconsistentsReportWhetherValuesWereNeverConsistentOrOnlyBrieflyConsistent() {
+        AtomicInteger changingAttempt = new AtomicInteger();
+        TimeoutException neverConsistent = assertThrows(TimeoutException.class,
+                () -> Inconsistents.retryUntilConsistent(30, 150, TimeUnit.MILLISECONDS, () -> {
+                    Thread.sleep(15);
+                    return changingAttempt.incrementAndGet();
+                }));
+
+        AtomicInteger patternedAttempt = new AtomicInteger();
+        TimeoutException brieflyConsistent = assertThrows(TimeoutException.class,
+                () -> Inconsistents.retryUntilConsistent(100, 180, TimeUnit.MILLISECONDS, () -> {
+                    Thread.sleep(5);
+                    return patternedAttempt.getAndIncrement() % 6 < 4 ? "alpha" : "beta";
+                }));
+
+        assertThat(neverConsistent.getCause()).isInstanceOf(ResultsNeverConsistentException.class);
+        assertThat(((ResultsNeverConsistentException) neverConsistent.getCause()).getTimeSinceStart()).isPositive();
+
+        assertThat(brieflyConsistent.getCause()).isInstanceOf(InconsistentResultsException.class);
+        InconsistentResultsException inconsistentResultsException = (InconsistentResultsException) brieflyConsistent.getCause();
+        assertThat(inconsistentResultsException.getMostConsistentValue()).isEqualTo("alpha");
+        assertThat(inconsistentResultsException.getMostConsistentTime()).isGreaterThan(0L);
+    }
+
+    @Test
+    void breakerTripsInvokesHandlersAndAutoResets() throws InterruptedException {
+        Breaker breaker = BreakerBuilder.newBuilder()
+                .autoResetAfter(100, TimeUnit.MILLISECONDS)
+                .build();
+        List<String> calls = new ArrayList<>();
+
+        breaker.tryDo(() -> {
+            calls.add("primary");
+            throw new IllegalStateException("boom");
+        }, () -> calls.add("failed"), () -> calls.add("broken"));
+        breaker.tryDo(() -> calls.add("should-not-run"), () -> calls.add("broken-only"));
+
+        Thread.sleep(200);
+
+        breaker.tryDo(() -> calls.add("after-reset"), () -> calls.add("broken-after-reset"));
+
+        assertThat(calls).containsExactly("primary", "failed", "broken", "broken-only", "after-reset");
+        assertThat(breaker.getState()).isEqualTo(State.OK);
+    }
+
+    @Test
+    void breakerTryGetUsesFallbacksOptionalResultsAndSharedExternalState() {
+        Breaker breaker = BreakerBuilder.newBuilder().build();
+        List<String> events = new ArrayList<>();
+
+        String recovered = breaker.tryGet(() -> {
+            events.add("primary");
+            throw new IllegalStateException("fail");
+        }, () -> events.add("failed"), () -> {
+            events.add("fallback");
+            return "fallback";
+        });
+
+        AtomicBoolean brokenPrimaryCalled = new AtomicBoolean();
+        String brokenResult = breaker.tryGet(() -> {
+            brokenPrimaryCalled.set(true);
+            return "primary";
+        }, () -> "broken");
+        AtomicBoolean optionalPrimaryCalled = new AtomicBoolean();
+
+        assertThat(recovered).isEqualTo("fallback");
+        assertThat(brokenResult).isEqualTo("broken");
+        assertThat(breaker.tryGet(() -> {
+            optionalPrimaryCalled.set(true);
+            return "ignored";
+        })).isEmpty();
+        assertThat(events).containsExactly("primary", "failed", "fallback");
+        assertThat(brokenPrimaryCalled.get()).isFalse();
+        assertThat(optionalPrimaryCalled.get()).isFalse();
+
+        ConcurrentMap<String, Object> state = new ConcurrentHashMap<>();
+        Breaker firstSharedBreaker = BreakerBuilder.newBuilder().storeStateIn(state, "shared").build();
+        Breaker secondSharedBreaker = BreakerBuilder.newBuilder().storeStateIn(state, "shared").build();
+        Breaker isolatedBreaker = BreakerBuilder.newBuilder().storeStateIn(state, "isolated").build();
+
+        assertThat(state).isEmpty();
+        firstSharedBreaker.tryDo(() -> {
+            throw new IllegalStateException("trip shared state");
+        });
+
+        AtomicBoolean sharedPrimaryCalled = new AtomicBoolean();
+        assertThat(secondSharedBreaker.tryGet(() -> {
+            sharedPrimaryCalled.set(true);
+            return "primary";
+        }, () -> "shared-fallback")).isEqualTo("shared-fallback");
+        assertThat(sharedPrimaryCalled.get()).isFalse();
+        assertThat(state).hasSize(2);
+        assertThat(isolatedBreaker.tryGet(() -> "primary")).contains("primary");
+    }
+
+    @Test
+    void rateLimiterValidatesItsBuilderAndSpacesOutCalls() throws Exception {
+        assertThatThrownBy(() -> RateLimiterBuilder.newBuilder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("A rate must be set");
+        assertThatThrownBy(() -> RateLimiterBuilder.newBuilder().withRate(5, TimeUnit.SECONDS).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("A rate limit strategy must be set");
+
+        RateLimiter rateLimiter = RateLimiterBuilder.newBuilder()
+                .withRate(5, TimeUnit.SECONDS)
+                .withConstantThroughput()
+                .build();
+
+        List<Long> invocationTimes = new ArrayList<>();
+        rateLimiter.doWhenReady(() -> invocationTimes.add(System.nanoTime()));
+        rateLimiter.doWhenReady(() -> invocationTimes.add(System.nanoTime()));
+        Integer result = rateLimiter.getWhenReady(() -> 7);
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(invocationTimes.get(1) - invocationTimes.get(0));
+        assertThat(elapsedMillis).isGreaterThanOrEqualTo(150L);
+        assertThat(result).isEqualTo(7);
     }
 }

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
@@ -266,6 +266,31 @@ public class Duct_tapeTest {
     }
 
     @Test
+    void rateLimiterKeepsItsSpacingAfterAFailedInvocation() {
+        RateLimiter rateLimiter = RateLimiterBuilder.newBuilder()
+                .withRate(5, TimeUnit.SECONDS)
+                .withConstantThroughput()
+                .build();
+
+        rateLimiter.doWhenReady(() -> {
+        });
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> rateLimiter.getWhenReady(() -> {
+                    throw new IllegalStateException("boom");
+                }));
+
+        AtomicBoolean recoveryExecuted = new AtomicBoolean();
+        long recoveryStart = System.nanoTime();
+        rateLimiter.doWhenReady(() -> recoveryExecuted.set(true));
+        long recoveryDelayMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - recoveryStart);
+
+        assertThat(failure).hasMessage("boom");
+        assertThat(recoveryExecuted.get()).isTrue();
+        assertThat(recoveryDelayMillis).isGreaterThanOrEqualTo(150L);
+    }
+
+    @Test
     void breakerCanPersistAndReadStateThroughACustomStateStore() {
         RecordingStateStore stateStore = new RecordingStateStore();
         Breaker breaker = BreakerBuilder.newBuilder().storeStateIn(stateStore).build();

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_rnorth_duct_tape.duct_tape;
+
+import org.junit.jupiter.api.Test;
+
+class Duct_tapeTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/src/test/java/org_rnorth_duct_tape/duct_tape/Duct_tapeTest.java
@@ -12,6 +12,7 @@ import org.rnorth.ducttape.TimeoutException;
 import org.rnorth.ducttape.circuitbreakers.Breaker;
 import org.rnorth.ducttape.circuitbreakers.BreakerBuilder;
 import org.rnorth.ducttape.circuitbreakers.State;
+import org.rnorth.ducttape.circuitbreakers.StateStore;
 import org.rnorth.ducttape.inconsistents.InconsistentResultsException;
 import org.rnorth.ducttape.inconsistents.Inconsistents;
 import org.rnorth.ducttape.inconsistents.ResultsNeverConsistentException;
@@ -27,6 +28,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -260,5 +263,60 @@ public class Duct_tapeTest {
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(invocationTimes.get(1) - invocationTimes.get(0));
         assertThat(elapsedMillis).isGreaterThanOrEqualTo(150L);
         assertThat(result).isEqualTo(7);
+    }
+
+    @Test
+    void breakerCanPersistAndReadStateThroughACustomStateStore() {
+        RecordingStateStore stateStore = new RecordingStateStore();
+        Breaker breaker = BreakerBuilder.newBuilder().storeStateIn(stateStore).build();
+        AtomicBoolean failedHandlerCalled = new AtomicBoolean();
+
+        String fallback = breaker.tryGet(() -> {
+            throw new IllegalStateException("boom");
+        }, () -> failedHandlerCalled.set(true), () -> "fallback");
+
+        assertThat(fallback).isEqualTo("fallback");
+        assertThat(failedHandlerCalled.get()).isTrue();
+        assertThat(stateStore.getState()).isEqualTo(State.BROKEN);
+        assertThat(stateStore.getLastFailure()).isPositive();
+
+        AtomicBoolean blockedPrimaryCalled = new AtomicBoolean();
+        assertThat(breaker.tryGet(() -> {
+            blockedPrimaryCalled.set(true);
+            return "primary";
+        }, () -> "broken"))
+                .isEqualTo("broken");
+        assertThat(blockedPrimaryCalled.get()).isFalse();
+
+        stateStore.setState(State.OK);
+
+        assertThat(breaker.tryGet(() -> "recovered")).contains("recovered");
+        assertThat(breaker.getState()).isEqualTo(State.OK);
+    }
+
+    private static final class RecordingStateStore implements StateStore {
+
+        private final AtomicReference<State> state = new AtomicReference<>(State.OK);
+        private final AtomicLong lastFailure = new AtomicLong();
+
+        @Override
+        public State getState() {
+            return state.get();
+        }
+
+        @Override
+        public void setState(State newState) {
+            state.set(newState);
+        }
+
+        @Override
+        public long getLastFailure() {
+            return lastFailure.get();
+        }
+
+        @Override
+        public void setLastFailure(long newLastFailure) {
+            lastFailure.set(newLastFailure);
+        }
     }
 }

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/user-code-filter.json
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.rnorth.ducttape.**"
+    }
+  ]
+}

--- a/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/user-code-filter.json
+++ b/tests/src/org.rnorth.duct-tape/duct-tape/1.0.8/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.rnorth.ducttape.**"
+      "includeClasses" : "org.rnorth.ducttape.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1560

This PR introduces tests and metadata for org.rnorth.duct-tape:duct-tape:1.0.8, enabling support for this library.

Summary:
- Strategy: optimistic_dynamic_access_iterative_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 164827
- Cached input tokens: 1082624
- Output tokens: 27084
- Entries: 1
- Iterations: 3
- Library coverage percentage: 93.45
- Generated lines of code: 286
- Tested library lines of code: 214

Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 923/975 (94.67%)
- Line: 214/229 (93.45%)
- Method: 68/77 (88.31%)
