### PR TITLE
Skip native-build-tools snapshot setup by default

### DIFF
--- a/.github/actions/setup-native-build-tools/action.yml
+++ b/.github/actions/setup-native-build-tools/action.yml
@@ -6,7 +6,7 @@ inputs:
   enabled-by-default:
     description: "Whether to enable this setup step even if no same-named branch is found."
     required: false
-    default: "true" # TODO: Revert to "false" once spring-smoke-tests have NBT updated
+    default: "false"
   java-version:
     description: "Java version to use when building native-build-tools"
     required: false


### PR DESCRIPTION
## Summary
- set `setup-native-build-tools` `enabled-by-default` back to `false`
- remove the stale TODO now that Spring AOT smoke tests on `main` use NBT `1.1.0`

## Why
This avoids spending valuable CI time checking out, building, publishing, and wiring native-build-tools when the snapshot setup is no longer needed by default. Same-named native-build-tools branch testing still works, and workflows can still opt in explicitly.

Fixes #2585

## Testing
- Not run; GitHub Action default-only change.