### PR TITLE
[GenAI] Test fix for org.apache.httpcomponents:httpcore:4.4.10 using gpt-5.5

### DIFF
--- a/metadata/org.apache.httpcomponents/httpcore/4.4.10/reachability-metadata.json
+++ b/metadata/org.apache.httpcomponents/httpcore/4.4.10/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.ExceptionUtils"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "initCause",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.VersionInfo"
+      },
+      "glob": "org/apache/http/version.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.10",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10-sources.jar",
+    "repository-url" : "https://github.com/apache/httpcomponents-core",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10-javadoc.jar",
+    "description" : "Apache HttpCore provides low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
     "tested-versions" : [
       "4.4.10"
     ],

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -1,15 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "org.apache.http" ],
-    "metadata-version": "4.4.9",
-    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-sources.jar",
-    "repository-url": "https://github.com/apache/httpcomponents-core",
-    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-tests.jar",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-javadoc.jar",
-    "description": "Apache HttpCore provides the low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "4.4.10",
+    "tested-versions" : [
+      "4.4.10"
+    ],
+    "allowed-packages" : [
+      "org.apache.http"
+    ]
+  },
+  {
+    "metadata-version" : "4.4.9",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-sources.jar",
+    "repository-url" : "https://github.com/apache/httpcomponents-core",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9-javadoc.jar",
+    "description" : "Apache HttpCore provides the low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
+    "tested-versions" : [
       "4.4.9"
+    ],
+    "allowed-packages" : [
+      "org.apache.http"
     ]
   }
 ]

--- a/stats/org.apache.httpcomponents/httpcore/4.4.10/stats.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.10/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.10",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 326,
+        "missed" : 24415,
+        "ratio" : 0.013177,
+        "total" : 24741
+      },
+      "line" : {
+        "covered" : 86,
+        "missed" : 6074,
+        "ratio" : 0.013961,
+        "total" : 6160
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 1400,
+        "ratio" : 0.015471,
+        "total" : 1422
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/.gitignore
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/build.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.httpcomponents:httpcore:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.httpcomponents:httpcore:4.4.10
+library.version = 4.4.10
+metadata.dir = org.apache.httpcomponents/httpcore/4.4.10/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/settings.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.httpcomponents.httpcore_tests'

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class ExceptionUtilsTest {
+
+    @Test
+    void initCauseAssignsTheProvidedCause() {
+        IllegalArgumentException throwable = new IllegalArgumentException("outer");
+        IllegalStateException cause = new IllegalStateException("inner");
+
+        ExceptionUtils.initCause(throwable, cause);
+
+        assertThat(throwable).hasCause(cause);
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.entity.SerializableEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializableEntityTest {
+
+    @Test
+    void bufferizedEntitySerializesContentWhenCreated() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta"));
+
+        SerializableEntity entity = new SerializableEntity(payload, true);
+        byte[] expectedBytes = serialize(payload);
+
+        assertThat(entity.isRepeatable()).isTrue();
+        assertThat(entity.isStreaming()).isFalse();
+        assertThat(entity.getContentLength()).isEqualTo(expectedBytes.length);
+        assertThat(readAllBytes(entity.getContent())).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    void streamingEntityWritesSerializedObjectToOutputStream() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("gamma", "delta"));
+
+        SerializableEntity entity = new SerializableEntity(payload);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        assertThat(entity.isStreaming()).isTrue();
+
+        entity.writeTo(out);
+
+        assertThat(out.toByteArray()).isEqualTo(serialize(payload));
+    }
+
+    private static byte[] readAllBytes(InputStream content) throws IOException {
+        try (InputStream inputStream = content) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionInfoTest {
+
+    @Test
+    void loadVersionInfoReadsPackagedVersionProperties() {
+        ClassLoader classLoader = VersionInfo.class.getClassLoader();
+        VersionInfo versionInfo = VersionInfo.loadVersionInfo("org.apache.http", classLoader);
+
+        assertThat(versionInfo).isNotNull();
+        assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
+        assertThat(versionInfo.getModule()).isEqualTo("httpcore");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.9");
+        assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
+        assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
+    }
+
+    @Test
+    void getUserAgentUsesThePackagedRelease() {
+        String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
+
+        assertThat(userAgent)
+                .isEqualTo("httpcore-test/4.4.9 (Java/" + System.getProperty("java.version") + ")");
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -21,7 +21,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.9");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.10");
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +31,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.9 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/4.4.10 (Java/" + System.getProperty("java.version") + ")");
     }
 }

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.10/user-code-filter.json
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #1810

This PR provides test fixes and new metadata for org.apache.httpcomponents:httpcore:4.4.10, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 125239
- Cached input tokens: 1388032
- Output tokens: 4737
- Entries found: 7
- Iterations: 1
- Library coverage percentage: 1.4
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 1.4

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `f6c0383148f7f65fe6cb61600ddf0dde31af3c22`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.httpcomponents:httpcore:4.4.9: 4/4 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.10: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.httpcomponents:httpcore:4.4.9: 3/3 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.10: 3/3 covered calls (100.00%)

**Resources:**
- org.apache.httpcomponents:httpcore:4.4.9: 1/1 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.10: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.httpcomponents:httpcore:4.4.9: 326/24610 (1.32%)
- org.apache.httpcomponents:httpcore:4.4.10: 326/24741 (1.32%)

**Line:**
- org.apache.httpcomponents:httpcore:4.4.9: 86/6127 (1.40%)
- org.apache.httpcomponents:httpcore:4.4.10: 86/6160 (1.40%)

**Method:**
- org.apache.httpcomponents:httpcore:4.4.9: 22/1421 (1.55%)
- org.apache.httpcomponents:httpcore:4.4.10: 22/1422 (1.55%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.httpcomponents/httpcore/4.4.9/gradle.properties b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/gradle.properties
index 9e27c129..1650be5b 100644
--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.9/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = org.apache.httpcomponents:httpcore:4.4.9
-library.version = 4.4.9
-metadata.dir = org.apache.httpcomponents/httpcore/4.4.9/
+library.coordinates = org.apache.httpcomponents:httpcore:4.4.10
+library.version = 4.4.10
+metadata.dir = org.apache.httpcomponents/httpcore/4.4.10/
diff --git a/tests/src/org.apache.httpcomponents/httpcore/4.4.9/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
index 374c99d9..15259ad4 100644
--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.9/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -21,7 +21,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.9");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.10");
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +31,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.9 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/4.4.10 (Java/" + System.getProperty("java.version") + ")");
     }
 }

```
