### PR TITLE
Do not assign automated failure issues to kimeta

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -548,9 +548,9 @@ jobs:
                 done
               fi
 
-              ASSIGNEE="kimeta"
+              ASSIGNEE_ARGS=()
               if [[ "$FAILURE_LABEL" == "fails-native-image-build" ]]; then
-                ASSIGNEE="vjovanov"
+                ASSIGNEE_ARGS=(--assignee "vjovanov")
               fi
 
               gh issue create \
@@ -559,7 +559,7 @@ jobs:
                 --body-file "$BODY_FILE" \
                 --label "library-unsupported-version" \
                 --label "$FAILURE_LABEL" \
-                --assignee "$ASSIGNEE"
+                "${ASSIGNEE_ARGS[@]}"
 
               rm "$BODY_FILE"
             done


### PR DESCRIPTION
## Summary
- remove the default `kimeta` assignee from automated compatibility failure issue creation
- keep the existing explicit `vjovanov` assignment for `fails-native-image-build`

Fixes: #2519