### PR TITLE
Support Groovy in scaffold and AI generation

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
@@ -153,6 +153,7 @@ public class DiscoverArtifactMetadata extends DefaultTask {
                 Find the repository URL, the sources URL, the test suite URL, the documentation URL, and a concise two-sentence explanation for the following library: %s
                 Also determine whether this is a language-specific library. If it is language-specific, set the "language" field using:
                 - { "name": "kotlin", "version": "<kotlin major.minor, e.g. 2.0>" } for Kotlin libraries
+                - { "name": "groovy", "version": "<groovy major.minor, e.g. 4.0>" } for Groovy libraries
                 - { "name": "scala", "version": "2" } for Scala 2 libraries
                 - { "name": "scala", "version": "3" } for Scala 3 libraries
                 If the library is not language-specific, leave the "language" field absent.

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLs.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLs.java
@@ -278,6 +278,7 @@ public class PopulateArtifactURLs extends DefaultTask {
                 Find the repository URL, the sources URL, the test suite URL, the documentation URL, and a concise two-sentence explanation for the following library: %s:%s:%s
                 Also determine whether this is a language-specific library. If it is language-specific, set the "language" field using:
                 - { "name": "kotlin", "version": "<kotlin major.minor, e.g. 2.0>" } for Kotlin libraries
+                - { "name": "groovy", "version": "<groovy major.minor, e.g. 4.0>" } for Groovy libraries
                 - { "name": "scala", "version": "2" } for Scala 2 libraries
                 - { "name": "scala", "version": "3" } for Scala 3 libraries
                 If the library is not language-specific, leave the "language" field absent.

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
@@ -166,6 +166,7 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
         Set<String> packages = new LinkedHashSet<>();
         discoverTestPackages(testsDirectory.resolve("src/test/java"), packages);
         discoverTestPackages(testsDirectory.resolve("src/test/kotlin"), packages);
+        discoverTestPackages(testsDirectory.resolve("src/test/groovy"), packages);
         discoverTestPackages(testsDirectory.resolve("src/test/scala"), packages);
         return packages;
     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -353,6 +353,7 @@ class ScaffoldTask extends DefaultTask {
     private enum ScaffoldFlavor {
         JAVA("/scaffold/build.gradle.template", "/scaffold/Test.java.template", "src/test/java/$sanitizedGroup$/$sanitizedArtifact$/$capitalizedSanitizedArtifact$Test.java"),
         KOTLIN("/scaffold/build.gradle.kotlin.template", "/scaffold/Test.kt.template", "src/test/kotlin/$sanitizedGroup$/$sanitizedArtifact$/$capitalizedSanitizedArtifact$Test.kt"),
+        GROOVY("/scaffold/build.gradle.groovy.template", "/scaffold/Test.groovy.template", "src/test/groovy/$sanitizedGroup$/$sanitizedArtifact$/$capitalizedSanitizedArtifact$Test.groovy"),
         SCALA2("/scaffold/build.gradle.scala2.template", "/scaffold/Test.scala.template", "src/test/scala/$sanitizedGroup$/$sanitizedArtifact$/$capitalizedSanitizedArtifact$Test.scala"),
         SCALA3("/scaffold/build.gradle.scala3.template", "/scaffold/Test.scala.template", "src/test/scala/$sanitizedGroup$/$sanitizedArtifact$/$capitalizedSanitizedArtifact$Test.scala");
 
@@ -372,6 +373,9 @@ class ScaffoldTask extends DefaultTask {
             }
             if (language.isKotlin()) {
                 return KOTLIN;
+            }
+            if (language.isGroovy()) {
+                return GROOVY;
             }
             if (language.isScala2()) {
                 return SCALA2;

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/LibraryLanguage.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/LibraryLanguage.java
@@ -34,4 +34,9 @@ public record LibraryLanguage(
     public boolean isKotlin() {
         return "kotlin".equals(name);
     }
+
+    @JsonIgnore
+    public boolean isGroovy() {
+        return "groovy".equals(name);
+    }
 }

--- a/tests/tck-build-logic/src/main/resources/scaffold/Test.groovy.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/Test.groovy.template
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package $sanitizedGroup$.$sanitizedArtifact$
+
+import org.junit.jupiter.api.Test
+
+class $capitalizedSanitizedArtifact$Test {
+    @Test
+    void test() {
+        println "This is just a placeholder, implement your test"
+    }
+}

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.groovy.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.groovy.template
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+plugins {
+    id "org.graalvm.internal.tck"
+    id "groovy"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "$group$:$artifact$:$libraryVersion"
+    testImplementation localGroovy()
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -184,6 +184,52 @@ class ScaffoldTaskTests {
     }
 
     @Test
+    void runUsesDiscoveredGroovyScaffoldAndSeedsIndexEntry() throws IOException {
+        Coordinates coordinates = Coordinates.parse("org.apache.groovy:groovy-json:4.0.21");
+        installLibraryArtifact(coordinates, List.of(
+                "groovy/json/JsonSlurper.class",
+                "groovy/json/JsonOutput.class"
+        ));
+        Project project = createProject();
+        writeDiscoveredArtifactMetadata(project, new DiscoveredArtifactMetadata(
+                coordinates.toString(),
+                "https://example.com/source",
+                "https://example.com/repository",
+                "https://example.com/tests",
+                "https://example.com/docs",
+                "Groovy JSON provides JSON parsing and generation APIs. It is designed for Groovy applications.",
+                new LibraryLanguage("groovy", "4.0")
+        ));
+        ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
+
+        task.run();
+
+        assertThat(tempDir.resolve("tests/src/org.apache.groovy/groovy-json/4.0.21/src/test/groovy/org_apache_groovy/groovy_json/Groovy_jsonTest.groovy"))
+                .exists();
+        assertGeneratedFileMatchesTemplate(
+                coordinates,
+                "tests/src/org.apache.groovy/groovy-json/4.0.21/build.gradle",
+                "/scaffold/build.gradle.groovy.template"
+        );
+        assertThat(Files.readString(tempDir.resolve("tests/src/org.apache.groovy/groovy-json/4.0.21/build.gradle"), StandardCharsets.UTF_8))
+                .contains("id \"groovy\"")
+                .contains("testImplementation localGroovy()")
+                .contains("JavaLanguageVersion.of(21)")
+                .doesNotContain("25");
+        List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
+                tempDir.resolve("metadata/org.apache.groovy/groovy-json/index.json").toFile(),
+                new TypeReference<>() {}
+        );
+        assertThat(indexEntries.get(0))
+                .containsEntry("source-code-url", "https://example.com/source")
+                .containsEntry("repository-url", "https://example.com/repository")
+                .containsEntry("test-code-url", "https://example.com/tests")
+                .containsEntry("documentation-url", "https://example.com/docs")
+                .containsEntry("description", "Groovy JSON provides JSON parsing and generation APIs. It is designed for Groovy applications.")
+                .containsEntry("language", Map.of("name", "groovy", "version", "4.0"));
+    }
+
+    @Test
     void runUsesDiscoveredScala3Scaffold() throws IOException {
         Coordinates coordinates = Coordinates.parse("org.typelevel:cats-core_3:2.12.0");
         installLibraryArtifact(coordinates, List.of(

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadataTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadataTests.java
@@ -48,6 +48,7 @@ class DiscoverArtifactMetadataTests {
         assertThat(output)
                 .contains("Find the repository URL, the sources URL, the test suite URL, the documentation URL, and a concise two-sentence explanation for the following library: io.ktor:ktor-server-core-jvm:3.1.0")
                 .contains("Also determine whether this is a language-specific library.")
+                .contains("{ \"name\": \"groovy\", \"version\": \"<groovy major.minor, e.g. 4.0>\" }")
                 .contains("{ \"name\": \"scala\", \"version\": \"3\" }")
                 .contains("If the library is not language-specific, leave the \"language\" field absent.")
                 .contains("Update this file directly:")

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLsTests.java
@@ -50,6 +50,7 @@ class PopulateArtifactURLsTests {
                 .contains("Find the repository URL, the sources URL, the test suite URL, the documentation URL, and a concise two-sentence explanation for the following library: ch.qos.logback:logback-classic:1.4.1")
                 .contains("Also determine whether this is a language-specific library.")
                 .contains("{ \"name\": \"kotlin\", \"version\": \"<kotlin major.minor, e.g. 2.0>\" }")
+                .contains("{ \"name\": \"groovy\", \"version\": \"<groovy major.minor, e.g. 4.0>\" }")
                 .contains("{ \"name\": \"scala\", \"version\": \"2\" }")
                 .contains("If the library is not language-specific, leave the \"language\" field absent.")
                 .contains("The sources URL, the test suite URL, and the documentation URL must be for the EXACT version \"1.4.1\".")


### PR DESCRIPTION
Closes #3183.

## Summary
- add Groovy as a scaffold language alongside Java, Kotlin, and Scala
- add Groovy build and test templates under `src/test/groovy`
- teach artifact discovery/populate prompts to emit structured Groovy language metadata
- scan Groovy test packages when splitting test-only metadata

## Testing
- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.ScaffoldTaskTests --tests org.graalvm.internal.tck.harness.tasks.DiscoverArtifactMetadataTests --tests org.graalvm.internal.tck.harness.tasks.PopulateArtifactURLsTests --stacktrace`
- `./gradlew -p tests/tck-build-logic check --stacktrace` fails in existing `:validatePlugins` validation for `AbstractLibraryStatsTask#getStatsFile()`; tests completed before that failure.