### PR TITLE
Refine review skill numeric evidence rules

### DIFF
--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -17,7 +17,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
 - Do not accept changes that remove meaningful test coverage just to make `java` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
-- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the repaired test no longer covers the same runtime surface.
+- For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Prefer small, targeted review comments. This label is for JVM runtime repair work, not a full redesign of historical tests.
 
 ## Workflow
@@ -51,16 +52,19 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 4. Check dynamic-access coverage across versions.
    - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
    - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - Do not use `user-code-filter.json`, agent configuration, or metadata file contents to argue that the reported dynamic-access values are not comparable. Use the stats values as reported unless the stats are missing or stale.
    - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
    - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
-   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
-   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
-   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
-   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/runtime behavior change.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Do not manually count entries from metadata files.
+   - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
+   - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Do not report metadata entry count issues unless the PR-reported new total metadata entry count is lower than 25% of the PR-reported original total metadata entry count.
+   - When the new total is below 25% of the original and the tests and dynamic-access stats still claim comparable coverage, ask for restored metadata or a concrete explanation of the API/runtime-surface change.
+   - If the PR description does not report usable old and new metadata entry counts, do not infer them from metadata files; ask for refreshed PR summary evidence when the comparison is needed.
 
 6. Check CI before deciding.
    - Expected minimum: `javaTest` or equivalent changed-metadata JVM test checks are green for the target coordinate.
@@ -76,14 +80,14 @@ Approve when all of these are true:
 - The PR is scoped to the target existing library and the Java runtime failure it fixes.
 - Tests still execute and assert the same meaningful library behavior after the runtime repair.
 - Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API/runtime surface.
-- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API/runtime surface.
+- Total metadata entry counts are not below the 25% severe-drop threshold, or the reduction is convincingly explained by a changed upstream API/runtime surface.
 - Required metadata, compile, and Java runtime test checks are green.
 
 Request changes when any of these are true:
 
 - The fix makes JVM tests pass by deleting tests, skipping execution, swallowing the failing exception.
 - Dynamic-access coverage drops without a credible explanation and replacement coverage.
-- Metadata entry count drops substantially without a credible explanation.
+- Total metadata entry count drops below 25% of the original without a credible explanation.
 - CI failures indicate the Java runtime problem is not actually fixed.
 
 Ask for follow-up instead of rejecting when:
@@ -91,14 +95,14 @@ Ask for follow-up instead of rejecting when:
 - Stats needed for the old/new version comparison are missing or stale.
 - CI failed in a way that looks like infrastructure noise.
 - The API or runtime behavior change is plausible but the PR does not explain why a coverage drop is expected.
-- Metadata entry counts differ substantially but the changed upstream API/runtime surface makes the reduction plausible.
+- Total metadata entry count drops below 25% of the original, but the changed upstream API/runtime surface makes the reduction plausible.
 
 ## Output Style
 
 Keep comments short and factual:
 
 - For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
-- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
+- For metadata entry drops: report only drops where the new total metadata has fewer than 25% as many entries as the previous version's total metadata; cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For deleted or bypassed coverage: say that the PR fixes Java runtime execution by removing coverage and should instead adapt the test to the new runtime behavior.
 - For swallowed exceptions: say that catching or ignoring the failing exception hides the runtime failure instead of proving the library behavior works.
 - For unrelated changes: say the PR should stay scoped to the `fixes-java-run-fail` repair and remove unrelated files.

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -19,6 +19,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
 - Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer small, targeted review comments. This label is for JVM runtime repair work, not a full redesign of historical tests.
 
 ## Workflow
@@ -40,6 +41,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - Treat generated test project files such as `.gitignore`, `build.gradle`, `gradle.properties`, `settings.gradle`, and `user-code-filter.json` as normal when they live under the target version's test directory.
    - Accept narrow runtime setup changes when they are necessary for the JVM test to exercise the same library behavior, such as test resources, dependency updates, system properties, service loading, or initialization ordering.
    - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject legacy native-image metadata config files. Metadata for generated support and test-only metadata must use `reachability-metadata.json`.
    - Reject or request changes if the PR removes tests, disables test classes, catches and ignores the failing exception.
 
 3. Review the Java runtime fix.
@@ -106,4 +108,5 @@ Keep comments short and factual:
 - For deleted or bypassed coverage: say that the PR fixes Java runtime execution by removing coverage and should instead adapt the test to the new runtime behavior.
 - For swallowed exceptions: say that catching or ignoring the failing exception hides the runtime failure instead of proving the library behavior works.
 - For unrelated changes: say the PR should stay scoped to the `fixes-java-run-fail` repair and remove unrelated files.
