### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-core:12.3.0

### DIFF
--- a/metadata/org.flywaydb/flyway-core/12.3.0/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-core/12.3.0/reachability-metadata.json
@@ -1,0 +1,237 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBaselineMigrationPrefix",
+          "parameterTypes": []
+        },
+        {
+          "name": "setBaselineMigrationPrefix",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClean",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClean",
+          "parameterTypes": [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModel",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.SchemaModel",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getScriptFilename",
+          "parameterTypes": []
+        },
+        {
+          "name": "setScriptFilename",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getScriptFilename",
+          "parameterTypes": []
+        },
+        {
+          "name": "getUndoFilename",
+          "parameterTypes": []
+        },
+        {
+          "name": "setScriptFilename",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setUndoFilename",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type": "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type": "org.flywaydb.core.internal.logging.log4j2.Log4j2LogCreator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type": "org.flywaydb.core.internal.logging.slf4j.Slf4jLogCreator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isCheckDriftOnMigrate",
+          "parameterTypes": []
+        },
+        {
+          "name": "isPublishResult",
+          "parameterTypes": []
+        },
+        {
+          "name": "setCheckDriftOnMigrate",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setPublishResult",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.license.VersionPrinter"
+      },
+      "glob": "org/flywaydb/core/internal/version.txt"
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.3.0",
+    "test-version" : "11.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/12.3.0/flyway-core-12.3.0-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-12.3.0/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
+    "tested-versions" : [
+      "12.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache",
+      "org.flywaydb",
+      "org.slf4j"
+    ]
+  },
+  {
     "metadata-version" : "11.14.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/11.14.1/flyway-core-11.14.1-sources.jar",
     "repository-url" : "https://github.com/flyway/flyway",

--- a/stats/org.flywaydb/flyway-core/12.3.0/stats.json
+++ b/stats/org.flywaydb/flyway-core/12.3.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "12.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.108108,
+          "coveredCalls" : 4,
+          "totalCalls" : 37
+        },
+        "resources" : {
+          "coverageRatio" : 0.666667,
+          "coveredCalls" : 4,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 0.186047,
+      "coveredCalls" : 8,
+      "totalCalls" : 43
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 17760,
+        "missed" : 30364,
+        "ratio" : 0.369047,
+        "total" : 48124
+      },
+      "line" : {
+        "covered" : 3895,
+        "missed" : 6750,
+        "ratio" : 0.365899,
+        "total" : 10645
+      },
+      "method" : {
+        "covered" : 942,
+        "missed" : 1601,
+        "ratio" : 0.370429,
+        "total" : 2543
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#1608

This PR provides new metadata needed for the org.flywaydb:flyway-core:12.3.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.flywaydb:flyway-core:11.14.1`): 50
- Metadata entries (new `org.flywaydb:flyway-core:12.3.0`): 50
- Library coverage (previous): 36.79%
- Library coverage (new): 36.59%
### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-core:11.14.1: 8/43 covered calls (18.60%)
- org.flywaydb:flyway-core:12.3.0: 8/43 covered calls (18.60%)

**Reflection:**
- org.flywaydb:flyway-core:11.14.1: 4/37 covered calls (10.81%)
- org.flywaydb:flyway-core:12.3.0: 4/37 covered calls (10.81%)

**Resources:**
- org.flywaydb:flyway-core:11.14.1: 4/6 covered calls (66.67%)
- org.flywaydb:flyway-core:12.3.0: 4/6 covered calls (66.67%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-core:11.14.1: 17315/46754 (37.03%)
- org.flywaydb:flyway-core:12.3.0: 17760/48124 (36.90%)

**Line:**
- org.flywaydb:flyway-core:11.14.1: 3801/10333 (36.79%)
- org.flywaydb:flyway-core:12.3.0: 3895/10645 (36.59%)

**Method:**
- org.flywaydb:flyway-core:11.14.1: 950/2471 (38.45%)
- org.flywaydb:flyway-core:12.3.0: 942/2543 (37.04%)
