### PR TITLE
[GenAI] Add support for werken-xpath:werken-xpath:0.9.4 using gpt-5.5

### DIFF
--- a/metadata/werken-xpath/werken-xpath/0.9.4/reachability-metadata.json
+++ b/metadata/werken-xpath/werken-xpath/0.9.4/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.werken.xpath.parser.XPathLexer"
+      },
+      "type": "antlr.CommonToken",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/werken-xpath/werken-xpath/index.json
+++ b/metadata/werken-xpath/werken-xpath/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.9.4",
+    "source-code-url" : "https://sources.debian.org/src/werken.xpath/0.9.4-16/",
+    "repository-url" : "https://sourceforge.net/p/werken-xpath/code/",
+    "test-code-url" : "https://sources.debian.org/src/werken.xpath/0.9.4-16/test/",
+    "documentation-url" : "https://sources.debian.org/src/werken.xpath/0.9.4-16/apidocs/",
+    "description" : "Werken XPath is a Java XPath engine that parses XPath expressions and evaluates them by walking JDOM trees. It is intended as a reusable XPath layer for higher-level XML tools such as XPointer, XSLT, or other XPath-based specifications.",
+    "tested-versions" : [
+      "0.9.4"
+    ],
+    "allowed-packages" : [
+      "com.werken.xpath"
+    ]
+  }
+]

--- a/stats/werken-xpath/werken-xpath/0.9.4/stats.json
+++ b/stats/werken-xpath/werken-xpath/0.9.4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.9.4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5096,
+        "missed" : 3780,
+        "ratio" : 0.574132,
+        "total" : 8876
+      },
+      "line" : {
+        "covered" : 1384,
+        "missed" : 1049,
+        "ratio" : 0.568845,
+        "total" : 2433
+      },
+      "method" : {
+        "covered" : 198,
+        "missed" : 106,
+        "ratio" : 0.651316,
+        "total" : 304
+      }
+    }
+  } ]
+}

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/.gitignore
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/build.gradle
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "werken-xpath:werken-xpath:$libraryVersion"
+    testImplementation 'antlr:antlr:2.7.7'
+    testImplementation 'jdom:jdom:b7'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/build.gradle
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "werken-xpath:werken-xpath:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/gradle.properties
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = werken-xpath:werken-xpath:0.9.4
+library.version = 0.9.4
+metadata.dir = werken-xpath/werken-xpath/0.9.4/

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/settings.gradle
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'werken-xpath.werken-xpath_tests'

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package werken_xpath.werken_xpath;
+
+import org.junit.jupiter.api.Test;
+
+class Werken_xpathTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
@@ -6,11 +6,193 @@
  */
 package werken_xpath.werken_xpath;
 
+import com.werken.xpath.ContextSupport;
+import com.werken.xpath.DefaultVariableContext;
+import com.werken.xpath.ElementNamespaceContext;
+import com.werken.xpath.XPath;
+import org.jdom.Attribute;
+import org.jdom.Comment;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.jdom.ProcessingInstruction;
 import org.junit.jupiter.api.Test;
 
