### PR TITLE
Add review skills for failure-fix PR labels

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -21,6 +21,16 @@ It encodes the historical approve/close/rerun logic for bulk tested-version upda
 Reviews pull requests with the `library-new-request` label.
 It covers new-library metadata PRs, including titles like `[GenAI] Add support for com.fasterxml:classmate:1.5.1 using gpt-5.4`, and encodes the review rules already used in this repository: reject scaffold-only tests, keep test packages separate from library packages so tests do not bypass visibility boundaries, and question metadata coverage claims that are not supported by the diff.
 
+### `review-fixes-javac-fail`
+
+Reviews pull requests with the `fixes-javac-fail` label.
+It covers compile-failure repair PRs for existing libraries and applies a lighter review than `library-new-request`: keep the diff scoped to the compile fix, preserve meaningful tests, and block regressions where dynamic-access coverage drops between the previously tested version and the new version.
+
+### `review-fixes-native-image-run-fail`
+
+Reviews pull requests with the `fixes-native-image-run-fail` label.
+It covers native-image runtime-failure repair PRs for existing libraries and applies a lighter review than `library-new-request`: verify the native path is fixed rather than skipped, keep metadata and test changes scoped, and block regressions where dynamic-access coverage drops between the previously tested version and the new version.
+
 ### `close-new-library-support-pr`
 
 Closes new-library support pull requests.

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -13,7 +13,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 ## Review Principles
 
 - Confirm the PR has label `fixes-javac-fail`.
-- Expect compile-focused changes: test source updates, imports, renamed APIs, dependency adjustments, or metadata index changes needed to test the newer library version.
+- Expect compile-focused changes plus the normal generated support files for the newly tested version: test source updates, imports, renamed APIs, dependency adjustments, a new metadata-version directory, stats, and metadata index changes.
 - Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
 - Do not accept changes that remove meaningful test coverage just to make `javac` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
@@ -28,11 +28,14 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - Gather files, reviews, inline comments, and CI checks.
 
 2. Validate the diff scope.
-   - Expected files are usually limited to:
+   - Expected files are usually limited to the target coordinate's generated new-version support:
+     - `metadata/<group>/<artifact>/<new-version>/reachability-metadata.json`
      - `metadata/<group>/<artifact>/index.json`
-     - `tests/src/<group>/<artifact>/<version>/**`
-     - metadata files for the same target coordinate when the compile fix also requires metadata maintenance
+     - `stats/<group>/<artifact>/<new-version>/stats.json`
+     - `tests/src/<group>/<artifact>/<new-version>/**`
    - Accept compatibility edits that keep one test source working across multiple tested versions.
