### PR TITLE
[GenAI] Test fix for org.osgi:org.osgi.core:4.3.1 using gpt-5.4

### DIFF
--- a/metadata/org.osgi/org.osgi.core/4.3.1/reachability-metadata.json
+++ b/metadata/org.osgi/org.osgi.core/4.3.1/reachability-metadata.json
@@ -1,0 +1,115 @@
+{
+  "reflection": [
+    {
+      "type": "java.lang.String"
+    },
+    {
+      "type": "java.math.BigInteger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.security.BasicPermission"
+    },
+    {
+      "type": "java.security.Permission"
+    },
+    {
+      "type": "java.util.HashMap"
+    },
+    {
+      "type": "java.util.Hashtable"
+    },
+    {
+      "type": "java.util.Locale",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.osgi.framework.AdaptPermission"
+    },
+    {
+      "type": "org.osgi.framework.AdminPermission"
+    },
+    {
+      "type": "org.osgi.framework.BundlePermission"
+    },
+    {
+      "type": "org.osgi.framework.CapabilityPermission"
+    },
+    {
+      "type": "org.osgi.framework.PackagePermission"
+    },
+    {
+      "type": "org.osgi.framework.ServicePermission"
+    }
+  ],
+  "serialization": [
+    {
+      "type": "java.lang.String"
+    },
+    {
+      "type": "java.security.BasicPermission"
+    },
+    {
+      "type": "java.security.Permission"
+    },
+    {
+      "type": "java.util.HashMap"
+    },
+    {
+      "type": "java.util.Hashtable"
+    },
+    {
+      "type": "org.osgi.framework.AdaptPermission"
+    },
+    {
+      "type": "org.osgi.framework.AdminPermission"
+    },
+    {
+      "type": "org.osgi.framework.BundlePermission"
+    },
+    {
+      "type": "org.osgi.framework.CapabilityPermission"
+    },
+    {
+      "type": "org.osgi.framework.PackagePermission"
+    },
+    {
+      "type": "org.osgi.framework.ServicePermission"
+    },
+    {
+      "type": "java.security.PermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.AdaptPermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.AdminPermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.BundlePermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.CapabilityPermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.PackagePermissionCollection"
+    },
+    {
+      "type": "org.osgi.framework.ServicePermissionCollection"
+    }
+  ]
+}

--- a/metadata/org.osgi/org.osgi.core/index.json
+++ b/metadata/org.osgi/org.osgi.core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.3.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1-sources.jar",
+    "repository-url" : "https://github.com/osgi/osgi",
+    "test-code-url" : "https://github.com/osgi/osgi/tree/r4v431-core-cmpn-spec-final/org.osgi.test.cases.framework",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1-javadoc.jar",
+    "description" : "This artifact provides the OSGi Core Release 4.3.1 API interfaces and classes used to compile OSGi bundles. It defines the framework contracts for bundles, module lifecycle, service registration, and runtime interaction in OSGi-based applications.",
     "tested-versions" : [
       "4.3.1"
     ],

--- a/metadata/org.osgi/org.osgi.core/index.json
+++ b/metadata/org.osgi/org.osgi.core/index.json
@@ -1,15 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "org.osgi" ],
-    "metadata-version": "4.3.0",
-    "source-code-url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.0/org.osgi.core-4.3.0-sources.jar",
-    "repository-url": "https://github.com/osgi/osgi",
-    "test-code-url": "https://github.com/osgi/osgi/tree/r4v43-core-ri-ct-final",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.0/org.osgi.core-4.3.0-javadoc.jar",
-    "description": "This artifact provides the core OSGi Service Platform Release 4.3 interfaces and classes. It defines the Framework APIs for bundles, lifecycle management, module wiring, and services used when compiling OSGi-based applications.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "4.3.1",
+    "tested-versions" : [
+      "4.3.1"
+    ],
+    "allowed-packages" : [
+      "org.osgi"
+    ]
+  },
+  {
+    "metadata-version" : "4.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.0/org.osgi.core-4.3.0-sources.jar",
+    "repository-url" : "https://github.com/osgi/osgi",
+    "test-code-url" : "https://github.com/osgi/osgi/tree/r4v43-core-ri-ct-final",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.0/org.osgi.core-4.3.0-javadoc.jar",
+    "description" : "This artifact provides the core OSGi Service Platform Release 4.3 interfaces and classes. It defines the Framework APIs for bundles, lifecycle management, module wiring, and services used when compiling OSGi-based applications.",
+    "tested-versions" : [
       "4.3.0"
+    ],
+    "allowed-packages" : [
+      "org.osgi"
     ]
   }
 ]

