### PR TITLE
[GenAI] Test fix for org.fusesource.jansi:jansi:1.16 using gpt-5.5

### DIFF
--- a/metadata/org.fusesource.jansi/jansi/1.16/reachability-metadata.json
+++ b/metadata/org.fusesource.jansi/jansi/1.16/reachability-metadata.json
@@ -1,0 +1,79 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.io.File",
+      "methods": [
+        {
+          "name": "toPath",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "addSuppressed",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.nio.file.Files",
+      "methods": [
+        {
+          "name": "setPosixFilePermissions",
+          "parameterTypes": [
+            "java.nio.file.Path",
+            "java.util.Set"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.nio.file.Path"
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.nio.file.attribute.PosixFilePermissions",
+      "methods": [
+        {
+          "name": "fromString",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.fusesource.jansi/jansi/index.json
+++ b/metadata/org.fusesource.jansi/jansi/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.16",
+    "tested-versions" : [
+      "1.16"
+    ],
+    "allowed-packages" : [
+      "org.fusesource.hawtjni.runtime",
+      "org.fusesource.jansi"
+    ]
+  },
+  {
     "metadata-version" : "1.13",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/1.13/jansi-1.13-sources.jar",
     "repository-url" : "https://github.com/fusesource/jansi",

--- a/metadata/org.fusesource.jansi/jansi/index.json
+++ b/metadata/org.fusesource.jansi/jansi/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.16",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/1.16/jansi-1.16-sources.jar",
+    "repository-url" : "https://github.com/fusesource/jansi",
+    "test-code-url" : "https://github.com/fusesource/jansi/tree/jansi-project-1.16/jansi/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/1.16/jansi-1.16-javadoc.jar",
+    "description" : "Jansi is a Java library for generating and interpreting ANSI escape sequences in console output. It wraps output streams and native terminal support so Java applications can emit styled text and interact with terminal capabilities across platforms.",
     "tested-versions" : [
       "1.16"
     ],

--- a/stats/org.fusesource.jansi/jansi/1.16/stats.json
+++ b/stats/org.fusesource.jansi/jansi/1.16/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.16",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 10,
+          "totalCalls" : 10
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 11,
+      "totalCalls" : 11
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 638,
+        "missed" : 6343,
+        "ratio" : 0.091391,
+        "total" : 6981
+      },
+      "line" : {
+        "covered" : 116,
+        "missed" : 1365,
+        "ratio" : 0.078325,
+        "total" : 1481
+      },
+      "method" : {
+        "covered" : 15,
+        "missed" : 352,
+        "ratio" : 0.040872,
+        "total" : 367
+      }
+    }
+  } ]
+}

--- a/tests/src/org.fusesource.jansi/jansi/1.16/.gitignore
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.fusesource.jansi/jansi/1.16/build.gradle
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.fusesource.jansi:jansi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.fusesource.jansi/jansi/1.16/gradle.properties
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.fusesource.jansi:jansi:1.16
+library.version = 1.16
+metadata.dir = org.fusesource.jansi/jansi/1.16/

--- a/tests/src/org.fusesource.jansi/jansi/1.16/settings.gradle
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.fusesource.jansi.jansi_tests'

--- a/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_jansi.jansi;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LibraryTest {
+
+    private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
+
+    @Test
+    void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
+        Library library = new Library(MISSING_LIBRARY_NAME, "integration-test", classLoader);
+
+        assertThatThrownBy(library::load)
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining("Could not load library. Reasons:");
+
+        assertThat(classLoader.requestedResources).containsExactly(
+                library.getPlatformSpecifcResourcePath(),
+                library.getOperatingSystemSpecifcResourcePath(),
+                library.getResorucePath());
+    }
+
+    public static final class TrackingResourceClassLoader extends ClassLoader {
+
+        private final List<String> requestedResources = new ArrayList<String>();
+
+        public TrackingResourceClassLoader(final ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResources.add(name);
+            return null;
+        }
+    }
+}

--- a/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -6,12 +6,19 @@
  */
 package org_fusesource_jansi.jansi;
 
-import org.fusesource.hawtjni.runtime.Library;
-import org.junit.jupiter.api.Test;
-
+import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,33 +26,130 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class LibraryTest {
 
     private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
+    private static final String EXTRACTED_LIBRARY_NAME = "graalvmjansiextractnative";
+    private static final String TEST_LIBRARY_VERSION = "integration-test";
 
     @Test
     void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
         TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
-        Library library = new Library(MISSING_LIBRARY_NAME, "integration-test", classLoader);
+        Library library = new Library(MISSING_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
 
         assertThatThrownBy(library::load)
                 .isInstanceOf(UnsatisfiedLinkError.class)
                 .hasMessageContaining("Could not load library. Reasons:");
 
-        assertThat(classLoader.requestedResources).containsExactly(
-                library.getPlatformSpecifcResourcePath(),
-                library.getOperatingSystemSpecifcResourcePath(),
-                library.getResorucePath());
+        assertThat(classLoader.requestedResources).containsExactlyElementsOf(expectedResourceLookups(library));
+    }
+
+    @Test
+    void loadMakesExtractedNativeLibraryExecutableBeforeLoading(@TempDir final Path tempDirectory) throws IOException {
+        Path extractionDirectory = tempDirectory.resolve("extracted");
+        Files.createDirectories(extractionDirectory);
+        Path userHomeFile = tempDirectory.resolve("user-home-file");
+        Files.write(userHomeFile, new byte[0]);
+
+        Library directoryProbe = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, null);
+        String versionedLibraryName = EXTRACTED_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION;
+        String resourceName = resourcePath(directoryProbe.getSpecificSearchDirs()[0], versionedLibraryName);
+        Path resourceFile = tempDirectory.resolve(mapLibraryName(versionedLibraryName));
+        Files.write(resourceFile, "not a native library".getBytes(StandardCharsets.UTF_8));
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
+                LibraryTest.class.getClassLoader(),
+                resourceName,
+                resourceFile.toUri().toURL());
+        Library library = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+
+        String previousTempDirectory = setSystemProperty("java.io.tmpdir", extractionDirectory.toString());
+        String previousUserHome = setSystemProperty("user.home", userHomeFile.toString());
+        try {
+            assertThatThrownBy(library::load)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessageContaining("Could not load library. Reasons:");
+        } finally {
+            restoreSystemProperty("java.io.tmpdir", previousTempDirectory);
+            restoreSystemProperty("user.home", previousUserHome);
+        }
+
+        assertThat(classLoader.requestedResources).contains(resourceName);
+        List<Path> extractedLibraries = extractedLibraries(extractionDirectory, versionedLibraryName);
+        assertThat(extractedLibraries).hasSize(1);
+        if (!Library.getPlatform().startsWith("windows")) {
+            assertThat(Files.isExecutable(extractedLibraries.get(0))).isTrue();
+        }
+    }
+
+    private static List<String> expectedResourceLookups(final Library library) {
+        List<String> paths = new ArrayList<String>();
+        for (String directory : library.getSpecificSearchDirs()) {
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION));
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME));
+        }
+        return paths;
+    }
+
+    private static String resourcePath(final String directory, final String libraryName) {
+        return "META-INF/native/" + directory + "/" + mapLibraryName(libraryName);
+    }
+
+    private static String mapLibraryName(final String libraryName) {
+        String mappedName = System.mapLibraryName(libraryName);
+        if (mappedName.endsWith(".dylib")) {
+            return mappedName.substring(0, mappedName.length() - ".dylib".length()) + ".jnilib";
+        }
+        return mappedName;
+    }
+
+    private static List<Path> extractedLibraries(final Path directory, final String libraryName) throws IOException {
+        String mappedName = mapLibraryName(libraryName);
+        int extensionStart = mappedName.lastIndexOf('.');
+        String prefix = mappedName.substring(0, extensionStart) + "-";
+        String suffix = mappedName.substring(extensionStart);
+        try (Stream<Path> files = Files.list(directory)) {
+            return files.filter(path -> extractedLibraryNameMatches(path, prefix, suffix)).collect(Collectors.toList());
+        }
+    }
+
+    private static boolean extractedLibraryNameMatches(final Path path, final String prefix, final String suffix) {
+        String fileName = path.getFileName().toString();
+        return fileName.startsWith(prefix) && fileName.endsWith(suffix);
+    }
+
+    private static String setSystemProperty(final String key, final String value) {
+        String previousValue = System.getProperty(key);
+        System.setProperty(key, value);
+        return previousValue;
+    }
+
+    private static void restoreSystemProperty(final String key, final String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previousValue);
+        }
     }
 
     public static final class TrackingResourceClassLoader extends ClassLoader {
 
         private final List<String> requestedResources = new ArrayList<String>();
+        private final String resourceName;
+        private final URL resource;
 
         public TrackingResourceClassLoader(final ClassLoader parent) {
+            this(parent, null, null);
+        }
+
+        public TrackingResourceClassLoader(final ClassLoader parent, final String resourceName, final URL resource) {
             super(parent);
+            this.resourceName = resourceName;
+            this.resource = resource;
         }
 
         @Override
         public URL getResource(final String name) {
             requestedResources.add(name);
+            if (name.equals(resourceName)) {
+                return resource;
+            }
             return null;
         }
     }

