### PR TITLE
Clarify future-defaults instructions for agent runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@
 ## One command for complete infrastructure testing
 ./gradlew testAllInfra -Pparallelism=4 --stacktrace
 
-Run the future-defaults lane locally with:
-GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew testAllInfra -Pparallelism=4 --stacktrace
+## Future-defaults testing
+- Do not run `future-defaults-all` by default on regular released GraalVM/JDK versions.
+- Run the future-defaults lane only when explicitly validating against an early-access or latest GraalVM build, including versions named `ea`, `dev`, or `latest`.
 
 ## Code Style
 - Always try to reuse existing code.
@@ -47,13 +48,11 @@ GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew testAllInfra -Pparalleli
   - ./gradlew pullAllowedDockerImages -Pcoordinates=group:artifact:version
   - ./gradlew checkMetadataFiles -Pcoordinates=group:artifact:version
   - ./gradlew test -Pcoordinates=group:artifact:version
-  - GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=group:artifact:version
+  - If using an early-access/latest GraalVM build, also run: GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=group:artifact:version
 - Sharded example (1/64):
   - ./gradlew pullAllowedDockerImages -Pcoordinates=1/64
   - ./gradlew checkMetadataFiles -Pcoordinates=1/64
   - ./gradlew test -Pcoordinates=1/64
-
-Metadata CI currently runs both `current-defaults` and `future-defaults-all`.
 
 ### Generating Metadata
 - Generate metadata for a certain library version:


### PR DESCRIPTION
### What does this PR do?
- Clarify that regular released GraalVM/JDK validation should use the default test command.
- Restrict `future-defaults-all` guidance to early-access, development, or latest GraalVM builds.
- Document `ea`, `dev`, and `latest` version names as signals for running the extra future-defaults lane.

This keeps agent-driven validation from treating future-defaults failures on regular released builds as the default expectation, while still preserving coverage for EA/latest builds where future-defaults validation is intended.

Fixes #2604