### PR TITLE
[GenAI] Add support for io.dropwizard.metrics:metrics-jmx:4.2.0 using gpt-5.5

### DIFF
--- a/metadata/io.dropwizard.metrics/metrics-jmx/4.2.0/reachability-metadata.json
+++ b/metadata/io.dropwizard.metrics/metrics-jmx/4.2.0/reachability-metadata.json
@@ -1,0 +1,77 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxCounter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxCounterMBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxGauge"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxGaugeMBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxHistogram"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxHistogramMBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxMeter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxMeterMBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxTimer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter$JmxListener"
+      },
+      "type": "com.codahale.metrics.jmx.JmxReporter$JmxTimerMBean",
+      "allPublicMethods": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.jmx.JmxReporter"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/io.dropwizard.metrics/metrics-jmx/index.json
+++ b/metadata/io.dropwizard.metrics/metrics-jmx/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-jmx/4.2.0/metrics-jmx-4.2.0-sources.jar",
+    "repository-url" : "https://github.com/dropwizard/metrics",
+    "test-code-url" : "https://github.com/dropwizard/metrics/tree/v4.2.0/metrics-jmx/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-jmx/4.2.0/metrics-jmx-4.2.0-javadoc.jar",
+    "description" : "Dropwizard Metrics provides Java application instrumentation primitives such as gauges, counters, histograms, meters, and timers. The metrics-jmx module exposes those metrics through JMX MBeans so they can be inspected and monitored with standard JMX tools.",
+    "tested-versions" : [
+      "4.2.0"
+    ],
+    "allowed-packages" : [
+      "com.codahale.metrics.jmx"
+    ]
+  }
+]

--- a/stats/io.dropwizard.metrics/metrics-jmx/4.2.0/stats.json
+++ b/stats/io.dropwizard.metrics/metrics-jmx/4.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 603,
+        "missed" : 377,
+        "ratio" : 0.615306,
+        "total" : 980
+      },
+      "line" : {
+        "covered" : 154,
+        "missed" : 95,
+        "ratio" : 0.618474,
+        "total" : 249
+      },
+      "method" : {
+        "covered" : 51,
+        "missed" : 30,
+        "ratio" : 0.62963,
+        "total" : 81
+      }
+    }
+  } ]
+}

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/.gitignore
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/build.gradle
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.dropwizard.metrics:metrics-jmx:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/gradle.properties
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.dropwizard.metrics:metrics-jmx:4.2.0
+library.version = 4.2.0
+metadata.dir = io.dropwizard.metrics/metrics-jmx/4.2.0/

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/settings.gradle
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.dropwizard.metrics.metrics-jmx_tests'

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
@@ -97,6 +97,35 @@ public class Metrics_jmxTest {
     }
 
     @Test
+    void reporterStopUnregistersMBeansAndRestartPublishesCurrentMetrics() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        MBeanServer server = MBeanServerFactory.newMBeanServer();
+        String domain = uniqueDomain("lifecycle");
+        ObjectName initialCounterName = metricName(domain, "counters", "initial.requests");
+        ObjectName restartedCounterName = metricName(domain, "counters", "restarted.requests");
+
+        try (JmxReporter reporter = JmxReporter.forRegistry(registry)
+                .registerWith(server)
+                .inDomain(domain)
+                .build()) {
+            registry.counter("initial.requests");
+
+            reporter.start();
+            assertThat(server.isRegistered(initialCounterName)).isTrue();
+
+            reporter.stop();
+            assertThat(server.isRegistered(initialCounterName)).isFalse();
+
+            registry.remove("initial.requests");
+            registry.counter("restarted.requests");
+
+            reporter.start();
+            assertThat(server.isRegistered(initialCounterName)).isFalse();
+            assertThat(server.isRegistered(restartedCounterName)).isTrue();
+        }
+    }
+
+    @Test
     void reporterHonorsMetricFiltersAndCustomObjectNameFactories() throws Exception {
         MetricRegistry registry = new MetricRegistry();
         registry.counter("visible.requests").inc(4);

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_dropwizard_metrics.metrics_jmx;
+
+import org.junit.jupiter.api.Test;
+
+class Metrics_jmxTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
@@ -6,6 +6,7 @@
  */
 package io_dropwizard_metrics.metrics_jmx;
 
+import java.lang.management.ManagementFactory;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -94,6 +95,25 @@ public class Metrics_jmxTest {
         }
 
         assertThat(server.queryNames(new ObjectName(domain + ":*"), null)).isEmpty();
+    }
+
+    @Test
+    void reporterUsesPlatformMBeanServerWhenNoServerIsConfigured() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.counter("platform.requests");
+        MBeanServer platformServer = ManagementFactory.getPlatformMBeanServer();
+        String domain = uniqueDomain("platform");
+        ObjectName counterName = metricName(domain, "counters", "platform.requests");
+
+        try (JmxReporter reporter = JmxReporter.forRegistry(registry)
+                .inDomain(domain)
+                .build()) {
+            reporter.start();
+
+            assertThat(platformServer.isRegistered(counterName)).isTrue();
+        }
+
+        assertThat(platformServer.isRegistered(counterName)).isFalse();
     }
 
     @Test

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
@@ -6,11 +6,217 @@
  */
 package io_dropwizard_metrics.metrics_jmx;
 