+- For legacy metadata files: say that metadata must use `reachability-metadata.json` and ask for old config files such as `reflect-config.json` or `resource-config.json` to be replaced.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -17,7 +17,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Be more relaxed than `library-new-request`: do not reject only because a test resembles older coverage, stays in an existing package layout, or contains compatibility branches for multiple supported versions.
 - Do not accept changes that remove meaningful test coverage just to make `javac` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
-- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the generated metadata no longer covers the same runtime surface.
+- For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Prefer small, targeted review comments. This label is for repair work, not a full redesign of historical tests.
 
 ## Workflow
@@ -49,16 +50,19 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 4. Check dynamic-access coverage across versions.
    - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
    - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - Do not use `user-code-filter.json`, agent configuration, or metadata file contents to argue that the reported dynamic-access values are not comparable. Use the stats values as reported unless the stats are missing or stale.
    - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
    - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
-   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
-   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
-   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
-   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/package change.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Do not manually count entries from metadata files.
+   - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
+   - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Do not report metadata entry count issues unless the PR-reported new total metadata entry count is lower than 25% of the PR-reported original total metadata entry count.
+   - When the new total is below 25% of the original and the tests and dynamic-access stats still claim comparable coverage, ask for restored metadata or a concrete explanation of the API/package change.
+   - If the PR description does not report usable old and new metadata entry counts, do not infer them from metadata files; ask for refreshed PR summary evidence when the comparison is needed.
 
 6. Check CI before deciding.
    - Expected minimum: `compileTestJava` or equivalent changed-metadata compile checks are green for the target coordinate.
@@ -73,14 +77,14 @@ Approve when all of these are true:
 - The PR is scoped to the target existing library and the compile failure it fixes.
 - Tests still exercise the same meaningful library behavior after the compile repair.
 - Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
-- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API surface.
+- Total metadata entry counts are not below the 25% severe-drop threshold, or the reduction is convincingly explained by a changed upstream API surface.
 - Required compile and metadata test checks are green.
 
 Request changes when any of these are true:
 
 - The fix makes compilation pass by weakening or bypassing the test instead of adapting it to the changed API while preserving meaningful coverage.
 - Dynamic-access coverage drops without a credible explanation and replacement coverage.
-- Metadata entry count drops substantially without a credible explanation.
+- Total metadata entry count drops below 25% of the original without a credible explanation.
 - CI failures indicate the compile problem is not actually fixed.
 
 Ask for follow-up instead of rejecting when:
@@ -88,14 +92,14 @@ Ask for follow-up instead of rejecting when:
 - Stats needed for the old/new version comparison are missing or stale.
 - CI failed in a way that looks like infrastructure noise.
 - The API change is plausible but the PR does not explain why a coverage drop is expected.
-- Metadata entry counts differ substantially but the changed upstream API surface makes the reduction plausible.
+- Total metadata entry count drops below 25% of the original, but the changed upstream API surface makes the reduction plausible.
 
 ## Output Style
 
 Keep comments short and factual:
 
 - For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
-- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
+- For metadata entry drops: report only drops where the new total metadata has fewer than 25% as many entries as the previous version's total metadata; cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For deleted coverage: say that the PR fixes compilation by removing coverage and should instead adapt the test to the new API.
 - For unrelated changes: say the PR should stay scoped to the `fixes-javac-fail` repair and remove unrelated files.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -19,6 +19,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
 - Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer small, targeted review comments. This label is for repair work, not a full redesign of historical tests.
 
 ## Workflow
@@ -39,6 +40,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - Treat a new `reachability-metadata.json` for the tested version as normal for this label, including `{}` when validation and stats are coherent.
    - Treat generated test project files such as `.gitignore`, `build.gradle`, `gradle.properties`, `settings.gradle`, and `user-code-filter.json` as normal when they live under the target version's test directory.
    - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject legacy native-image metadata config files. Metadata for generated support and test-only metadata must use `reachability-metadata.json`.
    - Reject or request changes if the PR removes tests, disables test classes, catches and ignores the failing exception.
 
 3. Review the compile fix.
@@ -102,4 +104,5 @@ Keep comments short and factual:
 - For metadata entry drops: report only drops where the new total metadata has fewer than 25% as many entries as the previous version's total metadata; cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For deleted coverage: say that the PR fixes compilation by removing coverage and should instead adapt the test to the new API.
 - For unrelated changes: say the PR should stay scoped to the `fixes-javac-fail` repair and remove unrelated files.
