### PR TITLE
[GenAI] Add support for tools.jackson.core:jackson-databind:3.0.0-rc2 using gpt-5.5

### DIFF
--- a/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
+++ b/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
@@ -1,0 +1,100 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.PotentialCreator"
+      },
+      "type" : "char[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.BasicSerializerFactory"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.AnnotatedFieldCollector"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.jdk.CollectionDeserializer"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "java.math.BigDecimal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.BasicSerializerFactory"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.BasicSerializerFactory"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.BasicSerializerFactory"
+      },
+      "type" : "java.util.ImmutableCollections$MapN"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.BasicSerializerFactory"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.cfg.DeserializerFactoryConfig"
+      },
+      "type" : "tools.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.cfg.SerializerFactoryConfig"
+      },
+      "type" : "tools.jackson.databind.ser.Serializers[]"
+    }
+  ]
+}

--- a/metadata/tools.jackson.core/jackson-databind/index.json
+++ b/metadata/tools.jackson.core/jackson-databind/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0.0-rc2",
+    "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.0.0-rc2/jackson-databind-3.0.0-rc2-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-3.0.0-rc2",
+    "test-code-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-3.0.0-rc2/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.0.0-rc2/jackson-databind-3.0.0-rc2-javadoc.jar",
+    "description" : "Jackson Databind provides Jackson's general data-binding layer, mapping Java objects to and from JSON and other supported data formats through the Jackson streaming core. It supplies the object mapper APIs, serializers, deserializers, type handling, and annotation-driven configuration used by applications and other Jackson modules.",
+    "tested-versions" : [
+      "3.0.0-rc2"
+    ],
+    "allowed-packages" : [
+      "tools.jackson.databind"
+    ]
+  }
+]

--- a/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
+++ b/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0-rc2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.21875,
+          "coveredCalls" : 14,
+          "totalCalls" : 64
+        }
+      },
+      "coverageRatio" : 0.21875,
+      "coveredCalls" : 14,
+      "totalCalls" : 64
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 32752,
+        "missed" : 112713,
+        "ratio" : 0.225154,
+        "total" : 145465
+      },
+      "line" : {
+        "covered" : 8260,
+        "missed" : 26206,
+        "ratio" : 0.239656,
+        "total" : 34466
+      },
+      "method" : {
+        "covered" : 1966,
+        "missed" : 5977,
+        "ratio" : 0.247514,
+        "total" : 7943
+      }
+    }
+  } ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -11,6 +11,16 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
+    components {
+        withModule("com.fasterxml.jackson.core:jackson-annotations") {
+            allVariants {
+                withDependencies {
+                    removeAll { it.group == "com.fasterxml.jackson" && it.name == "jackson-bom" }
+                }
+            }
+        }
+    }
+
     testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = tools.jackson.core:jackson-databind:3.0.0-rc2
+library.version = 3.0.0-rc2
+metadata.dir = tools.jackson.core/jackson-databind/3.0.0-rc2/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'tools.jackson.core.jackson-databind_tests'

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -6,11 +6,255 @@
  */
 package tools_jackson_core.jackson_databind;
 
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ser.std.StdSerializer;
 import org.junit.jupiter.api.Test;
 
