### PR TITLE
[GenAI] Test fix for commons-io:commons-io:2.17.0 using gpt-5.5

### DIFF
--- a/metadata/commons-io/commons-io/2.17.0/reachability-metadata.json
+++ b/metadata/commons-io/commons-io/2.17.0/reachability-metadata.json
@@ -1,0 +1,69 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.SerializableFileTime"
+      },
+      "type" : "java.time.Instant",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.SerializableFileTime"
+      },
+      "type" : "java.time.Ser",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner"
+      },
+      "type" : "sun.misc.Cleaner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java9Cleaner"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "invokeCleaner",
+          "parameterTypes" : [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "java.io.File"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "org.apache.commons.io.monitor.FileEntry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "org.apache.commons.io.monitor.SerializableFileTime"
+    }
+  ]
+}

--- a/metadata/commons-io/commons-io/index.json
+++ b/metadata/commons-io/commons-io/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.17.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0-sources.jar",
+    "repository-url" : "https://github.com/apache/commons-io",
+    "test-code-url" : "https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0-javadoc.jar",
+    "description" : "Apache Commons IO provides utility classes and stream implementations that simplify working with files, paths, readers, writers, and byte or character streams in Java. It also includes file filters, comparators, and convenience methods for common I/O tasks such as copying, reading, writing, and deleting.",
     "tested-versions" : [
       "2.17.0"
     ],

--- a/metadata/commons-io/commons-io/index.json
+++ b/metadata/commons-io/commons-io/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.17.0",
+    "tested-versions" : [
+      "2.17.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.io"
+    ]
+  },
+  {
     "metadata-version" : "2.11.0",
     "source-code-url" : "https://repo1.maven.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0-sources.jar",
     "repository-url" : "https://github.com/apache/commons-io",

--- a/stats/commons-io/commons-io/2.17.0/stats.json
+++ b/stats/commons-io/commons-io/2.17.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.17.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 12,
+          "totalCalls" : 12
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 14,
+      "totalCalls" : 14
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1017,
+        "missed" : 36329,
+        "ratio" : 0.027232,
+        "total" : 37346
+      },
+      "line" : {
+        "covered" : 260,
+        "missed" : 8112,
+        "ratio" : 0.031056,
+        "total" : 8372
+      },
+      "method" : {
+        "covered" : 100,
+        "missed" : 2909,
+        "ratio" : 0.033234,
+        "total" : 3009
+      }
+    }
+  } ]
+}

--- a/tests/src/commons-io/commons-io/2.17.0/.gitignore
+++ b/tests/src/commons-io/commons-io/2.17.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/commons-io/commons-io/2.17.0/build.gradle
+++ b/tests/src/commons-io/commons-io/2.17.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "commons-io:commons-io:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/gradle.properties
+++ b/tests/src/commons-io/commons-io/2.17.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = commons-io:commons-io:2.17.0
+library.version = 2.17.0
+metadata.dir = commons-io/commons-io/2.17.0/