-class Werken_xpathTest {
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Werken_xpathTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void selectsElementsWithAbsoluteDescendantParentAndSelfPaths() {
+        Document document = bookDocument();
+
+        List<?> rootSelection = select("/", document);
+        assertThat(rootSelection).hasSize(1);
+        assertThat(rootSelection.get(0)).isSameAs(document);
+        assertThat(elementIds(select("/book", document))).containsExactly("book-1");
+        assertThat(elementIds(select("//title", document))).containsExactly(
+                "book-1-title-1",
+                "chapter-1-title-1",
+                "chapter-2-title-1",
+                "chapter-3-title-1",
+                "chapter-4-title-1",
+                "chapter-5-title-1",
+                "chapter-6-title-1");
+        assertThat(elementIds(select("/book/chapter/../chapter/.", document))).containsExactly(
+                "chapter-1", "chapter-2", "chapter-3", "chapter-4", "chapter-5", "chapter-6");
+    }
+
+    @Test
+    void filtersByPositionAttributesBooleanExpressionsAndBuiltInFunctions() {
+        Document document = bookDocument();
+
+        assertThat(elementIds(select("//chapter[2]/title", document))).containsExactly("chapter-2-title-1");
+        assertThat(elementIds(select("//chapter[last()]", document))).containsExactly("chapter-6");
+        assertThat(elementIds(select("/book/chapter[@author='bob']", document)))
+                .containsExactly("chapter-1", "chapter-3");
+        assertThat(elementIds(select("/book/chapter[@author='bob' or @author='rebecca']", document)))
+                .containsExactly("chapter-1", "chapter-2", "chapter-3");
+        assertThat(elementIds(select("/book/chapter[not(@author)]", document))).containsExactly("chapter-6");
+        assertThat(elementIds(select("//chapter[contains(@id, 'chapter-3') or starts-with(@author, 'reb')]", document)))
+                .containsExactly("chapter-2", "chapter-3");
+    }
+
+    @Test
+    void returnsAttributesCommentsAndProcessingInstructions() {
+        Document document = bookDocument();
+
+        assertThat(attributeValues(select("/book/chapter[@author='bob']/@id", document)))
+                .containsExactly("chapter-1", "chapter-3");
+        assertThat(elementIds(select("//chapter[@id='chapter-3']/title", document)))
+                .containsExactly("chapter-3-title-1");
+        List<?> comments = select("//chapter[@id='chapter-4']/comment()", document);
+        assertThat(comments).hasSize(1);
+        Comment comment = (Comment) comments.get(0);
+        assertThat(comment.getText()).isEqualTo("reviewed");
+
+        List<?> instructions = select("//processing-instruction(display)", document);
+        assertThat(instructions).hasSize(1);
+        ProcessingInstruction instruction = (ProcessingInstruction) instructions.get(0);
+        assertThat(instruction.getTarget()).isEqualTo("display");
+        assertThat(instruction.getData()).isEqualTo("mode='compact'");
+    }
+
+    @Test
+    void evaluatesVariablesThroughContextSupport() {
+        Document document = bookDocument();
+        DefaultVariableContext variables = new DefaultVariableContext();
+        variables.setVariableValue("wantedAuthor", "bob");
+        variables.setVariableValue("wantedId", "chapter-5");
+
+        ContextSupport support = new ContextSupport();
+        support.setVariableContext(variables);
+
+        assertThat(elementIds(select(support, "/book/chapter[@author=$wantedAuthor]", document)))
+                .containsExactly("chapter-1", "chapter-3");
+        assertThat(elementIds(select(support, "/book/chapter[@id=$wantedId]/title", document)))
+                .containsExactly("chapter-5-title-1");
+    }
+
+    @Test
+    void resolvesNamespacePrefixesFromElementNamespaceContext() {
+        Namespace libraryNamespace = Namespace.getNamespace("lib", "urn:library");
+        Element catalog = new Element("catalog");
+        catalog.addNamespaceDeclaration(libraryNamespace);
+        Element namespacedBook = new Element("book", libraryNamespace)
+                .setAttribute("id", "namespaced-book");
+        namespacedBook.addContent(new Element("title", libraryNamespace).setAttribute("id", "namespaced-title")
+                .addContent("Namespaced XPath"));
+        catalog.addContent(namespacedBook);
+        Document document = new Document(catalog);
+
+        ContextSupport support = new ContextSupport();
+        support.setNamespaceContext(new ElementNamespaceContext(catalog));
+
+        assertThat(elementIds(select(support, "/catalog/lib:book", document))).containsExactly("namespaced-book");
+        assertThat(elementIds(select(support, "/catalog/lib:book/lib:title", document)))
+                .containsExactly("namespaced-title");
+        assertThat(attributeValues(select(support, "/catalog/lib:book/@id", document)))
+                .containsExactly("namespaced-book");
+    }
+
+    @Test
+    void appliesRelativeExpressionsToElementsAndNodeSets() {
+        Document document = bookDocument();
+        Element book = document.getRootElement();
+        List<?> chapters = select("/book/chapter[@author='bob']", document);
+
+        assertThat(elementIds(new XPath("chapter/title").applyTo(book)))
+                .containsExactly(
+                        "chapter-1-title-1",
+                        "chapter-2-title-1",
+                        "chapter-3-title-1",
+                        "chapter-4-title-1",
+                        "chapter-5-title-1",
+                        "chapter-6-title-1");
+        assertThat(elementIds(new XPath("title").applyTo(chapters)))
+                .containsExactly("chapter-1-title-1", "chapter-3-title-1");
+    }
+
+    @Test
+    void exposesOriginalExpressionTextAndReadableRepresentation() {
+        XPath xpath = new XPath("//chapter[@author='bob']/title");
+
+        assertThat(xpath.getString()).isEqualTo("//chapter[@author='bob']/title");
+        assertThat(xpath.toString()).contains("//chapter[@author='bob']/title");
+    }
+
+    private static List<?> select(String xpath, Document document) {
+        return new XPath(xpath).applyTo(document);
+    }
+
+    private static List<?> select(ContextSupport support, String xpath, Document document) {
+        return new XPath(xpath).applyTo(support, document);
+    }
+
+    private static List<String> elementIds(List<?> nodes) {
+        return nodes.stream()
+                .map(Element.class::cast)
+                .map(element -> element.getAttributeValue("id"))
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> attributeValues(List<?> nodes) {
+        return nodes.stream()
+                .map(Attribute.class::cast)
+                .map(Attribute::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private static Document bookDocument() {
+        Element book = new Element("book").setAttribute("id", "book-1");
+        book.addContent(new ProcessingInstruction("display", "mode='compact'"));
+        book.addContent(new Element("title").setAttribute("id", "book-1-title-1")
+                .addContent("How to Test Some XPath Implementation"));
+        chapters().forEach(book::addContent);
+        return new Document(book);
+    }
+
+    private static List<Element> chapters() {
+        Element chapterFour = chapter("chapter-4", "james", "This is chapter Four");
+        chapterFour.addContent(new Comment("reviewed"));
+        return Arrays.asList(
+                chapter("chapter-1", "bob", "This is chapter One"),
+                chapter("chapter-2", "rebecca", "This is chapter Two"),
+                chapter("chapter-3", "bob", "This is chapter Three"),
+                chapterFour,
+                chapter("chapter-5", "fred", "This is chapter Five"),
+                chapter("chapter-6", null, "This is chapter Six"));
+    }
+
+    private static Element chapter(String id, String author, String title) {
+        Element chapter = new Element("chapter").setAttribute("id", id);
+        if (author != null) {
+            chapter.setAttribute("author", author);
+        }
+        chapter.addContent(new Element("title").setAttribute("id", id + "-title-1").addContent(title));
+        return chapter;
     }
 }

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
@@ -113,6 +113,22 @@ public class Werken_xpathTest {
     }
 
     @Test
+    void selectsTextNodesAndUsesStringLengthInPredicates() {
+        Element library = new Element("library");
+        library.addContent(new Element("book")
+                .setAttribute("id", "short-title")
+                .addContent(new Element("title").addContent("XPath")));
+        library.addContent(new Element("book")
+                .setAttribute("id", "long-title")
+                .addContent(new Element("title").addContent("Native Image")));
+        Document document = new Document(library);
+
+        assertThat(stringValues(select("/library/book/title/text()", document))).containsExactly("XPath", "Native Image");
+        assertThat(elementIds(select("/library/book[string-length(title/text()) > 5]", document)))
+                .containsExactly("long-title");
+    }
+
+    @Test
     void resolvesNamespacePrefixesFromElementNamespaceContext() {
         Namespace libraryNamespace = Namespace.getNamespace("lib", "urn:library");
         Element catalog = new Element("catalog");
@@ -179,6 +195,12 @@ public class Werken_xpathTest {
         return nodes.stream()
                 .map(Attribute.class::cast)
                 .map(Attribute::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> stringValues(List<?> nodes) {
+        return nodes.stream()
+                .map(String.class::cast)
                 .collect(Collectors.toList());
     }
 

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/src/test/java/werken_xpath/werken_xpath/Werken_xpathTest.java
@@ -61,6 +61,22 @@ public class Werken_xpathTest {
     }
 
     @Test
+    void selectsElementsWithWildcardNameTests() {
+        Document document = bookDocument();
+
+        assertThat(elementIds(select("/book/*", document))).containsExactly(
+                "book-1-title-1",
+                "chapter-1",
+                "chapter-2",
+                "chapter-3",
+                "chapter-4",
+                "chapter-5",
+                "chapter-6");
+        assertThat(elementIds(select("/book/chapter[@author='bob']/*", document)))
+                .containsExactly("chapter-1-title-1", "chapter-3-title-1");
+    }
+
+    @Test
     void returnsAttributesCommentsAndProcessingInstructions() {
         Document document = bookDocument();
 

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/user-code-filter.json
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.werken.xpath.**"
+    }
+  ]
+}

--- a/tests/src/werken-xpath/werken-xpath/0.9.4/user-code-filter.json
+++ b/tests/src/werken-xpath/werken-xpath/0.9.4/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.werken.xpath.**"
+      "includeClasses" : "com.werken.xpath.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2396

This PR introduces tests and metadata for werken-xpath:werken-xpath:0.9.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 332839
- Cached input tokens: 5164544
- Output tokens: 36251
- Entries: 2
- Iterations: 7
- Library coverage percentage: 56.88
- Generated lines of code: 204
- Tested library lines of code: 1384

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `37c7ebae6e7dc60cd5f716b34be96fc522346b08`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 5096/8876 (57.41%)
- Line: 1384/2433 (56.88%)
- Method: 198/304 (65.13%)
