### PR TITLE
Add skill for reviewing fixes-java-run-fail

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,11 @@ It covers new-library metadata PRs, including titles like `[GenAI] Add support f
 Reviews pull requests with the `fixes-javac-fail` label.
 It covers compile-failure repair PRs for existing libraries and applies a lighter review than `library-new-request`: keep the diff scoped to the compile fix, preserve meaningful tests, and block regressions where dynamic-access coverage drops between the previously tested version and the new version.
 
+### `review-fixes-java-run-fail`
+
+Reviews pull requests with the `fixes-java-run-fail` label.
+It covers JVM runtime-failure repair PRs for existing libraries and applies a lighter review than `library-new-request`: keep the diff scoped to the Java runtime fix, preserve meaningful tests and assertions, and block regressions where dynamic-access coverage drops between the previously tested version and the new version.
+
 ### `review-fixes-native-image-run-fail`
 
 Reviews pull requests with the `fixes-native-image-run-fail` label.

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: review-fixes-java-run-fail
+description: Review pull requests with the `fixes-java-run-fail` label in graalvm-reachability-metadata. Use when asked to review or triage a PR described as `fixes-java-run-fail` or one that fixes Java/JVM runtime test failures for an existing library version update. Focus on validating the Java runtime fix, keeping the diff scoped, and ensuring dynamic-access coverage does not drop between the previously tested version and the new version.
+argument-hint: "[pr-number-or-url]"
+---
+
+# Review `fixes-java-run-fail` PRs
+
+These PRs repair tests, dependencies, or narrow runtime setup after an existing library version compiles, but the JVM-based test fails when it runs. Review them more lightly than `library-new-request` PRs: the library already exists, so the goal is to restore Java runtime behavior for the new version while preserving meaningful test and dynamic-access coverage.
+
+The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
+
+## Review Principles
+
+- Confirm the PR has label `fixes-java-run-fail`.
+- Expect runtime-focused changes plus the normal generated support files for the newly tested version: test source updates, dependency adjustments, runtime configuration, a new metadata-version directory, stats, and metadata index changes.
+- Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
+- Do not accept changes that remove meaningful test coverage just to make `java` pass.
+- Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
+- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the repaired test no longer covers the same runtime surface.
+- Prefer small, targeted review comments. This label is for JVM runtime repair work, not a full redesign of historical tests.
+
+## Workflow
+
+1. Inspect the PR summary.
+   - Resolve the target PR from the optional argument, or infer it from context when possible.
+   - Confirm the PR has label `fixes-java-run-fail`.
+   - Identify the target coordinate, the previous tested version, and the new tested version from the PR body, title, changed `index.json`, and changed test path.
+   - Gather files, reviews, inline comments, and CI checks.
+
+2. Validate the diff scope.
+   - Expected files are usually limited to the target coordinate's generated new-version support:
+     - `metadata/<group>/<artifact>/<new-version>/reachability-metadata.json`
+     - `metadata/<group>/<artifact>/index.json`
+     - `stats/<group>/<artifact>/<new-version>/stats.json`
+     - `tests/src/<group>/<artifact>/<new-version>/**`
+   - Accept compatibility edits that keep one test source working across multiple tested versions.
+   - Treat a new `reachability-metadata.json` for the tested version as normal for this label, including `{}` when validation and stats are coherent.
+   - Treat generated test project files such as `.gitignore`, `build.gradle`, `gradle.properties`, `settings.gradle`, and `user-code-filter.json` as normal when they live under the target version's test directory.
+   - Accept narrow runtime setup changes when they are necessary for the JVM test to exercise the same library behavior, such as test resources, dependency updates, system properties, service loading, or initialization ordering.
+   - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject or request changes if the PR removes tests, disables test classes, drops assertions, catches and ignores the failing exception, or bypasses the runtime path that failed.
+
+3. Review the Java runtime fix.
+   - Confirm the edit addresses the actual JVM runtime failure, such as changed runtime behavior, missing test resources, service loading changes, dependency conflicts, classpath/module issues, initialization order, changed exception types, or changed API semantics that only fail during execution.
+   - Compatibility branches are acceptable when they keep older and newer tested versions covered by the same test.
+   - Version-specific logic is acceptable when the upstream runtime behavior genuinely changed, but it should be narrow and documented by the code structure or assertions.
+   - Test expectation changes are acceptable only when they still assert meaningful behavior for the new version instead of accepting any output or exception.
+   - Do not require the stricter `library-new-request` rules about scaffold-only tests or test package placement unless the PR is also adding a new library.
+
+4. Check dynamic-access coverage across versions.
+   - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
+   - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
+   - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
+   - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
+
+5. Compare metadata entry counts.
+   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
+   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
+   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
+   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/runtime behavior change.
+
+6. Check CI before deciding.
+   - Expected minimum: `javaTest` or equivalent changed-metadata JVM test checks are green for the target coordinate.
+   - Compile and metadata validation checks should also be green; a Java runtime fix should not introduce a compile or metadata validation regression.
+   - Prefer seeing the full target `test` lane green because a Java runtime fix can still reduce native-image coverage.
+   - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
+   - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
+
+## Decision Rules
+
+Approve when all of these are true:
+
+- The PR is scoped to the target existing library and the Java runtime failure it fixes.
+- Tests still execute and assert the same meaningful library behavior after the runtime repair.
+- Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API/runtime surface.
+- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API/runtime surface.
+- Required metadata, compile, and Java runtime test checks are green.
+
+Request changes when any of these are true:
+
+- The fix makes JVM tests pass by deleting tests, removing assertions, skipping execution, swallowing the failing exception, or bypassing the library behavior.
+- Dynamic-access coverage drops without a credible explanation and replacement coverage.
+- Metadata entry count drops substantially without a credible explanation.
+- The diff includes unrelated libraries, workflow/build changes, or broad refactors that are not needed for the Java runtime fix.
+- CI failures indicate the Java runtime problem is not actually fixed.
+
+Ask for follow-up instead of rejecting when:
+
+- Stats needed for the old/new version comparison are missing or stale.
+- CI failed in a way that looks like infrastructure noise.
+- The API or runtime behavior change is plausible but the PR does not explain why a coverage drop is expected.
+- Metadata entry counts differ substantially but the changed upstream API/runtime surface makes the reduction plausible.
+
+## Output Style
+
+Keep comments short and factual:
+
+- For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
+- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
+- For deleted or bypassed coverage: say that the PR fixes Java runtime execution by removing coverage and should instead adapt the test to the new runtime behavior.
+- For swallowed exceptions: say that catching or ignoring the failing exception hides the runtime failure instead of proving the library behavior works.
+- For unrelated changes: say the PR should stay scoped to the `fixes-java-run-fail` repair and remove unrelated files.
+- For missing stats: ask for regenerated library stats or CI evidence before approval.


### PR DESCRIPTION
Closes #2523
Adds a repo-local review skill for PRs labeled `fixes-java-run-fail`. The workflow mirrors `review-fixes-javac-fail`, with JVM runtime-specific guidance for reviewing test execution fixes, runtime setup changes, exception handling, and dynamic-access coverage preservation.