--- a/stats/org.osgi/org.osgi.core/4.3.1/stats.json
+++ b/stats/org.osgi/org.osgi.core/4.3.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.3.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4558,
+        "missed" : 8937,
+        "ratio" : 0.337755,
+        "total" : 13495
+      },
+      "line" : {
+        "covered" : 910,
+        "missed" : 1728,
+        "ratio" : 0.344958,
+        "total" : 2638
+      },
+      "method" : {
+        "covered" : 130,
+        "missed" : 185,
+        "ratio" : 0.412698,
+        "total" : 315
+      }
+    }
+  } ]
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/.gitignore
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/build.gradle
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.osgi:org.osgi.core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        all {
+            buildArgs.add('--initialize-at-run-time=org.osgi.framework.AdaptPermissionCollection')
+            buildArgs.add('--initialize-at-run-time=org.osgi.framework.AdminPermissionCollection')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/gradle.properties
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.osgi:org.osgi.core:4.3.1
+library.version = 4.3.1
+metadata.dir = org.osgi/org.osgi.core/4.3.1/

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/settings.gradle
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.osgi.org.osgi.core_tests'

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.cert.X509Certificate;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.AdaptPermission;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+
+public class AdaptPermissionCollection1Test {
+    @Test
+    void loadsAdaptPermissionCollectionClass() throws ClassNotFoundException {
+        assertThat(Class.forName("org.osgi.framework.AdaptPermissionCollection").getName())
+                .isEqualTo("org.osgi.framework.AdaptPermissionCollection");
+    }
+
+    @Test
+    void newPermissionCollectionStartsEmptyAndAppliesWildcardPermission() {
+        AdaptPermission permission = new AdaptPermission("*", AdaptPermission.ADAPT);
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        assertThat(collection.getClass().getName())
+                .isEqualTo("org.osgi.framework.AdaptPermissionCollection");
+        assertThat(collection.elements().hasMoreElements()).isFalse();
+
+        collection.add(permission);
+
+        assertThat(
+                        collection.implies(
+                                new AdaptPermission(
+                                        "com.example.Type",
+                                        new TestBundle(),
+                                        AdaptPermission.ADAPT)))
+                .isTrue();
+    }
+
+    @Test
+    void serializedEmptyPermissionCollectionRemainsEmpty()
+            throws IOException, ClassNotFoundException {
+        PermissionCollection collection =
+                new AdaptPermission("*", AdaptPermission.ADAPT).newPermissionCollection();
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+
+        assertThat(restoredCollection.getClass().getName())
+                .isEqualTo("org.osgi.framework.AdaptPermissionCollection");
+        assertThat(restoredCollection.elements().hasMoreElements()).isFalse();
+    }
+
+    @Test
+    void serializedPermissionCollectionStoresWildcardPermission()
+            throws IOException, ClassNotFoundException {
+        AdaptPermission permission = new AdaptPermission("*", AdaptPermission.ADAPT);
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        collection.add(permission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        Enumeration<Permission> elements = restoredCollection.elements();
+
+        assertThat(
+                        restoredCollection.implies(
+                                new AdaptPermission(
+                                        "com.example.Type",
+                                        new TestBundle(),
+                                        AdaptPermission.ADAPT)))
+                .isTrue();
+        assertThat(elements.hasMoreElements()).isTrue();
+        assertThat(elements.nextElement()).isEqualTo(permission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+
+    private static final class TestBundle implements Bundle {
+        @Override
+        public int getState() {
+            return Bundle.ACTIVE;
+        }
+
+        @Override
+        public void start(int options) throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void start() throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void stop(int options) throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void stop() throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void update(InputStream input) throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void update() throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void uninstall() throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Dictionary<String, String> getHeaders() {
+            return null;
+        }
+
+        @Override
+        public long getBundleId() {
+            return 1L;
+        }
+
+        @Override
+        public String getLocation() {
+            return "test-location";
+        }
+
+        @Override
+        public ServiceReference[] getRegisteredServices() {
+            return null;
+        }
+
+        @Override
+        public ServiceReference[] getServicesInUse() {
+            return null;
+        }
+
+        @Override
+        public boolean hasPermission(Object permission) {
+            return true;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return null;
+        }
+
+        @Override
+        public Dictionary<String, String> getHeaders(String locale) {
+            return null;
+        }
+
+        @Override
+        public String getSymbolicName() {
+            return "test.bundle";
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getEntryPaths(String path) {
+            return null;
+        }
+
+        @Override
+        public URL getEntry(String path) {
+            return null;
+        }
+
+        @Override
+        public long getLastModified() {
+            return 0L;
+        }
+
+        @Override
+        public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
+            return null;
+        }
+
+        @Override
+        public BundleContext getBundleContext() {
+            return null;
+        }
+
+        @Override
+        public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int signersType) {
+            return Map.of();
+        }
+
+        @Override
+        public Version getVersion() {
+            return null;
+        }
+
+        @Override
+        public Object adapt(Class type) {
+            return null;
+        }
+
+        @Override
+        public File getDataFile(String filename) {
+            return null;
+        }
+
+        @Override
+        public int compareTo(Object other) {
+            return Long.compare(getBundleId(), ((Bundle) other).getBundleId());
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
@@ -248,8 +248,8 @@ public class AdaptPermissionCollection1Test {
         }
 
         @Override
-        public int compareTo(Object other) {
-            return Long.compare(getBundleId(), ((Bundle) other).getBundleId());
+        public int compareTo(Bundle other) {
+            return Long.compare(getBundleId(), other.getBundleId());
         }
     }
 }

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdminPermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdminPermissionCollection1Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Enumeration;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.AdminPermission;
+
+public class AdminPermissionCollection1Test {
+    @Test
+    void loadsAdminPermissionCollectionClass() throws ClassNotFoundException {
+        assertThat(Class.forName("org.osgi.framework.AdminPermissionCollection").getName())
+                .isEqualTo("org.osgi.framework.AdminPermissionCollection");
+    }
+
+    @Test
+    void newPermissionCollectionStartsEmptyAndAppliesWildcardAdminPermission() {
+        AdminPermission permission = new AdminPermission();
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        assertThat(collection.getClass().getName())
+                .isEqualTo("org.osgi.framework.AdminPermissionCollection");
+        assertThat(collection.elements().hasMoreElements()).isFalse();
+
+        collection.add(permission);
+
+        assertThat(collection.implies(new AdminPermission())).isTrue();
+    }
+
+    @Test
+    void serializedPermissionCollectionImpliesWildcardAdminPermission()
+            throws IOException, ClassNotFoundException {
+        AdminPermission permission = new AdminPermission();
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        collection.add(permission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        Enumeration<Permission> elements = restoredCollection.elements();
+
+        assertThat(restoredCollection.implies(new AdminPermission())).isTrue();
+        assertThat(elements.hasMoreElements()).isTrue();
+        assertThat(elements.nextElement()).isEqualTo(permission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/BundlePermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/BundlePermissionCollection1Test.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.ObjectStreamField;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundlePermission;
+
+public class BundlePermissionCollection1Test {
+    @Test
+    void serializationDescriptorUsesDeclaredPersistentFields() {
+        PermissionCollection collection =
+                new BundlePermission("com.example.bundle", BundlePermission.REQUIRE)
+                        .newPermissionCollection();
+        ObjectStreamClass descriptor = ObjectStreamClass.lookup(collection.getClass());
+        ObjectStreamField permissionsField = descriptor.getField("permissions");
+        ObjectStreamField allAllowedField = descriptor.getField("all_allowed");
+
+        assertThat(descriptor.getName()).isEqualTo("org.osgi.framework.BundlePermissionCollection");
+        assertThat(permissionsField.getType()).isEqualTo(Hashtable.class);
+        assertThat(allAllowedField.getType()).isEqualTo(boolean.class);
+    }
+
+    @Test
+    void newPermissionCollectionStartsEmptyAndUsesBundlePermissionCollectionType() {
+        BundlePermission permission =
+                new BundlePermission("com.example.bundle", BundlePermission.REQUIRE);
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        assertThat(collection.getClass().getName())
+                .isEqualTo("org.osgi.framework.BundlePermissionCollection");
+        assertThat(collection.elements().hasMoreElements()).isFalse();
+
+        collection.add(permission);
+
+        assertThat(
+                        collection.implies(
+                                new BundlePermission(
+                                        "com.example.bundle", BundlePermission.REQUIRE)))
+                .isTrue();
+    }
+
+    @Test
+    void serializedPermissionCollectionAppliesWildcardBundlePermissions()
+            throws IOException, ClassNotFoundException {
+        BundlePermission permission = new BundlePermission("com.example.*", BundlePermission.REQUIRE);
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        collection.add(permission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        Enumeration<Permission> elements = restoredCollection.elements();
+
+        assertThat(restoredCollection.getClass().getName())
+                .isEqualTo("org.osgi.framework.BundlePermissionCollection");
+        assertThat(
+                        restoredCollection.implies(
+                                new BundlePermission("com.example.bundle", BundlePermission.REQUIRE)))
+                .isTrue();
+        assertThat(elements.hasMoreElements()).isTrue();
+        assertThat(elements.nextElement()).isEqualTo(permission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/CapabilityPermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/CapabilityPermissionCollection1Test.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.ObjectStreamField;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.CapabilityPermission;
+
+public class CapabilityPermissionCollection1Test {
+    @Test
+    void serializationDescriptorUsesHashMapPersistentFields() {
+        PermissionCollection collection =
+                new CapabilityPermission("com.example.capability", CapabilityPermission.PROVIDE)
+                        .newPermissionCollection();
+        ObjectStreamClass descriptor = ObjectStreamClass.lookup(collection.getClass());
+        ObjectStreamField permissionsField = descriptor.getField("permissions");
+        ObjectStreamField filterPermissionsField = descriptor.getField("filterPermissions");
+
+        assertThat(descriptor.getName())
+                .isEqualTo("org.osgi.framework.CapabilityPermissionCollection");
+        assertThat(permissionsField.getType()).isEqualTo(HashMap.class);
+        assertThat(filterPermissionsField.getType()).isEqualTo(HashMap.class);
+    }
+
+    @Test
+    void serializedPermissionCollectionAppliesWildcardCapabilityPermissions()
+            throws IOException, ClassNotFoundException {
+        CapabilityPermission permission =
+                new CapabilityPermission("com.example.*", CapabilityPermission.PROVIDE);
+        PermissionCollection collection = permission.newPermissionCollection();
+
+        collection.add(permission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        Enumeration<Permission> elements = restoredCollection.elements();
+
+        assertThat(
+                        restoredCollection.implies(
+                                new CapabilityPermission(
+                                        "com.example.capability", CapabilityPermission.PROVIDE)))
+                .isTrue();
+        assertThat(elements.hasMoreElements()).isTrue();
+        assertThat(elements.nextElement()).isEqualTo(permission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/FrameworkUtil1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/FrameworkUtil1Test.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+public class FrameworkUtil1Test {
+    @Test
+    void createFilterMatchesPlainStringProperties() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter("(name=osgi)");
+
+        assertThat(filter.matches(Map.of("name", "osgi"))).isTrue();
+        assertThat(filter.matches(Map.of("name", "other"))).isFalse();
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/FrameworkUtilFilterImpl1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/FrameworkUtilFilterImpl1Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+public class FrameworkUtilFilterImpl1Test {
+    @Test
+    void matchesComparableValuesUsingStringConstructorConversion() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter("(version>=42)");
+
+        assertThat(filter.matches(Map.of("version", new BigInteger("42")))).isTrue();
+        assertThat(filter.matches(Map.of("version", new BigInteger("41")))).isFalse();
+    }
+
+    @Test
+    void matchesUnknownValuesUsingStringConstructorConversion() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter("(locale=en)");
+
+        assertThat(filter.matches(Map.of("locale", Locale.ENGLISH))).isTrue();
+        assertThat(filter.matches(Map.of("locale", Locale.FRENCH))).isFalse();
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.ObjectStreamField;
+import java.lang.reflect.Method;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.PackagePermission;
+
+public class PackagePermissionCollection1Test {
+    @Test
+    void syntheticClassLookupResolvesPersistentFieldTypes() throws ReflectiveOperationException {
+        Class<?> collectionClass = Class.forName("org.osgi.framework.PackagePermissionCollection");
+        Method syntheticClassLookup = collectionClass.getDeclaredMethod("class$", String.class);
+        syntheticClassLookup.setAccessible(true);
+
+        assertThat(syntheticClassLookup.invoke(null, "java.util.Hashtable"))
+                .isEqualTo(Hashtable.class);
+        assertThat(syntheticClassLookup.invoke(null, "java.util.HashMap")).isEqualTo(HashMap.class);
+    }
+
+    @Test
+    void serializationDescriptorUsesExpectedPersistentFieldTypes() {
+        PermissionCollection collection =
+                new PackagePermission("com.example.package", PackagePermission.IMPORT)
+                        .newPermissionCollection();
+        ObjectStreamClass descriptor = ObjectStreamClass.lookup(collection.getClass());
+        ObjectStreamField permissionsField = descriptor.getField("permissions");
+        ObjectStreamField allAllowedField = descriptor.getField("all_allowed");
+        ObjectStreamField filterPermissionsField = descriptor.getField("filterPermissions");
+
+        assertThat(descriptor.getName())
+                .isEqualTo("org.osgi.framework.PackagePermissionCollection");
+        assertThat(permissionsField.getType()).isEqualTo(Hashtable.class);
+        assertThat(allAllowedField.getType()).isEqualTo(Boolean.TYPE);
+        assertThat(filterPermissionsField.getType()).isEqualTo(HashMap.class);
+    }
+
+    @Test
+    void serializedPermissionCollectionRetainsWildcardAndFilterPackagePermissions()
+            throws IOException, ClassNotFoundException {
+        PackagePermission wildcardPermission =
+                new PackagePermission("com.example.*", PackagePermission.IMPORT);
+        PackagePermission filterPermission =
+                new PackagePermission("(package.name=com.filtered.package)", PackagePermission.IMPORT);
+        PermissionCollection collection = wildcardPermission.newPermissionCollection();
+
+        collection.add(wildcardPermission);
+        collection.add(filterPermission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        List<Permission> elements = Collections.list(restoredCollection.elements());
+
+        assertThat(
+                        restoredCollection.implies(
+                                new PackagePermission("com.example.package", PackagePermission.IMPORT)))
+                .isTrue();
+        assertThat(
+                        restoredCollection.implies(
+                                new PackagePermission(
+                                        "com.filtered.package", PackagePermission.IMPORT)))
+                .isTrue();
+        assertThat(elements).containsExactlyInAnyOrder(wildcardPermission, filterPermission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
@@ -15,7 +15,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.ObjectStreamField;
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Collections;
@@ -27,14 +27,21 @@ import org.osgi.framework.PackagePermission;
 
 public class PackagePermissionCollection1Test {
     @Test
-    void syntheticClassLookupResolvesPersistentFieldTypes() throws ReflectiveOperationException {
+    void serialPersistentFieldsUseExpectedFieldTypes() throws ReflectiveOperationException {
         Class<?> collectionClass = Class.forName("org.osgi.framework.PackagePermissionCollection");
-        Method syntheticClassLookup = collectionClass.getDeclaredMethod("class$", String.class);
-        syntheticClassLookup.setAccessible(true);
+        Field serialPersistentFields = collectionClass.getDeclaredField("serialPersistentFields");
+        serialPersistentFields.setAccessible(true);
 
-        assertThat(syntheticClassLookup.invoke(null, "java.util.Hashtable"))
-                .isEqualTo(Hashtable.class);
-        assertThat(syntheticClassLookup.invoke(null, "java.util.HashMap")).isEqualTo(HashMap.class);
+        ObjectStreamField[] persistentFields =
+                (ObjectStreamField[]) serialPersistentFields.get(null);
+
+        assertThat(persistentFields).hasSize(3);
+        assertThat(persistentFields[0].getName()).isEqualTo("permissions");
+        assertThat(persistentFields[0].getType()).isEqualTo(Hashtable.class);
+        assertThat(persistentFields[1].getName()).isEqualTo("all_allowed");
+        assertThat(persistentFields[1].getType()).isEqualTo(Boolean.TYPE);
+        assertThat(persistentFields[2].getName()).isEqualTo("filterPermissions");
+        assertThat(persistentFields[2].getType()).isEqualTo(HashMap.class);
     }
 
     @Test

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/ServicePermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/ServicePermissionCollection1Test.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.org_osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.ObjectStreamField;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.ServicePermission;
+
+public class ServicePermissionCollection1Test {
+    @Test
+    void isolatedClassLoaderCreatesServicePermissionCollectionViaPublicApi()
+            throws ReflectiveOperationException, IOException {
+        URL libraryUrl = ServicePermission.class.getProtectionDomain().getCodeSource().getLocation();
+
+        try (ChildFirstOsgiClassLoader classLoader = new ChildFirstOsgiClassLoader(libraryUrl)) {
+            Class<?> servicePermissionClass =
+                    Class.forName("org.osgi.framework.ServicePermission", true, classLoader);
+            Constructor<?> constructor =
+                    servicePermissionClass.getConstructor(String.class, String.class);
+            Object permissionInstance =
+                    constructor.newInstance("com.example.Service", ServicePermission.GET);
+            Object collection =
+                    servicePermissionClass.getMethod("newPermissionCollection")
+                            .invoke(permissionInstance);
+
+            assertThat(collection.getClass().getName())
+                    .isEqualTo("org.osgi.framework.ServicePermissionCollection");
+        }
+    }
+
+    @Test
+    void serializationDescriptorUsesExpectedPersistentFieldTypes() {
+        PermissionCollection collection =
+                new ServicePermission("com.example.Service", ServicePermission.GET)
+                        .newPermissionCollection();
+        ObjectStreamClass descriptor = ObjectStreamClass.lookup(collection.getClass());
+        ObjectStreamField permissionsField = descriptor.getField("permissions");
+        ObjectStreamField allAllowedField = descriptor.getField("all_allowed");
+        ObjectStreamField filterPermissionsField = descriptor.getField("filterPermissions");
+
+        assertThat(descriptor.getName())
+                .isEqualTo("org.osgi.framework.ServicePermissionCollection");
+        assertThat(permissionsField.getType()).isEqualTo(Hashtable.class);
+        assertThat(allAllowedField.getType()).isEqualTo(Boolean.TYPE);
+        assertThat(filterPermissionsField.getType()).isEqualTo(HashMap.class);
+    }
+
+    @Test
+    void serializedPermissionCollectionRetainsWildcardAndFilterServicePermissions()
+            throws IOException, ClassNotFoundException {
+        ServicePermission wildcardPermission =
+                new ServicePermission("com.example.*", ServicePermission.GET);
+        ServicePermission filterPermission =
+                new ServicePermission("(objectClass=com.filtered.Service)", ServicePermission.GET);
+        PermissionCollection collection = wildcardPermission.newPermissionCollection();
+
+        collection.add(wildcardPermission);
+        collection.add(filterPermission);
+
+        PermissionCollection restoredCollection = roundTrip(collection);
+        List<Permission> elements = Collections.list(restoredCollection.elements());
+
+        assertThat(
+                        restoredCollection.implies(
+                                new ServicePermission("com.example.Service", ServicePermission.GET)))
+                .isTrue();
+        assertThat(
+                        restoredCollection.implies(
+                                new ServicePermission("com.filtered.Service", ServicePermission.GET)))
+                .isTrue();
+        assertThat(elements).containsExactlyInAnyOrder(wildcardPermission, filterPermission);
+    }
+
+    private PermissionCollection roundTrip(PermissionCollection collection)
+            throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(collection);
+        }
+
+        try (ObjectInputStream objectInput =
+                new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+            return (PermissionCollection) objectInput.readObject();
+        }
+    }
+
+    private static final class ChildFirstOsgiClassLoader extends URLClassLoader {
+        private ChildFirstOsgiClassLoader(URL libraryUrl) {
+            super(new URL[] {libraryUrl}, ServicePermissionCollection1Test.class.getClassLoader());
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+            if (name.startsWith("org.osgi.")) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    try {
+                        loadedClass = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.osgi/org.osgi.core/4.3.1/user-code-filter.json
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.osgi.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2120

This PR provides test fixes and new metadata for org.osgi:org.osgi.core:4.3.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 65086
- Cached input tokens: 628608
- Output tokens: 8213
- Entries found: 15
- Iterations: 1
- Library coverage percentage: 34.5
- Previous library version metadata entries: 59
- Previous library version coverage percentage: 34.5

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.osgi:org.osgi.core:4.3.0: 5/11 covered calls (45.45%)
- org.osgi:org.osgi.core:4.3.1: 4/4 covered calls (100.00%)

**Reflection:**
- org.osgi:org.osgi.core:4.3.0: 5/11 covered calls (45.45%)
- org.osgi:org.osgi.core:4.3.1: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.osgi:org.osgi.core:4.3.0: 4614/13565 (34.01%)
- org.osgi:org.osgi.core:4.3.1: 4558/13495 (33.78%)

**Line:**
- org.osgi:org.osgi.core:4.3.0: 910/2638 (34.50%)
- org.osgi:org.osgi.core:4.3.1: 910/2638 (34.50%)

**Method:**
- org.osgi:org.osgi.core:4.3.0: 130/315 (41.27%)
- org.osgi:org.osgi.core:4.3.1: 130/315 (41.27%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.osgi/org.osgi.core/4.3.0/gradle.properties b/tests/src/org.osgi/org.osgi.core/4.3.1/gradle.properties
index 75511c9c..648280ec 100644
--- a/tests/src/org.osgi/org.osgi.core/4.3.0/gradle.properties
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = org.osgi:org.osgi.core:4.3.0
-library.version = 4.3.0
-metadata.dir = org.osgi/org.osgi.core/4.3.0/
+library.coordinates = org.osgi:org.osgi.core:4.3.1
+library.version = 4.3.1
+metadata.dir = org.osgi/org.osgi.core/4.3.1/
diff --git a/tests/src/org.osgi/org.osgi.core/4.3.0/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
index de10fee3..deb91322 100644
--- a/tests/src/org.osgi/org.osgi.core/4.3.0/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/AdaptPermissionCollection1Test.java
@@ -248,8 +248,8 @@ public class AdaptPermissionCollection1Test {
         }
 
         @Override
-        public int compareTo(Object other) {
-            return Long.compare(getBundleId(), ((Bundle) other).getBundleId());
+        public int compareTo(Bundle other) {
+            return Long.compare(getBundleId(), other.getBundleId());
         }
     }
 }
diff --git a/tests/src/org.osgi/org.osgi.core/4.3.0/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
index f75eeb25..63cab876 100644
--- a/tests/src/org.osgi/org.osgi.core/4.3.0/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
+++ b/tests/src/org.osgi/org.osgi.core/4.3.1/src/test/java/org_osgi/org_osgi_core/PackagePermissionCollection1Test.java
@@ -15,7 +15,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.ObjectStreamField;
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Collections;
@@ -27,14 +27,21 @@ import org.osgi.framework.PackagePermission;
 
 public class PackagePermissionCollection1Test {
     @Test
-    void syntheticClassLookupResolvesPersistentFieldTypes() throws ReflectiveOperationException {
+    void serialPersistentFieldsUseExpectedFieldTypes() throws ReflectiveOperationException {
         Class<?> collectionClass = Class.forName("org.osgi.framework.PackagePermissionCollection");
-        Method syntheticClassLookup = collectionClass.getDeclaredMethod("class$", String.class);
-        syntheticClassLookup.setAccessible(true);
+        Field serialPersistentFields = collectionClass.getDeclaredField("serialPersistentFields");
+        serialPersistentFields.setAccessible(true);
 
-        assertThat(syntheticClassLookup.invoke(null, "java.util.Hashtable"))
-                .isEqualTo(Hashtable.class);
-        assertThat(syntheticClassLookup.invoke(null, "java.util.HashMap")).isEqualTo(HashMap.class);
+        ObjectStreamField[] persistentFields =
+                (ObjectStreamField[]) serialPersistentFields.get(null);
+
+        assertThat(persistentFields).hasSize(3);
+        assertThat(persistentFields[0].getName()).isEqualTo("permissions");
+        assertThat(persistentFields[0].getType()).isEqualTo(Hashtable.class);
+        assertThat(persistentFields[1].getName()).isEqualTo("all_allowed");
+        assertThat(persistentFields[1].getType()).isEqualTo(Boolean.TYPE);
+        assertThat(persistentFields[2].getName()).isEqualTo("filterPermissions");
+        assertThat(persistentFields[2].getType()).isEqualTo(HashMap.class);
     }
 
     @Test

```
