### PR TITLE
[GenAI] Add support for jakarta.el:jakarta.el-api:3.0.2 using gpt-5.5

### DIFF
--- a/metadata/jakarta.el/jakarta.el-api/3.0.2/reachability-metadata.json
+++ b/metadata/jakarta.el/jakarta.el-api/3.0.2/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ImportHandler"
+      },
+      "type" : "java.lang.Math"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ELUtil"
+      },
+      "bundle" : "javax.el.PrivateMessages"
+    }
+  ]
+}

--- a/metadata/jakarta.el/jakarta.el-api/index.json
+++ b/metadata/jakarta.el/jakarta.el-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/3.0.2/jakarta.el-api-3.0.2-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/expression-language",
+    "test-code-url" : "https://github.com/jakartaee/expression-language/tree/3.0.2-RI-COMB-RELEASE/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/3.0.2/jakarta.el-api-3.0.2-javadoc.jar",
+    "description" : "Jakarta Expression Language API defines the standard interfaces and classes for parsing and evaluating expression language expressions in Jakarta EE and compatible Java runtimes. It provides resolver, mapper, context, and expression abstractions used by frameworks and implementations to bind expression syntax to application objects, methods, and properties.",
+    "tested-versions" : [
+      "3.0.2"
+    ],
+    "allowed-packages" : [
+      "javax.el"
+    ]
+  }
+]