--- a/tests/src/org.fusesource.jansi/jansi/1.16/user-code-filter.json
+++ b/tests/src/org.fusesource.jansi/jansi/1.16/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.fusesource.hawtjni.runtime.**"
+    },
+    {
+      "includeClasses" : "org.fusesource.jansi.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2571

This PR provides test fixes and new metadata for org.fusesource.jansi:jansi:1.16, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 91081
- Cached input tokens: 879104
- Output tokens: 12264
- Entries found: 11
- Iterations: 2
- Library coverage percentage: 7.83
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 3.2

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `8449ddc25c14bbfbf99a74ff9786417e5dea34ea`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.fusesource.jansi:jansi:1.13: 1/1 covered calls (100.00%)
- org.fusesource.jansi:jansi:1.16: 11/11 covered calls (100.00%)

**Reflection:**
- org.fusesource.jansi:jansi:1.13: N/A
- org.fusesource.jansi:jansi:1.16: 10/10 covered calls (100.00%)

**Resources:**
- org.fusesource.jansi:jansi:1.13: 1/1 covered calls (100.00%)
- org.fusesource.jansi:jansi:1.16: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.fusesource.jansi:jansi:1.13: 231/6218 (3.72%)
- org.fusesource.jansi:jansi:1.16: 638/6981 (9.14%)

**Line:**
- org.fusesource.jansi:jansi:1.13: 43/1345 (3.20%)
- org.fusesource.jansi:jansi:1.16: 116/1481 (7.83%)

**Method:**
- org.fusesource.jansi:jansi:1.13: 13/346 (3.76%)
- org.fusesource.jansi:jansi:1.16: 15/367 (4.09%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.fusesource.jansi/jansi/1.13/gradle.properties 2/tests/src/org.fusesource.jansi/jansi/1.16/gradle.properties
index 2cfabc4394..1a7a653874 100644
--- 1/tests/src/org.fusesource.jansi/jansi/1.13/gradle.properties
+++ 2/tests/src/org.fusesource.jansi/jansi/1.16/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = org.fusesource.jansi:jansi:1.13
-library.version = 1.13
-metadata.dir = org.fusesource.jansi/jansi/1.13/
+library.coordinates = org.fusesource.jansi:jansi:1.16
+library.version = 1.16
+metadata.dir = org.fusesource.jansi/jansi/1.16/
diff --git 1/tests/src/org.fusesource.jansi/jansi/1.13/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java 2/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
index ae7645ddae..b3ebe3dfee 100644
--- 1/tests/src/org.fusesource.jansi/jansi/1.13/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ 2/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -6,12 +6,19 @@
  */
 package org_fusesource_jansi.jansi;
 
-import org.fusesource.hawtjni.runtime.Library;
-import org.junit.jupiter.api.Test;
-
+import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,33 +26,130 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class LibraryTest {
 
     private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
+    private static final String EXTRACTED_LIBRARY_NAME = "graalvmjansiextractnative";
+    private static final String TEST_LIBRARY_VERSION = "integration-test";
 
     @Test
     void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
         TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
-        Library library = new Library(MISSING_LIBRARY_NAME, "integration-test", classLoader);
+        Library library = new Library(MISSING_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
 
         assertThatThrownBy(library::load)
                 .isInstanceOf(UnsatisfiedLinkError.class)
                 .hasMessageContaining("Could not load library. Reasons:");
 
-        assertThat(classLoader.requestedResources).containsExactly(
-                library.getPlatformSpecifcResourcePath(),
-                library.getOperatingSystemSpecifcResourcePath(),
-                library.getResorucePath());
+        assertThat(classLoader.requestedResources).containsExactlyElementsOf(expectedResourceLookups(library));
+    }
+
+    @Test
+    void loadMakesExtractedNativeLibraryExecutableBeforeLoading(@TempDir final Path tempDirectory) throws IOException {
+        Path extractionDirectory = tempDirectory.resolve("extracted");
+        Files.createDirectories(extractionDirectory);
+        Path userHomeFile = tempDirectory.resolve("user-home-file");
+        Files.write(userHomeFile, new byte[0]);
+
+        Library directoryProbe = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, null);
+        String versionedLibraryName = EXTRACTED_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION;
+        String resourceName = resourcePath(directoryProbe.getSpecificSearchDirs()[0], versionedLibraryName);
+        Path resourceFile = tempDirectory.resolve(mapLibraryName(versionedLibraryName));
+        Files.write(resourceFile, "not a native library".getBytes(StandardCharsets.UTF_8));
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
+                LibraryTest.class.getClassLoader(),
+                resourceName,
+                resourceFile.toUri().toURL());
+        Library library = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+
+        String previousTempDirectory = setSystemProperty("java.io.tmpdir", extractionDirectory.toString());
+        String previousUserHome = setSystemProperty("user.home", userHomeFile.toString());
+        try {
+            assertThatThrownBy(library::load)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessageContaining("Could not load library. Reasons:");
+        } finally {
+            restoreSystemProperty("java.io.tmpdir", previousTempDirectory);
+            restoreSystemProperty("user.home", previousUserHome);
+        }
+
+        assertThat(classLoader.requestedResources).contains(resourceName);
+        List<Path> extractedLibraries = extractedLibraries(extractionDirectory, versionedLibraryName);
+        assertThat(extractedLibraries).hasSize(1);
+        if (!Library.getPlatform().startsWith("windows")) {
+            assertThat(Files.isExecutable(extractedLibraries.get(0))).isTrue();
+        }
+    }
+
+    private static List<String> expectedResourceLookups(final Library library) {
+        List<String> paths = new ArrayList<String>();
+        for (String directory : library.getSpecificSearchDirs()) {
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION));
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME));
+        }
+        return paths;
+    }
+
+    private static String resourcePath(final String directory, final String libraryName) {
+        return "META-INF/native/" + directory + "/" + mapLibraryName(libraryName);
+    }
+
+    private static String mapLibraryName(final String libraryName) {
+        String mappedName = System.mapLibraryName(libraryName);
+        if (mappedName.endsWith(".dylib")) {
+            return mappedName.substring(0, mappedName.length() - ".dylib".length()) + ".jnilib";
+        }
+        return mappedName;
+    }
+
+    private static List<Path> extractedLibraries(final Path directory, final String libraryName) throws IOException {
+        String mappedName = mapLibraryName(libraryName);
+        int extensionStart = mappedName.lastIndexOf('.');
+        String prefix = mappedName.substring(0, extensionStart) + "-";
+        String suffix = mappedName.substring(extensionStart);
+        try (Stream<Path> files = Files.list(directory)) {
+            return files.filter(path -> extractedLibraryNameMatches(path, prefix, suffix)).collect(Collectors.toList());
+        }
+    }
+
+    private static boolean extractedLibraryNameMatches(final Path path, final String prefix, final String suffix) {
+        String fileName = path.getFileName().toString();
+        return fileName.startsWith(prefix) && fileName.endsWith(suffix);
+    }
+
+    private static String setSystemProperty(final String key, final String value) {
+        String previousValue = System.getProperty(key);
+        System.setProperty(key, value);
+        return previousValue;
+    }
+
+    private static void restoreSystemProperty(final String key, final String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previousValue);
+        }
     }
 
     public static final class TrackingResourceClassLoader extends ClassLoader {
 
         private final List<String> requestedResources = new ArrayList<String>();
+        private final String resourceName;
+        private final URL resource;
 
         public TrackingResourceClassLoader(final ClassLoader parent) {
+            this(parent, null, null);
+        }
+
+        public TrackingResourceClassLoader(final ClassLoader parent, final String resourceName, final URL resource) {
             super(parent);
+            this.resourceName = resourceName;
+            this.resource = resource;
         }
 
         @Override
         public URL getResource(final String name) {
             requestedResources.add(name);
+            if (name.equals(resourceName)) {
+                return resource;
+            }
             return null;
         }
     }

```
