### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0 using gpt-5.4

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/reachability-metadata.json
@@ -1,0 +1,13 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.17.0",
+    "tested-versions" : [
+      "2.17.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
+    ]
+  },
+  {
     "metadata-version" : "2.13.4",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.13.4/jackson-jr-objects-2.13.4-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jr",

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.17.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.17.0/jackson-jr-objects-2.17.0-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-2.17.0/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.17.0/jackson-jr-objects-2.17.0-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrapper types, arrays, and Java beans, and for writing those values back as JSON. It builds on jackson-core with minimal dependencies and provides immutable JSON entry points plus builder-style composer APIs for direct JSON output.",
     "tested-versions" : [
       "2.17.0"
     ],

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/stats.json
@@ -1,0 +1,32 @@
+{
+  "versions" : [ {
+    "version" : "2.17.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 16
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 16
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4596,
+        "missed" : 7891,
+        "ratio" : 0.368063,
+        "total" : 12487
+      },
+      "line" : "N/A",
+      "method" : {
+        "covered" : 255,
+        "missed" : 411,
+        "ratio" : 0.382883,
+        "total" : 666
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jr:jackson-jr-objects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0
+library.version = 2.17.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jr.jackson-jr-objects_tests'

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @BeforeEach
+    void resetConstructorCounters() {
+        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,9 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +23,31 @@ public class BeanConstructorsDynamicAccessTest {
     void resetConstructorCounters() {
         PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
         PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
+        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+
+        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+        constructors.forceAccess();
+
+        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
@@ -38,6 +65,16 @@ public class BeanConstructorsDynamicAccessTest {
 
         assertThat(bean.name).isEqualTo("Ada");
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        Object createBean() throws Exception {
+            return create();
+        }
     }
 
     public static final class PublicDefaultCtorBean {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyIntrospectorDynamicAccessTest {
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
+
+    @Test
+    void collectsDeclaredConstructorsForDeserialization() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+
+        assertThat(definition.defaultCtor).isNotNull();
+        assertThat(definition.stringCtor).isNotNull();
+        assertThat(definition.longCtor).isNotNull();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+    }
+
+    @Test
+    void collectsDeclaredFieldsAndMethodsForSerialization() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
+
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class BaseBean {
+        public int visible;
+    }
+
+    static final class IntrospectedBean extends BaseBean {
+        private String name;
+        private boolean active;
+
+        private IntrospectedBean() {
+        }
+
+        private IntrospectedBean(String name) {
+            this.name = name;
+        }
+
+        private IntrospectedBean(long visible) {
+            this.visible = (int) visible;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
@@ -30,6 +31,7 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     @Test
     void collectsDeclaredConstructorsForDeserialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
 
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
@@ -37,7 +39,9 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
 
         assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
         assertThat(objectBean.getName()).isEqualTo("Ada");
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
@@ -48,9 +52,14 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
         String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
         assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -8,6 +8,7 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.List;
 
+import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
@@ -22,22 +23,35 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
     private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
     private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON_WITH_FORCE_ACCESS.with(
+            JSON.Feature.USE_FIELD_MATCHING_GETTERS);
 
     @Test
-    void collectsDeclaredConstructorsForDeserialization() {
+    void collectsDeclaredConstructorsForDeserialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
 
-        assertThat(definition.defaultCtor).isNotNull();
-        assertThat(definition.stringCtor).isNotNull();
-        assertThat(definition.longCtor).isNotNull();
+        IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
+                "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
+        IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+
+        assertThat(definition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(objectBean.getName()).isEqualTo("Ada");
+        assertThat(objectBean.isActive()).isTrue();
+        assertThat(objectBean.visible).isEqualTo(7);
+        assertThat(stringBean.getName()).isEqualTo("Ada");
+        assertThat(longBean.visible).isEqualTo(7);
     }
 
     @Test
-    void collectsDeclaredFieldsAndMethodsForSerialization() {
+    void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");
         POJODefinition.Prop name = property(definition, "name");
@@ -48,6 +62,13 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(name.setter).isNotNull();
         assertThat(active.isGetter).isNotNull();
         assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
+
+        assertThat(json).contains("\"title\":\"Ada\"");
     }
 
     private static List<String> propertyNames(POJODefinition definition) {
@@ -80,6 +101,14 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.visible = (int) visible;
         }
 
+        static IntrospectedBean create(String name, boolean active, int visible) {
+            IntrospectedBean bean = new IntrospectedBean();
+            bean.name = name;
+            bean.active = active;
+            bean.visible = visible;
+            return bean;
+        }
+
         public String getName() {
             return name;
         }
@@ -94,6 +123,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         public void setActive(boolean active) {
             this.active = active;
+        }
+    }
+
+    static final class FieldNamedGetterBean {
+        private final String title;
+
+        FieldNamedGetterBean(String title) {
+            this.title = title;
+        }
+
+        public String title() {
+            return title;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.awt.Point;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void populatesFieldBackedJdkBeanProperties() throws Exception {
+        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(point.x).isEqualTo(3);
+        assertThat(point.y).isEqualTo(4);
+    }
+
+    @Test
+    void populatesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class PublicSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public PublicSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class SetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public SetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -6,8 +6,6 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.awt.Point;
-
 import com.fasterxml.jackson.jr.ob.JSON;
 import org.junit.jupiter.api.Test;
 
@@ -17,16 +15,26 @@ public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void populatesFieldBackedJdkBeanProperties() throws Exception {
-        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
+    void populatesFieldBackedBeanProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
 
-        assertThat(point.x).isEqualTo(3);
-        assertThat(point.y).isEqualTo(4);
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
     }
 
     @Test
     void populatesPublicSetterBackedProperties() throws Exception {
         PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFluentSetterBackedProperties() throws Exception {
+        FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
                 "{\"name\":\"Ada\"}");
 
         assertThat(bean.getName()).isEqualTo("Ada");
@@ -40,6 +48,20 @@ public class BeanPropertyReaderDynamicAccessTest {
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class FieldBackedReaderBean {
+        private boolean constructed;
+        public int x;
+        public int y;
+
+        public FieldBackedReaderBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
     }
 
     public static final class PublicSetterBackedReaderBean {
@@ -60,6 +82,28 @@ public class BeanPropertyReaderDynamicAccessTest {
         public void setName(String name) {
             this.name = name;
             setterCalls++;
+        }
+    }
+
+    public static final class FluentSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public FluentSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public FluentSetterBackedReaderBean setName(String name) {
+            this.name = name;
+            setterCalls++;
+            return this;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,12 +7,36 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
 
     @Test
     void populatesFieldBackedBeanProperties() throws Exception {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -7,12 +7,32 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void readsFieldBackedValuesThroughBeanPropertyWriter() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id",
+                FieldBackedWriterBean.class.getField("id"), null);
+        FieldBackedWriterBean bean = new FieldBackedWriterBean();
+
+        assertThat(writer.getValueFor(bean)).isEqualTo(3);
+    }
+
+    @Test
+    void invokesGetterBackedValuesThroughBeanPropertyWriter() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null,
+                GetterBackedWriterBean.class.getMethod("getName"));
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+
+        assertThat(writer.getValueFor(bean)).isEqualTo("Ada");
+        assertThat(bean.getGetterCalls()).isEqualTo(1);
+    }
 
     @Test
     void serializesFieldBackedProperties() throws Exception {
@@ -23,9 +43,11 @@ public class BeanPropertyWriterDynamicAccessTest {
 
     @Test
     void serializesGetterBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+        String json = JSON_WITH_FORCE_ACCESS.asString(bean);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getGetterCalls()).isEqualTo(1);
     }
 
     public static final class FieldBackedWriterBean {
@@ -33,13 +55,19 @@ public class BeanPropertyWriterDynamicAccessTest {
     }
 
     public static final class GetterBackedWriterBean {
+        private int getterCalls;
         private String name;
 
         public GetterBackedWriterBean(String name) {
             this.name = name;
         }
 
+        public int getGetterCalls() {
+            return getterCalls;
+        }
+
         public String getName() {
+            getterCalls++;
             return name;
         }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -7,36 +7,21 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-
-    @Test
-    void readsFieldBackedValuesThroughBeanPropertyWriter() throws Exception {
-        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id",
-                FieldBackedWriterBean.class.getField("id"), null);
-        FieldBackedWriterBean bean = new FieldBackedWriterBean();
-
-        assertThat(writer.getValueFor(bean)).isEqualTo(3);
-    }
-
-    @Test
-    void invokesGetterBackedValuesThroughBeanPropertyWriter() throws Exception {
-        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null,
-                GetterBackedWriterBean.class.getMethod("getName"));
-        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
-
-        assertThat(writer.getValueFor(bean)).isEqualTo("Ada");
-        assertThat(bean.getterCalls()).isEqualTo(1);
-    }
+    private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.USE_FIELDS);
+    private static final JSON JSON_WITH_GETTER_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.WRITE_READONLY_BEAN_PROPERTIES);
 
     @Test
     void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
 
         assertThat(json).isEqualTo("{\"id\":3}");
     }
@@ -44,10 +29,10 @@ public class BeanPropertyWriterDynamicAccessTest {
     @Test
     void serializesGetterBackedProperties() throws Exception {
         GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
-        String json = JSON_WITH_FORCE_ACCESS.asString(bean);
+        String json = JSON_WITH_GETTER_ACCESS.asString(bean);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
-        assertThat(bean.getterCalls()).isEqualTo(1);
+        assertThat(bean.getterCalls).isEqualTo(1);
     }
 
     public static final class FieldBackedWriterBean {
@@ -56,23 +41,15 @@ public class BeanPropertyWriterDynamicAccessTest {
 
     public static final class GetterBackedWriterBean {
         private int getterCalls;
-        private String name;
+        private final String name;
 
         public GetterBackedWriterBean(String name) {
             this.name = name;
         }
 
-        private int getterCalls() {
-            return getterCalls;
-        }
-
         public String getName() {
             getterCalls++;
             return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyWriterDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void serializesFieldBackedProperties() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+
+        assertThat(json).isEqualTo("{\"id\":3}");
+    }
+
+    @Test
+    void serializesGetterBackedProperties() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+
+        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+    }
+
+    public static final class GetterBackedWriterBean {
+        private String name;
+
+        public GetterBackedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -31,7 +31,7 @@ public class BeanPropertyWriterDynamicAccessTest {
         GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
 
         assertThat(writer.getValueFor(bean)).isEqualTo("Ada");
-        assertThat(bean.getGetterCalls()).isEqualTo(1);
+        assertThat(bean.getterCalls()).isEqualTo(1);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class BeanPropertyWriterDynamicAccessTest {
         String json = JSON_WITH_FORCE_ACCESS.asString(bean);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
-        assertThat(bean.getGetterCalls()).isEqualTo(1);
+        assertThat(bean.getterCalls()).isEqualTo(1);
     }
 
     public static final class FieldBackedWriterBean {
@@ -62,7 +62,7 @@ public class BeanPropertyWriterDynamicAccessTest {
             this.name = name;
         }
 
-        public int getGetterCalls() {
+        private int getterCalls() {
             return getterCalls;
         }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.ClassKey;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
+        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+
+        assertThat(key).isNotNull();
+        assertThat(key.hashCode()).isZero();
+    }
+
+    @Test
+    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
+                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+
+        assertThat(reference.getFrom()).isEqualTo("source");
+        assertThat(reference.getFieldName()).isEqualTo("name");
+        assertThat(reference.getIndex()).isEqualTo(2);
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -7,8 +7,6 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.JSONObjectException;
-import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,20 +15,45 @@ public class BeanReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
-        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
 
-        assertThat(key).isNotNull();
-        assertThat(key.hashCode()).isZero();
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
     }
 
     @Test
-    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
-                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
 
-        assertThat(reference.getFrom()).isEqualTo("source");
-        assertThat(reference.getFieldName()).isEqualTo("name");
-        assertThat(reference.getIndex()).isEqualTo(2);
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionBuilderDynamicAccessTest {
+    @Test
+    void createsEmptyTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray((Class) elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray((Class) elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    private static Class<?> runtimeArrayElementType() throws Exception {
+        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    public static final class ArrayElement {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -7,13 +7,53 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
     @Test
-    void readsEmptyTypedArrays() throws Exception {
+    void createsEmptyTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray(elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
 
         Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
@@ -24,7 +64,7 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
-    void readsSingletonTypedArrays() throws Exception {
+    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
 
         Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
@@ -35,7 +75,7 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
-    void readsMultiValueTypedArrays() throws Exception {
+    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
 
         Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
@@ -46,12 +86,23 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @SuppressWarnings("unchecked")
+    private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
+        return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
     private static Class<String> runtimeStringType() throws Exception {
         return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
     }
 
     public static final class ArrayElement {
-        private ArrayElement() {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -7,63 +7,51 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
     @Test
-    void createsEmptyTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsEmptyTypedArrays() throws Exception {
+        Class<String> elementType = runtimeStringType();
 
-        Object[] values = builder.emptyArray((Class) elementType);
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
 
         assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(String[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
     @Test
-    void createsSingletonTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsSingletonTypedArrays() throws Exception {
+        Class<String> elementType = runtimeStringType();
 
-        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
 
-        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values).containsExactly("solo");
+        assertThat(values).isInstanceOf(String[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
     @Test
-    void createsMultiValueTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsMultiValueTypedArrays() throws Exception {
+        Class<String> elementType = runtimeStringType();
 
-        Object[] values = builder.start()
-                .add(new ArrayElement("left"))
-                .add(new ArrayElement("right"))
-                .buildArray((Class) elementType);
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
 
-        assertThat(values).hasSize(2);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
-        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values).isInstanceOf(String[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
-    private static Class<?> runtimeArrayElementType() throws Exception {
-        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    @SuppressWarnings("unchecked")
+    private static Class<String> runtimeStringType() throws Exception {
+        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
     }
 
     public static final class ArrayElement {
-        public String name;
-
-        public ArrayElement() {
-        }
-
-        public ArrayElement(String name) {
-            this.name = name;
+        private ArrayElement() {
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -8,47 +8,60 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapBuilderDefaultDynamicAccessTest {
+    @BeforeEach
+    void resetConstructorCalls() {
+        ConstructorTrackingMap.CONSTRUCTOR_CALLS.set(0);
+    }
+
     @Test
     void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
 
         Map<String, Object> counts = builder.start()
                 .put("alpha", 1)
                 .put("beta", 2)
                 .build();
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
     void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
 
         Map<String, Object> counts = builder.emptyMap();
 
-        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
     void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
 
         Map<String, Object> counts = builder.singletonMap("only", 99);
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
-    public static final class CountsMap extends LinkedHashMap<String, Object> {
-        public CountsMap() {
+    public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public ConstructorTrackingMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -10,11 +10,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -23,13 +25,8 @@ public class MapBuilderDefaultDynamicAccessTest {
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
-
-        Map<String, Object> counts = builder.start()
-                .put("alpha", 1)
-                .put("beta", 2)
-                .build();
+    void readsMultiEntryJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"alpha\":1,\"beta\":2}");
 
         assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
@@ -37,24 +34,45 @@ public class MapBuilderDefaultDynamicAccessTest {
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
-
-        Map<String, Object> counts = builder.emptyMap();
+    void readsEmptyJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{}");
 
         assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
-
-        Map<String, Object> counts = builder.singletonMap("only", 99);
+    void readsSingletonJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"only\":99}");
 
         assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("only", 99);
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
+        MapBuilder builder = configuredMapBuilder();
+
+        Map<String, Object> counts = builder.start()
+                .put("discarded", true)
+                .start()
+                .put("kept", true)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsOnly(entry("kept", true));
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    private static JSON jsonWithConfiguredMaps() {
+        return JSON.builder()
+                .mapBuilder(configuredMapBuilder())
+                .build();
+    }
+
+    private static MapBuilder configuredMapBuilder() {
+        return MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
     }
 
     public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -61,7 +60,9 @@ public class MapBuilderDefaultDynamicAccessTest {
                 .build();
 
         assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
-        assertThat(counts).containsOnly(entry("kept", true));
+        assertThat(counts).hasSize(1);
+        assertThat(counts).containsEntry("kept", true);
+        assertThat(counts).doesNotContainKey("discarded");
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBuilderDefaultDynamicAccessTest {
+    @Test
+    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.start()
+                .put("alpha", 1)
+                .put("beta", 2)
+                .build();
+
+        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.emptyMap();
+
+        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).containsEntry("only", 99);
+    }
+
+    public static final class CountsMap extends LinkedHashMap<String, Object> {
+        public CountsMap() {
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -17,41 +17,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SimpleValueReaderDynamicAccessTest {
     @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved.getName()).isEqualTo(className);
+        assertThat(resolved).isEqualTo(LoadableType.class);
     }
 
     @Test
     void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type.getName()).isEqualTo(className);
+        assertThat(holder.type).isEqualTo(LoadableType.class);
     }
 
     @Test
     void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
                 "{\"primary\":\"" + className + "\"}");
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
-        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
+        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
     }
 
-    private static String runtimeJdkClassName() {
-        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    private static String loadableClassName() {
+        return LoadableType.class.getName();
     }
 
     public static final class TypeHolder {
         public Class<?> type;
+    }
+
+    public static final class LoadableType {
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void resolvesTopLevelClassesFromStringValues() throws Exception {
+        String className = runtimeJdkClassName();
+
+        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+
+        assertThat(resolved.getName()).isEqualTo(className);
+    }
+
+    @Test
+    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
+        String className = runtimeJdkClassName();
+
+        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
+                "{\"type\":\"" + className + "\"}");
+
+        assertThat(holder.type.getName()).isEqualTo(className);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
+        String className = runtimeJdkClassName();
+
+        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
+                "{\"primary\":\"" + className + "\"}");
+        List<Class> classes = JSON.std.listOfFrom(Class.class,
+                "[\"" + className + "\"]");
+
+        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
+        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+    }
+
+    private static String runtimeJdkClassName() {
+        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    }
+
+    public static final class TypeHolder {
+        public Class<?> type;
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -48,7 +48,9 @@ public class SimpleValueReaderDynamicAccessTest {
     }
 
     private static String loadableClassName() {
-        return LoadableType.class.getName();
+        String propertyName = "simple.value.reader.class." + System.nanoTime();
+        System.setProperty(propertyName, LoadableType.class.getName());
+        return System.getProperty(propertyName);
     }
 
     public static final class TypeHolder {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -18,16 +18,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
     @Test
-    void resolvesSyntheticGenericArrayTypesFromResolvedComponentTypes() {
+    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
         TypeResolver resolver = new TypeResolver();
-        ResolvedType stringType = resolver.resolve(TypeBindings.emptyBindings(), String.class);
-        GenericArrayType genericArrayType = new SyntheticGenericArrayType(stringType);
+        Object runtimeComponentValue = runtimeComponentValue();
+        Class<?> componentClass = runtimeComponentValue.getClass();
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
 
         ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType()).isEqualTo(stringType);
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
     }
 
     @Test
@@ -60,6 +62,13 @@ public class TypeResolverDynamicAccessTest {
     }
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    private static Object runtimeComponentValue() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return Integer.valueOf(7);
+        }
+        return Thread.currentThread().getName();
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.type.ResolvedType;
+import com.fasterxml.jackson.jr.type.TypeBindings;
+import com.fasterxml.jackson.jr.type.TypeResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType declaringType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                StringArrayContainer.class.getGenericSuperclass());
+        Type genericArrayType = GenericArrayContainer.class
+                .getDeclaredMethod("setValues", Object[].class)
+                .getGenericParameterTypes()[0];
+
+        ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
+    static class GenericArrayContainer<T> {
+        private T[] values;
+
+        public T[] getValues() {
+            return values;
+        }
+
+        public void setValues(T[] values) {
+            this.values = values;
+        }
+    }
+
+    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -11,11 +11,25 @@ import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesFromResolvedComponentTypes() {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType stringType = resolver.resolve(TypeBindings.emptyBindings(), String.class);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(stringType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(stringType);
+    }
+
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
@@ -23,8 +37,8 @@ public class TypeResolverDynamicAccessTest {
                 TypeBindings.emptyBindings(),
                 StringArrayContainer.class.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
-                .getDeclaredMethod("setValues", Object[].class)
-                .getGenericParameterTypes()[0];
+                .getDeclaredField("values")
+                .getGenericType();
 
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
@@ -46,5 +60,18 @@ public class TypeResolverDynamicAccessTest {
     }
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -32,6 +34,15 @@ public class ValueReaderLocatorDynamicAccessTest {
                 .beanFrom(Direction.class, "\"GO-SOUTH\"");
 
         assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitions() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
+
+        ValueReader reader = locator.findReader(Direction.class);
+
+        assertThat(reader).isNotNull();
     }
 
     private static JSON enumAwareJson(JSON.Feature... features) {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -23,25 +23,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ValueReaderLocatorDynamicAccessTest {
     @Test
     void readsEnumsFromModifierProvidedDefinitions() throws Exception {
-        ValueReaderLocatorDynamicAccessDirection direction = enumAwareJson()
-                .beanFrom(ValueReaderLocatorDynamicAccessDirection.class, "\"go-north\"");
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
 
-        assertThat(direction).isEqualTo(ValueReaderLocatorDynamicAccessDirection.NORTH);
+        assertThat(direction).isEqualTo(Direction.NORTH);
     }
 
     @Test
     void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
-        ValueReaderLocatorDynamicAccessDirection direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-                .beanFrom(ValueReaderLocatorDynamicAccessDirection.class, "\"GO-SOUTH\"");
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
 
-        assertThat(direction).isEqualTo(ValueReaderLocatorDynamicAccessDirection.SOUTH);
+        assertThat(direction).isEqualTo(Direction.SOUTH);
     }
 
     @Test
     void createsEnumReadersFromModifierProvidedDefinitions() {
         ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
 
-        ValueReader reader = locator.findReader(ValueReaderLocatorDynamicAccessDirection.class);
+        ValueReader reader = locator.findReader(Direction.class);
 
         assertThat(reader).isNotNull();
     }
@@ -53,6 +52,10 @@ public class ValueReaderLocatorDynamicAccessTest {
                 .build();
     }
 
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
 
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
@@ -64,10 +67,10 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != ValueReaderLocatorDynamicAccessDirection.class) {
+            if (pojoType != Direction.class) {
                 return null;
             }
-            return new POJODefinition(ValueReaderLocatorDynamicAccessDirection.class, enumProps(), null, null, null);
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -83,15 +86,10 @@ public class ValueReaderLocatorDynamicAccessTest {
 
         private static Field enumField(String enumConstantName) {
             try {
-                return ValueReaderLocatorDynamicAccessDirection.class.getField(enumConstantName);
+                return Direction.class.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }
         }
     }
-}
-
-enum ValueReaderLocatorDynamicAccessDirection {
-    NORTH,
-    SOUTH
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -23,24 +23,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ValueReaderLocatorDynamicAccessTest {
     @Test
     void readsEnumsFromModifierProvidedDefinitions() throws Exception {
-        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+        ValueReaderLocatorDynamicAccessDirection direction = enumAwareJson()
+                .beanFrom(ValueReaderLocatorDynamicAccessDirection.class, "\"go-north\"");
 
-        assertThat(direction).isEqualTo(Direction.NORTH);
+        assertThat(direction).isEqualTo(ValueReaderLocatorDynamicAccessDirection.NORTH);
     }
 
     @Test
     void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
-        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+        ValueReaderLocatorDynamicAccessDirection direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(ValueReaderLocatorDynamicAccessDirection.class, "\"GO-SOUTH\"");
 
-        assertThat(direction).isEqualTo(Direction.SOUTH);
+        assertThat(direction).isEqualTo(ValueReaderLocatorDynamicAccessDirection.SOUTH);
     }
 
     @Test
     void createsEnumReadersFromModifierProvidedDefinitions() {
         ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
 
-        ValueReader reader = locator.findReader(Direction.class);
+        ValueReader reader = locator.findReader(ValueReaderLocatorDynamicAccessDirection.class);
 
         assertThat(reader).isNotNull();
     }
@@ -52,10 +53,6 @@ public class ValueReaderLocatorDynamicAccessTest {
                 .build();
     }
 
-    public enum Direction {
-        NORTH,
-        SOUTH
-    }
 
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
@@ -67,10 +64,10 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != Direction.class) {
+            if (pojoType != ValueReaderLocatorDynamicAccessDirection.class) {
                 return null;
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            return new POJODefinition(ValueReaderLocatorDynamicAccessDirection.class, enumProps(), null, null, null);
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -86,10 +83,15 @@ public class ValueReaderLocatorDynamicAccessTest {
 
         private static Field enumField(String enumConstantName) {
             try {
-                return Direction.class.getField(enumConstantName);
+                return ValueReaderLocatorDynamicAccessDirection.class.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }
         }
     }
+}
+
+enum ValueReaderLocatorDynamicAccessDirection {
+    NORTH,
+    SOUTH
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueReaderLocatorDynamicAccessTest {
+    @Test
+    void readsEnumsFromModifierProvidedDefinitions() throws Exception {
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+
+        assertThat(direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+
+        assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    private static JSON enumAwareJson(JSON.Feature... features) {
+        return JSON.builder()
+                .enable(features)
+                .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
+
+    public static class EnumDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class EnumDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != Direction.class) {
+                return null;
+            }
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+        }
+
+        private static POJODefinition.Prop[] enumProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp("go-north", "NORTH"),
+                    enumProp("go-south", "SOUTH")
+            };
+        }
+
+        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(String enumConstantName) {
+            try {
+                return Direction.class.getField(enumConstantName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,164 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "fields" : [
+        {
+          "name" : "NORTH"
+        },
+        {
+          "name" : "SOUTH"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -155,6 +155,30 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -269,7 +269,7 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessDirection",
       "fields" : [
         {
           "name" : "NORTH"

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,31 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -155,7 +155,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
       "methods" : [
@@ -167,7 +167,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
       "methods" : [

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -261,6 +261,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -269,7 +269,7 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessDirection",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
       "fields" : [
         {
           "name" : "NORTH"

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,6 +4,38 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
       "methods" : [
         {
@@ -31,6 +63,38 @@
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean"
     },
     {
       "condition" : {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -109,7 +109,7 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$ConstructorTrackingMap",
       "methods" : [
         {
           "name" : "<init>",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jr.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2139

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 777278
- Cached input tokens: 10303616
- Output tokens: 138704
- Entries found: 4
- Iterations: 21
- Library coverage percentage: 36.81
- Previous library version metadata entries: 18
- Previous library version coverage percentage: 34.08

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `f550d5105dbb34e4d459df60fa657336450cde08`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)

**Reflection:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 4131/12120 (34.08%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 4596/12487 (36.81%)

**Line:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: N/A
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: N/A

**Method:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 235/648 (36.27%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 255/666 (38.29%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/gradle.properties 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/gradle.properties
index df92cc871d..c74a5dfc77 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/gradle.properties
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4
-library.version = 2.13.4
-metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0
+library.version = 2.17.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
new file mode 100644
index 0000000000..4b9e6fc27b
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -0,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @BeforeEach
+    void resetConstructorCounters() {
+        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
+        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+
+        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+        constructors.forceAccess();
+
+        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        Object createBean() throws Exception {
+            return create();
+        }
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
index bb54f90047..bd54ecaf2c 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -8,8 +8,10 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.List;
 
+import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
@@ -22,22 +24,43 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
     private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
     private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON_WITH_FORCE_ACCESS.with(
+            JSON.Feature.USE_FIELD_MATCHING_GETTERS);
 
     @Test
-    void collectsDeclaredConstructorsForDeserialization() {
+    void collectsDeclaredConstructorsForDeserialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
 
-        assertThat(definition.defaultCtor).isNotNull();
-        assertThat(definition.stringCtor).isNotNull();
-        assertThat(definition.longCtor).isNotNull();
+        IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
+                "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
+        IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(objectBean.getName()).isEqualTo("Ada");
+        assertThat(objectBean.isActive()).isTrue();
+        assertThat(objectBean.visible).isEqualTo(7);
+        assertThat(stringBean.getName()).isEqualTo("Ada");
+        assertThat(longBean.visible).isEqualTo(7);
     }
 
     @Test
-    void collectsDeclaredFieldsAndMethodsForSerialization() {
+    void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");
         POJODefinition.Prop name = property(definition, "name");
@@ -50,6 +73,13 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(active.setter).isNotNull();
     }
 
+    @Test
+    void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
+
+        assertThat(json).contains("\"title\":\"Ada\"");
+    }
+
     private static List<String> propertyNames(POJODefinition definition) {
         return definition.getProperties().stream().map(prop -> prop.name).toList();
     }
@@ -80,6 +110,14 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.visible = (int) visible;
         }
 
+        static IntrospectedBean create(String name, boolean active, int visible) {
+            IntrospectedBean bean = new IntrospectedBean();
+            bean.name = name;
+            bean.active = active;
+            bean.visible = visible;
+            return bean;
+        }
+
         public String getName() {
             return name;
         }
@@ -96,4 +134,16 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.active = active;
         }
     }
+
+    static final class FieldNamedGetterBean {
+        private final String title;
+
+        FieldNamedGetterBean(String title) {
+            this.title = title;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
index ff1af27cb8..ff55ef0382 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -6,9 +6,8 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.awt.Point;
-
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,11 +16,35 @@ public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void populatesFieldBackedJdkBeanProperties() throws Exception {
-        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldBackedBeanProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
 
-        assertThat(point.x).isEqualTo(3);
-        assertThat(point.y).isEqualTo(4);
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
     }
 
     @Test
@@ -33,6 +56,15 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
+    @Test
+    void populatesFluentSetterBackedProperties() throws Exception {
+        FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
     @Test
     void populatesPrivateSetterBackedProperties() throws Exception {
         SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
@@ -42,6 +74,20 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
+    public static final class FieldBackedReaderBean {
+        private boolean constructed;
+        public int x;
+        public int y;
+
+        public FieldBackedReaderBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
     public static final class PublicSetterBackedReaderBean {
         private String name;
         private int setterCalls;
@@ -63,6 +109,28 @@ public class BeanPropertyReaderDynamicAccessTest {
         }
     }
 
+    public static final class FluentSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public FluentSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public FluentSetterBackedReaderBean setName(String name) {
+            this.name = name;
+            setterCalls++;
+            return this;
+        }
+    }
+
     public static final class SetterBackedReaderBean {
         private String name;
         private int setterCalls;
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
index 5d877e7339..dd41a65a32 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -12,20 +12,27 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.USE_FIELDS);
+    private static final JSON JSON_WITH_GETTER_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.WRITE_READONLY_BEAN_PROPERTIES);
 
     @Test
     void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
 
         assertThat(json).isEqualTo("{\"id\":3}");
     }
 
     @Test
     void serializesGetterBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+        String json = JSON_WITH_GETTER_ACCESS.asString(bean);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
     }
 
     public static final class FieldBackedWriterBean {
@@ -33,18 +40,16 @@ public class BeanPropertyWriterDynamicAccessTest {
     }
 
     public static final class GetterBackedWriterBean {
-        private String name;
+        private int getterCalls;
+        private final String name;
 
         public GetterBackedWriterBean(String name) {
             this.name = name;
         }
 
         public String getName() {
+            getterCalls++;
             return name;
         }
-
-        public void setName(String name) {
-            this.name = name;
-        }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
index da83f22971..17f9c7a7db 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -7,8 +7,6 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.JSONObjectException;
-import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,20 +15,45 @@ public class BeanReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
-        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
 
-        assertThat(key).isNotNull();
-        assertThat(key.hashCode()).isZero();
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
     }
 
     @Test
-    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
-                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
 
-        assertThat(reference.getFrom()).isEqualTo("source");
-        assertThat(reference.getFieldName()).isEqualTo("name");
-        assertThat(reference.getIndex()).isEqualTo(2);
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
index 2b7b6119bc..994dafe71d 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -14,20 +14,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
     @Test
-    void createsEmptyTypedArrays() throws Exception {
+    void createsEmptyTypedArraysDirectly() throws Exception {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.emptyArray((Class) elementType);
+        Object[] values = builder.emptyArray(elementType);
 
         assertThat(values).isEmpty();
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
     @Test
-    void createsSingletonTypedArrays() throws Exception {
+    void createsSingletonTypedArraysDirectly() throws Exception {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
 
@@ -37,14 +37,14 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
-    void createsMultiValueTypedArrays() throws Exception {
+    void createsMultiValueTypedArraysDirectly() throws Exception {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.start()
                 .add(new ArrayElement("left"))
                 .add(new ArrayElement("right"))
-                .buildArray((Class) elementType);
+                .buildArray(elementType);
 
         assertThat(values).hasSize(2);
         assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
@@ -52,8 +52,47 @@ public class CollectionBuilderDynamicAccessTest {
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
-    private static Class<?> runtimeArrayElementType() throws Exception {
-        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    @Test
+    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+
+        assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+
+        assertThat(values).containsExactly("solo");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
+        return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<String> runtimeStringType() throws Exception {
+        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
     }
 
     public static final class ArrayElement {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
index c444877391..2d801978bc 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -8,47 +8,79 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapBuilderDefaultDynamicAccessTest {
-    @Test
-    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+    @BeforeEach
+    void resetConstructorCalls() {
+        ConstructorTrackingMap.CONSTRUCTOR_CALLS.set(0);
+    }
 
-        Map<String, Object> counts = builder.start()
-                .put("alpha", 1)
-                .put("beta", 2)
-                .build();
+    @Test
+    void readsMultiEntryJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"alpha\":1,\"beta\":2}");
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+    void readsEmptyJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{}");
 
-        Map<String, Object> counts = builder.emptyMap();
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsSingletonJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"only\":99}");
 
-        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+    void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
+        MapBuilder builder = configuredMapBuilder();
 
-        Map<String, Object> counts = builder.singletonMap("only", 99);
+        Map<String, Object> counts = builder.start()
+                .put("discarded", true)
+                .start()
+                .put("kept", true)
+                .build();
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
-        assertThat(counts).containsEntry("only", 99);
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).hasSize(1);
+        assertThat(counts).containsEntry("kept", true);
+        assertThat(counts).doesNotContainKey("discarded");
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
     }
 
-    public static final class CountsMap extends LinkedHashMap<String, Object> {
-        public CountsMap() {
+    private static JSON jsonWithConfiguredMaps() {
+        return JSON.builder()
+                .mapBuilder(configuredMapBuilder())
+                .build();
+    }
+
+    private static MapBuilder configuredMapBuilder() {
+        return MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
+    }
+
+    public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public ConstructorTrackingMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
index ea76969375..9cb0bb785b 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -17,41 +17,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SimpleValueReaderDynamicAccessTest {
     @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved.getName()).isEqualTo(className);
+        assertThat(resolved).isEqualTo(LoadableType.class);
     }
 
     @Test
     void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type.getName()).isEqualTo(className);
+        assertThat(holder.type).isEqualTo(LoadableType.class);
     }
 
     @Test
     void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = loadableClassName();
 
         Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
                 "{\"primary\":\"" + className + "\"}");
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
-        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
+        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
     }
 
-    private static String runtimeJdkClassName() {
-        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    private static String loadableClassName() {
+        String propertyName = "simple.value.reader.class." + System.nanoTime();
+        System.setProperty(propertyName, LoadableType.class.getName());
+        return System.getProperty(propertyName);
     }
 
     public static final class TypeHolder {
         public Class<?> type;
     }
+
+    public static final class LoadableType {
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
index 6be26d0186..9e15382236 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -11,11 +11,27 @@ import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+        TypeResolver resolver = new TypeResolver();
+        Object runtimeComponentValue = runtimeComponentValue();
+        Class<?> componentClass = runtimeComponentValue.getClass();
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
+    }
+
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
@@ -23,8 +39,8 @@ public class TypeResolverDynamicAccessTest {
                 TypeBindings.emptyBindings(),
                 StringArrayContainer.class.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
-                .getDeclaredMethod("setValues", Object[].class)
-                .getGenericParameterTypes()[0];
+                .getDeclaredField("values")
+                .getGenericType();
 
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
@@ -47,4 +63,24 @@ public class TypeResolverDynamicAccessTest {
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
     }
+
+    private static Object runtimeComponentValue() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return Integer.valueOf(7);
+        }
+        return Thread.currentThread().getName();
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
index 5bad780bdb..703886be9a 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -34,6 +36,15 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(direction).isEqualTo(Direction.SOUTH);
     }
 
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitions() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
+
+        ValueReader reader = locator.findReader(Direction.class);
+
+        assertThat(reader).isNotNull();
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/resources/META-INF/native-image/reachability-metadata.json 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
index 41368c6192..dda75ae4d5 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,5 +1,62 @@
 {
   "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
@@ -32,6 +89,38 @@
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
     },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean"
+    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
@@ -64,6 +153,30 @@
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
     },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
@@ -109,7 +222,7 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$ConstructorTrackingMap",
       "methods" : [
         {
           "name" : "<init>",
@@ -146,6 +259,12 @@
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
     },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"

```
