### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.core:jackson-core:2.6.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.core/jackson-core/2.6.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-core/2.6.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
+      },
+      "type" : "com.fasterxml.jackson.core.json.PackageVersion",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.core/jackson-core/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-core/index.json
@@ -1,11 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.6.0",
+    "tested-versions" : [
+      "2.6.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.core"
+    ]
+  },
+  {
     "metadata-version" : "2.1.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.1.3/jackson-core-2.1.3-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-core",
     "test-code-url" : "https://github.com/FasterXML/jackson-core/tree/jackson-core-2.1.3/src/test",
     "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.1.3/jackson-core-2.1.3-javadoc.jar",
+    "description" : "Jackson Core provides the core abstractions and streaming JSON parser and generator implementation for Jackson. It lets Java applications read and write JSON incrementally with a low-level token-based API.",
     "tested-versions" : [
       "2.1.3",
       "2.1.4",
@@ -38,7 +48,6 @@
     ],
     "allowed-packages" : [
       "com.fasterxml.jackson.core"
-    ],
-    "description" : "Jackson Core provides the core abstractions and streaming JSON parser and generator implementation for Jackson. It lets Java applications read and write JSON incrementally with a low-level token-based API."
+    ]
   }
 ]

--- a/stats/com.fasterxml.jackson.core/jackson-core/2.6.0/stats.json
+++ b/stats/com.fasterxml.jackson.core/jackson-core/2.6.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.6.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 278,
+        "missed" : 48006,
+        "ratio" : 0.005758,
+        "total" : 48284
+      },
+      "line" : {
+        "covered" : 50,
+        "missed" : 11226,
+        "ratio" : 0.004434,
+        "total" : 11276
+      },
+      "method" : {
+        "covered" : 18,
+        "missed" : 1597,
+        "ratio" : 0.011146,
+        "total" : 1615
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.core:jackson-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.core:jackson-core:2.6.0
+library.version = 2.6.0
+metadata.dir = com.fasterxml.jackson.core/jackson-core/2.6.0/

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.core.jackson-core_tests'

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_core.jackson_core;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionUtilTest {
+    @Test
+    void versionForReadsVersionFileFromClassPackage() {
+        Version version = VersionUtil.versionFor(VersionUtilTest.class);
+
+        assertThat(version.isUknownVersion()).isFalse();
+        assertThat(version.toString()).isEqualTo("2.1.3-test");
+        assertThat(version.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
+        assertThat(version.getArtifactId()).isEqualTo("jackson-core-test");
+    }
+
+    @Test
+    void mavenVersionForReadsPomPropertiesFromClassLoaderResource() {
+        ClassLoader classLoader = VersionUtilTest.class.getClassLoader();
+
+        Version version = VersionUtil.mavenVersionFor(classLoader, "com.example.versionutil", "versionutil-fixture");
+
+        assertThat(version.isUknownVersion()).isFalse();
+        assertThat(version.toString()).isEqualTo("4.5.6");
+        assertThat(version.getGroupId()).isEqualTo("com.example.versionutil");
+        assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
+    }
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
@@ -7,20 +7,21 @@
 package com_fasterxml_jackson_core.jackson_core;
 
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.core.util.VersionUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class VersionUtilTest {
+public class VersionUtilTest {
     @Test
-    void versionForReadsVersionFileFromClassPackage() {
-        Version version = VersionUtil.versionFor(VersionUtilTest.class);
+    void versionForReadsPackageVersionFromClassPackage() {
+        Version version = VersionUtil.versionFor(PackageVersion.class);
 
+        assertThat(version).isEqualTo(PackageVersion.VERSION);
         assertThat(version.isUknownVersion()).isFalse();
-        assertThat(version.toString()).isEqualTo("2.1.3-test");
         assertThat(version.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
-        assertThat(version.getArtifactId()).isEqualTo("jackson-core-test");
+        assertThat(version.getArtifactId()).isEqualTo("jackson-core");
     }
 
     @Test
@@ -31,6 +32,16 @@ class VersionUtilTest {
 
         assertThat(version.isUknownVersion()).isFalse();
         assertThat(version.toString()).isEqualTo("4.5.6");
+        assertThat(version.getGroupId()).isEqualTo("com.example.versionutil");
+        assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
+    }
+
+    @Test
+    void parseVersionReadsVersionComponents() {
+        Version version = VersionUtil.parseVersion("4.5.6-SNAPSHOT", "com.example.versionutil", "versionutil-fixture");
+
+        assertThat(version.isUknownVersion()).isFalse();
+        assertThat(version.toString()).isEqualTo("4.5.6-SNAPSHOT");
         assertThat(version.getGroupId()).isEqualTo("com.example.versionutil");
         assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
     }

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/maven/com/example/versionutil/versionutil-fixture/pom.properties
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/maven/com/example/versionutil/versionutil-fixture/pom.properties
@@ -1,0 +1,3 @@
+version=4.5.6
+artifactId=versionutil-fixture
+groupId=com.example.versionutil

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
+      },
+      "glob" : "META-INF/maven/com/example/versionutil/versionutil-fixture/pom.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
+      },
+      "glob" : "com_fasterxml_jackson_core/jackson_core/VERSION.txt"
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,18 +1,4 @@
 {
-  "reflection" : [
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
-      },
-      "type" : "com.fasterxml.jackson.core.json.PackageVersion",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    }
-  ],
   "resources" : [
     {
       "condition" : {

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,16 +1,24 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
+      },
+      "type" : "com.fasterxml.jackson.core.json.PackageVersion",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
   "resources" : [
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
       },
       "glob" : "META-INF/maven/com/example/versionutil/versionutil-fixture/pom.properties"
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
-      },
-      "glob" : "com_fasterxml_jackson_core/jackson_core/VERSION.txt"
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/com_fasterxml_jackson_core/jackson_core/VERSION.txt
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/com_fasterxml_jackson_core/jackson_core/VERSION.txt
@@ -1,0 +1,3 @@
+2.1.3-test
+com.fasterxml.jackson.core
+jackson-core-test

--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #1807

This PR provides test fixes and new metadata for com.fasterxml.jackson.core:jackson-core:2.6.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 133409
- Cached input tokens: 1375232
- Output tokens: 10625
- Entries found: 2
- Iterations: 2
- Library coverage percentage: 0.44
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 0.77

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `f6c0383148f7f65fe6cb61600ddf0dde31af3c22`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.core:jackson-core:2.1.3: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.core:jackson-core:2.6.0: 3/3 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.core:jackson-core:2.1.3: N/A
- com.fasterxml.jackson.core:jackson-core:2.6.0: 2/2 covered calls (100.00%)

**Resources:**
- com.fasterxml.jackson.core:jackson-core:2.1.3: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.core:jackson-core:2.6.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.core:jackson-core:2.1.3: 300/36844 (0.81%)
- com.fasterxml.jackson.core:jackson-core:2.6.0: 278/48284 (0.58%)

**Line:**
- com.fasterxml.jackson.core:jackson-core:2.1.3: 66/8590 (0.77%)
- com.fasterxml.jackson.core:jackson-core:2.6.0: 50/11276 (0.44%)

**Method:**
- com.fasterxml.jackson.core:jackson-core:2.1.3: 12/1169 (1.03%)
- com.fasterxml.jackson.core:jackson-core:2.6.0: 18/1615 (1.11%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/gradle.properties b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/gradle.properties
index c2bea17e..256b2c4a 100644
--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = com.fasterxml.jackson.core:jackson-core:2.1.3
-library.version = 2.1.3
-metadata.dir = com.fasterxml.jackson.core/jackson-core/2.1.3/
+library.coordinates = com.fasterxml.jackson.core:jackson-core:2.6.0
+library.version = 2.6.0
+metadata.dir = com.fasterxml.jackson.core/jackson-core/2.6.0/
diff --git a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
index 30352128..49ab38a9 100644
--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/java/com_fasterxml_jackson_core/jackson_core/VersionUtilTest.java
@@ -7,20 +7,21 @@
 package com_fasterxml_jackson_core.jackson_core;
 
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.core.util.VersionUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class VersionUtilTest {
+public class VersionUtilTest {
     @Test
-    void versionForReadsVersionFileFromClassPackage() {
-        Version version = VersionUtil.versionFor(VersionUtilTest.class);
+    void versionForReadsPackageVersionFromClassPackage() {
+        Version version = VersionUtil.versionFor(PackageVersion.class);
 
+        assertThat(version).isEqualTo(PackageVersion.VERSION);
         assertThat(version.isUknownVersion()).isFalse();
-        assertThat(version.toString()).isEqualTo("2.1.3-test");
         assertThat(version.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
-        assertThat(version.getArtifactId()).isEqualTo("jackson-core-test");
+        assertThat(version.getArtifactId()).isEqualTo("jackson-core");
     }
 
     @Test
@@ -34,4 +35,14 @@ class VersionUtilTest {
         assertThat(version.getGroupId()).isEqualTo("com.example.versionutil");
         assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
     }
+
+    @Test
+    void parseVersionReadsVersionComponents() {
+        Version version = VersionUtil.parseVersion("4.5.6-SNAPSHOT", "com.example.versionutil", "versionutil-fixture");
+
+        assertThat(version.isUknownVersion()).isFalse();
+        assertThat(version.toString()).isEqualTo("4.5.6-SNAPSHOT");
+        assertThat(version.getGroupId()).isEqualTo("com.example.versionutil");
+        assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
+    }
 }
diff --git a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
index 5e9d291c..853fee1d 100644
--- a/tests/src/com.fasterxml.jackson.core/jackson-core/2.1.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.core/jackson-core/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,12 +5,6 @@
         "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
       },
       "glob" : "META-INF/maven/com/example/versionutil/versionutil-fixture/pom.properties"
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.core.util.VersionUtil"
-      },
-      "glob" : "com_fasterxml_jackson_core/jackson_core/VERSION.txt"
     }
   ]
 }

```