+   - Treat a new `reachability-metadata.json` for the tested version as normal for this label, including `{}` when validation and stats are coherent.
+   - Treat generated test project files such as `.gitignore`, `build.gradle`, `gradle.properties`, `settings.gradle`, and `user-code-filter.json` as normal when they live under the target version's test directory.
    - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
    - Reject or request changes if the PR removes tests, disables test classes, or drops assertions without replacing equivalent coverage.
 

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: review-fixes-javac-fail
+description: Review pull requests with the `fixes-javac-fail` label in graalvm-reachability-metadata. Use when asked to review or triage a PR that fixes Java compilation failures for an existing library version update. Focus on validating the compile fix, keeping the diff scoped, and ensuring dynamic-access coverage does not drop between the previously tested version and the new version.
+argument-hint: "[pr-number-or-url]"
+---
+
+# Review `fixes-javac-fail` PRs
+
+These PRs repair test sources or test dependencies after an existing library is bumped and the new version no longer compiles with the old test code. Review them more lightly than `library-new-request` PRs: the library already exists, so the goal is to preserve working coverage across the version update rather than prove a brand-new metadata contribution from scratch.
+
+The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
+
+## Review Principles
+
+- Confirm the PR has label `fixes-javac-fail`.
+- Expect compile-focused changes: test source updates, imports, renamed APIs, dependency adjustments, or metadata index changes needed to test the newer library version.
+- Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
+- Do not accept changes that remove meaningful test coverage just to make `javac` pass.
+- Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
+- Prefer small, targeted review comments. This label is for repair work, not a full redesign of historical tests.
+
+## Workflow
+
+1. Inspect the PR summary.
+   - Resolve the target PR from the optional argument, or infer it from context when possible.
+   - Confirm the PR has label `fixes-javac-fail`.
+   - Identify the target coordinate, the previous tested version, and the new tested version from the PR body, title, changed `index.json`, and changed test path.
+   - Gather files, reviews, inline comments, and CI checks.
+
+2. Validate the diff scope.
+   - Expected files are usually limited to:
+     - `metadata/<group>/<artifact>/index.json`
+     - `tests/src/<group>/<artifact>/<version>/**`
+     - metadata files for the same target coordinate when the compile fix also requires metadata maintenance
+   - Accept compatibility edits that keep one test source working across multiple tested versions.
+   - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject or request changes if the PR removes tests, disables test classes, or drops assertions without replacing equivalent coverage.
+
+3. Review the compile fix.
+   - Confirm the edit addresses the actual Java compilation failure, such as renamed classes, changed method signatures, module boundaries, annotation processors, or dependency coordinates.
+   - Compatibility branches are acceptable when they keep older and newer tested versions covered by the same test.
+   - Version-specific logic is acceptable when the upstream API genuinely changed, but it should be narrow and documented by the code structure or assertions.
+   - Do not require the stricter `library-new-request` rules about scaffold-only tests or test package placement unless the PR is also adding a new library.
+
+4. Check dynamic-access coverage across versions.
+   - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
+   - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
+   - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
+   - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
+
+5. Check CI before deciding.
+   - Expected minimum: `compileTestJava` or equivalent changed-metadata compile checks are green for the target coordinate.
+   - Prefer seeing the full target `test` lane green because a compile fix can still reduce runtime or native coverage.
+   - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
+   - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
+
+## Decision Rules
+
+Approve when all of these are true:
+
+- The PR is scoped to the target existing library and the compile failure it fixes.
+- Tests still exercise the same meaningful library behavior after the compile repair.
+- Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
+- Required compile and metadata test checks are green.
+
+Request changes when any of these are true:
+
+- The fix makes compilation pass by deleting tests, removing assertions, skipping native-image execution, or bypassing the library behavior.
+- Dynamic-access coverage drops without a credible explanation and replacement coverage.
+- The diff includes unrelated libraries, workflow/build changes, or broad refactors that are not needed for the compile fix.
+- CI failures indicate the compile problem is not actually fixed.
+
+Ask for follow-up instead of rejecting when:
+
+- Stats needed for the old/new version comparison are missing or stale.
+- CI failed in a way that looks like infrastructure noise.
+- The API change is plausible but the PR does not explain why a coverage drop is expected.
+
+## Output Style
+
+Keep comments short and factual:
+
+- For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
+- For deleted coverage: say that the PR fixes compilation by removing coverage and should instead adapt the test to the new API.
+- For unrelated changes: say the PR should stay scoped to the `fixes-javac-fail` repair and remove unrelated files.
+- For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -17,6 +17,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
 - Do not accept changes that remove meaningful test coverage just to make `javac` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
+- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the generated metadata no longer covers the same runtime surface.
 - Prefer small, targeted review comments. This label is for repair work, not a full redesign of historical tests.
 
 ## Workflow
@@ -52,7 +53,14 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
-5. Check CI before deciding.
+5. Compare metadata entry counts.
+   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
+   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
+   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
+   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/package change.
+
+6. Check CI before deciding.
    - Expected minimum: `compileTestJava` or equivalent changed-metadata compile checks are green for the target coordinate.
    - Prefer seeing the full target `test` lane green because a compile fix can still reduce runtime or native coverage.
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
@@ -65,12 +73,14 @@ Approve when all of these are true:
 - The PR is scoped to the target existing library and the compile failure it fixes.
 - Tests still exercise the same meaningful library behavior after the compile repair.
 - Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
+- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API surface.
 - Required compile and metadata test checks are green.
 
 Request changes when any of these are true:
 
 - The fix makes compilation pass by deleting tests, removing assertions, skipping native-image execution, or bypassing the library behavior.
 - Dynamic-access coverage drops without a credible explanation and replacement coverage.
+- Metadata entry count drops substantially without a credible explanation.
 - The diff includes unrelated libraries, workflow/build changes, or broad refactors that are not needed for the compile fix.
 - CI failures indicate the compile problem is not actually fixed.
 
@@ -79,12 +89,14 @@ Ask for follow-up instead of rejecting when:
 - Stats needed for the old/new version comparison are missing or stale.
 - CI failed in a way that looks like infrastructure noise.
 - The API change is plausible but the PR does not explain why a coverage drop is expected.
+- Metadata entry counts differ substantially but the changed upstream API surface makes the reduction plausible.
 
 ## Output Style
 
 Keep comments short and factual:
 
 - For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
+- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For deleted coverage: say that the PR fixes compilation by removing coverage and should instead adapt the test to the new API.
 - For unrelated changes: say the PR should stay scoped to the `fixes-javac-fail` repair and remove unrelated files.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -17,6 +17,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Be more relaxed than `library-new-request`: do not reject only because a test is inherited from older support, uses compatibility branches, or keeps an existing package layout.
 - Do not accept fixes that hide the failing native path by skipping assertions, skipping native-image runtime execution, or weakening the test until the failure disappears.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
+- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the native-image fix no longer covers the same runtime surface.
 - Prefer concrete evidence from native run output, generated metadata, stats, and CI over style objections.
 
 ## Workflow
@@ -54,7 +55,14 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
-5. Check CI before deciding.
+5. Compare metadata entry counts.
+   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
+   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
+   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
+   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/package change.
+
+6. Check CI before deciding.
    - Expected minimum: native-image compile and native test execution are green for the target coordinate.
    - Metadata validation and Java tests should also pass for the changed coordinate.
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
@@ -67,12 +75,14 @@ Approve when all of these are true:
 - The PR is scoped to the target existing library and the native-image runtime failure it fixes.
 - The native-image runtime path still executes meaningful library behavior.
 - Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
+- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API surface.
 - Required metadata, Java, native-image compile, and native-image run checks are green.
 
 Request changes when any of these are true:
 
 - The fix makes native execution pass by skipping the failing native path, disabling assertions, or removing coverage.
 - Dynamic-access coverage drops without a credible explanation and replacement coverage.
+- Metadata entry count drops substantially without a credible explanation.
 - Metadata additions are unrelated to the failure or affect other libraries without justification.
 - CI failures indicate the native-image runtime problem is not actually fixed.
 
@@ -81,12 +91,14 @@ Ask for follow-up instead of rejecting when:
 - Stats needed for the old/new version comparison are missing or stale.
 - CI failed in a way that looks like infrastructure noise.
 - The API or native runtime change is plausible but the PR does not explain why a coverage drop is expected.
+- Metadata entry counts differ substantially but the changed upstream API surface makes the reduction plausible.
 
 ## Output Style
 
 Keep comments short and factual:
 
 - For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
+- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For native skips: say that the PR avoids the failing native path instead of fixing it, so it does not demonstrate native-image runtime coverage.
 - For unrelated changes: say the PR should stay scoped to the `fixes-native-image-run-fail` repair and remove unrelated files.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -31,8 +31,10 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - Expected files are usually limited to:
      - `metadata/<group>/<artifact>/<version>/reachability-metadata.json`
      - `metadata/<group>/<artifact>/index.json`
+     - `stats/<group>/<artifact>/<version>/stats.json`
      - `tests/src/<group>/<artifact>/<version>/**`
      - allowed Docker image entries or test resources only when the native test requires them
+   - Treat generated test project files such as `.gitignore`, `build.gradle`, `gradle.properties`, `settings.gradle`, and `user-code-filter.json` as normal when they live under the target version's test directory.
    - Accept metadata additions that are necessary for the new upstream version.
    - Accept narrow test edits that keep the same behavior covered across old and new versions.
    - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: review-fixes-native-image-run-fail