+- For legacy metadata files: say that metadata must use `reachability-metadata.json` and ask for old config files such as `reflect-config.json` or `resource-config.json` to be replaced.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -17,7 +17,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Be more relaxed than `library-new-request`: do not reject only because a test is inherited from older support, uses compatibility branches, or keeps an existing package layout.
 - Do not accept fixes that hide the failing native path by skipping assertions, skipping native-image runtime execution, or weakening the test until the failure disappears.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
-- Compare metadata entry counts between the previous metadata version and the new metadata version. They do not need to match exactly, but a large unexplained drop is suspicious because it can mean the native-image fix no longer covers the same runtime surface.
+- For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Prefer concrete evidence from native run output, generated metadata, stats, and CI over style objections.
 
 ## Workflow
@@ -50,17 +51,20 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 4. Check dynamic-access coverage across versions.
    - Compare `stats/<group>/<artifact>/<old-metadata-version>/stats.json` and `stats/<group>/<artifact>/<new-metadata-version>/stats.json` when stats files are present in the PR or available on the branch.
    - Compare `dynamicAccess.coverageRatio`, `coveredCalls`, `totalCalls`, and the `dynamicAccess.breakdown` entries for reflection, resources, proxies, serialization, JNI, or any other present report type.
+   - Do not use `user-code-filter.json`, agent configuration, or metadata file contents to argue that the reported dynamic-access values are not comparable. Use the stats values as reported unless the stats are missing or stale.
    - A lower `coverageRatio` or lower `coveredCalls` for the new version is blocking unless the total dynamic-access surface changed and the PR explains why the reduction is expected.
    - If metadata fixes make the native run pass but the dynamic-access ratio drops, ask for restored coverage first. Passing native execution is not enough by itself.
    - If `totalCalls` increases while `coveredCalls` stays flat or the ratio drops, ask for additional test coverage or metadata unless the uncovered calls are clearly outside the library behavior under test.
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare the number of entries in the previous `reachability-metadata.json` with the new version's `reachability-metadata.json`.
-   - Count entries across all present top-level metadata sections, such as `reflection`, `resources`, `bundles`, `serialization`, `jni`, and `proxies`.
-   - Do not require an exact match. Small differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
-   - Treat a large drop as blocking or at least requiring explanation when the tests and dynamic-access stats still claim comparable coverage.
-   - Be especially suspicious when metadata entries drop sharply while the PR does not describe a major upstream API/package change.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Do not manually count entries from metadata files.
+   - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
+   - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.
+   - Do not report metadata entry count issues unless the PR-reported new total metadata entry count is lower than 25% of the PR-reported original total metadata entry count.
+   - When the new total is below 25% of the original and the tests and dynamic-access stats still claim comparable coverage, ask for restored metadata or a concrete explanation of the API/package change.
+   - If the PR description does not report usable old and new metadata entry counts, do not infer them from metadata files; ask for refreshed PR summary evidence when the comparison is needed.
 
 6. Check CI before deciding.
    - Expected minimum: native-image compile and native test execution are green for the target coordinate.
@@ -75,14 +79,14 @@ Approve when all of these are true:
 - The PR is scoped to the target existing library and the native-image runtime failure it fixes.
 - The native-image runtime path still executes meaningful library behavior.
 - Dynamic-access coverage does not drop between the previous and new tested versions, or any apparent drop is convincingly explained by a changed upstream API surface.
-- Metadata entry counts are broadly comparable, or any large reduction is convincingly explained by a changed upstream API surface.
+- Total metadata entry counts are not below the 25% severe-drop threshold, or the reduction is convincingly explained by a changed upstream API surface.
 - Required metadata, Java, native-image compile, and native-image run checks are green.
 
 Request changes when any of these are true:
 
 - The fix makes native execution pass by skipping the failing native path, disabling assertions, or removing coverage.
 - Dynamic-access coverage drops without a credible explanation and replacement coverage.
-- Metadata entry count drops substantially without a credible explanation.
+- Total metadata entry count drops below 25% of the original without a credible explanation.
 - Metadata additions are unrelated to the failure or affect other libraries without justification.
 - CI failures indicate the native-image runtime problem is not actually fixed.
 
@@ -91,14 +95,14 @@ Ask for follow-up instead of rejecting when:
 - Stats needed for the old/new version comparison are missing or stale.
 - CI failed in a way that looks like infrastructure noise.
 - The API or native runtime change is plausible but the PR does not explain why a coverage drop is expected.
