### PR TITLE
Generate scheduled coverage Markdown

### DIFF
--- a/.github/workflows/publish-scheduled-coverage.yml
+++ b/.github/workflows/publish-scheduled-coverage.yml
@@ -2,7 +2,7 @@ name: "Publish coverage"
 
 on:
   schedule:
-    - cron: "15 3 * * *"
+    - cron: "15 */4 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd "${COVERAGE_DIR}"
           mkdir -p latest history
-          find . -mindepth 1 -maxdepth 1 ! -name .git ! -name latest ! -name history -exec rm -rf {} +
+          find . -mindepth 1 -maxdepth 1 ! -name .git ! -name latest ! -name history ! -name COVERAGE.md -exec rm -rf {} +
           find latest -mindepth 1 ! -name badges.json ! -name metrics-over-time.svg -exec rm -rf {} +
           find history -mindepth 1 ! -name history.json -exec rm -rf {} +
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -221,7 +221,7 @@ tasks.register("generateLibraryStats", GenerateLibraryStatsTask.class) { task ->
 }
 
 tasks.register("generateReadmeBadgeSummary", GenerateReadmeBadgeSummaryTask.class) { task ->
-    task.setDescription("Generates current README metrics data and updates README metrics history")
+    task.setDescription("Generates current README metrics data, coverage Markdown, and updates README metrics history")
     task.setGroup(METADATA_GROUP)
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractReadmeBadgeSummaryTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractReadmeBadgeSummaryTask.java
@@ -44,7 +44,11 @@ public abstract class AbstractReadmeBadgeSummaryTask extends DefaultTask {
     protected Path getOutputRoot() {
         Object property = getProject().findProperty("readmeMetricsOutputRoot");
         if (property != null && !property.toString().isBlank()) {
-            return Path.of(property.toString());
+            Path configuredPath = Path.of(property.toString());
+            if (configuredPath.isAbsolute()) {
+                return configuredPath;
+            }
+            return getRepoRoot().resolve(configuredPath).normalize();
         }
         return getProject().getLayout().getBuildDirectory().dir("coverage-stats").get().getAsFile().toPath();
     }
@@ -57,6 +61,11 @@ public abstract class AbstractReadmeBadgeSummaryTask extends DefaultTask {
     @Internal
     protected Path getMetricsOverviewGraphFile() {
         return getOutputRoot().resolve("latest").resolve("metrics-over-time.svg");
+    }
+
+    @Internal
+    protected Path getCoverageMarkdownFile() {
+        return getOutputRoot().resolve("COVERAGE.md");
     }
 
     @Internal

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateReadmeBadgeSummaryTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateReadmeBadgeSummaryTask.java
@@ -33,6 +33,12 @@ public abstract class GenerateReadmeBadgeSummaryTask extends AbstractReadmeBadge
                 getMetricsOverviewGraphFile(),
                 updatedHistory
         );
+        ReadmeBadgeSummarySupport.writeCoverageMarkdown(
+                getCoverageMarkdownFile(),
+                getStatsRoot(),
+                getMetadataRoot(),
+                summary
+        );
         getLogger().quiet("Updated README metrics artifacts under {}.", getOutputRoot());
     }
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -155,6 +156,46 @@ public final class ReadmeBadgeSummarySupport {
         );
     }
 