+description: Review pull requests with the `fixes-native-image-run-fail` label in graalvm-reachability-metadata. Use when asked to review or triage a PR that fixes a native-image runtime failure for an existing library version update. Focus on validating the runtime/native fix, keeping the diff scoped, and ensuring dynamic-access coverage does not drop between the previously tested version and the new version.
+argument-hint: "[pr-number-or-url]"
+---
+
+# Review `fixes-native-image-run-fail` PRs
+
+These PRs repair metadata or tests after an existing library version compiles and builds a native image, but the native image fails when the test runs. Review them more lightly than `library-new-request` PRs: the library is already supported, so the goal is to restore native-image behavior for a newer version while preserving existing dynamic-access coverage.
+
+The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
+
+## Review Principles
+
+- Confirm the PR has label `fixes-native-image-run-fail`.
+- Expect targeted metadata, resource, proxy, serialization, JNI, initialization, or test adjustments that make the native executable run successfully for the new version.
+- Be more relaxed than `library-new-request`: do not reject only because a test is inherited from older support, uses compatibility branches, or keeps an existing package layout.
+- Do not accept fixes that hide the failing native path by skipping assertions, skipping native-image runtime execution, or weakening the test until the failure disappears.
+- Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
+- Prefer concrete evidence from native run output, generated metadata, stats, and CI over style objections.
+
+## Workflow
+
+1. Inspect the PR summary.
+   - Resolve the target PR from the optional argument, or infer it from context when possible.
+   - Confirm the PR has label `fixes-native-image-run-fail`.
+   - Identify the target coordinate, the previous tested version, and the new tested version from the PR body, title, changed `index.json`, metadata path, and test path.
+   - Gather files, reviews, inline comments, and CI checks.
+
+2. Validate the diff scope.
+   - Expected files are usually limited to:
+     - `metadata/<group>/<artifact>/<version>/reachability-metadata.json`
+     - `metadata/<group>/<artifact>/index.json`
+     - `tests/src/<group>/<artifact>/<version>/**`
+     - allowed Docker image entries or test resources only when the native test requires them
+   - Accept metadata additions that are necessary for the new upstream version.
+   - Accept narrow test edits that keep the same behavior covered across old and new versions.
+   - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject or request changes if the PR fixes the native run by disabling the failing behavior.
+
+3. Review the native-image fix.
+   - Confirm the metadata or test change matches the observed native runtime failure, such as missing reflection, resources, proxies, serialization constructors, JNI access, or class initialization behavior.
+   - Metadata additions should be specific enough to the target library behavior; do not require hand-minimized entries when generated metadata is coherent and validation passes.
+   - Test changes are acceptable when the upstream API or runtime behavior changed, but they must still exercise the native path that previously failed.
+   - Do not require the stricter `library-new-request` rules about scaffold-only tests or test package placement unless the PR is also adding a new library.
+
+4. Check dynamic-access coverage across versions.
+   - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
+   - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
+   - If metadata fixes make the native run pass but the dynamic-access ratio drops, ask for restored coverage first. Passing native execution is not enough by itself.
+   - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
+   - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
+
+5. Check CI before deciding.
+   - Expected minimum: native-image compile and native test execution are green for the target coordinate.
+   - Metadata validation and Java tests should also pass for the changed coordinate.
+   - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
+   - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
+
+## Decision Rules
+
+Approve when all of these are true:
+
+- The PR is scoped to the target existing library and the native-image runtime failure it fixes.
+- The native-image runtime path still executes meaningful library behavior.
+- Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
+- Required metadata, Java, native-image compile, and native-image run checks are green.
+
+Request changes when any of these are true:
+
+- The fix makes native execution pass by skipping the failing native path, disabling assertions, or removing coverage.
+- Dynamic-access coverage drops without a credible explanation and replacement coverage.
+- Metadata additions are unrelated to the failure or affect other libraries without justification.
+- CI failures indicate the native-image runtime problem is not actually fixed.
+
+Ask for follow-up instead of rejecting when:
+
+- Stats needed for the old/new version comparison are missing or stale.
+- CI failed in a way that looks like infrastructure noise.
+- The API or native runtime change is plausible but the PR does not explain why a coverage drop is expected.
+
+## Output Style
+
+Keep comments short and factual:
+
+- For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
+- For native skips: say that the PR avoids the failing native path instead of fixing it, so it does not demonstrate native-image runtime coverage.
+- For unrelated changes: say the PR should stay scoped to the `fixes-native-image-run-fail` repair and remove unrelated files.
+- For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -33,6 +33,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
    - Expected files are usually limited to:
      - `metadata/<group>/<artifact>/<version>/reachability-metadata.json`
      - `metadata/<group>/<artifact>/index.json`
+     - `stats/<group>/<artifact>/<new-version>/stats.json`
      - `tests/src/<group>/<artifact>/<version>/**`
    - Be suspicious of changes to build logic, workflows, unrelated libraries, generated sources outside the target test directory, or wide refactors.
    - Treat extra `metadata/**` or `tests/src/**` trees for other coordinates as a blocking scope violation, not as a minor cleanup issue.


### PR DESCRIPTION
## Summary

This PR adds two review skills for existing-library failure-fix PR labels:

- `review-fixes-javac-fail` for PRs that repair Java compilation failures after a tested version update.
- `review-fixes-native-image-run-fail` for PRs that repair native-image runtime failures after a tested version update.

Both skills are intentionally more relaxed than `review-library-new-request`, because these PRs usually update or repair support for an already supported library rather than introducing a brand-new library from scratch.

## Review behavior added

The new skills guide reviewers to:

- Confirm the PR has the expected label and stays scoped to the target existing library/version.
- Allow normal generated files for version-update repair PRs, including metadata, index, stats, generated test project files, and narrow test resources when needed.
- Reject fixes that hide the failing path by skipping compilation, skipping native execution, weakening assertions, or disabling the behavior under test.
- Treat dynamic-access coverage preservation as the main quality gate between the previous metadata version and the new metadata version.
- Compare metadata entry counts between versions and flag large unexplained drops, while allowing small differences or credible upstream API/runtime-surface changes.
- Require the relevant CI checks for metadata validation, Java compilation, native-image compile, and native-image runtime execution before accepting.

## Rationale

The existing new-library review guidance is too strict for `fixes-javac-fail` and `fixes-native-image-run-fail` PRs. Those PRs often reuse existing tests and add generated metadata for a newer library version, so the important review question is whether the repair preserves meaningful coverage and keeps the dynamic-access surface from regressing unexpectedly.

Fixes: #1961
