### PR TITLE
[GenAI] Test fix for org.rocksdb:rocksdbjni:10.4.2 using gpt-5.5

### DIFF
--- a/metadata/org.rocksdb/rocksdbjni/10.4.2/reachability-metadata.json
+++ b/metadata/org.rocksdb/rocksdbjni/10.4.2/reachability-metadata.json
@@ -1,0 +1,51 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.rocksdb.RocksDB"
+      },
+      "type": "byte[]",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.rocksdb.RocksDB"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.rocksdb.NativeLibraryLoader"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.rocksdb.NativeLibraryLoader"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.rocksdb.NativeLibraryLoader"
+      },
+      "glob": "librocksdbjni-linux64.so"
+    }
+  ]
+}

--- a/metadata/org.rocksdb/rocksdbjni/index.json
+++ b/metadata/org.rocksdb/rocksdbjni/index.json
@@ -1,5 +1,15 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "10.4.2",
+    "tested-versions" : [
+      "10.4.2"
+    ],
+    "allowed-packages" : [
+      "org.rocksdb"
+    ]
+  },
+  {
     "metadata-version" : "7.1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/7.1.2/rocksdbjni-7.1.2-sources.jar",
     "repository-url" : "https://github.com/facebook/rocksdb",
@@ -14,7 +24,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "7.9.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/7.9.2/rocksdbjni-7.9.2-sources.jar",
     "repository-url" : "https://github.com/facebook/rocksdb",

--- a/metadata/org.rocksdb/rocksdbjni/index.json
+++ b/metadata/org.rocksdb/rocksdbjni/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "10.4.2"
     ],
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/10.4.2/rocksdbjni-10.4.2-sources.jar",
+    "repository-url" : "https://github.com/facebook/rocksdb",
+    "test-code-url" : "https://github.com/facebook/rocksdb/tree/v10.4.2/java/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/10.4.2/rocksdbjni-10.4.2-javadoc.jar",
+    "description" : "RocksDB JNI provides Java bindings for RocksDB, an embeddable persistent key-value store optimized for fast storage. The rocksdbjni artifact packages the native RocksDB libraries for supported platforms so Java applications can use RocksDB without building native binaries separately.",
     "allowed-packages" : [
       "org.rocksdb"
     ]