-- Metadata entry counts differ substantially but the changed upstream API surface makes the reduction plausible.
+- Total metadata entry count drops below 25% of the original, but the changed upstream API surface makes the reduction plausible.
 
 ## Output Style
 
 Keep comments short and factual:
 
 - For coverage drops: say that dynamic-access coverage must not regress between tested versions, cite the old and new values, and ask for either restored coverage or a concrete explanation.
-- For metadata entry drops: say that the new metadata has far fewer entries than the previous version, cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
+- For metadata entry drops: report only drops where the new total metadata has fewer than 25% as many entries as the previous version's total metadata; cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For native skips: say that the PR avoids the failing native path instead of fixing it, so it does not demonstrate native-image runtime coverage.
 - For unrelated changes: say the PR should stay scoped to the `fixes-native-image-run-fail` repair and remove unrelated files.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -19,6 +19,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
 - Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer concrete evidence from native run output, generated metadata, stats, and CI over style objections.
 
 ## Workflow
@@ -40,6 +41,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - Accept metadata additions that are necessary for the new upstream version.
    - Accept narrow test edits that keep the same behavior covered across old and new versions.
    - Be suspicious of unrelated build logic, workflows, generated sources, other libraries, or broad refactors.
+   - Reject legacy native-image metadata config files. Metadata for generated support and test-only metadata must use `reachability-metadata.json`.
    - Reject or request changes if the PR fixes the native run by disabling the failing behavior.
 
 3. Review the native-image fix.
@@ -105,4 +107,5 @@ Keep comments short and factual:
 - For metadata entry drops: report only drops where the new total metadata has fewer than 25% as many entries as the previous version's total metadata; cite the old and new counts, and ask for either restored metadata or a concrete explanation of the API/runtime-surface change.
 - For native skips: say that the PR avoids the failing native path instead of fixing it, so it does not demonstrate native-image runtime coverage.
 - For unrelated changes: say the PR should stay scoped to the `fixes-native-image-run-fail` repair and remove unrelated files.
+- For legacy metadata files: say that metadata must use `reachability-metadata.json` and ask for old config files such as `reflect-config.json` or `resource-config.json` to be replaced.
 - For missing stats: ask for regenerated library stats or CI evidence before approval.

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -21,6 +21,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 - Require at least 50% reported dynamic-access coverage when there are dynamic-access calls to cover. Use the exploded stats files under `stats/<group>/<artifact>/<metadata-version>/stats.json` when available, and block the PR when dynamic-access coverage is below 50% or the PR provides no credible dynamic-access coverage evidence for non-zero dynamic-access calls.
 - Treat dynamic-access coverage counts as a minimum gate, not complete metadata evidence. They can miss metadata required through downstream libraries, so do not use high coverage alone to prove that the submitted metadata is complete or necessary.
 - Treat `0/0` dynamic-access coverage as a valid no-calls case, not as failed coverage. Do not reject a PR only because the exploded stats report `0/0` dynamic-access calls while the PR adds metadata; those stats can miss metadata required through downstream libraries.
+- Do not explicitly read or review individual metadata entries. Use the metadata entry count reported in the PR description for the metadata/dynamic-access mismatch check; do not manually count entries from metadata files. Only request investigation when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count.
 
 ## Workflow
 
@@ -49,7 +50,8 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 
 4. Review the metadata files only for presence and scope.
    - Confirm the expected metadata files exist for the single target coordinate.
-   - Do not block the PR based on the internal contents of `reachability-metadata.json`.
+   - Do not read, list, or reason from individual entries inside `reachability-metadata.json`.
+   - For metadata/dynamic-access mismatch checks, use only the metadata entry count reported in the PR description, such as `Entries` or `Entries found`; do not manually count metadata entries from files.
    - Treat `reachability-metadata.json` containing `{}` as acceptable when the rest of the PR is coherent and validation passes.
    - Do not use the exploded stats files under `stats/<group>/<artifact>/<metadata-version>/stats.json` alone to argue that the submitted metadata is unnecessary.
 
@@ -59,6 +61,8 @@ Treat the following as hard review rules unless the PR provides a strong reason 
    - If the PR reports zero dynamic-access calls and `reachability-metadata.json` is `{}`, that is acceptable as long as the test is library-specific and the scope is otherwise correct.
    - If the PR reports zero dynamic-access calls while adding metadata, do not reject it on that basis alone; dynamic-access stats can miss metadata required through downstream libraries.
    - If the stats report less than 50% coverage for non-zero dynamic-access calls, or no usable coverage signal for claimed dynamic-access behavior, ask for stronger tests or refreshed coverage evidence.