--- a/stats/jakarta.el/jakarta.el-api/3.0.2/stats.json
+++ b/stats/jakarta.el/jakarta.el-api/3.0.2/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 28,
+      "totalCalls" : 28
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1887,
+        "missed" : 3557,
+        "ratio" : 0.34662,
+        "total" : 5444
+      },
+      "line" : {
+        "covered" : 480,
+        "missed" : 948,
+        "ratio" : 0.336134,
+        "total" : 1428
+      },
+      "method" : {
+        "covered" : 94,
+        "missed" : 173,
+        "ratio" : 0.35206,
+        "total" : 267
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/.gitignore
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/build.gradle
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.el:jakarta.el-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/gradle.properties
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.el:jakarta.el-api:3.0.2
+library.version = 3.0.2
+metadata.dir = jakarta.el/jakarta.el-api/3.0.2/

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/settings.gradle
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.el.jakarta.el-api_tests'

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
@@ -8,14 +8,25 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Objects;
 import javax.el.BeanELResolver;
 import javax.el.ELContext;
+import javax.el.ELException;
 import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
 import javax.el.FunctionMapper;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
 import javax.el.VariableMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class BeanELResolverTest {
+
+    @BeforeAll
+    static void configureExpressionFactory() {
+        System.setProperty("javax.el.ExpressionFactory", TestExpressionFactory.class.getName());
+    }
 
     @Test
     void getValueInvokesBeanGetter() {
@@ -39,6 +50,44 @@ public class BeanELResolverTest {
 
         assertThat(bean.getDisplayName()).isEqualTo("after");
         assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static final class TestExpressionFactory extends ExpressionFactory {
+
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not used by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Value expressions are not used by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Method expressions are not used by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            if (obj == null || targetType.isInstance(obj)) {
+                return obj;
+            }
+            if (targetType == String.class) {
+                return Objects.toString(obj);
+            }
+            throw new ELException("Unsupported conversion to " + targetType.getName());
+        }
+
+        @Override
+        public ELResolver getStreamELResolver() {
+            return null;
+        }
     }
 
     public static final class ProfileBean {

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.el.BeanELResolver;
+import javax.el.ELContext;
+import javax.el.ELResolver;
+import javax.el.FunctionMapper;
+import javax.el.VariableMapper;
+import org.junit.jupiter.api.Test;
+
+public class BeanELResolverTest {
+
+    @Test
+    void getValueInvokesBeanGetter() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+        ProfileBean bean = new ProfileBean("Duke");
+
+        Object value = resolver.getValue(context, bean, "displayName");
+
+        assertThat(value).isEqualTo("Duke");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void setValueInvokesBeanSetter() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+        ProfileBean bean = new ProfileBean("before");
+
+        resolver.setValue(context, bean, "displayName", "after");
+
+        assertThat(bean.getDisplayName()).isEqualTo("after");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static final class ProfileBean {
+        private String displayName;
+
+        public ProfileBean(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    private static final class SimpleELContext extends ELContext {
+
+        @Override
+        public ELResolver getELResolver() {
+            return null;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import javax.el.ELContext;
+import javax.el.ELException;
+import javax.el.ELProcessor;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ELProcessorTest {
+
+    @BeforeAll
+    static void configureExpressionFactory() {
+        System.setProperty("javax.el.ExpressionFactory", MinimalExpressionFactory.class.getName());
+    }
+
+    @Test
+    void defineFunctionByNameScansDeclaredMethods() throws Exception {
+        ELProcessor processor = newProcessor();
+
+        processor.defineFunction("math", "sum", FunctionLibrary.class.getName(), "sum");
+
+        assertMappedFunction(processor, "math", "sum", "sum");
+    }
+
+    @Test
+    void defineFunctionWithObjectSignatureLoadsParameterClasses() throws Exception {
+        ELProcessor processor = newProcessor();
+
+        processor.defineFunction(
+                "text",
+                "join",
+                FunctionLibrary.class.getName(),
+                "java.lang.String join(java.lang.String,java.lang.String)");
+
+        assertMappedFunction(processor, "text", "join", "join");
+    }
+
+    @Test
+    void defineFunctionWithPrimitiveArraySignatureResolvesArrayType() throws Exception {
+        ELProcessor processor = newProcessor();
+
+        processor.defineFunction("arrays", "sum", FunctionLibrary.class.getName(), "int sumArray(int[])");
+
+        assertMappedFunction(processor, "arrays", "sum", "sumArray");
+    }
+
+    @Test
+    void defineFunctionWithMultiDimensionalReferenceArraySignatureResolvesArrayType() throws Exception {
+        ELProcessor processor = newProcessor();
+
+        processor.defineFunction(
+                "arrays",
+                "cellCount",
+                FunctionLibrary.class.getName(),
+                "int countCells(java.lang.String[][])");
+
+        assertMappedFunction(processor, "arrays", "cellCount", "countCells");
+    }
+
+    private static ELProcessor newProcessor() {
+        configureExpressionFactory();
+        return new ELProcessor();
+    }
+
+    private static void assertMappedFunction(
+            ELProcessor processor, String prefix, String functionName, String expectedMethodName) {
+        Method mappedMethod = processor.getELManager()
+                .getELContext()
+                .getFunctionMapper()
+                .resolveFunction(prefix, functionName);
+
+        assertThat(mappedMethod).isNotNull();
+        assertThat(mappedMethod.getName()).isEqualTo(expectedMethodName);
+    }
+
+    public static final class FunctionLibrary {
+
+        public static int sum(int left, int right) {
+            return left + right;
+        }
+
+        public static String join(String left, String right) {
+            return left + right;
+        }
+
+        public static int sumArray(int[] values) {
+            int total = 0;
+            for (int value : values) {
+                total += value;
+            }
+            return total;
+        }
+
+        public static int countCells(String[][] values) {
+            int count = 0;
+            for (String[] row : values) {
+                count += row.length;
+            }
+            return count;
+        }
+    }
+
+    public static final class MinimalExpressionFactory extends ExpressionFactory {
+
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not used by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Value expressions are not used by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Method expressions are not used by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            if (obj == null || targetType.isInstance(obj)) {
+                return obj;
+            }
+            if (targetType == String.class) {
+                return Objects.toString(obj);
+            }
+            throw new ELException("Unsupported conversion to " + targetType.getName());
+        }
+
+        @Override
+        public ELResolver getStreamELResolver() {
+            return null;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Locale;
+import javax.el.BeanELResolver;
+import javax.el.ELClass;
+import javax.el.ELContext;
+import javax.el.ELException;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.FunctionMapper;
+import javax.el.MethodExpression;
+import javax.el.PropertyNotFoundException;
+import javax.el.StaticFieldELResolver;
+import javax.el.TypeConverter;
+import javax.el.ValueExpression;
+import javax.el.VariableMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ELUtilTest {
+
+    @BeforeAll
+    static void configureExpressionFactory() {
+        System.setProperty("javax.el.ExpressionFactory", TestExpressionFactory.class.getName());
+    }
+
+    @Test
+    void staticResolverInvokesVarargsConstructorOnPublicSuperclass() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object created = resolver.invoke(
+                context,
+                new ELClass(HiddenConstructable.class),
+                "<init>",
+                new Class<?>[] {String.class, String.class, String.class},
+                new Object[] {"hello", "native", "image"});
+
+        assertThat(created)
+                .isInstanceOf(PublicConstructable.class)
+                .isNotInstanceOf(HiddenConstructable.class);
+        assertThat(((PublicConstructable) created).message()).isEqualTo("hello:native,image");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void beanResolverInvokesPublicInterfaceMethodImplementedByNonPublicClass() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object greeting = resolver.invoke(
+                context,
+                new HiddenInterfaceGreeter(),
+                "greet",
+                new Class<?>[] {String.class},
+                new Object[] {"Duke"});
+
+        assertThat(greeting).isEqualTo("interface:Duke");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void beanResolverInvokesPublicSuperclassMethodFromNonPublicSubclass() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object description = resolver.invoke(
+                context,
+                new HiddenMethodChild(),
+                "describe",
+                new Class<?>[] {String.class},
+                new Object[] {"metadata"});
+
+        assertThat(description).isEqualTo("base:metadata");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void missingStaticFieldLoadsLocalizedMessageBundle() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+        context.setLocale(Locale.ENGLISH);
+
+        assertThatThrownBy(() -> resolver.getValue(context, new ELClass(PublicConstructable.class), "missing"))
+                .isInstanceOf(PropertyNotFoundException.class)
+                .hasMessageContaining(PublicConstructable.class.getName())
+                .hasMessageContaining("missing");
+    }
+
+    public static final class TestExpressionFactory extends ExpressionFactory {
+
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not used by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Value expressions are not used by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Method expressions are not used by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            return SimpleELContext.convert(obj, targetType);
+        }
+    }
+
+    public static class PublicConstructable {
+        private final String prefix;
+        private final String[] words;
+
+        public PublicConstructable(String prefix, String... words) {
+            this.prefix = prefix;
+            this.words = words.clone();
+        }
+
+        String message() {
+            return prefix + ":" + String.join(",", words);
+        }
+    }
+
+    private static final class HiddenConstructable extends PublicConstructable {
+
+        public HiddenConstructable(String prefix, String... words) {
+            super(prefix, words);
+        }
+    }
+
+    public interface PublicGreeter {
+
+        String greet(String name);
+    }
+
+    private static final class HiddenInterfaceGreeter implements PublicGreeter {
+
+        @Override
+        public String greet(String name) {
+            return "interface:" + name;
+        }
+    }
+
+    public static class PublicMethodBase {
+
+        public String describe(String value) {
+            return "base:" + value;
+        }
+    }
+
+    private static final class HiddenMethodChild extends PublicMethodBase {
+    }
+
+    private static final class SimpleELContext extends ELContext {
+        private final ELResolver resolver = new TypeConverter() {
+            @Override
+            public Object convertToType(ELContext context, Object obj, Class<?> targetType) {
+                context.setPropertyResolved(obj, targetType);
+                return convert(obj, targetType);
+            }
+        };
+
+        @Override
+        public ELResolver getELResolver() {
+            return resolver;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+
+        static Object convert(Object obj, Class<?> targetType) {
+            if (obj == null || targetType.isInstance(obj)) {
+                return obj;
+            }
+            if (targetType == String.class) {
+                return obj.toString();
+            }
+            if (targetType == int.class || targetType == Integer.class) {
+                return Integer.valueOf(obj.toString());
+            }
+            throw new ELException("Unsupported conversion to " + targetType.getName());
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class FactoryFinderTest {
+    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+
+    private final Thread currentThread = Thread.currentThread();
+    private final ClassLoader originalContextClassLoader = currentThread.getContextClassLoader();
+    private final String originalExpressionFactoryProperty = System.getProperty(EXPRESSION_FACTORY_PROPERTY);
+
+    @AfterEach
+    void restoreThreadState() {
+        currentThread.setContextClassLoader(originalContextClassLoader);
+        if (originalExpressionFactoryProperty == null) {
+            System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        } else {
+            System.setProperty(EXPRESSION_FACTORY_PROPERTY, originalExpressionFactoryProperty);
+        }
+    }
+
+    @Test
+    void loadsProviderWithPropertiesWhenContextClassLoaderIsNull() {
+        currentThread.setContextClassLoader(null);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, PropertiesExpressionFactory.class.getName());
+
+        Properties properties = new Properties();
+        properties.setProperty("javax.el.cacheSize", "64");
+
+        ExpressionFactory expressionFactory = ExpressionFactory.newInstance(properties);
+
+        assertThat(expressionFactory).isInstanceOf(PropertiesExpressionFactory.class);
+        PropertiesExpressionFactory propertiesExpressionFactory = (PropertiesExpressionFactory) expressionFactory;
+        assertThat(propertiesExpressionFactory.getProperties()).isSameAs(properties);
+        assertThat(propertiesExpressionFactory.getProperties()).containsEntry("javax.el.cacheSize", "64");
+    }
+
+    public static final class PropertiesExpressionFactory extends ExpressionFactory {
+        private final Properties properties;
+
+        public PropertiesExpressionFactory(Properties properties) {
+            this.properties = properties;
+        }
+
+        public Properties getProperties() {
+            return properties;
+        }
+
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not used by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Value expressions are not used by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Method expressions are not used by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            return obj;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import javax.el.ELException;
+import javax.el.ImportHandler;
+import org.junit.jupiter.api.Test;
+
+public class ImportHandlerTest {
+
+    @Test
+    void resolvesClassImportedByFullyQualifiedName() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importClass(ArrayList.class.getName());
+
+        Class<?> resolvedClass = importHandler.resolveClass("ArrayList");
+
+        assertThat(resolvedClass).isEqualTo(ArrayList.class);
+    }
+
+    @Test
+    void resolvesClassFromImportedPackage() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importPackage("java.util");
+
+        Class<?> resolvedClass = importHandler.resolveClass("ArrayList");
+
+        assertThat(resolvedClass).isEqualTo(ArrayList.class);
+    }
+
+    @Test
+    void resolvesStaticMemberToDeclaringClass() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importStatic(Math.class.getName() + ".max");
+
+        Class<?> resolvedClass = importHandler.resolveStatic("max");
+
+        assertThat(resolvedClass).isEqualTo(Math.class);
+    }
+
+    @Test
+    void returnsNullWhenImportedPackageDoesNotContainClass() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importPackage("java.util");
+
+        Class<?> resolvedClass = importHandler.resolveClass("NoSuchImportedType");
+
+        assertThat(resolvedClass).isNull();
+    }
+
+    @Test
+    void rejectsAbstractClassesResolvedThroughImports() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importClass(AbstractList.class.getName());
+
+        assertThatThrownBy(() -> importHandler.resolveClass("AbstractList"))
+                .isInstanceOf(ELException.class)
+                .hasMessageContaining("Imported class must be public");
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/Jakarta_el_apiTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/Jakarta_el_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import org.junit.jupiter.api.Test;
+
+class Jakarta_el_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/Jakarta_el_apiTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/Jakarta_el_apiTest.java
@@ -8,7 +8,7 @@ package jakarta_el.jakarta_el_api;
 
 import org.junit.jupiter.api.Test;
 
-class Jakarta_el_apiTest {
+public class Jakarta_el_apiTest {
     @Test
     void test() throws Exception {
         System.out.println("This is just a placeholder, implement your test");

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.el.ELClass;
+import javax.el.ELContext;
+import javax.el.ELResolver;
+import javax.el.FunctionMapper;
+import javax.el.StaticFieldELResolver;
+import javax.el.VariableMapper;
+import org.junit.jupiter.api.Test;
+
+public class StaticFieldELResolverTest {
+
+    @Test
+    void readsPublicStaticFieldValue() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object value = resolver.getValue(context, new ELClass(StaticFieldTarget.class), "GREETING");
+
+        assertThat(value).isEqualTo("hello");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void resolvesPublicStaticFieldType() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Class<?> type = resolver.getType(context, new ELClass(StaticFieldTarget.class), "GREETING");
+
+        assertThat(type).isEqualTo(String.class);
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static final class StaticFieldTarget {
+        public static final String GREETING = "hello";
+
+        private StaticFieldTarget() {
+        }
+    }
+
+    private static final class SimpleELContext extends ELContext {
+
+        @Override
+        public ELResolver getELResolver() {
+            return null;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,18 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "javax.el.FactoryFinder"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$TestExpressionFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "javax.el.BeanELResolver"
       },
       "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$ProfileBean",

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.el.FactoryFinder"
+      },
+      "type" : "jakarta_el.jakarta_el_api.FactoryFinderTest$PropertiesExpressionFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.Properties"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -13,6 +13,17 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.StaticFieldELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.StaticFieldELResolverTest$StaticFieldTarget",
+      "fields" : [
+        {
+          "name" : "GREETING"
+        }
+      ]
     }
   ]
 }

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,24 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$ProfileBean",
+      "methods" : [
+        {
+          "name" : "getDisplayName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setDisplayName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "javax.el.FactoryFinder"
       },
       "type" : "jakarta_el.jakarta_el_api.FactoryFinderTest$PropertiesExpressionFactory",

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "javax.el.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json
+++ b/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "javax.el.**"
+      "includeClasses" : "javax.el.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1451

This PR introduces tests and metadata for jakarta.el:jakarta.el-api:3.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 338211
- Cached input tokens: 3980288
- Output tokens: 38469
- Entries: 2
- Iterations: 7
- Library coverage percentage: 33.61
- Generated lines of code: 585
- Tested library lines of code: 480

Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 28/28 covered calls (100.00%)
- Reflection: 25/25 covered calls (100.00%)
- Resources: 3/3 covered calls (100.00%)

Library coverage:
- Instruction: 1887/5444 (34.66%)
- Line: 480/1428 (33.61%)
- Method: 94/267 (35.21%)