--- a/stats/org.rocksdb/rocksdbjni/10.4.2/stats.json
+++ b/stats/org.rocksdb/rocksdbjni/10.4.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "10.4.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1471,
+        "missed" : 36061,
+        "ratio" : 0.039193,
+        "total" : 37532
+      },
+      "line" : {
+        "covered" : 402,
+        "missed" : 7008,
+        "ratio" : 0.054251,
+        "total" : 7410
+      },
+      "method" : {
+        "covered" : 132,
+        "missed" : 2652,
+        "ratio" : 0.047414,
+        "total" : 2784
+      }
+    }
+  } ]
+}

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/.gitignore
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.rocksdb:rocksdbjni:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.rocksdb:rocksdbjni:$libraryVersion"
+    testRuntimeOnly "org.rocksdb:rocksdbjni:$libraryVersion:linux64"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/gradle.properties
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 10.4.2
+metadata.dir = org.rocksdb/rocksdbjni/10.4.2/

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/settings.gradle
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.rocksdb.rocksdbjni_tests'

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/NativeLibraryLoaderTest.java
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/NativeLibraryLoaderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_rocksdb.rocksdbjni;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.NativeLibraryLoader;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NativeLibraryLoaderTest {
+    private static final String PRIMARY_LIBRARY = "metadata-forge-missing-primary-rocksdbjni.jnilib";
+    private static final String FALLBACK_LIBRARY = "metadata-forge-missing-fallback-rocksdbjni.jnilib";
+    private static final Unsafe UNSAFE = unsafe();
+
+    @Test
+    void loadLibraryFromJarToTempLooksUpFallbackResourceWhenPrimaryIsUnavailable() throws Throwable {
+        NativeLibraryLoader loader = NativeLibraryLoader.getInstance();
+        StaticFieldValue<String> primaryLibraryField = staticFieldValue("jniLibraryFileName");
+        StaticFieldValue<String> fallbackLibraryField = staticFieldValue("fallbackJniLibraryFileName");
+
+        primaryLibraryField.set(PRIMARY_LIBRARY);
+        fallbackLibraryField.set(FALLBACK_LIBRARY);
+        try {
+            assertThatThrownBy(() -> invokeLoadLibraryFromJarToTemp(loader))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Neither " + PRIMARY_LIBRARY + " or " + FALLBACK_LIBRARY
+                            + " were found inside the JAR, and there is no fallback.");
+        } finally {
+            fallbackLibraryField.restore();
+            primaryLibraryField.restore();
+        }
+    }
+
+    private static void invokeLoadLibraryFromJarToTemp(NativeLibraryLoader loader) throws Throwable {
+        Method method = NativeLibraryLoader.class.getDeclaredMethod("loadLibraryFromJarToTemp", String.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(loader, (String) null);
+        } catch (InvocationTargetException invocationTargetException) {
+            throw invocationTargetException.getTargetException();
+        }
+    }
+
+    private static StaticFieldValue<String> staticFieldValue(String name) throws NoSuchFieldException {
+        Field field = NativeLibraryLoader.class.getDeclaredField(name);
+        Object base = UNSAFE.staticFieldBase(field);
+        long offset = UNSAFE.staticFieldOffset(field);
+        return new StaticFieldValue<>(base, offset, String.class.cast(UNSAFE.getObject(base, offset)));
+    }
+
+    private static Unsafe unsafe() {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return Unsafe.class.cast(field.get(null));
+        } catch (ReflectiveOperationException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+
+    private static final class StaticFieldValue<T> {
+        private final Object base;
+        private final long offset;
+        private final T originalValue;
+
+        private StaticFieldValue(Object base, long offset, T originalValue) {
+            this.base = base;
+            this.offset = offset;
+            this.originalValue = originalValue;
+        }
+
+        private void set(T value) {
+            UNSAFE.putObject(base, offset, value);
+        }
+
+        private void restore() {
+            set(originalValue);
+        }
+    }
+}

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_rocksdb.rocksdbjni;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.Slice;
+import org.rocksdb.Snapshot;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RocksdbjniTest {
+
+    @BeforeAll
+    static void loadNative() {
+        RocksDB.loadLibrary();
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void basicPutGetDelete() throws Exception {
+        Path dbPath = newDbDir("basicPutGetDelete");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            byte[] key = b("hello");
+            byte[] value = b("world");
+
+            db.put(key, value);
+            assertThat(db.get(key)).isEqualTo(value);
+
+            db.delete(key);
+            assertThat(db.get(key)).isNull();
+        }
+    }
+
+    @Test
+    void iteratorTraversesInKeyOrder() throws Exception {
+        Path dbPath = newDbDir("iteratorTraversesInKeyOrder");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            db.put(b("a"), b("1"));
+            db.put(b("c"), b("3"));
+            db.put(b("b"), b("2"));
+
+            List<String> keys = new ArrayList<>();
+            List<String> values = new ArrayList<>();
+            try (RocksIterator it = db.newIterator()) {
+                it.seekToFirst();
+                while (it.isValid()) {
+                    keys.add(s(it.key()));
+                    values.add(s(it.value()));
+                    it.next();
+                }
+            }
+
+            assertThat(keys).containsExactly("a", "b", "c");
+            assertThat(values).containsExactly("1", "2", "3");
+        }
+    }
+
+    @Test
+    void writeBatchIsAtomic() throws Exception {
+        Path dbPath = newDbDir("writeBatchIsAtomic");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            byte[] k1 = b("k1");
+            byte[] k2 = b("k2");
+
+            try (WriteOptions writeOptions = new WriteOptions();
+                 WriteBatch batch = new WriteBatch()) {
+                batch.put(k1, b("v1"));
+                batch.put(k2, b("v2"));
+                batch.delete(k1);
+
+                db.write(writeOptions, batch);
+            }
+
+            assertThat(db.get(k1)).isNull();
+            assertThat(db.get(k2)).isEqualTo(b("v2"));
+        }
+    }
+
+    @Test
+    void columnFamiliesMaintainIsolation() throws Exception {
+        Path dbPath = newDbDir("columnFamiliesMaintainIsolation");
+
+        try (DBOptions dbOptions = new DBOptions()
+                .setCreateIfMissing(true)
+                .setCreateMissingColumnFamilies(true)) {
+
+            ColumnFamilyOptions defaultCfOpts = new ColumnFamilyOptions();
+            ColumnFamilyOptions cf1Opts = new ColumnFamilyOptions();
+            List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+                    new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, defaultCfOpts),
+                    new ColumnFamilyDescriptor(b("cf1"), cf1Opts)
+            );
+
+            List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
+            RocksDB db = RocksDB.open(dbOptions, dbPath.toString(), cfDescriptors, cfHandles);
+
+            try (db; defaultCfOpts; cf1Opts) {
+                ColumnFamilyHandle defaultHandle = cfHandles.get(0);
+                ColumnFamilyHandle cf1Handle = cfHandles.get(1);
+
+                // Put in different CFs
+                db.put(defaultHandle, b("key"), b("default"));
+                db.put(cf1Handle, b("key"), b("cf1"));
+
+                // Verify isolation
+                assertThat(db.get(defaultHandle, b("key"))).isEqualTo(b("default"));
+                assertThat(db.get(cf1Handle, b("key"))).isEqualTo(b("cf1"));
+
+                // Same key in different CFs should not collide
+                assertThat(db.get(defaultHandle, b("missing"))).isNull();
+                assertThat(db.get(cf1Handle, b("missing"))).isNull();
+
+                // Close handles explicitly
+                for (ColumnFamilyHandle handle : cfHandles) {
+                    handle.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    void snapshotProvidesPointInTimeView() throws Exception {
+        Path dbPath = newDbDir("snapshotProvidesPointInTimeView");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            byte[] key = b("snap-key");
+            db.put(key, b("v1"));
+
+            Snapshot snapshot = db.getSnapshot();
+            try (ReadOptions ro = new ReadOptions().setSnapshot(snapshot)) {
+
+                // Modify after snapshot
+                db.put(key, b("v2"));
+
+                // Snapshot should still see old value
+                assertThat(db.get(ro, key)).isEqualTo(b("v1"));
+
+                // Without snapshot we see the latest
+                assertThat(db.get(key)).isEqualTo(b("v2"));
+            } finally {
+                db.releaseSnapshot(snapshot);
+            }
+        }
+    }
+
+    @Test
+    void multiGetRetrievesMultipleKeys() throws Exception {
+        Path dbPath = newDbDir("multiGetRetrievesMultipleKeys");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            db.put(b("k1"), b("v1"));
+            db.put(b("k2"), b("v2"));
+            // Intentionally leaving k3 missing
+            db.put(b("k4"), b("v4"));
+
+            List<byte[]> keys = Arrays.asList(b("k1"), b("k2"), b("k3"), b("k4"));
+            List<byte[]> values = db.multiGetAsList(keys);
+
+            assertThat(values).hasSize(4);
+            assertThat(values.get(0)).isEqualTo(b("v1"));
+            assertThat(values.get(1)).isEqualTo(b("v2"));
+            assertThat(values.get(2)).isNull(); // k3 missing
+            assertThat(values.get(3)).isEqualTo(b("v4"));
+        }
+    }
+
+    @Test
+    void deleteRangeRemovesKeysInHalfOpenInterval() throws Exception {
+        Path dbPath = newDbDir("deleteRangeRemovesKeysInHalfOpenInterval");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            db.put(b("a"), b("1"));
+            db.put(b("b"), b("2"));
+            db.put(b("c"), b("3"));
+            db.put(b("d"), b("4"));
+
+            // Delete keys in [b, d)
+            db.deleteRange(b("b"), b("d"));
+
+            assertThat(db.get(b("a"))).isEqualTo(b("1"));
+            assertThat(db.get(b("b"))).isNull();
+            assertThat(db.get(b("c"))).isNull();
+            assertThat(db.get(b("d"))).isEqualTo(b("4"));
+        }
+    }
+
+    @Test
+    void iteratorRespectsBoundsInReadOptions() throws Exception {
+        Path dbPath = newDbDir("iteratorRespectsBoundsInReadOptions");
+        try (Options options = new Options().setCreateIfMissing(true);
+             RocksDB db = RocksDB.open(options, dbPath.toString())) {
+
+            db.put(b("a"), b("1"));
+            db.put(b("b"), b("2"));
+            db.put(b("c"), b("3"));
+            db.put(b("d"), b("4"));
+
+            List<String> keys = new ArrayList<>();
+            try (Slice lower = new Slice(b("b"));
+                 Slice upper = new Slice(b("d"));
+                 ReadOptions ro = new ReadOptions()) {
+                ro.setIterateLowerBound(lower);
+                ro.setIterateUpperBound(upper);
+
+                try (RocksIterator it = db.newIterator(ro)) {
+                    // Start at the lower bound
+                    it.seek(b("b"));
+                    while (it.isValid()) {
+                        keys.add(s(it.key()));
+                        it.next();
+                    }
+                }
+            }
+
+            // Expect keys in [b, d) => b and c
+            assertThat(keys).containsExactly("b", "c");
+        }
+    }
+
+    // Helpers
+
+    private Path newDbDir(String name) throws IOException {
+        Path dir = tempDir.resolve(name + "-" + UUID.randomUUID());
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    private static byte[] b(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String s(byte[] b) {
+        return new String(b, StandardCharsets.UTF_8);
+    }
+}

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RocksdbjniTest {
+public class RocksdbjniTest {
 
     @BeforeAll
     static void loadNative() {

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/resources/META-INF/native-image/native-library-loader-test/reflect-config.json
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/resources/META-INF/native-image/native-library-loader-test/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "org.rocksdb.NativeLibraryLoader",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "sun.misc.Unsafe",
+    "allDeclaredFields": true
+  }
+]

--- a/tests/src/org.rocksdb/rocksdbjni/10.4.2/user-code-filter.json
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.rocksdb.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #927

This PR provides test fixes and new metadata for org.rocksdb:rocksdbjni:10.4.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 201985
- Cached input tokens: 1778688
- Output tokens: 19696
- Entries found: 8
- Iterations: 3
- Library coverage percentage: 5.43
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 5.21

### Metadata Forge

- Forge branch: `worktree-java-run-fail`
- Forge commit hash: `13bf6bc548fb884328f8c020960e704b2c30e822`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.rocksdb:rocksdbjni:7.9.2: 1/2 covered calls (50.00%)
- org.rocksdb:rocksdbjni:10.4.2: 2/2 covered calls (100.00%)

**Resources:**
- org.rocksdb:rocksdbjni:7.9.2: 1/2 covered calls (50.00%)
- org.rocksdb:rocksdbjni:10.4.2: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.rocksdb:rocksdbjni:7.9.2: 1308/34206 (3.82%)
- org.rocksdb:rocksdbjni:10.4.2: 1471/37532 (3.92%)

**Line:**
- org.rocksdb:rocksdbjni:7.9.2: 340/6522 (5.21%)
- org.rocksdb:rocksdbjni:10.4.2: 402/7410 (5.43%)

**Method:**
- org.rocksdb:rocksdbjni:7.9.2: 109/2447 (4.45%)
- org.rocksdb:rocksdbjni:10.4.2: 132/2784 (4.74%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.rocksdb/rocksdbjni/7.9.2/build.gradle b/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
index 83bcef63..33a6b25f 100644
--- a/tests/src/org.rocksdb/rocksdbjni/7.9.2/build.gradle
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.rocksdb:rocksdbjni:$libraryVersion"
+    testRuntimeOnly "org.rocksdb:rocksdbjni:$libraryVersion:linux64"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git a/tests/src/org.rocksdb/rocksdbjni/7.9.2/gradle.properties b/tests/src/org.rocksdb/rocksdbjni/10.4.2/gradle.properties
index 22439e28..796e4624 100644
--- a/tests/src/org.rocksdb/rocksdbjni/7.9.2/gradle.properties
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/gradle.properties
@@ -1,2 +1,2 @@
-library.version = 7.9.2
-metadata.dir = org.rocksdb/rocksdbjni/7.9.2/
+library.version = 10.4.2
+metadata.dir = org.rocksdb/rocksdbjni/10.4.2/
diff --git a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/NativeLibraryLoaderTest.java b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/NativeLibraryLoaderTest.java
new file mode 100644
index 00000000..0c75edea
--- /dev/null
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/NativeLibraryLoaderTest.java
@@ -0,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_rocksdb.rocksdbjni;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.NativeLibraryLoader;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NativeLibraryLoaderTest {
+    private static final String PRIMARY_LIBRARY = "metadata-forge-missing-primary-rocksdbjni.jnilib";
+    private static final String FALLBACK_LIBRARY = "metadata-forge-missing-fallback-rocksdbjni.jnilib";
+    private static final Unsafe UNSAFE = unsafe();
+
+    @Test
+    void loadLibraryFromJarToTempLooksUpFallbackResourceWhenPrimaryIsUnavailable() throws Throwable {
+        NativeLibraryLoader loader = NativeLibraryLoader.getInstance();
+        StaticFieldValue<String> primaryLibraryField = staticFieldValue("jniLibraryFileName");
+        StaticFieldValue<String> fallbackLibraryField = staticFieldValue("fallbackJniLibraryFileName");
+
+        primaryLibraryField.set(PRIMARY_LIBRARY);
+        fallbackLibraryField.set(FALLBACK_LIBRARY);
+        try {
+            assertThatThrownBy(() -> invokeLoadLibraryFromJarToTemp(loader))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Neither " + PRIMARY_LIBRARY + " or " + FALLBACK_LIBRARY
+                            + " were found inside the JAR, and there is no fallback.");
+        } finally {
+            fallbackLibraryField.restore();
+            primaryLibraryField.restore();
+        }
+    }
+
+    private static void invokeLoadLibraryFromJarToTemp(NativeLibraryLoader loader) throws Throwable {
+        Method method = NativeLibraryLoader.class.getDeclaredMethod("loadLibraryFromJarToTemp", String.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(loader, (String) null);
+        } catch (InvocationTargetException invocationTargetException) {
+            throw invocationTargetException.getTargetException();
+        }
+    }
+
+    private static StaticFieldValue<String> staticFieldValue(String name) throws NoSuchFieldException {
+        Field field = NativeLibraryLoader.class.getDeclaredField(name);
+        Object base = UNSAFE.staticFieldBase(field);
+        long offset = UNSAFE.staticFieldOffset(field);
+        return new StaticFieldValue<>(base, offset, String.class.cast(UNSAFE.getObject(base, offset)));
+    }
+
+    private static Unsafe unsafe() {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return Unsafe.class.cast(field.get(null));
+        } catch (ReflectiveOperationException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+
+    private static final class StaticFieldValue<T> {
+        private final Object base;
+        private final long offset;
+        private final T originalValue;
+
+        private StaticFieldValue(Object base, long offset, T originalValue) {
+            this.base = base;
+            this.offset = offset;
+            this.originalValue = originalValue;
+        }
+
+        private void set(T value) {
+            UNSAFE.putObject(base, offset, value);
+        }
+
+        private void restore() {
+            set(originalValue);
+        }
+    }
+}
diff --git a/tests/src/org.rocksdb/rocksdbjni/7.9.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
index 926b8e58..a473d3f3 100644
--- a/tests/src/org.rocksdb/rocksdbjni/7.9.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/java/org_rocksdb/rocksdbjni/RocksdbjniTest.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RocksdbjniTest {
+public class RocksdbjniTest {
 
     @BeforeAll
     static void loadNative() {
diff --git a/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/resources/META-INF/native-image/native-library-loader-test/reflect-config.json b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/resources/META-INF/native-image/native-library-loader-test/reflect-config.json
new file mode 100644
index 00000000..6778af40
--- /dev/null
+++ b/tests/src/org.rocksdb/rocksdbjni/10.4.2/src/test/resources/META-INF/native-image/native-library-loader-test/reflect-config.json
@@ -0,0 +1,11 @@
+[
+  {
+    "name": "org.rocksdb.NativeLibraryLoader",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "sun.misc.Unsafe",
+    "allDeclaredFields": true
+  }
+]

```