+   - Ask for metadata/coverage mismatch investigation only when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count.
+   - If the PR description does not report a usable metadata entry count, do not infer one from metadata files; ask for refreshed PR summary evidence when that count is needed for the mismatch check.
    - Prefer concrete test quality issues over speculation about whether specific metadata entries are needed.
 
 6. Check validation status.
@@ -91,7 +95,8 @@ Match the concise review style already used in this repository:
 - For version-pinned tests: say that tests should not reference the exact library version because the same test should support multiple library versions.
 - For multiple-library PRs: say that `library-new-request` PRs must push only one library and ask for the unrelated library additions to be removed.
 - For insufficient dynamic-access coverage: say that new-library PRs need at least 50% dynamic-access coverage when there are dynamic-access calls to cover, and ask for stronger tests or refreshed coverage evidence.
-- For metadata/coverage mismatch: ask for investigation only when the PR makes concrete coverage claims that are not supported by the diff, or when reported dynamic-access coverage is below the 50% minimum for non-zero dynamic-access calls. Do not argue from metadata contents alone.
+- For unsupported coverage claims: ask for refreshed coverage evidence when the PR makes concrete coverage claims that are not supported by the diff.
+- For metadata/dynamic-access entry mismatch: ask for investigation only when covered dynamic-access calls are at least 75% higher than the PR-reported metadata entry count. Do not manually count or argue from metadata contents.
 
 Keep comments short, factual, and blocking. Focus on the concrete defect, not a long explanation.
 

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -22,6 +22,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 - Treat dynamic-access coverage counts as a minimum gate, not complete metadata evidence. They can miss metadata required through downstream libraries, so do not use high coverage alone to prove that the submitted metadata is complete or necessary.
 - Treat `0/0` dynamic-access coverage as a valid no-calls case, not as failed coverage. Do not reject a PR only because the exploded stats report `0/0` dynamic-access calls while the PR adds metadata; those stats can miss metadata required through downstream libraries.
 - Do not explicitly read or review individual metadata entries. Use the metadata entry count reported in the PR description for the metadata/dynamic-access mismatch check; do not manually count entries from metadata files. Only request investigation when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count.
+- Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 
 ## Workflow
 
@@ -40,6 +41,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
      - `tests/src/<group>/<artifact>/<version>/**`
    - Be suspicious of changes to build logic, workflows, unrelated libraries, generated sources outside the target test directory, or wide refactors.
    - Treat extra `metadata/**` or `tests/src/**` trees for other coordinates as a blocking scope violation, not as a minor cleanup issue.
+   - Reject legacy native-image metadata config files. New-library metadata must be provided through `reachability-metadata.json`, including any test-only metadata under `tests/src/**`.
 
 3. Review the test source.
    - The test must be library-specific, not a lightly edited scaffold.
@@ -97,6 +99,7 @@ Match the concise review style already used in this repository:
 - For insufficient dynamic-access coverage: say that new-library PRs need at least 50% dynamic-access coverage when there are dynamic-access calls to cover, and ask for stronger tests or refreshed coverage evidence.
 - For unsupported coverage claims: ask for refreshed coverage evidence when the PR makes concrete coverage claims that are not supported by the diff.
 - For metadata/dynamic-access entry mismatch: ask for investigation only when covered dynamic-access calls are at least 75% higher than the PR-reported metadata entry count. Do not manually count or argue from metadata contents.
+- For legacy metadata files: say that metadata must use `reachability-metadata.json` and ask for old config files such as `reflect-config.json` or `resource-config.json` to be replaced.
 
 Keep comments short, factual, and blocking. Focus on the concrete defect, not a long explanation.
 


### PR DESCRIPTION
Fixes #2596

## Summary
- Update `library-new-request` review guidance to avoid reading individual metadata entries and use PR-reported metadata entry counts for the metadata/dynamic-access mismatch check.
- Require intervention for that mismatch only when covered dynamic-access calls are at least 75% higher than the PR-reported metadata entry count.
- Update the fix review skills to compare PR-reported total metadata entry counts instead of manually counting metadata files.
- Limit fix-review metadata entry count issues to cases where the PR-reported new total is below 25% of the PR-reported original total.
- Tell reviewers to take reported dynamic-access and metadata-count statistics as-is unless the evidence is missing or stale.
- Require metadata files in generated support PRs to use `reachability-metadata.json`; legacy native-image config files such as `reflect-config.json` or `resource-config.json` should be rejected.

## Validation
- `git diff --check -- skills/review-library-new-request/SKILL.md skills/review-fixes-java-run-fail/SKILL.md skills/review-fixes-javac-fail/SKILL.md skills/review-fixes-native-image-run-fail/SKILL.md`