### PR TITLE
Run new library verification every 8 hours

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -2,7 +2,7 @@ name: "Verify compatibility with latest library versions"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */8 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -39,7 +39,7 @@ Workflows testing metadata using [ci.json](../ci.json):
   - Triggers: PRs to master that change exploded stats files under [stats/](../stats/), [stats/schemas/library-stats-schema-v1.0.2.json](../stats/schemas/library-stats-schema-v1.0.2.json), or mirrored files under [metadata/](../metadata/).
   - Uses: [`validateLibraryStats`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to enforce schema compliance and normalized sorting.
 - Verify new library version compatibility ([.github/workflows/verify-new-library-version-compatibility.yml](../.github/workflows/verify-new-library-version-compatibility.yml))
-  - Triggers: scheduled run and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
+  - Triggers: every 8 hours and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
   - Uses: [`fetchExistingLibrariesWithNewerVersions`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) plus [`generateNewLibraryVersionCompatibilityMatrix`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to build a [`ci.json`](../ci.json)-driven matrix. The matrix generator limits each library to at most 30 newer versions per run before expanding across the configured GraalVM JDK/OS combinations, records tested versions only after they pass on every required environment, and creates a single aggregated failure issue per failed library version while preserving the prior failure issue format with added OS and JDK lines.
 
 Workflows for style and security:


### PR DESCRIPTION
Fixes #2600\n\n## Summary\n- Run the new library version compatibility workflow every 8 hours instead of once daily.\n- Update CI documentation to describe the new cadence.\n\n## Testing\n- Not run; GitHub Actions cron and docs-only change.\n\n## Reviewers\n- @vjovanov is the CODEOWNER for the changed `.github/*` and `docs/*` files.