### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.core:jackson-annotations:2.3.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.core/jackson-annotations/2.3.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-annotations/2.3.0/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.annotation.ObjectIdGenerators$UUIDGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.annotation.ObjectIdGenerators$UUIDGenerator"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.3.0",
+    "tested-versions" : [
+      "2.3.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.annotation"
+    ]
+  },
+  {
     "metadata-version" : "2.1.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.1.2/jackson-annotations-2.1.2-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-annotations",

--- a/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.3.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.3.0/jackson-annotations-2.3.0-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-annotations",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.3.0/jackson-annotations-2.3.0-javadoc.jar",
+    "description" : "Jackson Annotations provides core Java annotation types used by Jackson data-binding and related modules to configure JSON serialization, deserialization, type handling, and property naming. It is a small companion artifact that contains annotation APIs rather than runtime data-binding logic.",
     "tested-versions" : [
       "2.3.0"
     ],

--- a/stats/com.fasterxml.jackson.core/jackson-annotations/2.3.0/stats.json
+++ b/stats/com.fasterxml.jackson.core/jackson-annotations/2.3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 809,
+        "missed" : 13,
+        "ratio" : 0.984185,
+        "total" : 822
+      },
+      "line" : {
+        "covered" : 122,
+        "missed" : 5,
+        "ratio" : 0.96063,
+        "total" : 127
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 4,
+        "ratio" : 0.924528,
+        "total" : 53
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.core:jackson-annotations:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.core:jackson-annotations:2.3.0
+library.version = 2.3.0
+metadata.dir = com.fasterxml.jackson.core/jackson-annotations/2.3.0/

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.core.jackson-annotations_tests'

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_core.jackson_annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Modifier;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Jackson_annotationsTest {
+    @Test
+    void jsonFormatValueSupportsDefaultStringAndAnnotationInputs() {
+        JsonFormat.Value defaultValue = new JsonFormat.Value();
+
+        assertThat(defaultValue.getPattern()).isEmpty();
+        assertThat(defaultValue.getShape()).isEqualTo(JsonFormat.Shape.ANY);
+        assertThat(defaultValue.getLocale()).isNull();
+        assertThat(defaultValue.getTimeZone()).isNull();
+
+        JsonFormat.Value explicitValue = new JsonFormat.Value(
+                "yyyy-MM-dd",
+                JsonFormat.Shape.STRING,
+                "fr",
+                "UTC"
+        );
+
+        assertThat(explicitValue.getPattern()).isEqualTo("yyyy-MM-dd");
+        assertThat(explicitValue.getShape()).isEqualTo(JsonFormat.Shape.STRING);
+        assertThat(explicitValue.getLocale()).isEqualTo(Locale.FRENCH);
+        assertThat(explicitValue.getTimeZone().getID()).isEqualTo("UTC");
+
+        JsonFormat.Value defaultMarkerValue = new JsonFormat.Value(
+                "pattern",
+                JsonFormat.Shape.OBJECT,
+                JsonFormat.DEFAULT_LOCALE,
+                JsonFormat.DEFAULT_TIMEZONE
+        );
+
+        assertThat(defaultMarkerValue.getLocale()).isNull();
+        assertThat(defaultMarkerValue.getTimeZone()).isNull();
+
+        JsonFormat.Value emptyMarkerValue = new JsonFormat.Value(
+                "pattern",
+                JsonFormat.Shape.ARRAY,
+                "",
+                ""
+        );
+
+        assertThat(emptyMarkerValue.getLocale()).isNull();
+        assertThat(emptyMarkerValue.getTimeZone()).isNull();
+
+        JsonFormat.Value updatedValue = explicitValue
+                .withPattern("HH:mm")
+                .withShape(JsonFormat.Shape.NUMBER_INT)
+                .withLocale(Locale.CANADA_FRENCH)
+                .withTimeZone(TimeZone.getTimeZone("GMT+02:00"));
+
+        assertThat(updatedValue.getPattern()).isEqualTo("HH:mm");
+        assertThat(updatedValue.getShape()).isEqualTo(JsonFormat.Shape.NUMBER_INT);
+        assertThat(updatedValue.getLocale()).isEqualTo(Locale.CANADA_FRENCH);
+        assertThat(updatedValue.getTimeZone().getID()).isEqualTo("GMT+02:00");
+        assertThat(explicitValue.getPattern()).isEqualTo("yyyy-MM-dd");
+        assertThat(explicitValue.getShape()).isEqualTo(JsonFormat.Shape.STRING);
+        assertThat(explicitValue.getLocale()).isEqualTo(Locale.FRENCH);
+        assertThat(explicitValue.getTimeZone().getID()).isEqualTo("UTC");
+
+        JsonFormat annotation = jsonFormatAnnotation("dd/MM", JsonFormat.Shape.BOOLEAN, "de", "Europe/Berlin");
+        JsonFormat.Value annotationValue = new JsonFormat.Value(annotation);
+
+        assertThat(annotationValue.getPattern()).isEqualTo("dd/MM");
+        assertThat(annotationValue.getShape()).isEqualTo(JsonFormat.Shape.BOOLEAN);
+        assertThat(annotationValue.getLocale()).isEqualTo(Locale.GERMAN);
+        assertThat(annotationValue.getTimeZone().getID()).isEqualTo("Europe/Berlin");
+    }
+
+    @Test
+    void jsonFormatShapeRecognizesNumericAndStructuredKinds() {
+        assertThat(JsonFormat.Shape.values()).containsExactly(
+                JsonFormat.Shape.ANY,
+                JsonFormat.Shape.SCALAR,
+                JsonFormat.Shape.ARRAY,
+                JsonFormat.Shape.OBJECT,
+                JsonFormat.Shape.NUMBER,
+                JsonFormat.Shape.NUMBER_FLOAT,
+                JsonFormat.Shape.NUMBER_INT,
+                JsonFormat.Shape.STRING,
+                JsonFormat.Shape.BOOLEAN
+        );
+        assertThat(JsonFormat.Shape.valueOf("NUMBER_FLOAT")).isEqualTo(JsonFormat.Shape.NUMBER_FLOAT);
+
+        assertThat(JsonFormat.Shape.NUMBER.isNumeric()).isTrue();
+        assertThat(JsonFormat.Shape.NUMBER_FLOAT.isNumeric()).isTrue();
+        assertThat(JsonFormat.Shape.NUMBER_INT.isNumeric()).isTrue();
+        assertThat(JsonFormat.Shape.ANY.isNumeric()).isFalse();
+        assertThat(JsonFormat.Shape.SCALAR.isNumeric()).isFalse();
+        assertThat(JsonFormat.Shape.ARRAY.isNumeric()).isFalse();
+        assertThat(JsonFormat.Shape.OBJECT.isNumeric()).isFalse();
+        assertThat(JsonFormat.Shape.STRING.isNumeric()).isFalse();
+        assertThat(JsonFormat.Shape.BOOLEAN.isNumeric()).isFalse();
+
+        assertThat(JsonFormat.Shape.ARRAY.isStructured()).isTrue();
+        assertThat(JsonFormat.Shape.OBJECT.isStructured()).isTrue();
+        assertThat(JsonFormat.Shape.ANY.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.SCALAR.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.NUMBER.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.NUMBER_FLOAT.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.NUMBER_INT.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.STRING.isStructured()).isFalse();
+        assertThat(JsonFormat.Shape.BOOLEAN.isStructured()).isFalse();
+    }
+
+    @Test
+    void propertyAccessorFlagsMatchTheirAccessorKinds() {
+        assertThat(PropertyAccessor.values()).containsExactly(
+                PropertyAccessor.GETTER,
+                PropertyAccessor.SETTER,
+                PropertyAccessor.CREATOR,
+                PropertyAccessor.FIELD,
+                PropertyAccessor.IS_GETTER,
+                PropertyAccessor.NONE,
+                PropertyAccessor.ALL
+        );
+        assertThat(PropertyAccessor.valueOf("FIELD")).isEqualTo(PropertyAccessor.FIELD);
+
+        assertThat(PropertyAccessor.GETTER.getterEnabled()).isTrue();
+        assertThat(PropertyAccessor.GETTER.setterEnabled()).isFalse();
+        assertThat(PropertyAccessor.GETTER.creatorEnabled()).isFalse();
+        assertThat(PropertyAccessor.GETTER.fieldEnabled()).isFalse();
+        assertThat(PropertyAccessor.GETTER.isGetterEnabled()).isFalse();
+
+        assertThat(PropertyAccessor.SETTER.setterEnabled()).isTrue();
+        assertThat(PropertyAccessor.CREATOR.creatorEnabled()).isTrue();
+        assertThat(PropertyAccessor.FIELD.fieldEnabled()).isTrue();
+        assertThat(PropertyAccessor.IS_GETTER.isGetterEnabled()).isTrue();
+
+        assertThat(PropertyAccessor.NONE.creatorEnabled()).isFalse();
+        assertThat(PropertyAccessor.NONE.getterEnabled()).isFalse();
+        assertThat(PropertyAccessor.NONE.isGetterEnabled()).isFalse();
+        assertThat(PropertyAccessor.NONE.setterEnabled()).isFalse();
+        assertThat(PropertyAccessor.NONE.fieldEnabled()).isFalse();
+
+        assertThat(PropertyAccessor.ALL.creatorEnabled()).isTrue();
+        assertThat(PropertyAccessor.ALL.getterEnabled()).isTrue();
+        assertThat(PropertyAccessor.ALL.isGetterEnabled()).isTrue();
+        assertThat(PropertyAccessor.ALL.setterEnabled()).isTrue();
+        assertThat(PropertyAccessor.ALL.fieldEnabled()).isTrue();
+    }
+
+    @Test
+    void jsonTypeInfoAndJsonIncludeEnumsExposeStableDefaults() {
+        assertThat(JsonTypeInfo.Id.values()).containsExactly(
+                JsonTypeInfo.Id.NONE,
+                JsonTypeInfo.Id.CLASS,
+                JsonTypeInfo.Id.MINIMAL_CLASS,
+                JsonTypeInfo.Id.NAME,
+                JsonTypeInfo.Id.CUSTOM
+        );
+        assertThat(JsonTypeInfo.Id.valueOf("CLASS")).isEqualTo(JsonTypeInfo.Id.CLASS);
+        assertThat(JsonTypeInfo.Id.NONE.getDefaultPropertyName()).isNull();
+        assertThat(JsonTypeInfo.Id.CLASS.getDefaultPropertyName()).isEqualTo("@class");
+        assertThat(JsonTypeInfo.Id.MINIMAL_CLASS.getDefaultPropertyName()).isEqualTo("@c");
+        assertThat(JsonTypeInfo.Id.NAME.getDefaultPropertyName()).isEqualTo("@type");
+        assertThat(JsonTypeInfo.Id.CUSTOM.getDefaultPropertyName()).isNull();
+
+        assertThat(JsonTypeInfo.As.values()).containsExactly(
+                JsonTypeInfo.As.PROPERTY,
+                JsonTypeInfo.As.WRAPPER_OBJECT,
+                JsonTypeInfo.As.WRAPPER_ARRAY,
+                JsonTypeInfo.As.EXTERNAL_PROPERTY
+        );
+        assertThat(JsonTypeInfo.As.valueOf("WRAPPER_ARRAY")).isEqualTo(JsonTypeInfo.As.WRAPPER_ARRAY);
+
+        assertThat(JsonInclude.Include.values()).containsExactly(
+                JsonInclude.Include.ALWAYS,
+                JsonInclude.Include.NON_NULL,
+                JsonInclude.Include.NON_DEFAULT,
+                JsonInclude.Include.NON_EMPTY
+        );
+        assertThat(JsonInclude.Include.valueOf("NON_EMPTY")).isEqualTo(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Test
+    void jsonSubTypesRetainsNamedSubtypeDefinitions() {
+        JsonSubTypes.Type firstSubtype = jsonSubTypeAnnotation(FirstSubtype.class, "first");
+        JsonSubTypes.Type secondSubtype = jsonSubTypeAnnotation(SecondSubtype.class, "second");
+        JsonSubTypes jsonSubTypes = jsonSubTypesAnnotation(firstSubtype, secondSubtype);
+
+        assertThat(jsonSubTypes.value()).containsExactly(firstSubtype, secondSubtype);
+        assertThat(jsonSubTypes.value())
+                .extracting(JsonSubTypes.Type::value)
+                .containsExactly(FirstSubtype.class, SecondSubtype.class);
+        assertThat(jsonSubTypes.value())
+                .extracting(JsonSubTypes.Type::name)
+                .containsExactly("first", "second");
+    }
+
+    @Test
+    void propertyAnnotationsExposeIgnoreOrderAndUnwrapConfiguration() {
+        JsonIgnoreProperties ignoreProperties = jsonIgnorePropertiesAnnotation(true, "internalId", "debugOnly");
+        JsonPropertyOrder propertyOrder = jsonPropertyOrderAnnotation(true, "id", "name", "createdAt");
+        JsonUnwrapped unwrapped = jsonUnwrappedAnnotation(true, "address.", ".value");
+
+        assertThat(ignoreProperties.value()).containsExactly("internalId", "debugOnly");
+        assertThat(ignoreProperties.ignoreUnknown()).isTrue();
+
+        assertThat(propertyOrder.value()).containsExactly("id", "name", "createdAt");
+        assertThat(propertyOrder.alphabetic()).isTrue();
+
+        assertThat(unwrapped.enabled()).isTrue();
+        assertThat(unwrapped.prefix()).isEqualTo("address.");
+        assertThat(unwrapped.suffix()).isEqualTo(".value");
+    }
+
+    @Test
+    void visibilityRulesDependOnMemberModifiers() {
+        Member publicMember = memberWithModifiers(Modifier.PUBLIC);
+        Member protectedMember = memberWithModifiers(Modifier.PROTECTED);
+        Member packagePrivateMember = memberWithModifiers(0);
+        Member privateMember = memberWithModifiers(Modifier.PRIVATE);
+
+        assertThat(JsonAutoDetect.Visibility.values()).containsExactly(
+                JsonAutoDetect.Visibility.ANY,
+                JsonAutoDetect.Visibility.NON_PRIVATE,
+                JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC,
+                JsonAutoDetect.Visibility.PUBLIC_ONLY,
+                JsonAutoDetect.Visibility.NONE,
+                JsonAutoDetect.Visibility.DEFAULT
+        );
+        assertThat(JsonAutoDetect.Visibility.valueOf("PUBLIC_ONLY")).isEqualTo(JsonAutoDetect.Visibility.PUBLIC_ONLY);
+
+        assertThat(JsonAutoDetect.Visibility.ANY.isVisible(privateMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.NONE.isVisible(publicMember)).isFalse();
+        assertThat(JsonAutoDetect.Visibility.DEFAULT.isVisible(publicMember)).isFalse();
+
+        assertThat(JsonAutoDetect.Visibility.NON_PRIVATE.isVisible(publicMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.NON_PRIVATE.isVisible(protectedMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.NON_PRIVATE.isVisible(packagePrivateMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.NON_PRIVATE.isVisible(privateMember)).isFalse();
+
+        assertThat(JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC.isVisible(publicMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC.isVisible(protectedMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC.isVisible(packagePrivateMember)).isFalse();
+        assertThat(JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC.isVisible(privateMember)).isFalse();
+
+        assertThat(JsonAutoDetect.Visibility.PUBLIC_ONLY.isVisible(publicMember)).isTrue();
+        assertThat(JsonAutoDetect.Visibility.PUBLIC_ONLY.isVisible(protectedMember)).isFalse();
+        assertThat(JsonAutoDetect.Visibility.PUBLIC_ONLY.isVisible(packagePrivateMember)).isFalse();
+        assertThat(JsonAutoDetect.Visibility.PUBLIC_ONLY.isVisible(privateMember)).isFalse();
+    }
+
+    @Test
+    void objectIdKeyEqualityDependsOnTypeScopeAndKey() {
+        ObjectIdGenerator.IdKey baseKey = new ObjectIdGenerator.IdKey(String.class, Integer.class, "alpha");
+        ObjectIdGenerator.IdKey equalKey = new ObjectIdGenerator.IdKey(String.class, Integer.class, "alpha");
+        ObjectIdGenerator.IdKey differentType = new ObjectIdGenerator.IdKey(UUID.class, Integer.class, "alpha");
+        ObjectIdGenerator.IdKey differentScope = new ObjectIdGenerator.IdKey(String.class, Long.class, "alpha");
+        ObjectIdGenerator.IdKey differentKey = new ObjectIdGenerator.IdKey(String.class, Integer.class, "beta");
+        ObjectIdGenerator.IdKey nullScope = new ObjectIdGenerator.IdKey(String.class, null, "alpha");
+
+        assertThat(baseKey).isEqualTo(baseKey);
+        assertThat(baseKey).isEqualTo(equalKey);
+        assertThat(baseKey.hashCode()).isEqualTo(equalKey.hashCode());
+        assertThat(baseKey).isNotEqualTo(differentType);
+        assertThat(baseKey).isNotEqualTo(differentScope);
+        assertThat(baseKey).isNotEqualTo(differentKey);
+        assertThat(baseKey).isNotEqualTo(nullScope);
+        assertThat(baseKey).isNotEqualTo(null);
+        assertThat(baseKey).isNotEqualTo("alpha");
+    }
+
+    @Test
+    void intSequenceGeneratorTracksScopeKeysAndSerializationState() {
+        ObjectIdGenerators.IntSequenceGenerator generator = new ObjectIdGenerators.IntSequenceGenerator();
+
+        assertThat(generator.getScope()).isEqualTo(Object.class);
+        assertThat(generator.generateId(new Object())).isEqualTo(-1);
+        assertThat(generator.generateId(new Object())).isEqualTo(0);
+
+        assertThat(generator.forScope(Object.class)).isSameAs(generator);
+
+        ObjectIdGenerator<Integer> scopedGenerator = generator.forScope(String.class);
+        assertThat(scopedGenerator).isNotSameAs(generator);
+        assertThat(scopedGenerator.getScope()).isEqualTo(String.class);
+        assertThat(scopedGenerator.generateId(new Object())).isEqualTo(1);
+
+        ObjectIdGenerator<Integer> serializationGenerator = generator.newForSerialization(new Object());
+        assertThat(serializationGenerator).isNotSameAs(generator);
+        assertThat(serializationGenerator.getScope()).isEqualTo(Object.class);
+        assertThat(serializationGenerator.generateId(new Object())).isEqualTo(1);
+        assertThat(serializationGenerator.generateId(new Object())).isEqualTo(2);
+
+        assertThat(generator.key("user-1")).isEqualTo(
+                new ObjectIdGenerator.IdKey(ObjectIdGenerators.IntSequenceGenerator.class, Object.class, "user-1")
+        );
+
+        assertThat(generator.canUseFor(new ObjectIdGenerators.IntSequenceGenerator(Object.class, 25))).isTrue();
+        assertThat(generator.canUseFor(new ObjectIdGenerators.IntSequenceGenerator(String.class, 25))).isFalse();
+        assertThat(generator.canUseFor(new ObjectIdGenerators.UUIDGenerator())).isFalse();
+    }
+
+    @Test
+    void uuidGeneratorIsReusableAcrossScopesAndProducesUniqueIds() {
+        ObjectIdGenerators.UUIDGenerator generator = new ObjectIdGenerators.UUIDGenerator();
+
+        assertThat(generator.getScope()).isEqualTo(Object.class);
+        assertThat(generator.forScope(String.class)).isSameAs(generator);
+        assertThat(generator.newForSerialization(new Object())).isSameAs(generator);
+
+        UUID firstId = generator.generateId(new Object());
+        UUID secondId = generator.generateId(new Object());
+
+        assertThat(firstId).isNotNull();
+        assertThat(secondId).isNotNull();
+        assertThat(secondId).isNotEqualTo(firstId);
+        assertThat(generator.key("user-2")).isEqualTo(
+                new ObjectIdGenerator.IdKey(ObjectIdGenerators.UUIDGenerator.class, null, "user-2")
+        );
+        assertThat(generator.canUseFor(new ObjectIdGenerators.UUIDGenerator())).isTrue();
+        assertThat(generator.canUseFor(new ObjectIdGenerators.IntSequenceGenerator())).isFalse();
+    }
+
+    private static JsonFormat jsonFormatAnnotation(
+            final String pattern,
+            final JsonFormat.Shape shape,
+            final String locale,
+            final String timezone
+    ) {
+        return new JsonFormat() {
+            @Override
+            public String pattern() {
+                return pattern;
+            }
+
+            @Override
+            public JsonFormat.Shape shape() {
+                return shape;
+            }
+
+            @Override
+            public String locale() {
+                return locale;
+            }
+
+            @Override
+            public String timezone() {
+                return timezone;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonFormat.class;
+            }
+        };
+    }
+
+    private static JsonSubTypes jsonSubTypesAnnotation(final JsonSubTypes.Type... value) {
+        return new JsonSubTypes() {
+            @Override
+            public JsonSubTypes.Type[] value() {
+                return value;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonSubTypes.class;
+            }
+        };
+    }
+
+    private static JsonSubTypes.Type jsonSubTypeAnnotation(final Class<?> value, final String name) {
+        return new JsonSubTypes.Type() {
+            @Override
+            public Class<?> value() {
+                return value;
+            }
+
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonSubTypes.Type.class;
+            }
+        };
+    }
+
+    private static JsonIgnoreProperties jsonIgnorePropertiesAnnotation(
+            final boolean ignoreUnknown,
+            final String... value
+    ) {
+        return new JsonIgnoreProperties() {
+            @Override
+            public String[] value() {
+                return value;
+            }
+
+            @Override
+            public boolean ignoreUnknown() {
+                return ignoreUnknown;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonIgnoreProperties.class;
+            }
+        };
+    }
+
+    private static JsonPropertyOrder jsonPropertyOrderAnnotation(
+            final boolean alphabetic,
+            final String... value
+    ) {
+        return new JsonPropertyOrder() {
+            @Override
+            public String[] value() {
+                return value;
+            }
+
+            @Override
+            public boolean alphabetic() {
+                return alphabetic;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonPropertyOrder.class;
+            }
+        };
+    }
+
+    private static JsonUnwrapped jsonUnwrappedAnnotation(
+            final boolean enabled,
+            final String prefix,
+            final String suffix
+    ) {
+        return new JsonUnwrapped() {
+            @Override
+            public boolean enabled() {
+                return enabled;
+            }
+
+            @Override
+            public String prefix() {
+                return prefix;
+            }
+
+            @Override
+            public String suffix() {
+                return suffix;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return JsonUnwrapped.class;
+            }
+        };
+    }
+
+    private static Member memberWithModifiers(final int modifiers) {
+        return new Member() {
+            @Override
+            public Class<?> getDeclaringClass() {
+                return Jackson_annotationsTest.class;
+            }
+
+            @Override
+            public String getName() {
+                return "member";
+            }
+
+            @Override
+            public int getModifiers() {
+                return modifiers;
+            }
+
+            @Override
+            public boolean isSynthetic() {
+                return false;
+            }
+        };
+    }
+
+    private static final class FirstSubtype {
+    }
+
+    private static final class SecondSubtype {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
@@ -187,9 +187,11 @@ class Jackson_annotationsTest {
                 JsonTypeInfo.As.PROPERTY,
                 JsonTypeInfo.As.WRAPPER_OBJECT,
                 JsonTypeInfo.As.WRAPPER_ARRAY,
-                JsonTypeInfo.As.EXTERNAL_PROPERTY
+                JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                JsonTypeInfo.As.EXISTING_PROPERTY
         );
         assertThat(JsonTypeInfo.As.valueOf("WRAPPER_ARRAY")).isEqualTo(JsonTypeInfo.As.WRAPPER_ARRAY);
+        assertThat(JsonTypeInfo.As.valueOf("EXISTING_PROPERTY")).isEqualTo(JsonTypeInfo.As.EXISTING_PROPERTY);
 
         assertThat(JsonInclude.Include.values()).containsExactly(
                 JsonInclude.Include.ALWAYS,

--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.annotation.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #1999

This PR provides test fixes and new metadata for com.fasterxml.jackson.core:jackson-annotations:2.3.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 37198
- Cached input tokens: 116224
- Output tokens: 1376
- Entries found: 4
- Iterations: 1
- Library coverage percentage: 96.06
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 96.03

### Metadata Forge

- Forge branch: `mm/externalize-finalization-process`
- Forge commit hash: `70aa929ebd2721120043ef4cd48577f1ac93c4df`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.core:jackson-annotations:2.1.2: 0/0 covered calls (100.00%)
- com.fasterxml.jackson.core:jackson-annotations:2.3.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.core:jackson-annotations:2.1.2: 799/812 (98.40%)
- com.fasterxml.jackson.core:jackson-annotations:2.3.0: 809/822 (98.42%)

**Line:**
- com.fasterxml.jackson.core:jackson-annotations:2.1.2: 121/126 (96.03%)
- com.fasterxml.jackson.core:jackson-annotations:2.3.0: 122/127 (96.06%)

**Method:**
- com.fasterxml.jackson.core:jackson-annotations:2.1.2: 49/53 (92.45%)
- com.fasterxml.jackson.core:jackson-annotations:2.3.0: 49/53 (92.45%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.1.2/gradle.properties b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/gradle.properties
index 51ffd3db..0c32ff3e 100644
--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.1.2/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = com.fasterxml.jackson.core:jackson-annotations:2.1.2
-library.version = 2.1.2
-metadata.dir = com.fasterxml.jackson.core/jackson-annotations/2.1.2/
+library.coordinates = com.fasterxml.jackson.core:jackson-annotations:2.3.0
+library.version = 2.3.0
+metadata.dir = com.fasterxml.jackson.core/jackson-annotations/2.3.0/
diff --git a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.1.2/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
index 97de0a1e..28a8b17b 100644
--- a/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.1.2/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-annotations/2.3.0/src/test/java/com_fasterxml_jackson_core/jackson_annotations/Jackson_annotationsTest.java
@@ -187,9 +187,11 @@ class Jackson_annotationsTest {
                 JsonTypeInfo.As.PROPERTY,
                 JsonTypeInfo.As.WRAPPER_OBJECT,
                 JsonTypeInfo.As.WRAPPER_ARRAY,
-                JsonTypeInfo.As.EXTERNAL_PROPERTY
+                JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                JsonTypeInfo.As.EXISTING_PROPERTY
         );
         assertThat(JsonTypeInfo.As.valueOf("WRAPPER_ARRAY")).isEqualTo(JsonTypeInfo.As.WRAPPER_ARRAY);
+        assertThat(JsonTypeInfo.As.valueOf("EXISTING_PROPERTY")).isEqualTo(JsonTypeInfo.As.EXISTING_PROPERTY);
 
         assertThat(JsonInclude.Include.values()).containsExactly(
                 JsonInclude.Include.ALWAYS,

```
