### PR TITLE
[Automation] Generated metadata for com.hazelcast:hazelcast:5.3.0-BETA-1

### DIFF
--- a/metadata/com.hazelcast/hazelcast/5.3.0-BETA-1/reachability-metadata.json
+++ b/metadata/com.hazelcast/hazelcast/5.3.0-BETA-1/reachability-metadata.json
@@ -1,0 +1,33 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl$MetricsProvider"
+      },
+      "type": "com.hazelcast.internal.util.executor.ManagedExecutorService",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "getCompletedTaskCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaximumPoolSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPoolSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getQueueSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRemainingQueueCapacity",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.hazelcast/hazelcast/index.json
+++ b/metadata/com.hazelcast/hazelcast/index.json
@@ -1,36 +1,51 @@
 [
   {
-    "allowed-packages": [
-      "com.hazelcast"
+    "latest" : true,
+    "metadata-version" : "5.3.0-BETA-1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.3.0-BETA-1/hazelcast-5.3.0-BETA-1-sources.jar",
+    "repository-url" : "https://github.com/hazelcast/hazelcast",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.3.0-BETA-1/hazelcast-5.3.0-BETA-1-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.3.0-BETA-1/hazelcast-5.3.0-BETA-1-javadoc.jar",
+    "description" : "Hazelcast is a distributed computing and in-memory data platform for storing, querying, and processing data across a cluster. It provides distributed data structures, messaging, caching, and stream processing features for building scalable, fault-tolerant applications.",
+    "test-version" : "5.5.0",
+    "tested-versions" : [
+      "5.3.0-BETA-1"
     ],
-    "metadata-version": "5.2.1",
-    "source-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-sources.jar",
-    "repository-url": "https://github.com/hazelcast/hazelcast",
-    "test-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-tests.jar",
-    "documentation-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-javadoc.jar",
-    "description": "Hazelcast is an in-memory data grid and distributed computing platform for storing and processing data across a cluster of JVMs. It provides distributed data structures, caching, messaging, and cluster coordination for building scalable, fault-tolerant applications.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "com.hazelcast"
+    ]
+  },
+  {
+    "metadata-version" : "5.2.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-sources.jar",
+    "repository-url" : "https://github.com/hazelcast/hazelcast",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.2.1/hazelcast-5.2.1-javadoc.jar",
+    "description" : "Hazelcast is an in-memory data grid and distributed computing platform for storing and processing data across a cluster of JVMs. It provides distributed data structures, caching, messaging, and cluster coordination for building scalable, fault-tolerant applications.",
+    "tested-versions" : [
       "5.2.1",
       "5.2.2",
       "5.2.3",
       "5.2.4",
       "5.2.5"
+    ],
+    "allowed-packages" : [
+      "com.hazelcast"
     ]
   },
   {
-    "latest": true,
-    "allowed-packages": [
-      "com.hazelcast"
-    ],
-    "metadata-version": "5.5.0",
-    "source-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-sources.jar",
-    "repository-url": "https://github.com/hazelcast/hazelcast",
-    "test-code-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-tests.jar",
-    "documentation-url": "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-javadoc.jar",
-    "description": "Hazelcast is a distributed computing and in-memory data platform for storing, querying, and processing data across a cluster. It provides distributed data structures, messaging, and stream processing features for building scalable, fault-tolerant applications.",
-    "tested-versions": [
+    "metadata-version" : "5.5.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-sources.jar",
+    "repository-url" : "https://github.com/hazelcast/hazelcast",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/5.5.0/hazelcast-5.5.0-javadoc.jar",
+    "description" : "Hazelcast is a distributed computing and in-memory data platform for storing, querying, and processing data across a cluster. It provides distributed data structures, messaging, and stream processing features for building scalable, fault-tolerant applications.",
+    "tested-versions" : [
       "5.5.0",
       "5.6.0"
+    ],
+    "allowed-packages" : [
+      "com.hazelcast"
     ]
   }
 ]

--- a/stats/com.hazelcast/hazelcast/5.3.0-BETA-1/stats.json
+++ b/stats/com.hazelcast/hazelcast/5.3.0-BETA-1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.3.0-BETA-1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.105263,
+          "coveredCalls" : 50,
+          "totalCalls" : 475
+        },
+        "resources" : {
+          "coverageRatio" : 0.066667,
+          "coveredCalls" : 3,
+          "totalCalls" : 45
+        }
+      },
+      "coverageRatio" : 0.101923,
+      "coveredCalls" : 53,
+      "totalCalls" : 520
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 137860,
+        "missed" : 1083961,
+        "ratio" : 0.112832,
+        "total" : 1221821
+      },
+      "line" : {
+        "covered" : 32589,
+        "missed" : 228568,
+        "ratio" : 0.124787,
+        "total" : 261157
+      },
+      "method" : {
+        "covered" : 9425,
+        "missed" : 58636,
+        "ratio" : 0.138479,
+        "total" : 68061
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#736

This PR provides new metadata needed for the com.hazelcast:hazelcast:5.3.0-BETA-1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.hazelcast:hazelcast:5.5.0`): 1240
- Metadata entries (new `com.hazelcast:hazelcast:5.3.0-BETA-1`): 7
- Library coverage (previous): 12.96%
- Library coverage (new): 12.48%
### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.hazelcast:hazelcast:5.5.0: 59/516 covered calls (11.43%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 53/520 covered calls (10.19%)

**Reflection:**
- com.hazelcast:hazelcast:5.5.0: 56/467 covered calls (11.99%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 50/475 covered calls (10.53%)

**Resources:**
- com.hazelcast:hazelcast:5.5.0: 3/49 covered calls (6.12%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 3/45 covered calls (6.67%)

#### Library coverage

**Instruction:**
- com.hazelcast:hazelcast:5.5.0: 136866/1158621 (11.81%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 137860/1221821 (11.28%)

**Line:**
- com.hazelcast:hazelcast:5.5.0: 33359/257308 (12.96%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 32589/261157 (12.48%)

**Method:**
- com.hazelcast:hazelcast:5.5.0: 9498/65587 (14.48%)
- com.hazelcast:hazelcast:5.3.0-BETA-1: 9425/68061 (13.85%)