+    public static void writeCoverageMarkdown(
+            Path coverageFile,
+            Path statsRoot,
+            Path metadataRoot,
+            ReadmeBadgeSummary summary
+    ) {
+        writeTextWithTrailingNewline(
+                coverageFile,
+                buildCoverageMarkdown(statsRoot, metadataRoot, summary),
+                "Failed to write coverage Markdown to "
+        );
+    }
+
+    public static String buildCoverageMarkdown(
+            Path statsRoot,
+            Path metadataRoot,
+            ReadmeBadgeSummary summary
+    ) {
+        List<CoverageTableEntry> entries = buildCoverageTableEntries(statsRoot, metadataRoot);
+        StringBuilder markdown = new StringBuilder();
+        markdown.append("# Coverage\n\n");
+        markdown.append("Updated: ")
+                .append(summary.date())
+                .append("\n\n");
+        markdown.append("![Coverage over time](latest/metrics-over-time.svg)\n\n");
+        markdown.append("## Libraries\n\n");
+        markdown.append("| Library | Description | Dynamic access coverage |\n");
+        markdown.append("| --- | --- | ---: |\n");
+        for (CoverageTableEntry entry : entries) {
+            markdown.append("| `")
+                    .append(markdownCell(entry.coordinate()))
+                    .append("` | ")
+                    .append(markdownCell(entry.description()))
+                    .append(" | ")
+                    .append(markdownCell(formatDynamicAccessCoverage(entry.dynamicAccessCoverage())))
+                    .append(" |\n");
+        }
+        return markdown.toString();
+    }
+
     private static StatsMetrics buildStatsMetrics(LibraryStatsModels.LibraryStats libraryStats) {
         int coverageStatsArtifacts = libraryStats.entries() == null ? 0 : libraryStats.entries().size();
 
@@ -239,6 +280,104 @@ public final class ReadmeBadgeSummarySupport {
                 metadataIndexes,
                 testedVersions
         );
+    }
+
+    private static List<CoverageTableEntry> buildCoverageTableEntries(Path statsRoot, Path metadataRoot) {
+        if (!Files.isDirectory(metadataRoot)) {
+            throw new GradleException("Missing metadata root: " + metadataRoot);
+        }
+        LibraryStatsModels.LibraryStats libraryStats = LibraryStatsSupport.loadRepositoryStats(statsRoot);
+        Map<String, CoverageTableEntry> entriesByCoordinate = new TreeMap<>();
+
+        try (Stream<Path> paths = Files.find(metadataRoot, 3, (path, attrs) -> {
+            if (!attrs.isRegularFile()) {
+                return false;
+            }
+            Path relative = metadataRoot.relativize(path);
+            if (relative.getNameCount() != 3) {
+                return false;
+            }
+            String groupId = relative.getName(0).toString();
+            return "index.json".equals(relative.getName(2).toString()) && !EXCLUDED_GROUP_IDS.contains(groupId);
+        })) {
+            for (Path indexFile : paths.sorted().toList()) {
+                Path relative = metadataRoot.relativize(indexFile);
+                String coordinate = relative.getName(0) + ":" + relative.getName(1);
+                List<MetadataVersionsIndexEntry> indexEntries = readIndexEntries(indexFile);
+                entriesByCoordinate.put(
+                        coordinate,
+                        new CoverageTableEntry(
+                                coordinate,
+                                selectDescription(indexEntries),
+                                aggregateDynamicAccessCoverage(libraryStats.entries().get(coordinate))
+                        )
+                );
+            }
+        } catch (IOException e) {
+            throw new GradleException("Failed to traverse metadata root " + metadataRoot, e);
+        }
+
+        return List.copyOf(entriesByCoordinate.values());
+    }
+
+    private static String selectDescription(List<MetadataVersionsIndexEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return "";
+        }
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (entry != null && Boolean.TRUE.equals(entry.latest()) && !isBlank(entry.description())) {
+                return entry.description();
+            }
+        }
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (entry != null && !isBlank(entry.description())) {
+                return entry.description();
+            }
+        }
+        return "";
+    }
+
+    private static DynamicAccessCoverage aggregateDynamicAccessCoverage(LibraryStatsModels.ArtifactStats artifactStats) {
+        if (artifactStats == null || artifactStats.metadataVersions() == null) {
+            return DynamicAccessCoverage.notAvailable();
+        }
+
+        BigDecimal ratioSum = BigDecimal.ZERO;
+        long ratioCount = 0;
+        long coveredCalls = 0;
+        long totalCalls = 0;
+        for (LibraryStatsModels.MetadataVersionStats metadataVersionStats : artifactStats.metadataVersions().values()) {
+            if (metadataVersionStats == null || metadataVersionStats.versions() == null) {
+                continue;
+            }
+            for (LibraryStatsModels.VersionStats versionStats : metadataVersionStats.versions()) {
+                if (versionStats == null || versionStats.dynamicAccess() == null || !versionStats.dynamicAccess().isAvailable()) {
+                    continue;
+                }
+                ratioSum = ratioSum.add(versionStats.dynamicAccess().coverageRatio());
+                ratioCount++;
+                coveredCalls += versionStats.dynamicAccess().coveredCalls();
+                totalCalls += versionStats.dynamicAccess().totalCalls();
+            }
+        }
+
+        if (ratioCount == 0) {
+            return DynamicAccessCoverage.notAvailable();
+        }
+
+        BigDecimal coveragePercent;
+        if (totalCalls > 0) {
+            coveragePercent = BigDecimal.valueOf(coveredCalls)
+                    .divide(BigDecimal.valueOf(totalCalls), AVERAGE_SCALE, RoundingMode.HALF_UP)
+                    .multiply(HUNDRED)
+                    .setScale(1, RoundingMode.HALF_UP);
+        } else {
+            coveragePercent = ratioSum
+                    .divide(BigDecimal.valueOf(ratioCount), AVERAGE_SCALE, RoundingMode.HALF_UP)
+                    .multiply(HUNDRED)
+                    .setScale(1, RoundingMode.HALF_UP);
+        }
+        return new DynamicAccessCoverage(coveragePercent, coveredCalls, totalCalls, true);
     }
 
     private static List<MetadataVersionsIndexEntry> readIndexEntries(Path indexFile) {
@@ -716,6 +855,31 @@ public final class ReadmeBadgeSummarySupport {
         return formatInteger(value.setScale(0, RoundingMode.HALF_UP).intValue());
     }
 
+    private static String formatDynamicAccessCoverage(DynamicAccessCoverage coverage) {
+        if (!coverage.available()) {
+            return "N/A";
+        }
+        return formatPercent(coverage.coveragePercent())
+                + " ("
+                + formatInteger(coverage.coveredCalls())
+                + "/"
+                + formatInteger(coverage.totalCalls())
+                + " calls)";
+    }
+
+    private static String markdownCell(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim()
+                .replaceAll("\\s+", " ")
+                .replace("|", "\\|");
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
     private static String escapeXml(String value) {
         return value
                 .replace("&", "&amp;")
@@ -764,6 +928,10 @@ public final class ReadmeBadgeSummarySupport {
     }
 
     private static String formatInteger(int value) {
+        return formatInteger((long) value);
+    }
+
+    private static String formatInteger(long value) {
         NumberFormat format = NumberFormat.getIntegerInstance(Locale.US);
         format.setGroupingUsed(true);
         return format.format(value);
@@ -848,5 +1016,24 @@ public final class ReadmeBadgeSummarySupport {
             BigDecimal minValue,
             BigDecimal maxValue
     ) {
+    }
+
+    private record CoverageTableEntry(
+            String coordinate,
+            String description,
+            DynamicAccessCoverage dynamicAccessCoverage
+    ) {
+    }
+
+    private record DynamicAccessCoverage(
+            BigDecimal coveragePercent,
+            long coveredCalls,
+            long totalCalls,
+            boolean available
+    ) {
+
+        static DynamicAccessCoverage notAvailable() {
+            return new DynamicAccessCoverage(BigDecimal.ZERO, 0, 0, false);
+        }
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
@@ -325,6 +325,126 @@ class ReadmeBadgeSummarySupportTests {
         assertThat(svg).contains("text-anchor=\"end\">Jun 2026</text>");
     }
 
+    @Test
+    void buildCoverageMarkdownListsLibrariesWithDescriptionsAndDynamicAccessCoverage() throws IOException {
+        writeStatsFile(
+                "com.example",
+                "zeta",
+                "2.0.0",
+                """
+                {
+                  "versions": [
+                    {
+                      "dynamicAccess": {
+                        "breakdown": {
+                        },
+                        "coveredCalls": 1,
+                        "coverageRatio": 0.25,
+                        "totalCalls": 4
+                      },
+                      "version": "2.0.0"
+                    }
+                  ]
+                }
+                """
+        );
+        writeStatsFile(
+                "com.example",
+                "alpha",
+                "1.0.0",
+                """
+                {
+                  "versions": [
+                    {
+                      "dynamicAccess": {
+                        "breakdown": {
+                        },
+                        "coveredCalls": 1,
+                        "coverageRatio": 0.5,
+                        "totalCalls": 2
+                      },
+                      "version": "1.0.0"
+                    },
+                    {
+                      "dynamicAccess": {
+                        "breakdown": {
+                        },
+                        "coveredCalls": 2,
+                        "coverageRatio": 1.0,
+                        "totalCalls": 2
+                      },
+                      "version": "1.0.1"
+                    }
+                  ]
+                }
+                """
+        );
+        writeIndexFile(
+                "com.example",
+                "zeta",
+                """
+                [
+                  {
+                    "latest": true,
+                    "metadata-version": "2.0.0",
+                    "description": "Zeta library"
+                  }
+                ]
+                """
+        );
+        writeIndexFile(
+                "com.example",
+                "alpha",
+                """
+                [
+                  {
+                    "metadata-version": "0.9.0",
+                    "description": "Old alpha description"
+                  },
+                  {
+                    "latest": true,
+                    "metadata-version": "1.0.0",
+                    "description": "Alpha | library"
+                  }
+                ]
+                """
+        );
+        writeIndexFile(
+                "org.example",
+                "ignored",
+                """
+                [
+                  {
+                    "latest": true,
+                    "metadata-version": "1.0.0",
+                    "description": "Ignored sample library"
+                  }
+                ]
+                """
+        );
+
+        ReadmeBadgeSummarySupport.ReadmeBadgeSummary summary = ReadmeBadgeSummarySupport.buildSummary(
+                tempDir.resolve("stats"),
+                tempDir.resolve("metadata"),
+                LocalDate.of(2026, 4, 8)
+        );
+        String markdown = ReadmeBadgeSummarySupport.buildCoverageMarkdown(
+                tempDir.resolve("stats"),
+                tempDir.resolve("metadata"),
+                summary
+        );
+
+        assertThat(markdown).contains("# Coverage");
+        assertThat(markdown).contains("Updated: 2026-04-08");
+        assertThat(markdown).contains("![Coverage over time](latest/metrics-over-time.svg)");
+        assertThat(markdown).contains("| Library | Description | Dynamic access coverage |");
+        assertThat(markdown).contains("| `com.example:alpha` | Alpha \\| library | 75.0% (3/4 calls) |");
+        assertThat(markdown).contains("| `com.example:zeta` | Zeta library | 25.0% (1/4 calls) |");
+        assertThat(markdown).doesNotContain("org.example:ignored");
+        assertThat(markdown.indexOf("`com.example:alpha`")).isLessThan(markdown.indexOf("`com.example:zeta`"));
+        assertThat(markdown.indexOf("![Coverage over time]")).isLessThan(markdown.indexOf("## Libraries"));
+    }
+
     private void writeIndexFile(String groupId, String artifactId, String content) throws IOException {
         Path indexFile = tempDir.resolve("metadata").resolve(groupId).resolve(artifactId).resolve("index.json");
         Files.createDirectories(indexFile.getParent());


### PR DESCRIPTION
## What does this PR do?

Fixes #3187.

This updates the scheduled coverage publishing flow to generate a root COVERAGE.md artifact on the stats/coverage branch. The generated Markdown embeds the coverage-over-time graph first, then lists supported libraries alphabetically with their metadata description and dynamic access coverage.

The coverage workflow now runs every four hours and preserves COVERAGE.md alongside the existing latest/ and history/ published artifacts.

## Example generated coverage

Example excerpt from a local smoke run:

```markdown
# Coverage

Updated: 2026-04-28

![Coverage over time](latest/metrics-over-time.svg)

## Libraries

| Library | Description | Dynamic access coverage |
| --- | --- | ---: |
| `aopalliance:aopalliance` | AOP Alliance defines a small set of standard Java interfaces for aspect-oriented programming, especially method and constructor interception. Libraries use these interfaces to expose portable advice and interceptor contracts without depending on a particular AOP implementation. | 100.0% (0/0 calls) |
| `at.yawk.lz4:lz4-java` | lz4-java provides Java bindings and pure Java implementations of the LZ4 compression algorithm and XXHash hashing algorithm. It includes compressors, decompressors, and streaming APIs for high-performance data compression in Java applications. | 50.0% (5/10 calls) |
| `berkeleydb:je` | Berkeley DB Java Edition is a pure Java embedded database library that provides a transactional key-value store built on a B+Tree access method. It lets applications persist and query local data using direct database APIs, collections bindings, and an object persistence layer. | 37.6% (53/141 calls) |
```

## Code sections where the PR accesses files, network, docker or some external service

- .github/workflows/publish-scheduled-coverage.yml runs the scheduled GitHub Actions coverage publisher and pushes generated artifacts to the stats/coverage branch.
- tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java reads repository metadata and stats files to generate COVERAGE.md.

## Validation

- ./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.stats.ReadmeBadgeSummarySupportTests --stacktrace
- ./gradlew generateReadmeBadgeSummary -PreadmeMetricsOutputRoot=build/coverage-md-smoke-relative --stacktrace
- git diff --check

Note: ./gradlew -p tests/tck-build-logic check --stacktrace still fails on the existing unrelated Gradle plugin validation issue in AbstractLibraryStatsTask.getStatsFile().