+import java.util.Hashtable;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingWindowReservoir;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.jmx.DefaultObjectNameFactory;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.codahale.metrics.jmx.ObjectNameFactory;
 import org.junit.jupiter.api.Test;
 
-class Metrics_jmxTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Metrics_jmxTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void reporterPublishesExistingAndDynamicMetricsAsJmxMBeans() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        MBeanServer server = MBeanServerFactory.newMBeanServer();
+        String domain = uniqueDomain("published");
+
+        registry.register("queue.depth", (Gauge<Integer>) () -> 17);
+        Counter requests = registry.counter("requests");
+        requests.inc(5);
+        Meter throughput = registry.meter("throughput");
+        throughput.mark(3);
+        Histogram payloadSize = new Histogram(new SlidingWindowReservoir(5));
+        payloadSize.update(100);
+        payloadSize.update(200);
+        payloadSize.update(300);
+        registry.register("payload.size", payloadSize);
+        Timer requestTimer = registry.timer("request.timer");
+        requestTimer.update(1_500, TimeUnit.MICROSECONDS);
+
+        ObjectName gaugeName = metricName(domain, "gauges", "queue.depth");
+        ObjectName counterName = metricName(domain, "counters", "requests");
+        ObjectName meterName = metricName(domain, "meters", "throughput");
+        ObjectName histogramName = metricName(domain, "histograms", "payload.size");
+        ObjectName timerName = metricName(domain, "timers", "request.timer");
+
+        try (JmxReporter reporter = JmxReporter.forRegistry(registry)
+                .registerWith(server)
+                .inDomain(domain)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build()) {
+            reporter.start();
+
+            assertThat(server.isRegistered(gaugeName)).isTrue();
+            assertThat(server.isRegistered(counterName)).isTrue();
+            assertThat(server.isRegistered(meterName)).isTrue();
+            assertThat(server.isRegistered(histogramName)).isTrue();
+            assertThat(server.isRegistered(timerName)).isTrue();
+            assertThat(server.getAttribute(gaugeName, "Value")).isEqualTo(17);
+            assertThat(server.getAttribute(gaugeName, "Number")).isEqualTo(17);
+            assertThat(server.getAttribute(counterName, "Count")).isEqualTo(5L);
+            assertThat(server.getAttribute(meterName, "Count")).isEqualTo(3L);
+            assertThat(server.getAttribute(meterName, "RateUnit")).isEqualTo("events/second");
+            assertThat(server.getAttribute(histogramName, "Count")).isEqualTo(3L);
+            assertThat(server.getAttribute(histogramName, "Min")).isEqualTo(100L);
+            assertThat(server.getAttribute(histogramName, "Max")).isEqualTo(300L);
+            assertThat(server.getAttribute(histogramName, "SnapshotSize")).isEqualTo(3L);
+            assertThat(server.getAttribute(timerName, "Count")).isEqualTo(1L);
+            assertThat(server.getAttribute(timerName, "DurationUnit")).isEqualTo("milliseconds");
+            assertThat((Double) server.getAttribute(timerName, "Min")).isEqualTo(1.5d);
+
+            Counter dynamicCounter = registry.counter("dynamic.created");
+            dynamicCounter.inc(9);
+            ObjectName dynamicCounterName = metricName(domain, "counters", "dynamic.created");
+            assertThat(server.isRegistered(dynamicCounterName)).isTrue();
+            assertThat(server.getAttribute(dynamicCounterName, "Count")).isEqualTo(9L);
+
+            assertThat(registry.remove("requests")).isTrue();
+            assertThat(server.isRegistered(counterName)).isFalse();
+        }
+
+        assertThat(server.queryNames(new ObjectName(domain + ":*"), null)).isEmpty();
+    }
+
+    @Test
+    void reporterHonorsMetricFiltersAndCustomObjectNameFactories() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.counter("visible.requests").inc(4);
+        registry.counter("hidden.requests").inc(7);
+        registry.register("visible.load", (Gauge<Double>) () -> 0.75d);
+        MBeanServer server = MBeanServerFactory.newMBeanServer();
+        String domain = uniqueDomain("filtered");
+        RecordingObjectNameFactory objectNameFactory = new RecordingObjectNameFactory("primary");
+
+        try (JmxReporter reporter = JmxReporter.forRegistry(registry)
+                .registerWith(server)
+                .inDomain(domain)
+                .filter(MetricFilter.startsWith("visible"))
+                .createsObjectNamesWith(objectNameFactory)
+                .build()) {
+            reporter.start();
+
+            ObjectName visibleCounter = customMetricName(domain, "primary", "counters", "visible.requests");
+            ObjectName visibleGauge = customMetricName(domain, "primary", "gauges", "visible.load");
+            assertThat(server.isRegistered(visibleCounter)).isTrue();
+            assertThat(server.isRegistered(visibleGauge)).isTrue();
+            assertThat(server.getAttribute(visibleCounter, "Count")).isEqualTo(4L);
+            assertThat(server.getAttribute(visibleGauge, "Value")).isEqualTo(0.75d);
+            assertThat(server.queryNames(new ObjectName(domain + ":group=primary,metric=hidden.requests,*"), null))
+                    .isEmpty();
+            assertThat(objectNameFactory.requestedNames)
+                    .contains("counters:visible.requests", "gauges:visible.load")
+                    .doesNotContain("counters:hidden.requests");
+        }
+    }
+
+    @Test
+    void defaultObjectNameFactoryCreatesNonPatternNamesForWildcardMetricNames() throws Exception {
+        String domain = uniqueDomain("quoted");
+        DefaultObjectNameFactory factory = new DefaultObjectNameFactory();
+
+        ObjectName quotedName = factory.createName("gauges", domain, "cache:*?depth");
+
+        assertThat(quotedName.getDomain()).isEqualTo(domain);
+        assertThat(quotedName.isPattern()).isFalse();
+        assertThat(quotedName.getKeyProperty("name")).isEqualTo(ObjectName.quote("cache:*?depth"));
+        assertThat(quotedName.toString()).contains(ObjectName.quote("cache:*?depth"));
+    }
+
+    @Test
+    void perMetricRateAndDurationUnitsOverrideReporterDefaults() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        Meter defaultRateMeter = registry.meter("default.rate");
+        defaultRateMeter.mark(2);
+        Meter customRateMeter = registry.meter("custom.rate");
+        customRateMeter.mark(3);
+        Timer defaultDurationTimer = registry.timer("default.duration");
+        defaultDurationTimer.update(2, TimeUnit.SECONDS);
+        Timer customDurationTimer = registry.timer("custom.duration");
+        customDurationTimer.update(2_500, TimeUnit.MILLISECONDS);
+        MBeanServer server = MBeanServerFactory.newMBeanServer();
+        String domain = uniqueDomain("units");
+
+        try (JmxReporter reporter = JmxReporter.forRegistry(registry)
+                .registerWith(server)
+                .inDomain(domain)
+                .convertRatesTo(TimeUnit.MINUTES)
+                .convertDurationsTo(TimeUnit.SECONDS)
+                .specificRateUnits(Map.of("custom.rate", TimeUnit.MILLISECONDS))
+                .specificDurationUnits(Map.of("custom.duration", TimeUnit.MILLISECONDS))
+                .build()) {
+            reporter.start();
+
+            ObjectName defaultRateName = metricName(domain, "meters", "default.rate");
+            ObjectName customRateName = metricName(domain, "meters", "custom.rate");
+            ObjectName defaultDurationName = metricName(domain, "timers", "default.duration");
+            ObjectName customDurationName = metricName(domain, "timers", "custom.duration");
+            assertThat(server.getAttribute(defaultRateName, "RateUnit")).isEqualTo("events/minute");
+            assertThat(server.getAttribute(customRateName, "RateUnit")).isEqualTo("events/millisecond");
+            assertThat(server.getAttribute(defaultDurationName, "DurationUnit")).isEqualTo("seconds");
+            assertThat(server.getAttribute(customDurationName, "DurationUnit")).isEqualTo("milliseconds");
+            assertThat((Double) server.getAttribute(defaultDurationName, "Min")).isEqualTo(2.0d);
+            assertThat((Double) server.getAttribute(customDurationName, "Min")).isEqualTo(2_500.0d);
+        }
+    }
+
+    private static String uniqueDomain(String suffix) {
+        return "io.dropwizard.metrics.jmx.test." + suffix + "." + System.nanoTime();
+    }
+
+    private static ObjectName metricName(String domain, String type, String name) throws Exception {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", type);
+        properties.put("name", name);
+        return new ObjectName(domain, properties);
+    }
+
+    private static ObjectName customMetricName(String domain, String group, String type, String metric) throws Exception {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("group", group);
+        properties.put("type", type);
+        properties.put("metric", metric);
+        return new ObjectName(domain, properties);
+    }
+
+    private static final class RecordingObjectNameFactory implements ObjectNameFactory {
+        private final String group;
+        private final Set<String> requestedNames = new LinkedHashSet<>();
+
+        private RecordingObjectNameFactory(String group) {
+            this.group = group;
+        }
+
+        @Override
+        public ObjectName createName(String type, String domain, String name) {
+            requestedNames.add(type + ":" + name);
+            try {
+                Hashtable<String, String> properties = new Hashtable<>();
+                properties.put("group", group);
+                properties.put("type", type);
+                properties.put("metric", name);
+                return new ObjectName(domain, properties);
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(exception);
+            }
+        }
     }
 }

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/src/test/java/io_dropwizard_metrics/metrics_jmx/Metrics_jmxTest.java
@@ -7,7 +7,6 @@
 package io_dropwizard_metrics.metrics_jmx;
 
 import java.lang.management.ManagementFactory;