--- a/tests/src/commons-io/commons-io/2.17.0/settings.gradle
+++ b/tests/src/commons-io/commons-io/2.17.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'commons-io.commons-io_tests'

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.io.input.BufferedFileChannelInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class BufferedFileChannelInputStreamTest {
+
+    @Test
+    void readsEntireFileUsingTheFileConstructorAndClosesItsDirectBuffer(@TempDir final Path tempDirectory)
+            throws IOException {
+        final String fileContents = "0123456789abcdef";
+        final Path file = writeFile(tempDirectory, fileContents);
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final byte[] buffer = new byte[3];
+
+        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file.toFile(), 4)) {
+            assertThat(inputStream.available()).isZero();
+
+            outputStream.write(inputStream.read());
+            int read = inputStream.read(buffer, 0, buffer.length);
+            while (read != -1) {
+                outputStream.write(buffer, 0, read);
+                read = inputStream.read(buffer, 0, buffer.length);
+            }
+        }
+
+        assertThat(new String(outputStream.toByteArray(), StandardCharsets.UTF_8)).isEqualTo(fileContents);
+    }
+
+    @Test
+    void skipsAcrossBufferedAndChannelBytesUsingThePathConstructor(@TempDir final Path tempDirectory)
+            throws IOException {
+        final Path file = writeFile(tempDirectory, "abcdefghij");
+        final byte[] buffer = new byte[3];
+
+        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file, 3)) {
+            assertThat(inputStream.read()).isEqualTo((int) 'a');
+            assertThat(inputStream.skip(3)).isEqualTo(3L);
+            assertThat(inputStream.read(buffer, 0, buffer.length)).isEqualTo(3);
+            assertThat(new String(buffer, StandardCharsets.UTF_8)).isEqualTo("efg");
+            assertThat(inputStream.skip(10)).isEqualTo(3L);
+            assertThat(inputStream.read()).isEqualTo(-1);
+        }
+    }
+
+    private static Path writeFile(final Path tempDirectory, final String contents) throws IOException {
+        return Files.writeString(tempDirectory.resolve("buffered-file-channel-input-stream.txt"), contents,
+                StandardCharsets.UTF_8);
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
@@ -21,15 +21,18 @@ import org.junit.jupiter.api.io.TempDir;
 public class BufferedFileChannelInputStreamTest {
 
     @Test
-    void readsEntireFileUsingTheFileConstructorAndClosesItsDirectBuffer(@TempDir final Path tempDirectory)
+    void readsEntireFileUsingTheFileBuilderAndClosesItsDirectBuffer(@TempDir final Path tempDirectory)
             throws IOException {
         final String fileContents = "0123456789abcdef";
         final Path file = writeFile(tempDirectory, fileContents);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final byte[] buffer = new byte[3];
 
-        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file.toFile(), 4)) {
-            assertThat(inputStream.available()).isZero();
+        try (BufferedFileChannelInputStream inputStream = BufferedFileChannelInputStream.builder()
+                .setFile(file.toFile())
+                .setBufferSize(4)
+                .get()) {
+            assertThat(inputStream.available()).isEqualTo(4);
 
             outputStream.write(inputStream.read());
             int read = inputStream.read(buffer, 0, buffer.length);
@@ -43,12 +46,15 @@ public class BufferedFileChannelInputStreamTest {
     }
 
     @Test
-    void skipsAcrossBufferedAndChannelBytesUsingThePathConstructor(@TempDir final Path tempDirectory)
+    void skipsAcrossBufferedAndChannelBytesUsingThePathBuilder(@TempDir final Path tempDirectory)
             throws IOException {
         final Path file = writeFile(tempDirectory, "abcdefghij");
         final byte[] buffer = new byte[3];
 
-        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file, 3)) {
+        try (BufferedFileChannelInputStream inputStream = BufferedFileChannelInputStream.builder()
+                .setPath(file)
+                .setBufferSize(3)
+                .get()) {
             assertThat(inputStream.read()).isEqualTo((int) 'a');
             assertThat(inputStream.skip(3)).isEqualTo(3L);
             assertThat(inputStream.read(buffer, 0, buffer.length)).isEqualTo(3);

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ByteBufferCleanerInnerJava8CleanerTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ByteBufferCleanerInnerJava8CleanerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+public class ByteBufferCleanerInnerJava8CleanerTest {
+
+    @Test
+    void invokesConfiguredCleanerMethods() throws Exception {
+        final Class<?> cleanerClass = Class.forName("org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner");
+        final Object java8Cleaner = allocateWithoutConstructor(cleanerClass);
+        setField(cleanerClass, java8Cleaner, "cleanerMethod", CleanerHooks.class.getMethod("cleaner"));
+        setField(cleanerClass, java8Cleaner, "cleanMethod", CleanerProbe.class.getMethod("clean"));
+        CleanerHooks.reset();
+
+        final Method clean = cleanerClass.getDeclaredMethod("clean", ByteBuffer.class);
+        clean.setAccessible(true);
+        clean.invoke(java8Cleaner, ByteBuffer.allocate(1));
+
+        assertThat(CleanerHooks.cleanerInvocations()).isEqualTo(1);
+        assertThat(CleanerHooks.cleanInvocations()).isEqualTo(1);
+    }
+
+    private static Object allocateWithoutConstructor(final Class<?> type) throws Exception {
+        final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        final Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        final Object unsafe = theUnsafe.get(null);
+        final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+        return allocateInstance.invoke(unsafe, type);
+    }
+
+    private static void setField(final Class<?> type, final Object target, final String name, final Object value)
+            throws ReflectiveOperationException {
+        final Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    public static final class CleanerHooks {
+
+        private static final AtomicInteger CLEANER_INVOCATIONS = new AtomicInteger();
+
+        private static final CleanerProbe CLEANER = new CleanerProbe();
+
+        private CleanerHooks() {
+        }
+
+        public static CleanerProbe cleaner() {
+            CLEANER_INVOCATIONS.incrementAndGet();
+            return CLEANER;
+        }
+
+        private static int cleanerInvocations() {
+            return CLEANER_INVOCATIONS.get();
+        }
+
+        private static int cleanInvocations() {
+            return CLEANER.cleanInvocations();
+        }
+
+        private static void reset() {
+            CLEANER_INVOCATIONS.set(0);
+            CLEANER.reset();
+        }
+    }
+
+    public static final class CleanerProbe {
+
+        private final AtomicInteger cleanInvocations = new AtomicInteger();
+
+        public void clean() {
+            cleanInvocations.incrementAndGet();
+        }
+
+        private int cleanInvocations() {
+            return cleanInvocations.get();
+        }
+
+        private void reset() {
+            cleanInvocations.set(0);
+        }
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+import java.lang.reflect.Proxy;
+
+import org.apache.commons.io.input.ClassLoaderObjectInputStream;
+import org.junit.jupiter.api.Test;
+
+public class ClassLoaderObjectInputStreamTest {
+
+    @Test
+    void resolvesClassesWithTheProvidedClassLoader() throws Exception {
+        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(SerializablePayload.class);
+
+        try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
+                SerializablePayload.class.getClassLoader())) {
+            Class<?> resolvedClass = inputStream.resolveClassDescriptor(objectStreamClass);
+
+            assertThat(resolvedClass).isEqualTo(SerializablePayload.class);
+        }
+    }
+
+    @Test
+    void fallsBackToObjectInputStreamClassResolutionWhenTheProvidedLoaderCannotResolveTheClass() throws Exception {
+        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(String.class);
+        ClassLoader rejectingClassLoader = new RejectingClassLoader(
+                String.class.getName(),
+                ClassLoaderObjectInputStreamTest.class.getClassLoader());
+
+        try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
+                rejectingClassLoader)) {
+            Class<?> resolvedClass = inputStream.resolveClassDescriptor(objectStreamClass);
+
+            assertThat(resolvedClass).isEqualTo(String.class);
+        }
+    }
+
+    @Test
+    void resolvesProxyClassesWithTheProvidedClassLoader() throws Exception {
+        String[] interfaceNames = new String[] {NamedProxyContract.class.getName()};
+
+        try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
+                NamedProxyContract.class.getClassLoader())) {
+            Class<?> resolvedClass = inputStream.resolveProxyType(interfaceNames);
+
+            assertThat(Proxy.isProxyClass(resolvedClass)).isTrue();
+            assertThat(resolvedClass.getInterfaces()).containsExactly(NamedProxyContract.class);
+        }
+    }
+
+    @Test
+    void fallsBackToObjectInputStreamProxyResolutionWhenTheProvidedLoaderCannotDefineTheProxy() throws Exception {
+        String[] interfaceNames = new String[] {NonPublicProxyContract.class.getName()};
+        ClassLoader childClassLoader = new ClassLoader(NonPublicProxyContract.class.getClassLoader()) {
+        };
+
+        try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
+                childClassLoader)) {
+            Class<?> resolvedClass = inputStream.resolveProxyType(interfaceNames);
+
+            assertThat(Proxy.isProxyClass(resolvedClass)).isTrue();
+            assertThat(resolvedClass.getInterfaces()).containsExactly(NonPublicProxyContract.class);
+        }
+    }
+
+    private static byte[] emptyObjectStreamBytes() throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.flush();
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private interface NamedProxyContract extends Serializable {
+        String value();
+    }
+
+    interface NonPublicProxyContract extends Serializable {
+        String value();
+    }
+
+    private static final class SerializablePayload implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        private SerializablePayload(String value) {
+            this.value = value;
+        }
+
+        private String getValue() {
+            return value;
+        }
+    }
+
+    private static final class ExposedClassLoaderObjectInputStream extends ClassLoaderObjectInputStream {
+
+        private ExposedClassLoaderObjectInputStream(ClassLoader classLoader) throws IOException {
+            super(classLoader, new ByteArrayInputStream(emptyObjectStreamBytes()));
+        }
+
+        private Class<?> resolveClassDescriptor(ObjectStreamClass objectStreamClass)
+                throws IOException, ClassNotFoundException {
+            return super.resolveClass(objectStreamClass);
+        }
+
+        private Class<?> resolveProxyType(String[] interfaces) throws IOException, ClassNotFoundException {
+            return super.resolveProxyClass(interfaces);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(String rejectedClassName, ClassLoader parent) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
@@ -35,16 +35,16 @@ public class ClassLoaderObjectInputStreamTest {
 
     @Test
     void fallsBackToObjectInputStreamClassResolutionWhenTheProvidedLoaderCannotResolveTheClass() throws Exception {
-        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(String.class);
+        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(SerializablePayload.class);
         ClassLoader rejectingClassLoader = new RejectingClassLoader(
-                String.class.getName(),
+                SerializablePayload.class.getName(),
                 ClassLoaderObjectInputStreamTest.class.getClassLoader());
 
         try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
                 rejectingClassLoader)) {
             Class<?> resolvedClass = inputStream.resolveClassDescriptor(objectStreamClass);
 
-            assertThat(resolvedClass).isEqualTo(String.class);
+            assertThat(resolvedClass).isEqualTo(SerializablePayload.class);
         }
     }
 

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/IOUtilsTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/IOUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+public class IOUtilsTest {
+
+    private static final String RESOURCE_PATH = "commons-io/test-resource.txt";
+
+    @Test
+    void resolvesResourcesUsingIoUtilsClassWhenNoClassLoaderIsProvided() throws Exception {
+        URL resource = IOUtils.resourceToURL("/" + RESOURCE_PATH);
+
+        assertThat(resource).isNotNull();
+        assertThat(IOUtils.toString(resource, StandardCharsets.UTF_8)).isEqualTo("commons-io test resource\n");
+    }
+
+    @Test
+    void resolvesResourcesUsingTheProvidedClassLoader() throws Exception {
+        URL resource = IOUtils.resourceToURL(RESOURCE_PATH, getClass().getClassLoader());
+
+        assertThat(resource).isNotNull();
+        assertThat(IOUtils.toString(resource, StandardCharsets.UTF_8)).isEqualTo("commons-io test resource\n");
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/SerializableFileTimeTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/SerializableFileTimeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+
+import org.apache.commons.io.monitor.FileEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SerializableFileTimeTest {
+
+    @Test
+    void preservesFileEntryLastModifiedTimeAcrossSerialization(@TempDir final Path tempDirectory) throws Exception {
+        final Instant lastModifiedInstant = Instant.parse("2024-03-04T05:06:07.123456789Z");
+        final FileTime lastModifiedTime = FileTime.from(lastModifiedInstant);
+        final Path monitoredFile = tempDirectory.resolve("monitored-file.txt");
+        final FileEntry entry = new FileEntry(monitoredFile.toFile());
+        entry.setExists(true);
+        entry.setLastModified(lastModifiedTime);
+        entry.setLength(128L);
+
+        final FileEntry restored = deserialize(serialize(entry));
+
+        assertThat(restored.getFile()).isEqualTo(entry.getFile());
+        assertThat(restored.isExists()).isTrue();
+        assertThat(restored.getLastModifiedFileTime()).isEqualTo(lastModifiedTime);
+        assertThat(restored.getLastModified()).isEqualTo(lastModifiedTime.toMillis());
+        assertThat(restored.getLength()).isEqualTo(128L);
+    }
+
+    private static byte[] serialize(final FileEntry entry) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(entry);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private static FileEntry deserialize(final byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return (FileEntry) objectInputStream.readObject();
+        }
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
+import org.junit.jupiter.api.Test;
+
+public class ValidatingObjectInputStreamTest {
+
+    @Test
+    void deserializesAcceptedClassesThroughObjectInputStreamClassResolution() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta", "gamma"));
+        byte[] serializedPayload = serialize(payload);
+
+        try (ValidatingObjectInputStream inputStream = new ValidatingObjectInputStream(
+                new ByteArrayInputStream(serializedPayload))) {
+            inputStream.accept(ArrayList.class);
+
+            Object restored = inputStream.readObject();
+
+            assertThat(restored).isInstanceOf(ArrayList.class);
+            assertThat(restored).isEqualTo(payload);
+        }
+    }
+
+    private static byte[] serialize(Object value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
@@ -12,8 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.Serializable;
 
 import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.junit.jupiter.api.Test;
@@ -22,27 +21,43 @@ public class ValidatingObjectInputStreamTest {
 
     @Test
     void deserializesAcceptedClassesThroughObjectInputStreamClassResolution() throws Exception {
-        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta", "gamma"));
-        byte[] serializedPayload = serialize(payload);
+        final ValidatedPayload payload = new ValidatedPayload(42, true);
+        final byte[] serializedPayload = serialize(payload);
 
         try (ValidatingObjectInputStream inputStream = new ValidatingObjectInputStream(
                 new ByteArrayInputStream(serializedPayload))) {
-            inputStream.accept(ArrayList.class);
+            inputStream.accept(ValidatedPayload.class);
 
-            Object restored = inputStream.readObject();
+            final Object restored = inputStream.readObject();
 
-            assertThat(restored).isInstanceOf(ArrayList.class);
-            assertThat(restored).isEqualTo(payload);
+            assertThat(restored).isInstanceOf(ValidatedPayload.class);
+            final ValidatedPayload restoredPayload = (ValidatedPayload) restored;
+            assertThat(restoredPayload.count).isEqualTo(payload.count);
+            assertThat(restoredPayload.enabled).isEqualTo(payload.enabled);
         }
     }
 
-    private static byte[] serialize(Object value) throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private static byte[] serialize(final Object value) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
             objectOutputStream.writeObject(value);
         }
 
         return outputStream.toByteArray();
+    }
+
+    private static final class ValidatedPayload implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int count;
+
+        private final boolean enabled;
+
+        private ValidatedPayload(final int count, final boolean enabled) {
+            this.count = count;
+            this.enabled = enabled;
+        }
     }
 }

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/byte-buffer-cleaner-java8/reflect-config.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/byte-buffer-cleaner-java8/reflect-config.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner",
+    "allDeclaredFields" : true,
+    "allDeclaredMethods" : true,
+    "unsafeAllocated" : true
+  },
+  {
+    "name" : "sun.misc.Unsafe",
+    "fields" : [
+      {
+        "name" : "theUnsafe"
+      }
+    ],
+    "methods" : [
+      {
+        "name" : "allocateInstance",
+        "parameterTypes" : [
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "name" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerHooks",
+    "allDeclaredMethods" : true
+  },
+  {
+    "name" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerProbe",
+    "allDeclaredMethods" : true
+  }
+]

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,58 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NamedProxyContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NonPublicProxyContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : {
+        "proxy" : [
+          "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NonPublicProxyContract"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : {
+        "proxy" : [
+          "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NamedProxyContract"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.IOUtils"
+      },
+      "glob" : "commons-io/test-resource.txt"
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"
+    }
+  ]
+}

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -50,6 +50,18 @@
   "serialization" : [
     {
       "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "org.apache.commons.io.monitor.FileEntry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
+      },
+      "type" : "org.apache.commons.io.monitor.SerializableFileTime"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
       },
       "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -37,6 +37,44 @@
           "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NamedProxyContract"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner"
+      },
+      "type" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerHooks",
+      "methods" : [
+        {
+          "name" : "cleaner",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner"
+      },
+      "type" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerProbe",
+      "methods" : [
+        {
+          "name" : "clean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.serialization.ValidatingObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ValidatingObjectInputStreamTest$ValidatedPayload",
+      "serializable" : true
     }
   ],
   "resources" : [
@@ -45,32 +83,6 @@
         "typeReached" : "org.apache.commons.io.IOUtils"
       },
       "glob" : "commons-io/test-resource.txt"
-    }
-  ],
-  "serialization" : [
-    {
-      "condition" : {
-        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
-      },
-      "type" : "org.apache.commons.io.monitor.FileEntry"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.commons.io.monitor.FileEntry"
-      },
-      "type" : "org.apache.commons.io.monitor.SerializableFileTime"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
-      },
-      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.commons.io.serialization.ValidatingObjectInputStream"
-      },
-      "type" : "commons_io.commons_io.ValidatingObjectInputStreamTest$ValidatedPayload"
     }
   ]
 }

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -53,6 +53,12 @@
         "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
       },
       "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.serialization.ValidatingObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ValidatingObjectInputStreamTest$ValidatedPayload"
     }
   ]
 }

