### PR TITLE
[GenAI] Test fix for org.slf4j:slf4j-nop:1.5.6 using gpt-5.4

### DIFF
--- a/metadata/org.slf4j/slf4j-nop/1.5.6/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-nop/1.5.6/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMarkerBinder"
+      },
+      "type": "org.slf4j.helpers.BasicMarkerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMDCBinder"
+      },
+      "type": "org.slf4j.helpers.NOPMakerAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticLoggerBinder"
+      },
+      "type": "org.slf4j.impl.NOPLoggerFactory"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-nop/index.json
+++ b/metadata/org.slf4j/slf4j-nop/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.5.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.5.6/slf4j-nop-1.5.6-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_1.5.6/slf4j-nop/src/test/java",
+    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_1.5.6/slf4j-site/src/site/pages/manual.html",
+    "description" : "SLF4J NOP is a no-operation binding implementation for the SLF4J logging facade. It fulfills the required SLF4J backend dependency while intentionally discarding all log output.",
     "tested-versions" : [
       "1.5.6"
     ],

--- a/metadata/org.slf4j/slf4j-nop/index.json
+++ b/metadata/org.slf4j/slf4j-nop/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.5.6",
+    "tested-versions" : [
+      "1.5.6"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.5.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.5.3/slf4j-nop-1.5.3-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/stats/org.slf4j/slf4j-nop/1.5.6/stats.json
+++ b/stats/org.slf4j/slf4j-nop/1.5.6/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.6",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 80,
+        "missed" : 2,
+        "ratio" : 0.97561,
+        "total" : 82
+      },
+      "line" : {
+        "covered" : 21,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 21
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 14
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/.gitignore
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/build.gradle
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:slf4j-nop:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:slf4j-nop:1.5.6
+library.version = 1.5.6
+metadata.dir = org.slf4j/slf4j-nop/1.5.6/

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/settings.gradle
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.slf4j-nop_tests'

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_nop;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.StaticLoggerBinder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticLoggerBinderTest {
+
+    @Test
+    void staticLoggerBinderProvidesTheNopLoggerFactoryUsedBySlf4j() {
+        StaticLoggerBinder binder = StaticLoggerBinder.SINGLETON;
+        ILoggerFactory binderFactory = binder.getLoggerFactory();
+        ILoggerFactory apiFactory = LoggerFactory.getILoggerFactory();
+        Logger firstLogger = binderFactory.getLogger("first");
+        Logger secondLogger = binderFactory.getLogger("second");
+
+        assertThat(apiFactory).isSameAs(binderFactory);
+        assertThat(binder.getLoggerFactoryClassStr()).isEqualTo(binderFactory.getClass().getName());
+        assertThat(firstLogger).isSameAs(secondLogger);
+        assertThat(StaticLoggerBinder.SINGLETON).isSameAs(binder);
+    }
+}

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
@@ -18,7 +18,7 @@ public class StaticLoggerBinderTest {
 
     @Test
     void staticLoggerBinderProvidesTheNopLoggerFactoryUsedBySlf4j() {
-        StaticLoggerBinder binder = StaticLoggerBinder.SINGLETON;
+        StaticLoggerBinder binder = StaticLoggerBinder.getSingleton();
         ILoggerFactory binderFactory = binder.getLoggerFactory();
         ILoggerFactory apiFactory = LoggerFactory.getILoggerFactory();
         Logger firstLogger = binderFactory.getLogger("first");
@@ -27,6 +27,6 @@ public class StaticLoggerBinderTest {
         assertThat(apiFactory).isSameAs(binderFactory);
         assertThat(binder.getLoggerFactoryClassStr()).isEqualTo(binderFactory.getClass().getName());
         assertThat(firstLogger).isSameAs(secondLogger);
-        assertThat(StaticLoggerBinder.SINGLETON).isSameAs(binder);
+        assertThat(StaticLoggerBinder.getSingleton()).isSameAs(binder);
     }
 }

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticMDCBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticMDCBinderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_nop;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.slf4j.helpers.NOPMakerAdapter;
+import org.slf4j.impl.StaticMDCBinder;
+import org.slf4j.spi.MDCAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticMDCBinderTest {
+
+    @Test
+    void staticMdcBinderProvidesTheNopMdcAdapterUsedBySlf4j() {
+        StaticMDCBinder binder = StaticMDCBinder.SINGLETON;
+        MDCAdapter binderAdapter = binder.getMDCA();
+        MDCAdapter apiAdapter = MDC.getMDCAdapter();
+
+        assertThat(binderAdapter).isInstanceOf(NOPMakerAdapter.class);
+        assertThat(apiAdapter).isInstanceOf(NOPMakerAdapter.class);
+        assertThat(binder.getMDCAdapterClassStr()).isEqualTo(NOPMakerAdapter.class.getName());
+        assertThat(apiAdapter.getClass().getName()).isEqualTo(binder.getMDCAdapterClassStr());
+        assertThat(StaticMDCBinder.SINGLETON).isSameAs(binder);
+    }
+}

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticMarkerBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticMarkerBinderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_nop;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.impl.StaticMarkerBinder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticMarkerBinderTest {
+
+    @Test
+    void staticMarkerBinderProvidesTheBasicMarkerFactoryUsedBySlf4j() {
+        StaticMarkerBinder binder = StaticMarkerBinder.SINGLETON;
+        IMarkerFactory binderFactory = binder.getMarkerFactory();
+        IMarkerFactory apiFactory = MarkerFactory.getIMarkerFactory();
+        Marker binderMarker = binderFactory.getMarker("binder-marker");
+        Marker apiMarker = MarkerFactory.getMarker("binder-marker");
+
+        assertThat(binderFactory).isInstanceOf(BasicMarkerFactory.class);
+        assertThat(apiFactory).isSameAs(binderFactory);
+        assertThat(binder.getMarkerFactoryClassStr()).isEqualTo(BasicMarkerFactory.class.getName());
+        assertThat(apiMarker).isSameAs(binderMarker);
+        assertThat(StaticMarkerBinder.SINGLETON).isSameAs(binder);
+    }
+}

--- a/tests/src/org.slf4j/slf4j-nop/1.5.6/user-code-filter.json
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.slf4j.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2573

This PR provides test fixes and new metadata for org.slf4j:slf4j-nop:1.5.6, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 25013
- Cached input tokens: 102400
- Output tokens: 1689
- Entries found: 3
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 100.0

### Metadata Forge

- Forge branch: `master`
- Forge commit hash: `d330f21b7cbc08396a2dfffc024dc88810ece0df`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-nop:1.5.3: 3/3 covered calls (100.00%)
- org.slf4j:slf4j-nop:1.5.6: 3/3 covered calls (100.00%)

**Reflection:**
- org.slf4j:slf4j-nop:1.5.3: 3/3 covered calls (100.00%)
- org.slf4j:slf4j-nop:1.5.6: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-nop:1.5.3: 76/78 (97.44%)
- org.slf4j:slf4j-nop:1.5.6: 80/82 (97.56%)

**Line:**
- org.slf4j:slf4j-nop:1.5.3: 19/19 (100.00%)
- org.slf4j:slf4j-nop:1.5.6: 21/21 (100.00%)

**Method:**
- org.slf4j:slf4j-nop:1.5.3: 13/13 (100.00%)
- org.slf4j:slf4j-nop:1.5.6: 14/14 (100.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.slf4j/slf4j-nop/1.5.3/gradle.properties b/tests/src/org.slf4j/slf4j-nop/1.5.6/gradle.properties
index 946f3663d..45ca958e4 100644
--- a/tests/src/org.slf4j/slf4j-nop/1.5.3/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = org.slf4j:slf4j-nop:1.5.3
-library.version = 1.5.3
-metadata.dir = org.slf4j/slf4j-nop/1.5.3/
+library.coordinates = org.slf4j:slf4j-nop:1.5.6
+library.version = 1.5.6
+metadata.dir = org.slf4j/slf4j-nop/1.5.6/
diff --git a/tests/src/org.slf4j/slf4j-nop/1.5.3/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
index 3226356e5..20442326d 100644
--- a/tests/src/org.slf4j/slf4j-nop/1.5.3/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-nop/1.5.6/src/test/java/org_slf4j/slf4j_nop/StaticLoggerBinderTest.java
@@ -18,7 +18,7 @@ public class StaticLoggerBinderTest {
 
     @Test
     void staticLoggerBinderProvidesTheNopLoggerFactoryUsedBySlf4j() {
-        StaticLoggerBinder binder = StaticLoggerBinder.SINGLETON;
+        StaticLoggerBinder binder = StaticLoggerBinder.getSingleton();
         ILoggerFactory binderFactory = binder.getLoggerFactory();
         ILoggerFactory apiFactory = LoggerFactory.getILoggerFactory();
         Logger firstLogger = binderFactory.getLogger("first");
@@ -27,6 +27,6 @@ public class StaticLoggerBinderTest {
         assertThat(apiFactory).isSameAs(binderFactory);
         assertThat(binder.getLoggerFactoryClassStr()).isEqualTo(binderFactory.getClass().getName());
         assertThat(firstLogger).isSameAs(secondLogger);
-        assertThat(StaticLoggerBinder.SINGLETON).isSameAs(binder);
+        assertThat(StaticLoggerBinder.getSingleton()).isSameAs(binder);
     }
 }

```
