### PR TITLE
[Automation] Generated metadata for org.slf4j:slf4j-jdk14:1.5.7

### DIFF
--- a/metadata/org.slf4j/slf4j-jdk14/1.5.7/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-jdk14/1.5.7/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.impl.StaticMDCBinder"
+      },
+      "type" : "org.slf4j.helpers.BasicMDCAdapter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.impl.StaticMarkerBinder"
+      },
+      "type" : "org.slf4j.helpers.BasicMarkerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.impl.JDK14LoggerAdapter"
+      },
+      "type" : "org.slf4j.helpers.MarkerIgnoringBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.impl.JDK14LoggerAdapter"
+      },
+      "type" : "org.slf4j.impl.JDK14LoggerAdapter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.slf4j.impl.StaticLoggerBinder"
+      },
+      "type" : "org.slf4j.impl.JDK14LoggerFactory"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-jdk14/index.json
+++ b/metadata/org.slf4j/slf4j-jdk14/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.5.7",
+    "test-version" : "1.5.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/1.5.7/slf4j-jdk14-1.5.7-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_1.5.7_FINAL/slf4j-jdk14/src/test",
+    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_1.5.7_FINAL/slf4j-site/src/site/pages/manual.html",
+    "description" : "SLF4J JDK14 binding routes SLF4J API logging calls to Java's built-in java.util.logging framework. It supplies the runtime binding used by SLF4J 1.5.7 applications that want logs handled by the JDK 1.4 logging system.",
+    "tested-versions" : [
+      "1.5.7"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.5.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/stats/org.slf4j/slf4j-jdk14/1.5.7/stats.json
+++ b/stats/org.slf4j/slf4j-jdk14/1.5.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 304,
+        "missed" : 381,
+        "ratio" : 0.443796,
+        "total" : 685
+      },
+      "line" : {
+        "covered" : 77,
+        "missed" : 95,
+        "ratio" : 0.447674,
+        "total" : 172
+      },
+      "method" : {
+        "covered" : 21,
+        "missed" : 28,
+        "ratio" : 0.428571,
+        "total" : 49
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#2572

This PR provides new metadata needed for the org.slf4j:slf4j-jdk14:1.5.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.slf4j:slf4j-jdk14:1.5.6`): 5
- Metadata entries (new `org.slf4j:slf4j-jdk14:1.5.7`): 5
- Library coverage (previous): 44.77%
- Library coverage (new): 44.77%

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `f6c0383148f7f65fe6cb61600ddf0dde31af3c22`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-jdk14:1.5.6: 4/4 covered calls (100.00%)
- org.slf4j:slf4j-jdk14:1.5.7: 4/4 covered calls (100.00%)

**Reflection:**
- org.slf4j:slf4j-jdk14:1.5.6: 4/4 covered calls (100.00%)
- org.slf4j:slf4j-jdk14:1.5.7: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-jdk14:1.5.6: 304/685 (44.38%)
- org.slf4j:slf4j-jdk14:1.5.7: 304/685 (44.38%)

**Line:**
- org.slf4j:slf4j-jdk14:1.5.6: 77/172 (44.77%)
- org.slf4j:slf4j-jdk14:1.5.7: 77/172 (44.77%)

**Method:**
- org.slf4j:slf4j-jdk14:1.5.6: 21/49 (42.86%)
- org.slf4j:slf4j-jdk14:1.5.7: 21/49 (42.86%)