--- a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/commons-io/test-resource.txt
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/commons-io/test-resource.txt
@@ -1,0 +1,1 @@
+commons-io test resource

--- a/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
+++ b/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.commons.io.**"
+    }
+  ]
+}

--- a/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
+++ b/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.commons.io.**"
+      "includeClasses" : "org.apache.commons.io.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #2098

This PR provides test fixes and new metadata for commons-io:commons-io:2.17.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 200426
- Cached input tokens: 2778624
- Output tokens: 21772
- Entries found: 8
- Iterations: 3
- Library coverage percentage: 3.11
- Previous library version metadata entries: 8
- Previous library version coverage percentage: 2.24

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `f6c0383148f7f65fe6cb61600ddf0dde31af3c22`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- commons-io:commons-io:2.11.0: 10/10 covered calls (100.00%)
- commons-io:commons-io:2.17.0: 14/14 covered calls (100.00%)

**Reflection:**
- commons-io:commons-io:2.11.0: 8/8 covered calls (100.00%)
- commons-io:commons-io:2.17.0: 12/12 covered calls (100.00%)

**Resources:**
- commons-io:commons-io:2.11.0: 2/2 covered calls (100.00%)
- commons-io:commons-io:2.17.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- commons-io:commons-io:2.11.0: 664/30080 (2.21%)
- commons-io:commons-io:2.17.0: 1017/37346 (2.72%)