-import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -231,19 +230,13 @@ public class Metrics_jmxTest {
         return "io.dropwizard.metrics.jmx.test." + suffix + "." + System.nanoTime();
     }
 
-    private static ObjectName metricName(String domain, String type, String name) throws Exception {
-        Hashtable<String, String> properties = new Hashtable<>();
-        properties.put("type", type);
-        properties.put("name", name);
-        return new ObjectName(domain, properties);
+    private static ObjectName metricName(String domain, String type, String name) {
+        return new DefaultObjectNameFactory().createName(type, domain, name);
     }
 
     private static ObjectName customMetricName(String domain, String group, String type, String metric) throws Exception {
-        Hashtable<String, String> properties = new Hashtable<>();
-        properties.put("group", group);
-        properties.put("type", type);
-        properties.put("metric", metric);
-        return new ObjectName(domain, properties);
+        return new ObjectName(domain + ":group=" + ObjectName.quote(group) + ",type=" + ObjectName.quote(type)
+                + ",metric=" + ObjectName.quote(metric));
     }
 
     private static final class RecordingObjectNameFactory implements ObjectNameFactory {
@@ -258,11 +251,8 @@ public class Metrics_jmxTest {
         public ObjectName createName(String type, String domain, String name) {
             requestedNames.add(type + ":" + name);
             try {
-                Hashtable<String, String> properties = new Hashtable<>();
-                properties.put("group", group);
-                properties.put("type", type);
-                properties.put("metric", name);
-                return new ObjectName(domain, properties);
+                return new ObjectName(domain + ":group=" + ObjectName.quote(group) + ",type=" + ObjectName.quote(type)
+                        + ",metric=" + ObjectName.quote(name));
             } catch (Exception exception) {
                 throw new IllegalArgumentException(exception);
             }

--- a/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/user-code-filter.json
+++ b/tests/src/io.dropwizard.metrics/metrics-jmx/4.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.codahale.metrics.jmx.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3050

This PR introduces tests and metadata for io.dropwizard.metrics:metrics-jmx:4.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 230205
- Cached input tokens: 1573376
- Output tokens: 22014
- Entries: 16
- Iterations: 5
- Library coverage percentage: 61.85
- Generated lines of code: 224
- Tested library lines of code: 154

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `0b964928dc39e11a6fe207b923d5b2d7a499c36a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 603/980 (61.53%)
- Line: 154/249 (61.85%)
- Method: 51/81 (62.96%)
