### PR TITLE
[GenAI] Test fix for org.jboss.narayana.jta:jta:7.3.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.narayana.jta/jta/7.3.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.narayana.jta/jta/7.3.1.Final/reachability-metadata.json
@@ -1,0 +1,219 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.arjPropertyManager"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.CoreEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.recoveryPropertyManager"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.arjPropertyManager"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.logging.tsLogger"
+      },
+      "type" : "com.arjuna.ats.arjuna.logging.arjunaI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "byte[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.xa.XidImple"
+      },
+      "type" : "byte[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.ats.jta.common.JTAEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.CoreEnvironmentBean"
+      },
+      "type" : "com.arjuna.ats.internal.arjuna.utils.SocketProcessId",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "javax.xml.stream.XMLInputFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "org.apache.log4j.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "ConfigurationInfo.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "default-jbossts-properties.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "jbossts-properties.xml"
+    }
+  ]
+}

--- a/metadata/org.jboss.narayana.jta/jta/index.json
+++ b/metadata/org.jboss.narayana.jta/jta/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "7.3.1.Final",
+    "tested-versions" : [
+      "7.3.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.narayana.jta",
+      "com.arjuna.ats.arjuna.common",
+      "com.arjuna.ats.internal.arjuna.utils",
+      "com.arjuna.ats.arjuna.logging",
+      "com.arjuna.ats.jta.common",
+      "com.arjuna.ats.jta.logging",
+      "com.arjuna.common.logging"
+    ]
+  },
+  {
     "metadata-version" : "5.12.4.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-sources.jar",
     "repository-url" : "https://github.com/jbosstm/narayana",

--- a/metadata/org.jboss.narayana.jta/jta/index.json
+++ b/metadata/org.jboss.narayana.jta/jta/index.json
@@ -1,28 +1,35 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "7.3.1.Final",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "7.3.1.Final",
+    "source-code-url": "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/7.3.1.Final/jta-7.3.1.Final-sources.jar",
+    "repository-url": "https://github.com/jbosstm/narayana",
+    "test-code-url": "https://github.com/jbosstm/narayana/tree/7.3.1.Final/ArjunaJTA/jta/tests",
+    "documentation-url": "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/7.3.1.Final/jta-7.3.1.Final-javadoc.jar",
+    "description": "Narayana JTA provides a Jakarta Transactions (JTA) implementation for coordinating transactional work across local and XA resources. It supplies transaction manager, recovery, and integration components used by Java applications and application servers.",
+    "tested-versions": [
       "7.3.1.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.jboss.narayana.jta",
       "com.arjuna.ats.arjuna.common",
       "com.arjuna.ats.internal.arjuna.utils",
       "com.arjuna.ats.arjuna.logging",
       "com.arjuna.ats.jta.common",
       "com.arjuna.ats.jta.logging",
-      "com.arjuna.common.logging"
+      "com.arjuna.common.logging",
+      "com.arjuna.ats.internal.jta.resources.arjunacore",
+      "com.arjuna.ats.jta.xa"
     ]
   },
   {
-    "metadata-version" : "5.12.4.Final",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-sources.jar",
-    "repository-url" : "https://github.com/jbosstm/narayana",
-    "test-code-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-tests.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/narayana-jta/5.12.4.Final/narayana-jta-5.12.4.Final-javadoc.jar",
-    "description" : "Narayana JTA provides a Java Transaction API implementation built on the Narayana transaction manager. It coordinates transactional work and recovery across local resources, application servers, and XA-capable systems.",
-    "tested-versions" : [
+    "metadata-version": "5.12.4.Final",
+    "source-code-url": "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-sources.jar",
+    "repository-url": "https://github.com/jbosstm/narayana",
+    "test-code-url": "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-tests.jar",
+    "documentation-url": "https://repo1.maven.org/maven2/org/jboss/narayana/jta/narayana-jta/5.12.4.Final/narayana-jta-5.12.4.Final-javadoc.jar",
+    "description": "Narayana JTA provides a Java Transaction API implementation built on the Narayana transaction manager. It coordinates transactional work and recovery across local resources, application servers, and XA-capable systems.",
+    "tested-versions": [
       "5.12.4.Final",
       "5.12.5.Final",
       "5.12.6.Final",
@@ -42,7 +49,7 @@
       "7.2.2.Final",
       "7.3.0.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.jboss.narayana.jta",
       "com.arjuna.ats.arjuna.common",
       "com.arjuna.ats.internal.arjuna.utils",

--- a/stats/org.jboss.narayana.jta/jta/7.3.1.Final/stats.json
+++ b/stats/org.jboss.narayana.jta/jta/7.3.1.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "7.3.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 725,
+        "missed" : 17316,
+        "ratio" : 0.040186,
+        "total" : 18041
+      },
+      "line" : {
+        "covered" : 223,
+        "missed" : 4962,
+        "ratio" : 0.043009,
+        "total" : 5185
+      },
+      "method" : {
+        "covered" : 37,
+        "missed" : 930,
+        "ratio" : 0.038263,
+        "total" : 967
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/.gitignore
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/build.gradle
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.narayana.jta:jta:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.jboss.logging:jboss-logging:3.2.1.Final'
+    testImplementation 'org.jboss:jboss-transaction-spi:7.6.1.Final'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.narayana.jta:jta:7.3.1.Final
+library.version = 7.3.1.Final
+metadata.dir = org.jboss.narayana.jta/jta/7.3.1.Final/

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/settings.gradle
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.narayana.jta.jta_tests'

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/com/arjuna/common/logging/commonI18NLogger_$logger.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/com/arjuna/common/logging/commonI18NLogger_$logger.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.arjuna.common.logging;
+
+import java.io.Serializable;
+import java.net.URL;
+
+import org.jboss.logging.Logger;
+
+@SuppressWarnings("checkstyle:TypeName")
+public final class commonI18NLogger_$logger implements commonI18NLogger, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Logger logger;
+
+    public commonI18NLogger_$logger(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void warn_could_not_find_manifest(String manifestName, Throwable throwable) {
+        logger.warnf(throwable, "Could not find manifest %s", manifestName);
+    }
+
+    @Override
+    public void warn_could_not_find_config_file(URL url) {
+        logger.warnf("Could not find configuration file %s", url);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_1() {
+        logger.warn("Classloading utility could not load a class");
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_2(String className, Throwable throwable) {
+        logger.warnf(throwable, "Could not load class %s", className);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_3(String className, String loaderName, Throwable throwable) {
+        logger.warnf(throwable, "Could not load class %s with class loader %s", className, loaderName);
+    }
+
+    @Override
+    public String warn_common_ClassloadingUtility_4(String className, Throwable throwable) {
+        return String.format("Could not instantiate class %s: %s", className, throwable);
+    }
+
+    @Override
+    public String warn_common_ClassloadingUtility_5(String className, Throwable throwable) {
+        return String.format("Could not access class %s: %s", className, throwable);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_6(String className, Throwable throwable) {
+        logger.warnf(throwable, "Could not create class %s", className);
+    }
+
+    @Override
+    public String warn_common_NoSuchMethodException(String methodName, Throwable throwable) {
+        return String.format("Could not find method %s: %s", methodName, throwable);
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/JNDIManagerTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/JNDIManagerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.arjuna.ats.jta.utils.JNDIManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JNDIManagerTest {
+    @Test
+    void bindTransactionSynchronizationRegistryImplementationUsesConfiguredClass() throws Exception {
+        JTAEnvironmentBean environmentBean = jtaPropertyManager.getJTAEnvironmentBean();
+        String originalClassName = environmentBean.getTransactionSynchronizationRegistryClassName();
+        String originalJndiName = environmentBean.getTransactionSynchronizationRegistryJNDIContext();
+
+        try {
+            TestTransactionSynchronizationRegistry.CONSTRUCTOR_CALLS.set(0);
+            environmentBean.setTransactionSynchronizationRegistryClassName(
+                TestTransactionSynchronizationRegistry.class.getName()
+            );
+            environmentBean.setTransactionSynchronizationRegistryJNDIContext(
+                "java:/test/TransactionSynchronizationRegistry"
+            );
+
+            RecordingInitialContext initialContext = new RecordingInitialContext();
+
+            JNDIManager.bindJTATransactionSynchronizationRegistryImplementation(initialContext);
+
+            assertThat(TestTransactionSynchronizationRegistry.CONSTRUCTOR_CALLS).hasValue(1);
+            assertThat(initialContext.boundName).isEqualTo("java:/test/TransactionSynchronizationRegistry");
+            assertThat(initialContext.boundValue).isInstanceOf(TestTransactionSynchronizationRegistry.class);
+        } finally {
+            environmentBean.setTransactionSynchronizationRegistryClassName(originalClassName);
+            environmentBean.setTransactionSynchronizationRegistryJNDIContext(originalJndiName);
+        }
+    }
+
+    public static final class TestTransactionSynchronizationRegistry implements TransactionSynchronizationRegistry {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        private final Map<Object, Object> resources = new HashMap<>();
+        private boolean rollbackOnly;
+
+        public TestTransactionSynchronizationRegistry() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public Object getTransactionKey() {
+            return this;
+        }
+
+        @Override
+        public void putResource(Object key, Object value) {
+            resources.put(key, value);
+        }
+
+        @Override
+        public Object getResource(Object key) {
+            return resources.get(key);
+        }
+
+        @Override
+        public void registerInterposedSynchronization(Synchronization synchronization) {
+        }
+
+        @Override
+        public int getTransactionStatus() {
+            return Status.STATUS_NO_TRANSACTION;
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            rollbackOnly = true;
+        }
+
+        @Override
+        public boolean getRollbackOnly() {
+            return rollbackOnly;
+        }
+    }
+
+    private static final class RecordingInitialContext extends InitialContext {
+        private String boundName;
+        private Object boundValue;
+
+        private RecordingInitialContext() throws NamingException {
+            super(true);
+        }
+
+        @Override
+        public void rebind(String name, Object obj) {
+            boundName = name;
+            boundValue = obj;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import com.arjuna.ats.arjuna.coordinator.TwoPhaseOutcome;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XAOnePhaseResourceTest {
+    @Test
+    void packAndUnpackSerializableXaResource() throws Exception {
+        SerializableXaResource.COMMIT_CALLS.set(0);
+
+        XAOnePhaseResource resource = new XAOnePhaseResource(
+            new SerializableXaResource("pack-unpack"),
+            new SerializableXid(41, new byte[]{1, 2, 3}, new byte[]{4, 5, 6}),
+            null
+        );
+        OutputObjectState outputState = new OutputObjectState();
+
+        resource.pack(outputState);
+
+        XAOnePhaseResource restoredResource = new XAOnePhaseResource();
+        restoredResource.unpack(new InputObjectState(outputState));
+
+        assertThat(restoredResource.toString()).contains("pack-unpack");
+        assertThat(restoredResource.commit()).isEqualTo(TwoPhaseOutcome.FINISH_OK);
+        assertThat(SerializableXaResource.COMMIT_CALLS).hasValue(1);
+    }
+
+    private static final class SerializableXaResource implements XAResource, Serializable {
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger COMMIT_CALLS = new AtomicInteger();
+
+        private final String name;
+
+        private SerializableXaResource(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void commit(Xid xid, boolean onePhase) {
+            COMMIT_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public void end(Xid xid, int flags) {
+        }
+
+        @Override
+        public void forget(Xid xid) {
+        }
+
+        @Override
+        public int getTransactionTimeout() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSameRM(XAResource xaResource) {
+            return xaResource == this;
+        }
+
+        @Override
+        public int prepare(Xid xid) {
+            return XA_OK;
+        }
+
+        @Override
+        public Xid[] recover(int flag) {
+            return new Xid[0];
+        }
+
+        @Override
+        public void rollback(Xid xid) {
+        }
+
+        @Override
+        public boolean setTransactionTimeout(int seconds) {
+            return true;
+        }
+
+        @Override
+        public void start(Xid xid, int flags) {
+        }
+
+        @Override
+        public String toString() {
+            return "SerializableXaResource[" + name + "]";
+        }
+    }
+
+    private static final class SerializableXid implements Xid, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final int formatId;
+        private final byte[] globalTransactionId;
+        private final byte[] branchQualifier;
+
+        private SerializableXid(int formatId, byte[] globalTransactionId, byte[] branchQualifier) {
+            this.formatId = formatId;
+            this.globalTransactionId = globalTransactionId;
+            this.branchQualifier = branchQualifier;
+        }
+
+        @Override
+        public int getFormatId() {
+            return formatId;
+        }
+
+        @Override
+        public byte[] getGlobalTransactionId() {
+            return globalTransactionId;
+        }
+
+        @Override
+        public byte[] getBranchQualifier() {
+            return branchQualifier;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import com.arjuna.ats.arjuna.ObjectType;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XAResourceRecordTest {
+    @Test
+    void saveAndRestoreStateWithSerializableXaResource() throws Exception {
+        SerializableXaResource.COMMIT_CALLS.set(0);
+
+        XAResourceRecord resourceRecord = new XAResourceRecord(
+            null,
+            new SerializableXaResource("xa-resource-record"),
+            new SerializableXid(73, new byte[]{1, 3, 5}, new byte[]{2, 4, 6}),
+            null
+        );
+        resourceRecord.setProductName("Test Product");
+        resourceRecord.setProductVersion("2026.04");
+        resourceRecord.setJndiName("java:/test/XAResourceRecord");
+
+        OutputObjectState outputState = new OutputObjectState();
+
+        assertThat(resourceRecord.save_state(outputState, ObjectType.ANDPERSISTENT)).isTrue();
+
+        XAResourceRecord restoredRecord = new XAResourceRecord();
+
+        assertThat(restoredRecord.restore_state(new InputObjectState(outputState), ObjectType.ANDPERSISTENT)).isTrue();
+        assertThat(restoredRecord.getProductName()).isEqualTo("Test Product");
+        assertThat(restoredRecord.getProductVersion()).isEqualTo("2026.04");
+        assertThat(restoredRecord.getJndiName()).isEqualTo("java:/test/XAResourceRecord");
+        assertThat(restoredRecord.getXid().getFormatId()).isEqualTo(73);
+        assertThat(restoredRecord.getXid().getGlobalTransactionId()).containsExactly((byte) 1, (byte) 3, (byte) 5);
+        assertThat(restoredRecord.getXid().getBranchQualifier()).containsExactly((byte) 2, (byte) 4, (byte) 6);
+        assertThat(restoredRecord.toString()).contains("xa-resource-record");
+
+        XAResource restoredResource = (XAResource) restoredRecord.value();
+
+        assertThat(restoredResource).isInstanceOf(SerializableXaResource.class);
+
+        restoredResource.commit(restoredRecord.getXid(), true);
+
+        assertThat(SerializableXaResource.COMMIT_CALLS).hasValue(1);
+    }
+
+    private static final class SerializableXaResource implements XAResource, Serializable {
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger COMMIT_CALLS = new AtomicInteger();
+
+        private final String name;
+
+        private SerializableXaResource(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void commit(Xid xid, boolean onePhase) {
+            COMMIT_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public void end(Xid xid, int flags) {
+        }
+
+        @Override
+        public void forget(Xid xid) {
+        }
+
+        @Override
+        public int getTransactionTimeout() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSameRM(XAResource xaResource) {
+            return xaResource == this;
+        }
+
+        @Override
+        public int prepare(Xid xid) {
+            return XA_OK;
+        }
+
+        @Override
+        public Xid[] recover(int flag) {
+            return new Xid[0];
+        }
+
+        @Override
+        public void rollback(Xid xid) {
+        }
+
+        @Override
+        public boolean setTransactionTimeout(int seconds) {
+            return true;
+        }
+
+        @Override
+        public void start(Xid xid, int flags) {
+        }
+
+        @Override
+        public String toString() {
+            return "SerializableXaResource[" + name + "]";
+        }
+    }
+
+    private static final class SerializableXid implements Xid, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final int formatId;
+        private final byte[] globalTransactionId;
+        private final byte[] branchQualifier;
+
+        private SerializableXid(int formatId, byte[] globalTransactionId, byte[] branchQualifier) {
+            this.formatId = formatId;
+            this.globalTransactionId = globalTransactionId;
+            this.branchQualifier = branchQualifier;
+        }
+
+        @Override
+        public int getFormatId() {
+            return formatId;
+        }
+
+        @Override
+        public byte[] getGlobalTransactionId() {
+            return globalTransactionId;
+        }
+
+        @Override
+        public byte[] getBranchQualifier() {
+            return branchQualifier;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/serialization-config.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/serialization-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "java.lang.String"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXaResource"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXid"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXaResource"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXid"
+  }
+]

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,70 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.utils.JNDIManager"
+      },
+      "type" : "org_jboss_narayana_jta.jta.JNDIManagerTest$TestTransactionSynchronizationRegistry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXid",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXid",
+      "serializable" : true
+    }
+  ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.narayana.jta.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.jboss.narayana.jta.**"
+      "includeClasses" : "com.arjuna.ats.internal.jta.**"
+    },
+    {
+      "includeClasses" : "com.arjuna.ats.jta.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #1844

This PR provides test fixes and new metadata for org.jboss.narayana.jta:jta:7.3.1.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72138
- Cached input tokens: 1050112
- Output tokens: 7692
- Entries found: 44
- Iterations: 1
- Library coverage percentage: 4.3
- Previous library version metadata entries: 24
- Previous library version coverage percentage: 4.33

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `a721f4740a1e0ccfe4ae41d5a5e909f64a599aa1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.narayana.jta:jta:5.12.4.Final: 8/8 covered calls (100.00%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 9/9 covered calls (100.00%)

**Reflection:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 8/8 covered calls (100.00%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 9/9 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 759/18907 (4.01%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 725/18041 (4.02%)

**Line:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 222/5125 (4.33%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 223/5185 (4.30%)

**Method:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 38/957 (3.97%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 37/967 (3.83%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/gradle.properties b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
index ca5dacad..3bbab750 100644
--- a/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/gradle.properties
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = org.jboss.narayana.jta:jta:5.12.4.Final
-library.version = 5.12.4.Final
-metadata.dir = org.jboss.narayana.jta/jta/5.12.4.Final/
+library.coordinates = org.jboss.narayana.jta:jta:7.3.1.Final
+library.version = 7.3.1.Final
+metadata.dir = org.jboss.narayana.jta/jta/7.3.1.Final/
diff --git a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/com/arjuna/common/logging/commonI18NLogger_$logger.java b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/com/arjuna/common/logging/commonI18NLogger_$logger.java
new file mode 100644
index 00000000..25a99f73
--- /dev/null
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/com/arjuna/common/logging/commonI18NLogger_$logger.java
@@ -0,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.arjuna.common.logging;
+
+import java.io.Serializable;
+import java.net.URL;
+
+import org.jboss.logging.Logger;
+
+@SuppressWarnings("checkstyle:TypeName")
+public final class commonI18NLogger_$logger implements commonI18NLogger, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Logger logger;
+
+    public commonI18NLogger_$logger(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void warn_could_not_find_manifest(String manifestName, Throwable throwable) {
+        logger.warnf(throwable, "Could not find manifest %s", manifestName);
+    }
+
+    @Override
+    public void warn_could_not_find_config_file(URL url) {
+        logger.warnf("Could not find configuration file %s", url);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_1() {
+        logger.warn("Classloading utility could not load a class");
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_2(String className, Throwable throwable) {
+        logger.warnf(throwable, "Could not load class %s", className);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_3(String className, String loaderName, Throwable throwable) {
+        logger.warnf(throwable, "Could not load class %s with class loader %s", className, loaderName);
+    }
+
+    @Override
+    public String warn_common_ClassloadingUtility_4(String className, Throwable throwable) {
+        return String.format("Could not instantiate class %s: %s", className, throwable);
+    }
+
+    @Override
+    public String warn_common_ClassloadingUtility_5(String className, Throwable throwable) {
+        return String.format("Could not access class %s: %s", className, throwable);
+    }
+
+    @Override
+    public void warn_common_ClassloadingUtility_6(String className, Throwable throwable) {
+        logger.warnf(throwable, "Could not create class %s", className);
+    }
+
+    @Override
+    public String warn_common_NoSuchMethodException(String methodName, Throwable throwable) {
+        return String.format("Could not find method %s: %s", methodName, throwable);
+    }
+}
diff --git a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
new file mode 100644
index 00000000..c5bd7d92
--- /dev/null
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -0,0 +1,70 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.common.logging.commonI18NLogger_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.utils.JNDIManager"
+      },
+      "type" : "org_jboss_narayana_jta.jta.JNDIManagerTest$TestTransactionSynchronizationRegistry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXid",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXid",
+      "serializable" : true
+    }
+  ]
+}
diff --git a/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/user-code-filter.json b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
index 92f42bd7..eed3c8b5 100644
--- a/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/user-code-filter.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.jboss.narayana.jta.**"
+      "includeClasses" : "com.arjuna.ats.internal.jta.**"
+    },
+    {
+      "includeClasses" : "com.arjuna.ats.jta.**"
     }
   ]
 }

```