**Line:**
- commons-io:commons-io:2.11.0: 156/6973 (2.24%)
- commons-io:commons-io:2.17.0: 260/8372 (3.11%)

**Method:**
- commons-io:commons-io:2.11.0: 44/1892 (2.33%)
- commons-io:commons-io:2.17.0: 100/3009 (3.32%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/commons-io/commons-io/2.11.0/gradle.properties b/tests/src/commons-io/commons-io/2.17.0/gradle.properties
index 9a1ad762..62e5fe5b 100644
--- a/tests/src/commons-io/commons-io/2.11.0/gradle.properties
+++ b/tests/src/commons-io/commons-io/2.17.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = commons-io:commons-io:2.11.0
-library.version = 2.11.0
-metadata.dir = commons-io/commons-io/2.11.0/
+library.coordinates = commons-io:commons-io:2.17.0
+library.version = 2.17.0
+metadata.dir = commons-io/commons-io/2.17.0/
diff --git a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
index 1a5dbe7d..145e4c76 100644
--- a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/BufferedFileChannelInputStreamTest.java
@@ -21,15 +21,18 @@ import org.junit.jupiter.api.io.TempDir;
 public class BufferedFileChannelInputStreamTest {
 
     @Test
-    void readsEntireFileUsingTheFileConstructorAndClosesItsDirectBuffer(@TempDir final Path tempDirectory)
+    void readsEntireFileUsingTheFileBuilderAndClosesItsDirectBuffer(@TempDir final Path tempDirectory)
             throws IOException {
         final String fileContents = "0123456789abcdef";
         final Path file = writeFile(tempDirectory, fileContents);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final byte[] buffer = new byte[3];
 
-        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file.toFile(), 4)) {
-            assertThat(inputStream.available()).isZero();
+        try (BufferedFileChannelInputStream inputStream = BufferedFileChannelInputStream.builder()
+                .setFile(file.toFile())
+                .setBufferSize(4)
+                .get()) {
+            assertThat(inputStream.available()).isEqualTo(4);
 
             outputStream.write(inputStream.read());
             int read = inputStream.read(buffer, 0, buffer.length);
@@ -43,12 +46,15 @@ public class BufferedFileChannelInputStreamTest {
     }
 
     @Test
-    void skipsAcrossBufferedAndChannelBytesUsingThePathConstructor(@TempDir final Path tempDirectory)
+    void skipsAcrossBufferedAndChannelBytesUsingThePathBuilder(@TempDir final Path tempDirectory)
             throws IOException {
         final Path file = writeFile(tempDirectory, "abcdefghij");
         final byte[] buffer = new byte[3];
 
-        try (BufferedFileChannelInputStream inputStream = new BufferedFileChannelInputStream(file, 3)) {
+        try (BufferedFileChannelInputStream inputStream = BufferedFileChannelInputStream.builder()
+                .setPath(file)
+                .setBufferSize(3)
+                .get()) {
             assertThat(inputStream.read()).isEqualTo((int) 'a');
             assertThat(inputStream.skip(3)).isEqualTo(3L);
             assertThat(inputStream.read(buffer, 0, buffer.length)).isEqualTo(3);
diff --git a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ByteBufferCleanerInnerJava8CleanerTest.java b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ByteBufferCleanerInnerJava8CleanerTest.java
new file mode 100644
index 00000000..05398e2e
--- /dev/null
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ByteBufferCleanerInnerJava8CleanerTest.java
@@ -0,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+public class ByteBufferCleanerInnerJava8CleanerTest {
+
+    @Test
+    void invokesConfiguredCleanerMethods() throws Exception {
+        final Class<?> cleanerClass = Class.forName("org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner");
+        final Object java8Cleaner = allocateWithoutConstructor(cleanerClass);
+        setField(cleanerClass, java8Cleaner, "cleanerMethod", CleanerHooks.class.getMethod("cleaner"));
+        setField(cleanerClass, java8Cleaner, "cleanMethod", CleanerProbe.class.getMethod("clean"));
+        CleanerHooks.reset();
+
+        final Method clean = cleanerClass.getDeclaredMethod("clean", ByteBuffer.class);
+        clean.setAccessible(true);
+        clean.invoke(java8Cleaner, ByteBuffer.allocate(1));
+
+        assertThat(CleanerHooks.cleanerInvocations()).isEqualTo(1);
+        assertThat(CleanerHooks.cleanInvocations()).isEqualTo(1);
+    }
+
+    private static Object allocateWithoutConstructor(final Class<?> type) throws Exception {
+        final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        final Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        final Object unsafe = theUnsafe.get(null);
+        final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+        return allocateInstance.invoke(unsafe, type);
+    }
+
+    private static void setField(final Class<?> type, final Object target, final String name, final Object value)
+            throws ReflectiveOperationException {
+        final Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    public static final class CleanerHooks {
+
+        private static final AtomicInteger CLEANER_INVOCATIONS = new AtomicInteger();
+
+        private static final CleanerProbe CLEANER = new CleanerProbe();
+
+        private CleanerHooks() {
+        }
+
+        public static CleanerProbe cleaner() {
+            CLEANER_INVOCATIONS.incrementAndGet();
+            return CLEANER;
+        }
+
+        private static int cleanerInvocations() {
+            return CLEANER_INVOCATIONS.get();
+        }
+
+        private static int cleanInvocations() {
+            return CLEANER.cleanInvocations();
+        }
+
+        private static void reset() {
+            CLEANER_INVOCATIONS.set(0);
+            CLEANER.reset();
+        }
+    }
+
+    public static final class CleanerProbe {
+
+        private final AtomicInteger cleanInvocations = new AtomicInteger();
+
+        public void clean() {
+            cleanInvocations.incrementAndGet();
+        }
+
+        private int cleanInvocations() {
+            return cleanInvocations.get();
+        }
+
+        private void reset() {
+            cleanInvocations.set(0);
+        }
+    }
+}
diff --git a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
index da6127c4..0ce6d4d0 100644
--- a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ClassLoaderObjectInputStreamTest.java
@@ -35,16 +35,16 @@ public class ClassLoaderObjectInputStreamTest {
 
     @Test
     void fallsBackToObjectInputStreamClassResolutionWhenTheProvidedLoaderCannotResolveTheClass() throws Exception {
-        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(String.class);
+        ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(SerializablePayload.class);
         ClassLoader rejectingClassLoader = new RejectingClassLoader(
-                String.class.getName(),
+                SerializablePayload.class.getName(),
                 ClassLoaderObjectInputStreamTest.class.getClassLoader());
 
         try (ExposedClassLoaderObjectInputStream inputStream = new ExposedClassLoaderObjectInputStream(
                 rejectingClassLoader)) {
             Class<?> resolvedClass = inputStream.resolveClassDescriptor(objectStreamClass);
 
-            assertThat(resolvedClass).isEqualTo(String.class);
+            assertThat(resolvedClass).isEqualTo(SerializablePayload.class);
         }
     }
 
diff --git a/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/SerializableFileTimeTest.java b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/SerializableFileTimeTest.java
new file mode 100644
index 00000000..c3c2a143
--- /dev/null
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/SerializableFileTimeTest.java
@@ -0,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_io.commons_io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+
+import org.apache.commons.io.monitor.FileEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SerializableFileTimeTest {
+
+    @Test
+    void preservesFileEntryLastModifiedTimeAcrossSerialization(@TempDir final Path tempDirectory) throws Exception {
+        final Instant lastModifiedInstant = Instant.parse("2024-03-04T05:06:07.123456789Z");
+        final FileTime lastModifiedTime = FileTime.from(lastModifiedInstant);
+        final Path monitoredFile = tempDirectory.resolve("monitored-file.txt");
+        final FileEntry entry = new FileEntry(monitoredFile.toFile());
+        entry.setExists(true);
+        entry.setLastModified(lastModifiedTime);
+        entry.setLength(128L);
+
+        final FileEntry restored = deserialize(serialize(entry));
+
+        assertThat(restored.getFile()).isEqualTo(entry.getFile());
+        assertThat(restored.isExists()).isTrue();
+        assertThat(restored.getLastModifiedFileTime()).isEqualTo(lastModifiedTime);
+        assertThat(restored.getLastModified()).isEqualTo(lastModifiedTime.toMillis());
+        assertThat(restored.getLength()).isEqualTo(128L);
+    }
+
+    private static byte[] serialize(final FileEntry entry) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(entry);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private static FileEntry deserialize(final byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return (FileEntry) objectInputStream.readObject();
+        }
+    }
+}
diff --git a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
index 5598d064..54a8adeb 100644
--- a/tests/src/commons-io/commons-io/2.11.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/java/commons_io/commons_io/ValidatingObjectInputStreamTest.java
@@ -12,8 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.Serializable;
 
 import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.junit.jupiter.api.Test;
@@ -22,22 +21,24 @@ public class ValidatingObjectInputStreamTest {
 
     @Test
     void deserializesAcceptedClassesThroughObjectInputStreamClassResolution() throws Exception {
-        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta", "gamma"));
-        byte[] serializedPayload = serialize(payload);
+        final ValidatedPayload payload = new ValidatedPayload(42, true);
+        final byte[] serializedPayload = serialize(payload);
 
         try (ValidatingObjectInputStream inputStream = new ValidatingObjectInputStream(
                 new ByteArrayInputStream(serializedPayload))) {
-            inputStream.accept(ArrayList.class);
+            inputStream.accept(ValidatedPayload.class);
 
-            Object restored = inputStream.readObject();
+            final Object restored = inputStream.readObject();
 
-            assertThat(restored).isInstanceOf(ArrayList.class);
-            assertThat(restored).isEqualTo(payload);
+            assertThat(restored).isInstanceOf(ValidatedPayload.class);
+            final ValidatedPayload restoredPayload = (ValidatedPayload) restored;
+            assertThat(restoredPayload.count).isEqualTo(payload.count);
+            assertThat(restoredPayload.enabled).isEqualTo(payload.enabled);
         }
     }
 
-    private static byte[] serialize(Object value) throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private static byte[] serialize(final Object value) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
             objectOutputStream.writeObject(value);
@@ -45,4 +46,18 @@ public class ValidatingObjectInputStreamTest {
 
         return outputStream.toByteArray();
     }
+
+    private static final class ValidatedPayload implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int count;
+
+        private final boolean enabled;
+
+        private ValidatedPayload(final int count, final boolean enabled) {
+            this.count = count;
+            this.enabled = enabled;
+        }
+    }
 }
diff --git a/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/byte-buffer-cleaner-java8/reflect-config.json b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/byte-buffer-cleaner-java8/reflect-config.json
new file mode 100644
index 00000000..5e92da1f
--- /dev/null
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/byte-buffer-cleaner-java8/reflect-config.json
@@ -0,0 +1,32 @@
+[
+  {
+    "name" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner",
+    "allDeclaredFields" : true,
+    "allDeclaredMethods" : true,
+    "unsafeAllocated" : true
+  },
+  {
+    "name" : "sun.misc.Unsafe",
+    "fields" : [
+      {
+        "name" : "theUnsafe"
+      }
+    ],
+    "methods" : [
+      {
+        "name" : "allocateInstance",
+        "parameterTypes" : [
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "name" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerHooks",
+    "allDeclaredMethods" : true
+  },
+  {
+    "name" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerProbe",
+    "allDeclaredMethods" : true
+  }
+]
diff --git a/tests/src/commons-io/commons-io/2.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
index df3fac56..9d015dc1 100644
--- a/tests/src/commons-io/commons-io/2.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-io/commons-io/2.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -37,22 +37,52 @@
           "commons_io.commons_io.ClassLoaderObjectInputStreamTest$NamedProxyContract"
         ]
       }
-    }
-  ],
-  "resources" : [
+    },
     {
       "condition" : {
-        "typeReached" : "org.apache.commons.io.IOUtils"
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner"
       },
-      "glob" : "commons-io/test-resource.txt"
+      "type" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerHooks",
+      "methods" : [
+        {
+          "name" : "cleaner",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ByteBufferCleaner$Java8Cleaner"
+      },
+      "type" : "commons_io.commons_io.ByteBufferCleanerInnerJava8CleanerTest$CleanerProbe",
+      "methods" : [
+        {
+          "name" : "clean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.io.serialization.ValidatingObjectInputStream"
+      },
+      "type" : "commons_io.commons_io.ValidatingObjectInputStreamTest$ValidatedPayload",
+      "serializable" : true
     }
   ],
-  "serialization" : [
+  "resources" : [
     {
       "condition" : {
-        "typeReached" : "org.apache.commons.io.input.ClassLoaderObjectInputStream"
+        "typeReached" : "org.apache.commons.io.IOUtils"
       },
-      "type" : "commons_io.commons_io.ClassLoaderObjectInputStreamTest$SerializablePayload"
+      "glob" : "commons-io/test-resource.txt"
     }
   ]
 }
diff --git a/tests/src/commons-io/commons-io/2.11.0/user-code-filter.json b/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
index 6c2ecf1b..bb0863b0 100644
--- a/tests/src/commons-io/commons-io/2.11.0/user-code-filter.json
+++ b/tests/src/commons-io/commons-io/2.17.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.commons.io.**"
+      "includeClasses" : "org.apache.commons.io.**"
     }
   ]
 }

```
