### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0 using gpt-5.4

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
@@ -1,0 +1,122 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.JSONObjectException$Reference",
+      "methods" : [
+        {
+          "name" : "setFieldName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setFrom",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "setIndex",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.JSONObjectException$Reference",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.JSONObjectException$Reference"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.ClassKey",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.ClassKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "java.awt.Point",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "java.awt.Point",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "java.awt.Point"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "java.util.LinkedHashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -1,15 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "com.fasterxml.jackson.jr" ],
-    "metadata-version": "2.13.4",
-    "source-code-url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.13.4/jackson-jr-objects-2.13.4-sources.jar",
-    "repository-url": "https://github.com/FasterXML/jackson-jr",
-    "test-code-url": "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-2.13.4/jr-objects/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.13.4/jackson-jr-objects-2.13.4-javadoc.jar",
-    "description": "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrappers, and Java beans, and for writing those values back as JSON. It builds directly on jackson-core with minimal dependencies and also includes builder-style APIs for composing JSON output.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "2.21.0",
+    "tested-versions" : [
+      "2.21.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
+    ]
+  },
+  {
+    "metadata-version" : "2.13.4",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.13.4/jackson-jr-objects-2.13.4-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-2.13.4/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.13.4/jackson-jr-objects-2.13.4-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrappers, and Java beans, and for writing those values back as JSON. It builds directly on jackson-core with minimal dependencies and also includes builder-style APIs for composing JSON output.",
+    "tested-versions" : [
       "2.13.4"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
     ]
   }
 ]

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.21.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.21.0/jackson-jr-objects-2.21.0-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-2.21.0/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.21.0/jackson-jr-objects-2.21.0-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrappers, and Java beans, and for writing those values back as JSON. It builds directly on jackson-core with minimal dependencies and also includes builder-style APIs for composing JSON output.",
     "tested-versions" : [
       "2.21.0"
     ],

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
@@ -1,0 +1,32 @@
+{
+  "versions" : [ {
+    "version" : "2.21.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4259,
+        "missed" : 9451,
+        "ratio" : 0.310649,
+        "total" : 13710
+      },
+      "line" : "N/A",
+      "method" : {
+        "covered" : 235,
+        "missed" : 470,
+        "ratio" : 0.333333,
+        "total" : 705
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jr:jackson-jr-objects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0
+library.version = 2.21.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jr.jackson-jr-objects_tests'

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsBeansThroughNonPublicNoArgsConstructors() throws Exception {
+        HiddenNoArgsBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(HiddenNoArgsBean.class, "{}");
+
+        assertThat(bean.getMarker()).isEqualTo("created");
+    }
+
+    @Test
+    void createsRecordsThroughTheirCanonicalConstructors() throws Exception {
+        HiddenRecordBean record = JSON_WITH_FORCE_ACCESS.beanFrom(HiddenRecordBean.class,
+                "{\"name\":\"Ada\",\"count\":7}");
+
+        assertThat(record.name()).isEqualTo("Ada");
+        assertThat(record.count()).isEqualTo(7);
+    }
+
+    public static final class HiddenNoArgsBean {
+        private final String marker;
+
+        private HiddenNoArgsBean() {
+            marker = "created";
+        }
+
+        public String getMarker() {
+            return marker;
+        }
+    }
+
+    record HiddenRecordBean(String name, int count) {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,25 +6,34 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import java.util.LinkedHashMap;
+
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanConstructorsDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-
     @Test
-    void createsBeansThroughNonPublicNoArgsConstructors() throws Exception {
-        HiddenNoArgsBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(HiddenNoArgsBean.class, "{}");
+    void invokesNoArgsConstructorThroughBeanConstructorsCreate() throws Exception {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(HiddenNoArgsBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(HiddenNoArgsBean.class, constructors);
+        constructors.forceAccess();
 
-        assertThat(bean.getMarker()).isEqualTo("created");
+        HiddenNoArgsBean bean = (HiddenNoArgsBean) constructors.createBean();
+
+        assertThat(bean.marker()).isEqualTo("created");
     }
 
     @Test
-    void createsRecordsThroughTheirCanonicalConstructors() throws Exception {
-        HiddenRecordBean record = JSON_WITH_FORCE_ACCESS.beanFrom(HiddenRecordBean.class,
-                "{\"name\":\"Ada\",\"count\":7}");
+    void invokesCanonicalRecordConstructorThroughBeanConstructorsCreateRecord() throws Exception {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(HiddenRecordBean.class);
+        constructors.addRecordConstructor(BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                HiddenRecordBean.class, new LinkedHashMap<String, String>(), name -> name));
+        constructors.forceAccess();
+
+        HiddenRecordBean record = (HiddenRecordBean) constructors.createRecordBean("Ada", 7);
 
         assertThat(record.name()).isEqualTo("Ada");
         assertThat(record.count()).isEqualTo(7);
@@ -37,11 +46,25 @@ public class BeanConstructorsDynamicAccessTest {
             marker = "created";
         }
 
-        public String getMarker() {
+        public String marker() {
             return marker;
         }
     }
 
     record HiddenRecordBean(String name, int count) {
+    }
+
+    public static final class InspectableBeanConstructors extends BeanConstructors {
+        public InspectableBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        public Object createBean() throws Exception {
+            return create();
+        }
+
+        public Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyIntrospectorDynamicAccessTest {
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
+
+    @Test
+    void collectsDeclaredConstructorsForDeserialization() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+
+        assertThat(definition.defaultCtor).isNotNull();
+        assertThat(definition.stringCtor).isNotNull();
+        assertThat(definition.longCtor).isNotNull();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+    }
+
+    @Test
+    void collectsDeclaredFieldsAndMethodsForSerialization() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
+
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class BaseBean {
+        public int visible;
+    }
+
+    static final class IntrospectedBean extends BaseBean {
+        private String name;
+        private boolean active;
+
+        private IntrospectedBean() {
+        }
+
+        private IntrospectedBean(String name) {
+            this.name = name;
+        }
+
+        private IntrospectedBean(long visible) {
+            this.visible = (int) visible;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -6,72 +6,69 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyIntrospectorDynamicAccessTest {
-    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON.builder()
-            .enable(JSON.Feature.USE_FIELD_MATCHING_GETTERS)
-            .build();
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
 
     @Test
-    void deserializesBeansUsingDeclaredConstructors() throws Exception {
-        ConstructorIntrospectedBean fromObject = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "{\"count\":4}");
-        ConstructorIntrospectedBean fromString = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "\"Ada\"");
-        ConstructorIntrospectedBean fromNumber = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "7");
+    void collectsDeclaredConstructorsForNonRecordBeans() {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(ConstructorIntrospectedBean.class);
 
-        assertThat(fromObject.getCreationPath()).isEqualTo("default");
-        assertThat(fromObject.count).isEqualTo(4);
-        assertThat(fromString.getCreationPath()).isEqualTo("string");
-        assertThat(fromString.getName()).isEqualTo("Ada");
-        assertThat(fromNumber.getCreationPath()).isEqualTo("long");
-        assertThat(fromNumber.count).isEqualTo(7);
+        BeanPropertyIntrospector.addNonRecordConstructors(ConstructorIntrospectedBean.class, constructors);
+
+        assertThat(constructors.noArgsConstructor()).isNotNull();
+        assertThat(constructors.stringConstructor()).isNotNull();
+        assertThat(constructors.longConstructor()).isNotNull();
+        assertThat(constructors.intConstructor()).isNull();
     }
 
     @Test
-    void serializesAndDeserializesBeansUsingDeclaredFieldsAndMethods() throws Exception {
-        FieldAndMethodIntrospectedBean bean = JSON_WITH_FIELD_MATCHING_GETTERS.beanFrom(
-                FieldAndMethodIntrospectedBean.class,
-                "{\"visible\":5,\"nickname\":\"Bob\",\"active\":false}");
+    void collectsDeclaredFieldsAndMethodsForSerialization() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, FieldAndMethodIntrospectedBean.class);
 
-        assertThat(bean.visible).isEqualTo(5);
-        assertThat(bean.nickname()).isEqualTo("Bob");
-        assertThat(bean.isActive()).isFalse();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
 
-        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(bean);
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
 
-        assertThat(json).isEqualTo("{\"active\":false,\"nickname\":\"Bob\",\"visible\":5}");
-        assertThat(json).doesNotContain("ignoredStatic", "IGNORED_CONSTANT");
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
     }
 
     public static final class ConstructorIntrospectedBean {
-        public int count;
-
-        private final String creationPath;
-        private String name;
-
         public ConstructorIntrospectedBean() {
-            creationPath = "default";
         }
 
-        public ConstructorIntrospectedBean(String name) {
-            creationPath = "string";
-            this.name = name;
+        public ConstructorIntrospectedBean(String value) {
         }
 
-        public ConstructorIntrospectedBean(long count) {
-            creationPath = "long";
-            this.count = (int) count;
-        }
-
-        public String getCreationPath() {
-            return creationPath;
-        }
-
-        public String getName() {
-            return name;
+        public ConstructorIntrospectedBean(long value) {
         }
     }
 
@@ -83,18 +80,15 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         public static int ignoredStatic = 12;
         public static final int IGNORED_CONSTANT = 13;
 
-        private String nickname;
+        private String name;
         private boolean active;
 
-        public FieldAndMethodIntrospectedBean() {
+        public String getName() {
+            return name;
         }
 
-        public String nickname() {
-            return nickname;
-        }
-
-        public void setNickname(String nickname) {
-            this.nickname = nickname;
+        public void setName(String name) {
+            this.name = name;
         }
 
         public boolean isActive() {
@@ -103,6 +97,28 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         public void setActive(boolean active) {
             this.active = active;
+        }
+    }
+
+    public static final class InspectableBeanConstructors extends BeanConstructors {
+        public InspectableBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        public Constructor<?> noArgsConstructor() {
+            return _noArgsCtor;
+        }
+
+        public Constructor<?> stringConstructor() {
+            return _stringCtor;
+        }
+
+        public Constructor<?> longConstructor() {
+            return _longCtor;
+        }
+
+        public Constructor<?> intConstructor() {
+            return _intCtor;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -6,86 +6,95 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.util.List;
-
-import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
-import com.fasterxml.jackson.jr.ob.api.MapBuilder;
-import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
-import com.fasterxml.jackson.jr.ob.impl.JSONReader;
-import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
-import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.JSON;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyIntrospectorDynamicAccessTest {
-    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
-    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
-    private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON.builder()
+            .enable(JSON.Feature.USE_FIELD_MATCHING_GETTERS)
+            .build();
 
     @Test
-    void collectsDeclaredConstructorsForDeserialization() {
-        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+    void deserializesBeansUsingDeclaredConstructors() throws Exception {
+        ConstructorIntrospectedBean fromObject = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "{\"count\":4}");
+        ConstructorIntrospectedBean fromString = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "\"Ada\"");
+        ConstructorIntrospectedBean fromNumber = JSON.std.beanFrom(ConstructorIntrospectedBean.class, "7");
 
-        assertThat(definition.defaultCtor).isNotNull();
-        assertThat(definition.stringCtor).isNotNull();
-        assertThat(definition.longCtor).isNotNull();
-        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(fromObject.getCreationPath()).isEqualTo("default");
+        assertThat(fromObject.count).isEqualTo(4);
+        assertThat(fromString.getCreationPath()).isEqualTo("string");
+        assertThat(fromString.getName()).isEqualTo("Ada");
+        assertThat(fromNumber.getCreationPath()).isEqualTo("long");
+        assertThat(fromNumber.count).isEqualTo(7);
     }
 
     @Test
-    void collectsDeclaredFieldsAndMethodsForSerialization() {
-        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+    void serializesAndDeserializesBeansUsingDeclaredFieldsAndMethods() throws Exception {
+        FieldAndMethodIntrospectedBean bean = JSON_WITH_FIELD_MATCHING_GETTERS.beanFrom(
+                FieldAndMethodIntrospectedBean.class,
+                "{\"visible\":5,\"nickname\":\"Bob\",\"active\":false}");
 
-        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(bean.visible).isEqualTo(5);
+        assertThat(bean.nickname()).isEqualTo("Bob");
+        assertThat(bean.isActive()).isFalse();
 
-        POJODefinition.Prop visible = property(definition, "visible");
-        POJODefinition.Prop name = property(definition, "name");
-        POJODefinition.Prop active = property(definition, "active");
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(bean);
 
-        assertThat(visible.field).isNotNull();
-        assertThat(name.getter).isNotNull();
-        assertThat(name.setter).isNotNull();
-        assertThat(active.isGetter).isNotNull();
-        assertThat(active.setter).isNotNull();
+        assertThat(json).isEqualTo("{\"active\":false,\"nickname\":\"Bob\",\"visible\":5}");
+        assertThat(json).doesNotContain("ignoredStatic", "IGNORED_CONSTANT");
     }
 
-    private static List<String> propertyNames(POJODefinition definition) {
-        return definition.getProperties().stream().map(prop -> prop.name).toList();
-    }
+    public static final class ConstructorIntrospectedBean {
+        public int count;
 
-    private static POJODefinition.Prop property(POJODefinition definition, String name) {
-        return definition.getProperties().stream()
-                .filter(prop -> prop.name.equals(name))
-                .findFirst()
-                .orElseThrow();
-    }
-
-    static class BaseBean {
-        public int visible;
-    }
-
-    static final class IntrospectedBean extends BaseBean {
+        private final String creationPath;
         private String name;
-        private boolean active;
 
-        private IntrospectedBean() {
+        public ConstructorIntrospectedBean() {
+            creationPath = "default";
         }
 
-        private IntrospectedBean(String name) {
+        public ConstructorIntrospectedBean(String name) {
+            creationPath = "string";
             this.name = name;
         }
 
-        private IntrospectedBean(long visible) {
-            this.visible = (int) visible;
+        public ConstructorIntrospectedBean(long count) {
+            creationPath = "long";
+            this.count = (int) count;
+        }
+
+        public String getCreationPath() {
+            return creationPath;
         }
 
         public String getName() {
             return name;
         }
+    }
 
-        private void setName(String name) {
-            this.name = name;
+    public static class FieldBaseBean {
+        public int visible;
+    }
+
+    public static final class FieldAndMethodIntrospectedBean extends FieldBaseBean {
+        public static int ignoredStatic = 12;
+        public static final int IGNORED_CONSTANT = 13;
+
+        private String nickname;
+        private boolean active;
+
+        public FieldAndMethodIntrospectedBean() {
+        }
+
+        public String nickname() {
+            return nickname;
+        }
+
+        public void setNickname(String nickname) {
+            this.nickname = nickname;
         }
 
         public boolean isActive() {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -6,22 +6,34 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.awt.Point;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON MODIFIER_AWARE_JSON = JSON.builder()
+            .enable(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .register(new BeanPropertyReaderDefinitionExtension())
+            .build();
 
     @Test
-    void populatesFieldBackedJdkBeanProperties() throws Exception {
-        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
+    void populatesModifierDefinedFieldBackedProperties() throws Exception {
+        FieldBackedReaderBean bean = MODIFIER_AWARE_JSON.beanFrom(FieldBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
 
-        assertThat(point.x).isEqualTo(3);
-        assertThat(point.y).isEqualTo(4);
+        assertThat(bean.getName()).isEqualTo("Ada");
     }
 
     @Test
@@ -34,12 +46,23 @@ public class BeanPropertyReaderDynamicAccessTest {
     }
 
     @Test
-    void populatesPrivateSetterBackedProperties() throws Exception {
-        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+    void populatesModifierDefinedPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = MODIFIER_AWARE_JSON.beanFrom(SetterBackedReaderBean.class,
                 "{\"name\":\"Ada\"}");
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class FieldBackedReaderBean {
+        private String name;
+
+        public FieldBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 
     public static final class PublicSetterBackedReaderBean {
@@ -81,6 +104,61 @@ public class BeanPropertyReaderDynamicAccessTest {
         private void setName(String name) {
             this.name = name;
             setterCalls++;
+        }
+    }
+
+    public static final class BeanPropertyReaderDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new BeanPropertyReaderDefinitionModifier());
+        }
+    }
+
+    public static final class BeanPropertyReaderDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType == FieldBackedReaderBean.class) {
+                return new POJODefinition(FieldBackedReaderBean.class,
+                        new POJODefinition.Prop[] {
+                                new POJODefinition.Prop("name", "name",
+                                        declaredField(FieldBackedReaderBean.class, "name"),
+                                        null, null, null, null)
+                        },
+                        constructorsFor(FieldBackedReaderBean.class));
+            }
+            if (pojoType == SetterBackedReaderBean.class) {
+                return new POJODefinition(SetterBackedReaderBean.class,
+                        new POJODefinition.Prop[] {
+                                new POJODefinition.Prop("name", "name", null,
+                                        declaredMethod(SetterBackedReaderBean.class, "setName", String.class),
+                                        null, null, null)
+                        },
+                        constructorsFor(SetterBackedReaderBean.class));
+            }
+            return null;
+        }
+
+        private static BeanConstructors constructorsFor(Class<?> beanType) {
+            BeanConstructors constructors = new BeanConstructors(beanType);
+            BeanPropertyIntrospector.addNonRecordConstructors(beanType, constructors);
+            return constructors;
+        }
+
+        private static Field declaredField(Class<?> declaringType, String fieldName) {
+            try {
+                return declaringType.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+
+        private static Method declaredMethod(Class<?> declaringType, String methodName,
+                Class<?>... parameterTypes) {
+            try {
+                return declaringType.getDeclaredMethod(methodName, parameterTypes);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalStateException(ex);
+            }
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.awt.Point;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void populatesFieldBackedJdkBeanProperties() throws Exception {
+        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(point.x).isEqualTo(3);
+        assertThat(point.y).isEqualTo(4);
+    }
+
+    @Test
+    void populatesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class PublicSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public PublicSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class SetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public SetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -9,68 +9,59 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
-import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
-import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
-import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
-import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
-import com.fasterxml.jackson.jr.ob.impl.JSONReader;
-import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyReaderDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-    private static final JSON MODIFIER_AWARE_JSON = JSON.builder()
-            .enable(JSON.Feature.FORCE_REFLECTION_ACCESS)
-            .register(new BeanPropertyReaderDefinitionExtension())
-            .build();
-
     @Test
-    void populatesModifierDefinedFieldBackedProperties() throws Exception {
-        FieldBackedReaderBean bean = MODIFIER_AWARE_JSON.beanFrom(FieldBackedReaderBean.class,
-                "{\"name\":\"Ada\"}");
+    void setsFieldBackedProperties() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name",
+                publicField(FieldBackedReaderBean.class, "name"), null, -1);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
-        assertThat(bean.getName()).isEqualTo("Ada");
+        reader.setValueFor(bean, new Object[] { "Ada" });
+
+        assertThat(bean.name).isEqualTo("Ada");
     }
 
     @Test
-    void populatesPublicSetterBackedProperties() throws Exception {
-        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
-                "{\"name\":\"Ada\"}");
+    void invokesSetterBackedProperties() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                publicMethod(PublicSetterBackedReaderBean.class, "setName", String.class), -1);
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[] { "Ada" });
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
-    @Test
-    void populatesModifierDefinedPrivateSetterBackedProperties() throws Exception {
-        SetterBackedReaderBean bean = MODIFIER_AWARE_JSON.beanFrom(SetterBackedReaderBean.class,
-                "{\"name\":\"Ada\"}");
+    private static Field publicField(Class<?> declaringType, String fieldName) {
+        try {
+            return declaringType.getField(fieldName);
+        } catch (NoSuchFieldException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
 
-        assertThat(bean.getName()).isEqualTo("Ada");
-        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    private static Method publicMethod(Class<?> declaringType, String methodName,
+            Class<?>... parameterTypes) {
+        try {
+            return declaringType.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     public static final class FieldBackedReaderBean {
-        private String name;
-
-        public FieldBackedReaderBean() {
-        }
-
-        public String getName() {
-            return name;
-        }
+        public String name;
     }
 
     public static final class PublicSetterBackedReaderBean {
         private String name;
         private int setterCalls;
-
-        public PublicSetterBackedReaderBean() {
-        }
 
         public String getName() {
             return name;
@@ -83,82 +74,6 @@ public class BeanPropertyReaderDynamicAccessTest {
         public void setName(String name) {
             this.name = name;
             setterCalls++;
-        }
-    }
-
-    public static final class SetterBackedReaderBean {
-        private String name;
-        private int setterCalls;
-
-        public SetterBackedReaderBean() {
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public int getSetterCalls() {
-            return setterCalls;
-        }
-
-        private void setName(String name) {
-            this.name = name;
-            setterCalls++;
-        }
-    }
-
-    public static final class BeanPropertyReaderDefinitionExtension extends JacksonJrExtension {
-        @Override
-        protected void register(ExtensionContext ctxt) {
-            ctxt.insertModifier(new BeanPropertyReaderDefinitionModifier());
-        }
-    }
-
-    public static final class BeanPropertyReaderDefinitionModifier extends ReaderWriterModifier {
-        @Override
-        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType == FieldBackedReaderBean.class) {
-                return new POJODefinition(FieldBackedReaderBean.class,
-                        new POJODefinition.Prop[] {
-                                new POJODefinition.Prop("name", "name",
-                                        declaredField(FieldBackedReaderBean.class, "name"),
-                                        null, null, null, null)
-                        },
-                        constructorsFor(FieldBackedReaderBean.class));
-            }
-            if (pojoType == SetterBackedReaderBean.class) {
-                return new POJODefinition(SetterBackedReaderBean.class,
-                        new POJODefinition.Prop[] {
-                                new POJODefinition.Prop("name", "name", null,
-                                        declaredMethod(SetterBackedReaderBean.class, "setName", String.class),
-                                        null, null, null)
-                        },
-                        constructorsFor(SetterBackedReaderBean.class));
-            }
-            return null;
-        }
-
-        private static BeanConstructors constructorsFor(Class<?> beanType) {
-            BeanConstructors constructors = new BeanConstructors(beanType);
-            BeanPropertyIntrospector.addNonRecordConstructors(beanType, constructors);
-            return constructors;
-        }
-
-        private static Field declaredField(Class<?> declaringType, String fieldName) {
-            try {
-                return declaringType.getDeclaredField(fieldName);
-            } catch (NoSuchFieldException ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
-
-        private static Method declaredMethod(Class<?> declaringType, String methodName,
-                Class<?>... parameterTypes) {
-            try {
-                return declaringType.getDeclaredMethod(methodName, parameterTypes);
-            } catch (NoSuchMethodException ex) {
-                throw new IllegalStateException(ex);
-            }
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -21,7 +21,7 @@ public class BeanPropertyReaderDynamicAccessTest {
                 publicField(FieldBackedReaderBean.class, "name"), null, -1);
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[] { "Ada" });
+        reader.setValueFor(bean, new Object[] {"Ada"});
 
         assertThat(bean.name).isEqualTo("Ada");
     }
@@ -32,7 +32,7 @@ public class BeanPropertyReaderDynamicAccessTest {
                 publicMethod(PublicSetterBackedReaderBean.class, "setName", String.class), -1);
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[] { "Ada" });
+        reader.setValueFor(bean, new Object[] {"Ada"});
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,45 +6,65 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-
     @Test
-    void serializesFieldBackedPropertiesFromNonPublicBeans() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new NonPublicFieldBackedWriterBean());
+    void getsFieldBackedPropertyValues() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(-1, "id",
+                publicField(FieldBackedWriterBean.class, "id"), null);
 
-        assertThat(json).isEqualTo("{\"id\":3}");
+        Object value = writer.getValueFor(new FieldBackedWriterBean());
+
+        assertThat(value).isEqualTo(3);
     }
 
     @Test
-    void serializesGetterBackedPropertiesFromNonPublicBeans() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new NonPublicGetterBackedWriterBean("Ada"));
+    void invokesGetterBackedPropertyValues() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(-1, "name", null,
+                publicMethod(GetterBackedWriterBean.class, "getName"));
 
-        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        Object value = writer.getValueFor(new GetterBackedWriterBean("Ada"));
+
+        assertThat(value).isEqualTo("Ada");
     }
 
-    private static final class NonPublicFieldBackedWriterBean {
+    private static Field publicField(Class<?> declaringType, String fieldName) {
+        try {
+            return declaringType.getField(fieldName);
+        } catch (NoSuchFieldException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static Method publicMethod(Class<?> declaringType, String methodName,
+            Class<?>... parameterTypes) {
+        try {
+            return declaringType.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    public static final class FieldBackedWriterBean {
         public int id = 3;
     }
 
-    private static final class NonPublicGetterBackedWriterBean {
-        private String name;
+    public static final class GetterBackedWriterBean {
+        private final String name;
 
-        private NonPublicGetterBackedWriterBean(String name) {
+        public GetterBackedWriterBean(String name) {
             this.name = name;
         }
 
         public String getName() {
             return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyWriterDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void serializesFieldBackedProperties() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+
+        assertThat(json).isEqualTo("{\"id\":3}");
+    }
+
+    @Test
+    void serializesGetterBackedProperties() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+
+        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+    }
+
+    public static final class GetterBackedWriterBean {
+        private String name;
+
+        public GetterBackedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -15,27 +15,27 @@ public class BeanPropertyWriterDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+    void serializesFieldBackedPropertiesFromNonPublicBeans() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new NonPublicFieldBackedWriterBean());
 
         assertThat(json).isEqualTo("{\"id\":3}");
     }
 
     @Test
-    void serializesGetterBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+    void serializesGetterBackedPropertiesFromNonPublicBeans() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.asString(new NonPublicGetterBackedWriterBean("Ada"));
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
     }
 
-    public static final class FieldBackedWriterBean {
+    private static final class NonPublicFieldBackedWriterBean {
         public int id = 3;
     }
 
-    public static final class GetterBackedWriterBean {
+    private static final class NonPublicGetterBackedWriterBean {
         private String name;
 
-        public GetterBackedWriterBean(String name) {
+        private NonPublicGetterBackedWriterBean(String name) {
             this.name = name;
         }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.ClassKey;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
+        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+
+        assertThat(key).isNotNull();
+        assertThat(key.hashCode()).isZero();
+    }
+
+    @Test
+    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
+                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+
+        assertThat(reference.getFrom()).isEqualTo("source");
+        assertThat(reference.getFieldName()).isEqualTo("name");
+        assertThat(reference.getIndex()).isEqualTo(2);
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -7,8 +7,6 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.JSONObjectException;
-import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,20 +15,40 @@ public class BeanReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
-        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{}");
 
-        assertThat(key).isNotNull();
-        assertThat(key.hashCode()).isZero();
+        assertThat(bean.getMarker()).isEqualTo(1);
     }
 
     @Test
-    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
-                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class, "{}");
 
-        assertThat(reference.getFrom()).isEqualTo("source");
-        assertThat(reference.getFieldName()).isEqualTo("name");
-        assertThat(reference.getIndex()).isEqualTo(2);
+        assertThat(bean.getMarker()).isEqualTo(2);
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private final int marker;
+
+        public PublicDefaultCtorBean() {
+            marker = 1;
+        }
+
+        public int getMarker() {
+            return marker;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private final int marker;
+
+        private PrivateDefaultCtorBean() {
+            marker = 2;
+        }
+
+        public int getMarker() {
+            return marker;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -14,25 +14,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CollectionBuilderDynamicAccessTest {
     @Test
     void readsEmptyTypedArrays() throws Exception {
-        String[] values = JSON.std.arrayOfFrom(String.class, "[]");
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class, "[]");
 
         assertThat(values).isEmpty();
-        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
     }
 
     @Test
     void readsSingletonTypedArrays() throws Exception {
-        String[] values = JSON.std.arrayOfFrom(String.class, "[\"solo\"]");
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class, "[{\"name\":\"solo\"}]");
 
-        assertThat(values).containsExactly("solo");
-        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
+        assertThat(values).singleElement().extracting(element -> element.name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
     }
 
     @Test
     void readsMultiValueTypedArrays() throws Exception {
-        String[] values = JSON.std.arrayOfFrom(String.class, "[\"left\",\"right\"]");
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class,
+                "[{\"name\":\"left\"},{\"name\":\"right\"}]");
 
-        assertThat(values).containsExactly("left", "right");
-        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
+        assertThat(values).extracting(element -> element.name).containsExactly("left", "right");
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
+    }
+
+    public static final class ArrayElement {
+        public String name;
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -7,63 +7,32 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
     @Test
-    void createsEmptyTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
-
-        Object[] values = builder.emptyArray((Class) elementType);
+    void readsEmptyTypedArrays() throws Exception {
+        String[] values = JSON.std.arrayOfFrom(String.class, "[]");
 
         assertThat(values).isEmpty();
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
     }
 
     @Test
-    void createsSingletonTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsSingletonTypedArrays() throws Exception {
+        String[] values = JSON.std.arrayOfFrom(String.class, "[\"solo\"]");
 
-        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
-
-        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(values).containsExactly("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
     }
 
     @Test
-    void createsMultiValueTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsMultiValueTypedArrays() throws Exception {
+        String[] values = JSON.std.arrayOfFrom(String.class, "[\"left\",\"right\"]");
 
-        Object[] values = builder.start()
-                .add(new ArrayElement("left"))
-                .add(new ArrayElement("right"))
-                .buildArray((Class) elementType);
-
-        assertThat(values).hasSize(2);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
-        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
-    }
-
-    private static Class<?> runtimeArrayElementType() throws Exception {
-        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
-    }
-
-    public static final class ArrayElement {
-        public String name;
-
-        public ArrayElement() {
-        }
-
-        public ArrayElement(String name) {
-            this.name = name;
-        }
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values.getClass().getComponentType()).isSameAs(String.class);
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionBuilderDynamicAccessTest {
+    @Test
+    void createsEmptyTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray((Class) elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArrays() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<?> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray((Class) elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    private static Class<?> runtimeArrayElementType() throws Exception {
+        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    public static final class ArrayElement {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -43,11 +43,13 @@ public class MapBuilderDefaultDynamicAccessTest {
     @Test
     void readsNestedObjectsIntoConfiguredMapImplementationForEachObject() throws Exception {
         Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{\"outer\":{\"alpha\":1,\"beta\":2},\"count\":3}");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outer = (Map<String, Object>) counts.get("outer");
 
         assertThat(counts).isInstanceOf(CountsMap.class);
         assertThat(counts).containsEntry("count", 3);
-        assertThat(counts.get("outer")).isInstanceOf(CountsMap.class);
-        assertThat((Map<?, ?>) counts.get("outer")).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(outer).isInstanceOf(CountsMap.class);
+        assertThat(outer).containsEntry("alpha", 1).containsEntry("beta", 2);
         assertThat(CountsMap.getConstructorCalls()).isEqualTo(2);
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -8,47 +8,66 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapBuilderDefaultDynamicAccessTest {
-    @Test
-    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
-
-        Map<String, Object> counts = builder.start()
-                .put("alpha", 1)
-                .put("beta", 2)
-                .build();
-
-        assertThat(counts).isInstanceOf(CountsMap.class);
-        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+    @BeforeEach
+    void resetConstructorCalls() {
+        CountsMap.resetConstructorCalls();
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
-
-        Map<String, Object> counts = builder.emptyMap();
+    void readsEmptyObjectsIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{}");
 
         assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
-
-        Map<String, Object> counts = builder.singletonMap("only", 99);
+    void readsSingletonObjectsIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{\"only\":99}");
 
         assertThat(counts).isInstanceOf(CountsMap.class);
         assertThat(counts).containsEntry("only", 99);
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void readsNestedObjectsIntoConfiguredMapImplementationForEachObject() throws Exception {
+        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{\"outer\":{\"alpha\":1,\"beta\":2},\"count\":3}");
+
+        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).containsEntry("count", 3);
+        assertThat(counts.get("outer")).isInstanceOf(CountsMap.class);
+        assertThat((Map<?, ?>) counts.get("outer")).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(2);
+    }
+
+    private static JSON jsonWithCountsMaps() {
+        return JSON.std.with(MapBuilder.defaultImpl().newBuilder(CountsMap.class));
     }
 
     public static final class CountsMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
         public CountsMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        static void resetConstructorCalls() {
+            CONSTRUCTOR_CALLS.set(0);
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -7,11 +7,10 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,37 +23,31 @@ public class MapBuilderDefaultDynamicAccessTest {
     }
 
     @Test
-    void readsEmptyObjectsIntoConfiguredMapImplementation() throws Exception {
-        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{}");
+    void readsEmptyTypedMapSubclasses() throws Exception {
+        CountsMap counts = JSON.std.beanFrom(CountsMap.class, "{}");
 
-        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+        assertThat(counts).isEmpty();
         assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
     }
 
     @Test
-    void readsSingletonObjectsIntoConfiguredMapImplementation() throws Exception {
-        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{\"only\":99}");
+    void readsSingletonTypedMapSubclasses() throws Exception {
+        CountsMap counts = JSON.std.beanFrom(CountsMap.class, "{\"only\":99}");
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
         assertThat(counts).containsEntry("only", 99);
         assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
     }
 
     @Test
-    void readsNestedObjectsIntoConfiguredMapImplementationForEachObject() throws Exception {
-        Map<String, Object> counts = jsonWithCountsMaps().mapFrom("{\"outer\":{\"alpha\":1,\"beta\":2},\"count\":3}");
-        @SuppressWarnings("unchecked")
-        Map<String, Object> outer = (Map<String, Object>) counts.get("outer");
+    void readsTypedMapSubclassesInsideCollections() throws Exception {
+        List<CountsMap> counts = JSON.std.listOfFrom(CountsMap.class,
+                "[{\"alpha\":1},{\"beta\":2}]");
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
-        assertThat(counts).containsEntry("count", 3);
-        assertThat(outer).isInstanceOf(CountsMap.class);
-        assertThat(outer).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(counts).hasSize(2);
+        assertThat(counts).allSatisfy(count -> assertThat(count).isInstanceOf(CountsMap.class));
+        assertThat(counts.get(0)).containsEntry("alpha", 1);
+        assertThat(counts.get(1)).containsEntry("beta", 2);
         assertThat(CountsMap.getConstructorCalls()).isEqualTo(2);
-    }
-
-    private static JSON jsonWithCountsMaps() {
-        return JSON.std.with(MapBuilder.defaultImpl().newBuilder(CountsMap.class));
     }
 
     public static final class CountsMap extends LinkedHashMap<String, Object> {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBuilderDefaultDynamicAccessTest {
+    @Test
+    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.start()
+                .put("alpha", 1)
+                .put("beta", 2)
+                .build();
+
+        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.emptyMap();
+
+        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+
+        Map<String, Object> counts = builder.singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(CountsMap.class);
+        assertThat(counts).containsEntry("only", 99);
+    }
+
+    public static final class CountsMap extends LinkedHashMap<String, Object> {
+        public CountsMap() {
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -6,12 +6,31 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RecordsHelpersDynamicAccessTest {
+    @Test
+    void derivesCanonicalRecordConstructorAndOrderedProperties() {
+        Map<String, String> properties = new LinkedHashMap<>();
+
+        Constructor<?> canonical = BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                SampleRecord.class, properties, name -> name);
+
+        assertThat(canonical.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+        assertThat(properties).containsExactly(
+                Map.entry("name", "name"),
+                Map.entry("id", "id"),
+                Map.entry("active", "active"));
+    }
+
     @Test
     void deserializesRecordsThroughTheirCanonicalConstructor() throws Exception {
         SampleRecord record = JSON.std.beanFrom(SampleRecord.class, "{\"active\":true,\"id\":7,\"name\":\"Ada\"}");

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    @Test
+    void deserializesRecordsThroughTheirCanonicalConstructor() throws Exception {
+        SampleRecord record = JSON.std.beanFrom(SampleRecord.class, "{\"active\":true,\"id\":7,\"name\":\"Ada\"}");
+
+        assertThat(record.name()).isEqualTo("Ada");
+        assertThat(record.id()).isEqualTo(7);
+        assertThat(record.active()).isTrue();
+    }
+
+    @Test
+    void usesRecordComponentDefaultsWhenPrimitivePropertiesAreMissing() throws Exception {
+        SampleRecord record = JSON.std.beanFrom(SampleRecord.class, "{\"name\":\"Bob\",\"id\":3}");
+
+        assertThat(record.name()).isEqualTo("Bob");
+        assertThat(record.id()).isEqualTo(3);
+        assertThat(record.active()).isFalse();
+    }
+
+    public record SampleRecord(String name, int id, boolean active) {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -6,55 +6,81 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
-    void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = lateBoundClassName();
+    void resolvesClassNamesFromTheCurrentParserToken() throws Exception {
+        SimpleValueReader reader = classReader();
 
-        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+        try (JsonParser parser = jsonParser(quotedClassName())) {
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
 
-        assertThat(resolved).isEqualTo(LateBoundType.class);
+            Class<?> resolved = (Class<?>) reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(SimpleValueReaderDynamicAccessLateBoundType.class);
+        }
     }
 
     @Test
-    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = lateBoundClassName();
+    void resolvesClassNamesWhenAdvancingTheParser() throws Exception {
+        SimpleValueReader reader = classReader();
 
-        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
-                "{\"type\":\"" + className + "\"}");
+        try (JsonParser parser = jsonParser(quotedClassName())) {
+            Class<?> resolved = (Class<?>) reader.readNext(null, parser);
 
-        assertThat(holder.type).isEqualTo(LateBoundType.class);
+            assertThat(resolved).isEqualTo(SimpleValueReaderDynamicAccessLateBoundType.class);
+        }
     }
 
     @Test
-    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = lateBoundClassName();
+    void reportsInvalidClassNamesAfterAttemptingLookup() throws Exception {
+        SimpleValueReader reader = classReader();
 
-        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
-                "{\"primary\":\"" + className + "\"}");
-        List<Class> classes = JSON.std.listOfFrom(Class.class,
-                "[\"" + className + "\"]");
-
-        assertThat(classesByName.get("primary")).isEqualTo(LateBoundType.class);
-        assertThat(classes).singleElement().isEqualTo(LateBoundType.class);
+        try (JsonParser parser = jsonParser(quotedMissingClassName())) {
+            assertThatThrownBy(() -> reader.readNext(null, parser))
+                    .isInstanceOf(JSONObjectException.class)
+                    .hasMessageContaining("Failed to bind `java.lang.Class`")
+                    .hasMessageContaining(missingClassName());
+        }
     }
 
-    private static String lateBoundClassName() {
-        return SimpleValueReaderDynamicAccessTest.class.getName() + "$LateBoundType";
+    private static SimpleValueReader classReader() {
+        return new SimpleValueReader(Class.class, ValueLocatorBase.SER_CLASS);
     }
 
-    public static final class TypeHolder {
-        public Class<?> type;
+    private static JsonParser jsonParser(String json) throws IOException {
+        return new JsonFactory().createParser(json);
     }
 
-    public static final class LateBoundType {
+    private static String quotedClassName() {
+        return '"' + className() + '"';
     }
+
+    private static String quotedMissingClassName() {
+        return '"' + missingClassName() + '"';
+    }
+
+    private static String className() {
+        Class<?> valueType = new SimpleValueReaderDynamicAccessLateBoundType().getClass();
+        return valueType.getPackageName() + "." + valueType.getSimpleName();
+    }
+
+    private static String missingClassName() {
+        return className() + "Missing";
+    }
+}
+
+final class SimpleValueReaderDynamicAccessLateBoundType {
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void resolvesTopLevelClassesFromStringValues() throws Exception {
+        String className = runtimeJdkClassName();
+
+        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+
+        assertThat(resolved.getName()).isEqualTo(className);
+    }
+
+    @Test
+    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
+        String className = runtimeJdkClassName();
+
+        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
+                "{\"type\":\"" + className + "\"}");
+
+        assertThat(holder.type.getName()).isEqualTo(className);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
+        String className = runtimeJdkClassName();
+
+        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
+                "{\"primary\":\"" + className + "\"}");
+        List<Class> classes = JSON.std.listOfFrom(Class.class,
+                "[\"" + className + "\"]");
+
+        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
+        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+    }
+
+    private static String runtimeJdkClassName() {
+        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    }
+
+    public static final class TypeHolder {
+        public Class<?> type;
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -17,41 +17,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SimpleValueReaderDynamicAccessTest {
     @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = lateBoundClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved.getName()).isEqualTo(className);
+        assertThat(resolved).isEqualTo(LateBoundType.class);
     }
 
     @Test
     void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = lateBoundClassName();
 
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type.getName()).isEqualTo(className);
+        assertThat(holder.type).isEqualTo(LateBoundType.class);
     }
 
     @Test
     void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = runtimeJdkClassName();
+        String className = lateBoundClassName();
 
         Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
                 "{\"primary\":\"" + className + "\"}");
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
-        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+        assertThat(classesByName.get("primary")).isEqualTo(LateBoundType.class);
+        assertThat(classes).singleElement().isEqualTo(LateBoundType.class);
     }
 
-    private static String runtimeJdkClassName() {
-        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    private static String lateBoundClassName() {
+        return SimpleValueReaderDynamicAccessTest.class.getName() + "$LateBoundType";
     }
 
     public static final class TypeHolder {
         public Class<?> type;
+    }
+
+    public static final class LateBoundType {
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -11,11 +11,25 @@ import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesIntoArrayClasses() {
+        TypeResolver resolver = new TypeResolver();
+
+        ResolvedType resolvedArrayType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                new SyntheticGenericArrayType(String.class));
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
@@ -46,5 +60,18 @@ public class TypeResolverDynamicAccessTest {
     }
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -20,22 +20,25 @@ public class TypeResolverDynamicAccessTest {
     @Test
     void resolvesSyntheticGenericArrayTypesIntoArrayClasses() {
         TypeResolver resolver = new TypeResolver();
+        Class<?> elementType = runtimeSelectedElementType();
 
         ResolvedType resolvedArrayType = resolver.resolve(
                 TypeBindings.emptyBindings(),
-                new SyntheticGenericArrayType(String.class));
+                new SyntheticGenericArrayType(elementType));
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(arrayTypeFor(elementType));
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(elementType);
     }
 
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
+        Class<?> elementType = runtimeSelectedElementType();
+        Class<? extends GenericArrayContainer<?>> containerType = runtimeSelectedContainerType();
         ResolvedType declaringType = resolver.resolve(
                 TypeBindings.emptyBindings(),
-                StringArrayContainer.class.getGenericSuperclass());
+                containerType.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
                 .getDeclaredMethod("setValues", Object[].class)
                 .getGenericParameterTypes()[0];
@@ -43,8 +46,8 @@ public class TypeResolverDynamicAccessTest {
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(arrayTypeFor(elementType));
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(elementType);
     }
 
     static class GenericArrayContainer<T> {
@@ -60,6 +63,27 @@ public class TypeResolverDynamicAccessTest {
     }
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    static final class CharSequenceArrayContainer extends GenericArrayContainer<CharSequence> {
+    }
+
+    private static Class<?> runtimeSelectedElementType() {
+        return Thread.currentThread().getName().isEmpty() ? CharSequence.class : String.class;
+    }
+
+    private static Class<? extends GenericArrayContainer<?>> runtimeSelectedContainerType() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return CharSequenceArrayContainer.class;
+        }
+        return StringArrayContainer.class;
+    }
+
+    private static Class<?> arrayTypeFor(Class<?> elementType) {
+        if (elementType == String.class) {
+            return String[].class;
+        }
+        return CharSequence[].class;
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.type.ResolvedType;
+import com.fasterxml.jackson.jr.type.TypeBindings;
+import com.fasterxml.jackson.jr.type.TypeResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType declaringType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                StringArrayContainer.class.getGenericSuperclass());
+        Type genericArrayType = GenericArrayContainer.class
+                .getDeclaredMethod("setValues", Object[].class)
+                .getGenericParameterTypes()[0];
+
+        ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
+    static class GenericArrayContainer<T> {
+        private T[] values;
+
+        public T[] getValues() {
+            return values;
+        }
+
+        public void setValues(T[] values) {
+            this.values = values;
+        }
+    }
+
+    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,16 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(direction).isEqualTo(Direction.SOUTH);
     }
 
+    @Test
+    void readsRecordComponentsUsingDeclaredFieldsAndModifierProvidedEnumDefinitions() throws Exception {
+        TravelPlan plan = enumAwareJson().beanFrom(TravelPlan.class, """
+                {"direction":"go-south","steps":5}
+                """);
+
+        assertThat(plan.direction()).isEqualTo(Direction.SOUTH);
+        assertThat(plan.steps()).isEqualTo(5);
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -44,6 +55,9 @@ public class ValueReaderLocatorDynamicAccessTest {
     public enum Direction {
         NORTH,
         SOUTH
+    }
+
+    public record TravelPlan(Direction direction, int steps) {
     }
 
     public static class EnumDefinitionExtension extends JacksonJrExtension {
@@ -59,7 +73,7 @@ public class ValueReaderLocatorDynamicAccessTest {
             if (pojoType != Direction.class) {
                 return null;
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            return new POJODefinition(Direction.class, enumProps(), new BeanConstructors(Direction.class));
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -70,7 +84,7 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
 
         private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+            return new POJODefinition.Prop(externalName, enumConstantName, enumField(enumConstantName), null, null, null, null);
         }
 
         private static Field enumField(String enumConstantName) {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -10,12 +10,17 @@ import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.BeanReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +50,22 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(plan.steps()).isEqualTo(5);
     }
 
+    @Test
+    void resolvesRecordReadersUsingDeclaredRecordFields() {
+        BeanReader beanReader = new InspectableValueReaderLocator(new EnumDefinitionModifier())
+                .resolveBeanForDeser(TravelPlan.class, travelPlanDefinition());
+
+        assertThat(beanReader.propertiesByName()).containsOnlyKeys("direction", "steps");
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitionsDirectly() {
+        ValueReader enumReader = new InspectableValueReaderLocator(new EnumDefinitionModifier())
+                .createEnumReader(Direction.class);
+
+        assertThat(enumReader).isNotNull();
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -65,6 +86,16 @@ public class ValueReaderLocatorDynamicAccessTest {
         protected void register(ExtensionContext ctxt) {
             ctxt.insertModifier(new EnumDefinitionModifier());
         }
+    }
+
+    private static POJODefinition travelPlanDefinition() {
+        BeanConstructors constructors = new BeanConstructors(TravelPlan.class)
+                .addRecordConstructor(BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                        TravelPlan.class, new LinkedHashMap<String, String>(), name -> name));
+        return new POJODefinition(TravelPlan.class, new POJODefinition.Prop[] {
+                new POJODefinition.Prop("direction", "direction", null, null, null, null, null),
+                new POJODefinition.Prop("steps", "steps", null, null, null, null, null)
+        }, constructors);
     }
 
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
@@ -93,6 +124,20 @@ public class ValueReaderLocatorDynamicAccessTest {
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }
+        }
+    }
+
+    public static final class InspectableValueReaderLocator extends ValueReaderLocator {
+        public InspectableValueReaderLocator(ReaderWriterModifier readerModifier) {
+            super(null, readerModifier);
+        }
+
+        public BeanReader resolveBeanForDeser(Class<?> raw, POJODefinition beanDef) {
+            return _resolveBeanForDeser(raw, beanDef);
+        }
+
+        public ValueReader createEnumReader(Class<?> enumType) {
+            return enumReader(enumType);
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueReaderLocatorDynamicAccessTest {
+    @Test
+    void readsEnumsFromModifierProvidedDefinitions() throws Exception {
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+
+        assertThat(direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+
+        assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    private static JSON enumAwareJson(JSON.Feature... features) {
+        return JSON.builder()
+                .enable(features)
+                .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
+
+    public static class EnumDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class EnumDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != Direction.class) {
+                return null;
+            }
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+        }
+
+        private static POJODefinition.Prop[] enumProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp("go-north", "NORTH"),
+                    enumProp("go-south", "SOUTH")
+            };
+        }
+
+        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(String enumConstantName) {
+            try {
+                return Direction.class.getField(enumConstantName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,164 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "fields" : [
+        {
+          "name" : "NORTH"
+        },
+        {
+          "name" : "SOUTH"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,6 +4,35 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
       "methods" : [
         {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -182,6 +182,14 @@
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldAndMethodIntrospectedBean",
       "allDeclaredFields" : true,
       "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$SampleRecord",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -101,12 +101,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
-    },
-    {
-      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -13,24 +13,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
-    },
-    {
-      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
@@ -42,56 +24,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "setName",
-          "parameterTypes" : [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
     },
     {
       "condition" : {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -101,6 +101,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$CountsMap",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -159,6 +159,29 @@
           "name" : "SOUTH"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$ConstructorIntrospectedBean",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldBaseBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldAndMethodIntrospectedBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -123,6 +123,21 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TravelPlan",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TravelPlan",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$ConstructorIntrospectedBean",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -109,6 +109,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessLateBoundType"
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jr.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2564

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 920871
- Cached input tokens: 10925312
- Output tokens: 147006
- Entries found: 20
- Iterations: 22
- Library coverage percentage: 31.06
- Previous library version metadata entries: 18
- Previous library version coverage percentage: 34.08

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `6cfe2847f0afbb0910f26e2ed1efdb6d39e25fe7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

**Reflection:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 4131/12120 (34.08%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 4259/13710 (31.06%)

**Line:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: N/A
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: N/A

**Method:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4: 235/648 (36.27%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 235/705 (33.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/gradle.properties 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
index df92cc871d..261f6f0e49 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/gradle.properties
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.13.4
-library.version = 2.13.4
-metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0
+library.version = 2.21.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
new file mode 100644
index 0000000000..a7fcc93c56
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -0,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    @Test
+    void invokesNoArgsConstructorThroughBeanConstructorsCreate() throws Exception {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(HiddenNoArgsBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(HiddenNoArgsBean.class, constructors);
+        constructors.forceAccess();
+
+        HiddenNoArgsBean bean = (HiddenNoArgsBean) constructors.createBean();
+
+        assertThat(bean.marker()).isEqualTo("created");
+    }
+
+    @Test
+    void invokesCanonicalRecordConstructorThroughBeanConstructorsCreateRecord() throws Exception {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(HiddenRecordBean.class);
+        constructors.addRecordConstructor(BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                HiddenRecordBean.class, new LinkedHashMap<String, String>(), name -> name));
+        constructors.forceAccess();
+
+        HiddenRecordBean record = (HiddenRecordBean) constructors.createRecordBean("Ada", 7);
+
+        assertThat(record.name()).isEqualTo("Ada");
+        assertThat(record.count()).isEqualTo(7);
+    }
+
+    public static final class HiddenNoArgsBean {
+        private final String marker;
+
+        private HiddenNoArgsBean() {
+            marker = "created";
+        }
+
+        public String marker() {
+            return marker;
+        }
+    }
+
+    record HiddenRecordBean(String name, int count) {
+    }
+
+    public static final class InspectableBeanConstructors extends BeanConstructors {
+        public InspectableBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        public Object createBean() throws Exception {
+            return create();
+        }
+
+        public Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
+        }
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
index bb54f90047..88e94ed1d8 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -6,12 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 
-import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
-import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
-import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
@@ -20,22 +19,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyIntrospectorDynamicAccessTest {
     private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
-    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
     private static final JSONWriter JSON_WRITER = new JSONWriter();
 
     @Test
-    void collectsDeclaredConstructorsForDeserialization() {
-        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+    void collectsDeclaredConstructorsForNonRecordBeans() {
+        InspectableBeanConstructors constructors = new InspectableBeanConstructors(ConstructorIntrospectedBean.class);
 
-        assertThat(definition.defaultCtor).isNotNull();
-        assertThat(definition.stringCtor).isNotNull();
-        assertThat(definition.longCtor).isNotNull();
-        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        BeanPropertyIntrospector.addNonRecordConstructors(ConstructorIntrospectedBean.class, constructors);
+
+        assertThat(constructors.noArgsConstructor()).isNotNull();
+        assertThat(constructors.stringConstructor()).isNotNull();
+        assertThat(constructors.longConstructor()).isNotNull();
+        assertThat(constructors.intConstructor()).isNull();
     }
 
     @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() {
-        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, FieldAndMethodIntrospectedBean.class);
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
 
@@ -61,30 +61,33 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
                 .orElseThrow();
     }
 
-    static class BaseBean {
-        public int visible;
-    }
-
-    static final class IntrospectedBean extends BaseBean {
-        private String name;
-        private boolean active;
-
-        private IntrospectedBean() {
+    public static final class ConstructorIntrospectedBean {
+        public ConstructorIntrospectedBean() {
         }
 
-        private IntrospectedBean(String name) {
-            this.name = name;
+        public ConstructorIntrospectedBean(String value) {
         }
 
-        private IntrospectedBean(long visible) {
-            this.visible = (int) visible;
+        public ConstructorIntrospectedBean(long value) {
         }
+    }
+
+    public static class FieldBaseBean {
+        public int visible;
+    }
+
+    public static final class FieldAndMethodIntrospectedBean extends FieldBaseBean {
+        public static int ignoredStatic = 12;
+        public static final int IGNORED_CONSTANT = 13;
+
+        private String name;
+        private boolean active;
 
         public String getName() {
             return name;
         }
 
-        private void setName(String name) {
+        public void setName(String name) {
             this.name = name;
         }
 
@@ -96,4 +99,26 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.active = active;
         }
     }
+
+    public static final class InspectableBeanConstructors extends BeanConstructors {
+        public InspectableBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        public Constructor<?> noArgsConstructor() {
+            return _noArgsCtor;
+        }
+
+        public Constructor<?> stringConstructor() {
+            return _stringCtor;
+        }
+
+        public Constructor<?> longConstructor() {
+            return _longCtor;
+        }
+
+        public Constructor<?> intConstructor() {
+            return _intCtor;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
index ff1af27cb8..756d67481b 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -6,70 +6,63 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.awt.Point;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyReaderDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-
     @Test
-    void populatesFieldBackedJdkBeanProperties() throws Exception {
-        Point point = JSON_WITH_FORCE_ACCESS.beanFrom(Point.class, "{\"x\":3,\"y\":4}");
-
-        assertThat(point.x).isEqualTo(3);
-        assertThat(point.y).isEqualTo(4);
-    }
+    void setsFieldBackedProperties() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name",
+                publicField(FieldBackedReaderBean.class, "name"), null, -1);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
-    @Test
-    void populatesPublicSetterBackedProperties() throws Exception {
-        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
-                "{\"name\":\"Ada\"}");
+        reader.setValueFor(bean, new Object[] {"Ada"});
 
-        assertThat(bean.getName()).isEqualTo("Ada");
-        assertThat(bean.getSetterCalls()).isEqualTo(1);
+        assertThat(bean.name).isEqualTo("Ada");
     }
 
     @Test
-    void populatesPrivateSetterBackedProperties() throws Exception {
-        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
-                "{\"name\":\"Ada\"}");
+    void invokesSetterBackedProperties() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                publicMethod(PublicSetterBackedReaderBean.class, "setName", String.class), -1);
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[] {"Ada"});
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
-    public static final class PublicSetterBackedReaderBean {
-        private String name;
-        private int setterCalls;
-
-        public PublicSetterBackedReaderBean() {
-        }
-
-        public String getName() {
-            return name;
+    private static Field publicField(Class<?> declaringType, String fieldName) {
+        try {
+            return declaringType.getField(fieldName);
+        } catch (NoSuchFieldException ex) {
+            throw new IllegalStateException(ex);
         }
+    }
 
-        public int getSetterCalls() {
-            return setterCalls;
+    private static Method publicMethod(Class<?> declaringType, String methodName,
+            Class<?>... parameterTypes) {
+        try {
+            return declaringType.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalStateException(ex);
         }
+    }
 
-        public void setName(String name) {
-            this.name = name;
-            setterCalls++;
-        }
+    public static final class FieldBackedReaderBean {
+        public String name;
     }
 
-    public static final class SetterBackedReaderBean {
+    public static final class PublicSetterBackedReaderBean {
         private String name;
         private int setterCalls;
 
-        public SetterBackedReaderBean() {
-        }
-
         public String getName() {
             return name;
         }
@@ -78,7 +71,7 @@ public class BeanPropertyReaderDynamicAccessTest {
             return setterCalls;
         }
 
-        private void setName(String name) {
+        public void setName(String name) {
             this.name = name;
             setterCalls++;
         }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
index 5d877e7339..d486477ff0 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,26 +6,50 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
-    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
-
     @Test
-    void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new FieldBackedWriterBean());
+    void getsFieldBackedPropertyValues() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(-1, "id",
+                publicField(FieldBackedWriterBean.class, "id"), null);
 
-        assertThat(json).isEqualTo("{\"id\":3}");
+        Object value = writer.getValueFor(new FieldBackedWriterBean());
+
+        assertThat(value).isEqualTo(3);
     }
 
     @Test
-    void serializesGetterBackedProperties() throws Exception {
-        String json = JSON_WITH_FORCE_ACCESS.asString(new GetterBackedWriterBean("Ada"));
+    void invokesGetterBackedPropertyValues() throws Exception {
+        BeanPropertyWriter writer = new BeanPropertyWriter(-1, "name", null,
+                publicMethod(GetterBackedWriterBean.class, "getName"));
+
+        Object value = writer.getValueFor(new GetterBackedWriterBean("Ada"));
 
-        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(value).isEqualTo("Ada");
+    }
+
+    private static Field publicField(Class<?> declaringType, String fieldName) {
+        try {
+            return declaringType.getField(fieldName);
+        } catch (NoSuchFieldException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static Method publicMethod(Class<?> declaringType, String methodName,
+            Class<?>... parameterTypes) {
+        try {
+            return declaringType.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     public static final class FieldBackedWriterBean {
@@ -33,7 +57,7 @@ public class BeanPropertyWriterDynamicAccessTest {
     }
 
     public static final class GetterBackedWriterBean {
-        private String name;
+        private final String name;
 
         public GetterBackedWriterBean(String name) {
             this.name = name;
@@ -42,9 +66,5 @@ public class BeanPropertyWriterDynamicAccessTest {
         public String getName() {
             return name;
         }
-
-        public void setName(String name) {
-            this.name = name;
-        }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
index da83f22971..f3ad3e0d8c 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -7,8 +7,6 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.JSONObjectException;
-import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,20 +15,40 @@ public class BeanReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void createsLibraryBeansThroughPublicDefaultConstructors() throws Exception {
-        ClassKey key = JSON.std.beanFrom(ClassKey.class, "{}");
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{}");
 
-        assertThat(key).isNotNull();
-        assertThat(key.hashCode()).isZero();
+        assertThat(bean.getMarker()).isEqualTo(1);
     }
 
     @Test
-    void createsLibraryBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        JSONObjectException.Reference reference = JSON_WITH_FORCE_ACCESS.beanFrom(JSONObjectException.Reference.class,
-                "{\"from\":\"source\",\"fieldName\":\"name\",\"index\":2}");
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class, "{}");
 
-        assertThat(reference.getFrom()).isEqualTo("source");
-        assertThat(reference.getFieldName()).isEqualTo("name");
-        assertThat(reference.getIndex()).isEqualTo(2);
+        assertThat(bean.getMarker()).isEqualTo(2);
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private final int marker;
+
+        public PublicDefaultCtorBean() {
+            marker = 1;
+        }
+
+        public int getMarker() {
+            return marker;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private final int marker;
+
+        private PrivateDefaultCtorBean() {
+            marker = 2;
+        }
+
+        public int getMarker() {
+            return marker;
+        }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
index 2b7b6119bc..bf33f3176a 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -7,63 +7,37 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
     @Test
-    void createsEmptyTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
-
-        Object[] values = builder.emptyArray((Class) elementType);
+    void readsEmptyTypedArrays() throws Exception {
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class, "[]");
 
         assertThat(values).isEmpty();
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
     }
 
     @Test
-    void createsSingletonTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
-
-        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+    void readsSingletonTypedArrays() throws Exception {
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class, "[{\"name\":\"solo\"}]");
 
-        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(values).singleElement().extracting(element -> element.name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
     }
 
     @Test
-    void createsMultiValueTypedArrays() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
-        Class<?> elementType = runtimeArrayElementType();
+    void readsMultiValueTypedArrays() throws Exception {
+        ArrayElement[] values = JSON.std.arrayOfFrom(ArrayElement.class,
+                "[{\"name\":\"left\"},{\"name\":\"right\"}]");
 
-        Object[] values = builder.start()
-                .add(new ArrayElement("left"))
-                .add(new ArrayElement("right"))
-                .buildArray((Class) elementType);
-
-        assertThat(values).hasSize(2);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
-        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
-        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
-    }
-
-    private static Class<?> runtimeArrayElementType() throws Exception {
-        return JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+        assertThat(values).extracting(element -> element.name).containsExactly("left", "right");
+        assertThat(values.getClass().getComponentType()).isSameAs(ArrayElement.class);
     }
 
     public static final class ArrayElement {
         public String name;
-
-        public ArrayElement() {
-        }
-
-        public ArrayElement(String name) {
-            this.name = name;
-        }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
index c444877391..4453489d4a 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -7,48 +7,62 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapBuilderDefaultDynamicAccessTest {
-    @Test
-    void instantiatesConfiguredMapImplementationWhenStartingABuilder() {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+    @BeforeEach
+    void resetConstructorCalls() {
+        CountsMap.resetConstructorCalls();
+    }
 
-        Map<String, Object> counts = builder.start()
-                .put("alpha", 1)
-                .put("beta", 2)
-                .build();
+    @Test
+    void readsEmptyTypedMapSubclasses() throws Exception {
+        CountsMap counts = JSON.std.beanFrom(CountsMap.class, "{}");
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
-        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(counts).isEmpty();
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForEmptyMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
+    void readsSingletonTypedMapSubclasses() throws Exception {
+        CountsMap counts = JSON.std.beanFrom(CountsMap.class, "{\"only\":99}");
 
-        Map<String, Object> counts = builder.emptyMap();
-
-        assertThat(counts).isInstanceOf(CountsMap.class).isEmpty();
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(1);
     }
 
     @Test
-    void instantiatesConfiguredMapImplementationForSingletonMaps() throws Exception {
-        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(CountsMap.class);
-
-        Map<String, Object> counts = builder.singletonMap("only", 99);
+    void readsTypedMapSubclassesInsideCollections() throws Exception {
+        List<CountsMap> counts = JSON.std.listOfFrom(CountsMap.class,
+                "[{\"alpha\":1},{\"beta\":2}]");
 
-        assertThat(counts).isInstanceOf(CountsMap.class);
-        assertThat(counts).containsEntry("only", 99);
+        assertThat(counts).hasSize(2);
+        assertThat(counts).allSatisfy(count -> assertThat(count).isInstanceOf(CountsMap.class));
+        assertThat(counts.get(0)).containsEntry("alpha", 1);
+        assertThat(counts.get(1)).containsEntry("beta", 2);
+        assertThat(CountsMap.getConstructorCalls()).isEqualTo(2);
     }
 
     public static final class CountsMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
         public CountsMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        static void resetConstructorCalls() {
+            CONSTRUCTOR_CALLS.set(0);
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
         }
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
new file mode 100644
index 0000000000..5ea746ebdd
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -0,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    @Test
+    void derivesCanonicalRecordConstructorAndOrderedProperties() {
+        Map<String, String> properties = new LinkedHashMap<>();
+
+        Constructor<?> canonical = BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                SampleRecord.class, properties, name -> name);
+
+        assertThat(canonical.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+        assertThat(properties).containsExactly(
+                Map.entry("name", "name"),
+                Map.entry("id", "id"),
+                Map.entry("active", "active"));
+    }
+
+    @Test
+    void deserializesRecordsThroughTheirCanonicalConstructor() throws Exception {
+        SampleRecord record = JSON.std.beanFrom(SampleRecord.class, "{\"active\":true,\"id\":7,\"name\":\"Ada\"}");
+
+        assertThat(record.name()).isEqualTo("Ada");
+        assertThat(record.id()).isEqualTo(7);
+        assertThat(record.active()).isTrue();
+    }
+
+    @Test
+    void usesRecordComponentDefaultsWhenPrimitivePropertiesAreMissing() throws Exception {
+        SampleRecord record = JSON.std.beanFrom(SampleRecord.class, "{\"name\":\"Bob\",\"id\":3}");
+
+        assertThat(record.name()).isEqualTo("Bob");
+        assertThat(record.id()).isEqualTo(3);
+        assertThat(record.active()).isFalse();
+    }
+
+    public record SampleRecord(String name, int id, boolean active) {
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
index ea76969375..d0713a7015 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -6,52 +6,81 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
-    void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+    void resolvesClassNamesFromTheCurrentParserToken() throws Exception {
+        SimpleValueReader reader = classReader();
 
-        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+        try (JsonParser parser = jsonParser(quotedClassName())) {
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
 
-        assertThat(resolved.getName()).isEqualTo(className);
+            Class<?> resolved = (Class<?>) reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(SimpleValueReaderDynamicAccessLateBoundType.class);
+        }
     }
 
     @Test
-    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = runtimeJdkClassName();
+    void resolvesClassNamesWhenAdvancingTheParser() throws Exception {
+        SimpleValueReader reader = classReader();
 
-        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
-                "{\"type\":\"" + className + "\"}");
+        try (JsonParser parser = jsonParser(quotedClassName())) {
+            Class<?> resolved = (Class<?>) reader.readNext(null, parser);
 
-        assertThat(holder.type.getName()).isEqualTo(className);
+            assertThat(resolved).isEqualTo(SimpleValueReaderDynamicAccessLateBoundType.class);
+        }
     }
 
     @Test
-    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = runtimeJdkClassName();
+    void reportsInvalidClassNamesAfterAttemptingLookup() throws Exception {
+        SimpleValueReader reader = classReader();
+
+        try (JsonParser parser = jsonParser(quotedMissingClassName())) {
+            assertThatThrownBy(() -> reader.readNext(null, parser))
+                    .isInstanceOf(JSONObjectException.class)
+                    .hasMessageContaining("Failed to bind `java.lang.Class`")
+                    .hasMessageContaining(missingClassName());
+        }
+    }
+
+    private static SimpleValueReader classReader() {
+        return new SimpleValueReader(Class.class, ValueLocatorBase.SER_CLASS);
+    }
 
-        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
-                "{\"primary\":\"" + className + "\"}");
-        List<Class> classes = JSON.std.listOfFrom(Class.class,
-                "[\"" + className + "\"]");
+    private static JsonParser jsonParser(String json) throws IOException {
+        return new JsonFactory().createParser(json);
+    }
+
+    private static String quotedClassName() {
+        return '"' + className() + '"';
+    }
 
-        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
-        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
+    private static String quotedMissingClassName() {
+        return '"' + missingClassName() + '"';
     }
 
-    private static String runtimeJdkClassName() {
-        return System.getProperty(TypeHolder.class.getName(), String.join(".", "java", "util", "LinkedHashMap"));
+    private static String className() {
+        Class<?> valueType = new SimpleValueReaderDynamicAccessLateBoundType().getClass();
+        return valueType.getPackageName() + "." + valueType.getSimpleName();
     }
 
-    public static final class TypeHolder {
-        public Class<?> type;
+    private static String missingClassName() {
+        return className() + "Missing";
     }
 }
+
+final class SimpleValueReaderDynamicAccessLateBoundType {
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
index 6be26d0186..16d9ceb45d 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -11,17 +11,34 @@ import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesIntoArrayClasses() {
+        TypeResolver resolver = new TypeResolver();
+        Class<?> elementType = runtimeSelectedElementType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                new SyntheticGenericArrayType(elementType));
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(arrayTypeFor(elementType));
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(elementType);
+    }
+
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
+        Class<?> elementType = runtimeSelectedElementType();
+        Class<? extends GenericArrayContainer<?>> containerType = runtimeSelectedContainerType();
         ResolvedType declaringType = resolver.resolve(
                 TypeBindings.emptyBindings(),
-                StringArrayContainer.class.getGenericSuperclass());
+                containerType.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
                 .getDeclaredMethod("setValues", Object[].class)
                 .getGenericParameterTypes()[0];
@@ -29,8 +46,8 @@ public class TypeResolverDynamicAccessTest {
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(arrayTypeFor(elementType));
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(elementType);
     }
 
     static class GenericArrayContainer<T> {
@@ -47,4 +64,38 @@ public class TypeResolverDynamicAccessTest {
 
     static final class StringArrayContainer extends GenericArrayContainer<String> {
     }
+
+    static final class CharSequenceArrayContainer extends GenericArrayContainer<CharSequence> {
+    }
+
+    private static Class<?> runtimeSelectedElementType() {
+        return Thread.currentThread().getName().isEmpty() ? CharSequence.class : String.class;
+    }
+
+    private static Class<? extends GenericArrayContainer<?>> runtimeSelectedContainerType() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return CharSequenceArrayContainer.class;
+        }
+        return StringArrayContainer.class;
+    }
+
+    private static Class<?> arrayTypeFor(Class<?> elementType) {
+        if (elementType == String.class) {
+            return String[].class;
+        }
+        return CharSequence[].class;
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
index 5bad780bdb..f55b25e326 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -10,11 +10,17 @@ import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.BeanReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,6 +40,32 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(direction).isEqualTo(Direction.SOUTH);
     }
 
+    @Test
+    void readsRecordComponentsUsingDeclaredFieldsAndModifierProvidedEnumDefinitions() throws Exception {
+        TravelPlan plan = enumAwareJson().beanFrom(TravelPlan.class, """
+                {"direction":"go-south","steps":5}
+                """);
+
+        assertThat(plan.direction()).isEqualTo(Direction.SOUTH);
+        assertThat(plan.steps()).isEqualTo(5);
+    }
+
+    @Test
+    void resolvesRecordReadersUsingDeclaredRecordFields() {
+        BeanReader beanReader = new InspectableValueReaderLocator(new EnumDefinitionModifier())
+                .resolveBeanForDeser(TravelPlan.class, travelPlanDefinition());
+
+        assertThat(beanReader.propertiesByName()).containsOnlyKeys("direction", "steps");
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitionsDirectly() {
+        ValueReader enumReader = new InspectableValueReaderLocator(new EnumDefinitionModifier())
+                .createEnumReader(Direction.class);
+
+        assertThat(enumReader).isNotNull();
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -46,6 +78,9 @@ public class ValueReaderLocatorDynamicAccessTest {
         SOUTH
     }
 
+    public record TravelPlan(Direction direction, int steps) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -53,13 +88,23 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
     }
 
+    private static POJODefinition travelPlanDefinition() {
+        BeanConstructors constructors = new BeanConstructors(TravelPlan.class)
+                .addRecordConstructor(BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                        TravelPlan.class, new LinkedHashMap<String, String>(), name -> name));
+        return new POJODefinition(TravelPlan.class, new POJODefinition.Prop[] {
+                new POJODefinition.Prop("direction", "direction", null, null, null, null, null),
+                new POJODefinition.Prop("steps", "steps", null, null, null, null, null)
+        }, constructors);
+    }
+
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
             if (pojoType != Direction.class) {
                 return null;
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            return new POJODefinition(Direction.class, enumProps(), new BeanConstructors(Direction.class));
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -70,7 +115,7 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
 
         private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+            return new POJODefinition.Prop(externalName, enumConstantName, enumField(enumConstantName), null, null, null, null);
         }
 
         private static Field enumField(String enumConstantName) {
@@ -81,4 +126,18 @@ public class ValueReaderLocatorDynamicAccessTest {
             }
         }
     }
+
+    public static final class InspectableValueReaderLocator extends ValueReaderLocator {
+        public InspectableValueReaderLocator(ReaderWriterModifier readerModifier) {
+            super(null, readerModifier);
+        }
+
+        public BeanReader resolveBeanForDeser(Class<?> raw, POJODefinition beanDef) {
+            return _resolveBeanForDeser(raw, beanDef);
+        }
+
+        public ValueReader createEnumReader(Class<?> enumType) {
+            return enumReader(enumType);
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/resources/META-INF/native-image/reachability-metadata.json 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
index 41368c6192..31c5b40bbd 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,39 +4,18 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
-      "methods" : [
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
         {
-          "name" : "setName",
-          "parameterTypes" : [
-            "java.lang.String"
-          ]
+          "name" : "name"
         }
       ]
     },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
-    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
       "methods" : [
         {
           "name" : "setName",
@@ -46,24 +25,6 @@
         }
       ]
     },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
-      },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
-    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
@@ -146,6 +107,12 @@
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
     },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessLateBoundType"
+    },
     {
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
@@ -159,6 +126,52 @@
           "name" : "SOUTH"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TravelPlan",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TravelPlan",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$ConstructorIntrospectedBean",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldBaseBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldAndMethodIntrospectedBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$SampleRecord",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
     }
   ]
 }

```