-class Jackson_databindTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jackson_databindTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void roundTripsRecordWithNestedCollectionsEnumsNumbersAndOptionalValues() throws JacksonException {
+        Order order = new Order("order-1", OrderStatus.IN_PROGRESS,
+                List.of(new OrderLine("sku-1", 2, new BigDecimal("19.95")),
+                        new OrderLine("sku-2", 1, new BigDecimal("5.50"))),
+                Map.of("customer", "Ada", "channel", "web"), Optional.of("gift wrap"), OptionalInt.of(5));
+
+        String json = MAPPER.writeValueAsString(order);
+        Order roundTripped = MAPPER.readValue(json, Order.class);
+
+        assertThat(roundTripped).isEqualTo(order);
+        assertThat(roundTripped.note()).contains("gift wrap");
+        assertThat(roundTripped.priority().isPresent()).isTrue();
+        assertThat(roundTripped.priority().getAsInt()).isEqualTo(5);
+    }
+
+    @Test
+    void readsNestedPayloadsWithObjectReaderAndWritesPrettyJsonWithObjectWriter() throws JacksonException {
+        String json = """
+                {
+                  "metadata": {"source": "warehouse"},
+                  "payload": {
+                    "lines": [
+                      {"sku":"paper","quantity":3,"unitPrice":1.25},
+                      {"sku":"pen","quantity":4,"unitPrice":2.50}
+                    ]
+                  }
+                }
+                """;
+
+        List<OrderLine> lines = MAPPER.readerForListOf(OrderLine.class).at("/payload/lines").readValue(json);
+        String prettyJson = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(lines);
+
+        assertThat(lines).containsExactly(new OrderLine("paper", 3, new BigDecimal("1.25")),
+                new OrderLine("pen", 4, new BigDecimal("2.50")));
+        assertThat(prettyJson).contains(System.lineSeparator()).contains("\"sku\" : \"paper\"");
+    }
+
+    @Test
+    void updatesExistingBeanInstanceThroughReaderForUpdating() throws JacksonException {
+        MutableProfile profile = new MutableProfile();
+        profile.setName("initial");
+        profile.setScore(7);
+        profile.setActive(false);
+
+        MutableProfile updated = MAPPER.readerForUpdating(profile).readValue("{"
+                + "\"score\": 11,"
+                + "\"active\": true"
+                + "}");
+
+        assertThat(updated).isSameAs(profile);
+        assertThat(updated.getName()).isEqualTo("initial");
+        assertThat(updated.getScore()).isEqualTo(11);
+        assertThat(updated.isActive()).isTrue();
+    }
+
+    @Test
+    void treeModelSupportsMutationNavigationConversionAndRemoval() throws JacksonException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("status", "ok");
+        ObjectNode summary = root.putObject("summary");
+        summary.put("count", 2);
+        ArrayNode items = root.putArray("items");
+        items.addObject().put("sku", "paper").put("quantity", 3).put("unitPrice", 1.25);
+        items.addObject().put("sku", "pen").put("quantity", 4).put("unitPrice", 2.50);
+
+        JsonNode firstSku = root.at("/items/0/sku");
+        root.without("status");
+        OrderLine firstLine = MAPPER.treeToValue(root.at("/items/0"), OrderLine.class);
+        JsonNode tree = MAPPER.readTree(MAPPER.writeValueAsString(root));
+
+        assertThat(firstSku.asText()).isEqualTo("paper");
+        assertThat(root.has("status")).isFalse();
+        assertThat(firstLine).isEqualTo(new OrderLine("paper", 3, new BigDecimal("1.25")));
+        assertThat(tree.at("/summary/count").asInt()).isEqualTo(2);
+        assertThat(tree.path("missing").isMissingNode()).isTrue();
+    }
+
+    @Test
+    void customModuleSerializesAndDeserializesDomainValueObjects() throws JacksonException {
+        SimpleModule moneyModule = new SimpleModule("money-module");
+        moneyModule.addSerializer(Money.class, new MoneySerializer());
+        moneyModule.addDeserializer(Money.class, new MoneyDeserializer());
+        ObjectMapper mapper = JsonMapper.builder().addModule(moneyModule).build();
+
+        Invoice invoice = new Invoice("invoice-1", new Money("USD", new BigDecimal("42.75")));
+        String json = mapper.writeValueAsString(invoice);
+        Invoice roundTripped = mapper.readValue(json, Invoice.class);
+
+        assertThat(json).contains("\"total\":\"USD 42.75\"");
+        assertThat(roundTripped).isEqualTo(invoice);
+    }
+
+    @Test
+    void builderConfigurationAppliesNamingStrategyAndNumericCoercion() throws JacksonException {
+        ObjectMapper mapper = JsonMapper.builder()
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .build();
+
+        MetricReading reading = mapper.readValue("{"
+                + "\"sensor_id\": \"sensor-A\","
+                + "\"observed_value\": 12.5,"
+                + "\"healthy\": true"
+                + "}", MetricReading.class);
+        String readingJson = mapper.writeValueAsString(reading);
+        Map<String, Object> numbers = mapper.readValue("{\"b\": 1.25, \"a\": 2}",
+                new TypeReference<LinkedHashMap<String, Object>>() { });
+        String orderedJson = mapper.writeValueAsString(numbers);
+
+        assertThat(reading.getSensorId()).isEqualTo("sensor-A");
+        assertThat(reading.getObservedValue()).isEqualByComparingTo("12.5");
+        assertThat(readingJson).contains("\"sensor_id\":").contains("\"observed_value\":12.5");
+        assertThat(numbers.get("b")).isInstanceOf(BigDecimal.class);
+        assertThat(orderedJson).isEqualTo("{\"a\":2,\"b\":1.25}");
+    }
+
+    public record Order(String id, OrderStatus status, List<OrderLine> lines, Map<String, String> attributes,
+            Optional<String> note, OptionalInt priority) {
+    }
+
+    public record OrderLine(String sku, int quantity, BigDecimal unitPrice) {
+    }
+
+    public enum OrderStatus {
+        NEW,
+        IN_PROGRESS,
+        COMPLETE
+    }
+
+    public record Invoice(String id, Money total) {
+    }
+
+    public record Money(String currency, BigDecimal amount) {
+    }
+
+    public static final class MoneySerializer extends StdSerializer<Money> {
+        public MoneySerializer() {
+            super(Money.class);
+        }
+
+        @Override
+        public void serialize(Money value, JsonGenerator generator, SerializationContext context)
+                throws JacksonException {
+            generator.writeString(value.currency() + " " + value.amount());
+        }
+    }
+
+    public static final class MoneyDeserializer extends StdDeserializer<Money> {
+        public MoneyDeserializer() {
+            super(Money.class);
+        }
+
+        @Override
+        public Money deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            String[] parts = parser.getValueAsString().split(" ", 2);
+            return new Money(parts[0], new BigDecimal(parts[1]));
+        }
+    }
+
+    public static final class MutableProfile {
+        private String name;
+        private int score;
+        private boolean active;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getScore() {
+            return score;
+        }
+
+        public void setScore(int score) {
+            this.score = score;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    public static final class MetricReading {
+        private String sensorId;
+        private BigDecimal observedValue;
+        private boolean healthy;
+
+        public String getSensorId() {
+            return sensorId;
+        }
+
+        public void setSensorId(String sensorId) {
+            this.sensorId = sensorId;
+        }
+
+        public BigDecimal getObservedValue() {
+            return observedValue;
+        }
+
+        public void setObservedValue(BigDecimal observedValue) {
+            this.observedValue = observedValue;
+        }
+
+        public boolean isHealthy() {
+            return healthy;
+        }
+
+        public void setHealthy(boolean healthy) {
+            this.healthy = healthy;
+        }
     }
 }

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -15,6 +15,7 @@ import java.util.OptionalInt;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
@@ -181,6 +182,37 @@ public class Jackson_databindTest {
         assertThat(restored.isEnabled()).isFalse();
     }
 
+    @Test
+    void jsonViewsSelectPropertiesForSerializationAndDeserialization() throws JacksonException {
+        ObjectMapper mapper = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+                .build();
+        ViewScopedAccount account = new ViewScopedAccount("ada", "Ada Lovelace", "rotates token monthly", true);
+
+        String publicJson = mapper.writer().withView(Views.Public.class).writeValueAsString(account);
+        String internalJson = mapper.writer().withView(Views.Internal.class).writeValueAsString(account);
+        ViewScopedAccount publicInput = mapper.readerFor(ViewScopedAccount.class)
+                .withView(Views.Public.class)
+                .readValue("{"
+                        + "\"username\": \"grace\","
+                        + "\"displayName\": \"Grace Hopper\","
+                        + "\"internalNotes\": \"should be ignored\","
+                        + "\"enabled\": true"
+                        + "}");
+
+        assertThat(publicJson).contains("\"username\":\"ada\"")
+                .contains("\"displayName\":\"Ada Lovelace\"")
+                .doesNotContain("internalNotes")
+                .doesNotContain("enabled");
+        assertThat(internalJson).contains("\"username\":\"ada\"")
+                .contains("\"internalNotes\":\"rotates token monthly\"")
+                .contains("\"enabled\":true");
+        assertThat(publicInput.getUsername()).isEqualTo("grace");
+        assertThat(publicInput.getDisplayName()).isEqualTo("Grace Hopper");
+        assertThat(publicInput.getInternalNotes()).isNull();
+        assertThat(publicInput.isEnabled()).isFalse();
+    }
+
     public record Order(String id, OrderStatus status, List<OrderLine> lines, Map<String, String> attributes,
             Optional<String> note, OptionalInt priority) {
     }
@@ -296,6 +328,71 @@ public class Jackson_databindTest {
 
         @JsonIgnore
         public abstract void setApiToken(String apiToken);
+    }
+
+    public static final class Views {
+        public interface Public {
+        }
+
+        public interface Internal extends Public {
+        }
+    }
+
+    public static final class ViewScopedAccount {
+        private String username;
+        private String displayName;
+        private String internalNotes;
+        private boolean enabled;
+
+        public ViewScopedAccount() {
+        }
+
+        public ViewScopedAccount(String username, String displayName, String internalNotes, boolean enabled) {
+            this.username = username;
+            this.displayName = displayName;
+            this.internalNotes = internalNotes;
+            this.enabled = enabled;
+        }
+
+        @JsonView(Views.Public.class)
+        public String getUsername() {
+            return username;
+        }
+
+        @JsonView(Views.Public.class)
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        @JsonView(Views.Public.class)
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @JsonView(Views.Public.class)
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
+        }
+
+        @JsonView(Views.Internal.class)
+        public String getInternalNotes() {
+            return internalNotes;
+        }
+
+        @JsonView(Views.Internal.class)
+        public void setInternalNotes(String internalNotes) {
+            this.internalNotes = internalNotes;
+        }
+
+        @JsonView(Views.Internal.class)
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        @JsonView(Views.Internal.class)
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
     }
 
     public static final class ExternalAccount {

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -13,6 +13,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
@@ -155,6 +158,29 @@ public class Jackson_databindTest {
         assertThat(orderedJson).isEqualTo("{\"a\":2,\"b\":1.25}");
     }
 
+    @Test
+    void mixInsApplyExternalPropertyAnnotationsWithoutChangingTargetType() throws JacksonException {
+        ObjectMapper mapper = JsonMapper.builder()
+                .addMixIn(ExternalAccount.class, ExternalAccountMixin.class)
+                .build();
+        ExternalAccount account = new ExternalAccount("ada", "token-123", true);
+
+        String json = mapper.writeValueAsString(account);
+        ExternalAccount restored = mapper.readValue("{"
+                + "\"login_name\": \"grace\","
+                + "\"apiToken\": \"ignored-token\","
+                + "\"enabled\": false"
+                + "}", ExternalAccount.class);
+
+        assertThat(json).contains("\"login_name\":\"ada\"")
+                .contains("\"enabled\":true")
+                .doesNotContain("apiToken")
+                .doesNotContain("loginName");
+        assertThat(restored.getLoginName()).isEqualTo("grace");
+        assertThat(restored.getApiToken()).isNull();
+        assertThat(restored.isEnabled()).isFalse();
+    }
+
     public record Order(String id, OrderStatus status, List<OrderLine> lines, Map<String, String> attributes,
             Optional<String> note, OptionalInt priority) {
     }
@@ -255,6 +281,59 @@ public class Jackson_databindTest {
 
         public void setHealthy(boolean healthy) {
             this.healthy = healthy;
+        }
+    }
+
+    public abstract static class ExternalAccountMixin {
+        @JsonProperty("login_name")
+        public abstract String getLoginName();
+
+        @JsonProperty("login_name")
+        public abstract void setLoginName(String loginName);
+
+        @JsonIgnore
+        public abstract String getApiToken();
+
+        @JsonIgnore
+        public abstract void setApiToken(String apiToken);
+    }
+
+    public static final class ExternalAccount {
+        private String loginName;
+        private String apiToken;
+        private boolean enabled;
+
+        public ExternalAccount() {
+        }
+
+        public ExternalAccount(String loginName, String apiToken, boolean enabled) {
+            this.loginName = loginName;
+            this.apiToken = apiToken;
+            this.enabled = enabled;
+        }
+
+        public String getLoginName() {
+            return loginName;
+        }
+
+        public void setLoginName(String loginName) {
+            this.loginName = loginName;
+        }
+
+        public String getApiToken() {
+            return apiToken;
+        }
+
+        public void setApiToken(String apiToken) {
+            this.apiToken = apiToken;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 }

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tools_jackson_core.jackson_databind;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_databindTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,288 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ExternalAccount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ExternalAccount",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setLoginName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ExternalAccountMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.AnnotatedFieldCollector"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ExternalAccountMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.AnnotatedMethodCollector"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ExternalAccountMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Invoice",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "tools_jackson_core.jackson_databind.Jackson_databindTest$Money"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$MetricReading"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$MetricReading",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setHealthy",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setObservedValue",
+          "parameterTypes" : [
+            "java.math.BigDecimal"
+          ]
+        },
+        {
+          "name" : "setSensorId",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Money"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$MutableProfile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$MutableProfile",
+      "methods" : [
+        {
+          "name" : "setActive",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setScore",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Order",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderStatus",
+            "java.util.List",
+            "java.util.Map",
+            "java.util.Optional",
+            "java.util.OptionalInt"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderLine",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "java.math.BigDecimal"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderLine",
+      "methods" : [
+        {
+          "name" : "quantity",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "sku",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "unitPrice",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderLine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.jdk.CollectionDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderLine",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "java.math.BigDecimal"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.IndexedListSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderLine",
+      "methods" : [
+        {
+          "name" : "quantity",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "sku",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "unitPrice",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.BasicDeserializerFactory"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$OrderStatus"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ViewScopedAccount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ViewScopedAccount",
+      "methods" : [
+        {
+          "name" : "setDisplayName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setUsername",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.impl.FilteredBeanPropertyWriter$SingleView"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ViewScopedAccount",
+      "methods" : [
+        {
+          "name" : "getDisplayName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getInternalNotes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUsername",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isEnabled",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "tools.jackson.databind.**"
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "tools.jackson.databind.**"
+      "includeClasses" : "tools.jackson.databind.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2157

This PR introduces tests and metadata for tools.jackson.core:jackson-databind:3.0.0-rc2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 243741
- Cached input tokens: 2007040
- Output tokens: 25202
- Entries: 16
- Iterations: 5
- Library coverage percentage: 23.97
- Generated lines of code: 358
- Tested library lines of code: 8260

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `0b964928dc39e11a6fe207b923d5b2d7a499c36a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 14/64 covered calls (21.88%)
- Reflection: 14/64 covered calls (21.88%)

Library coverage:
- Instruction: 32752/145465 (22.52%)
- Line: 8260/34466 (23.97%)
- Method: 1966/7943 (24.75%)
