### PR TITLE
[GenAI] Test fix for io.grpc:grpc-context:1.57.0 using gpt-5.4

### DIFF
--- a/metadata/io.grpc/grpc-context/1.57.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-context/1.57.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.grpc.Context$LazyStorage"
+      },
+      "type": "io.grpc.override.ContextStorageOverride"
+    }
+  ]
+}

--- a/metadata/io.grpc/grpc-context/index.json
+++ b/metadata/io.grpc/grpc-context/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.57.0",
+    "tested-versions" : [
+      "1.57.0"
+    ],
+    "allowed-packages" : [
+      "io.grpc"
+    ]
+  },
+  {
     "metadata-version" : "1.27.2",
     "source-code-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.27.2/grpc-context-1.27.2-sources.jar",
     "repository-url" : "https://github.com/grpc/grpc-java",

--- a/metadata/io.grpc/grpc-context/index.json
+++ b/metadata/io.grpc/grpc-context/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.57.0",
+    "source-code-url" : "https://github.com/grpc/grpc-java/tree/v1.57.0/api/src/context/java",
+    "repository-url" : "https://github.com/grpc/grpc-java",
+    "test-code-url" : "https://github.com/grpc/grpc-java/tree/v1.57.0/api/src/test/java/io/grpc",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.57.0/grpc-api-1.57.0-javadoc.jar",
+    "description" : "grpc-context provides gRPC Java's context propagation API for carrying scoped values, deadlines, and cancellation state across API boundaries and threads. It lets applications bind request-scoped state to the current execution and propagate that state through asynchronous work.",
     "tested-versions" : [
       "1.57.0"
     ],

--- a/stats/io.grpc/grpc-context/1.57.0/stats.json
+++ b/stats/io.grpc/grpc-context/1.57.0/stats.json
@@ -1,0 +1,16 @@
+{
+  "versions" : [ {
+    "version" : "1.57.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : "N/A",
+      "line" : "N/A",
+      "method" : "N/A"
+    }
+  } ]
+}

--- a/tests/src/io.grpc/grpc-context/1.57.0/.gitignore
+++ b/tests/src/io.grpc/grpc-context/1.57.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
+++ b/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.grpc:grpc-context:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
+++ b/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "io.grpc:grpc-context:$libraryVersion"
+    testImplementation "io.grpc:grpc-api:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/io.grpc/grpc-context/1.57.0/gradle.properties
+++ b/tests/src/io.grpc/grpc-context/1.57.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.grpc:grpc-context:1.57.0
+library.version = 1.57.0
+metadata.dir = io.grpc/grpc-context/1.57.0/

--- a/tests/src/io.grpc/grpc-context/1.57.0/settings.gradle
+++ b/tests/src/io.grpc/grpc-context/1.57.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.grpc.grpc-context_tests'

--- a/tests/src/io.grpc/grpc-context/1.57.0/src/test/java/io_grpc/grpc_context/Grpc_contextTest.java
+++ b/tests/src/io.grpc/grpc-context/1.57.0/src/test/java/io_grpc/grpc_context/Grpc_contextTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Context;
+import io.grpc.Deadline;
+
+class Grpc_contextTest {
+
+    @Test
+    void valuesAreAvailableInAttachedContextsAndForkKeepsValuesWithoutCancellation() {
+        Context.Key<String> tenantKey = Context.keyWithDefault("tenant", "default-tenant");
+        Context.Key<String> requestKey = Context.key("request-id");
+        Context.Key<String> userKey = Context.key("user");
+        Context.Key<String> traceKey = Context.key("trace");
+
+        Context baseContext = Context.ROOT.withValues(requestKey, "req-1", userKey, "alice", traceKey, "trace-1")
+                .withValue(tenantKey, "team-a");
+
+        assertThat(tenantKey.get(Context.ROOT)).isEqualTo("default-tenant");
+        assertThat(requestKey.get(Context.ROOT)).isNull();
+        assertThat(requestKey.get(baseContext)).isEqualTo("req-1");
+        assertThat(userKey.get(baseContext)).isEqualTo("alice");
+        assertThat(traceKey.get(baseContext)).isEqualTo("trace-1");
+        assertThat(tenantKey.toString()).isEqualTo("tenant");
+
+        Context previous = baseContext.attach();
+        try {
+            assertThat(Context.current()).isSameAs(baseContext);
+            assertThat(requestKey.get()).isEqualTo("req-1");
+            assertThat(userKey.get()).isEqualTo("alice");
+            assertThat(tenantKey.get()).isEqualTo("team-a");
+
+            Context nested = Context.current().withValue(userKey, "bob");
+            Context nestedPrevious = nested.attach();
+            try {
+                assertThat(Context.current()).isSameAs(nested);
+                assertThat(userKey.get()).isEqualTo("bob");
+                assertThat(requestKey.get()).isEqualTo("req-1");
+            } finally {
+                nested.detach(nestedPrevious);
+            }
+
+            assertThat(Context.current()).isSameAs(baseContext);
+            assertThat(userKey.get()).isEqualTo("alice");
+        } finally {
+            baseContext.detach(previous);
+        }
+
+        assertThat(Context.current()).isSameAs(Context.ROOT);
+        assertThat(tenantKey.get()).isEqualTo("default-tenant");
+
+        Context.CancellableContext cancellable = baseContext.withCancellation();
+        Context forked = cancellable.fork();
+        RuntimeException cause = new RuntimeException("cancelled");
+
+        assertThat(requestKey.get(forked)).isEqualTo("req-1");
+        assertThat(cancellable.cancel(cause)).isTrue();
+        assertThat(cancellable.isCancelled()).isTrue();
+        assertThat(forked.isCancelled()).isFalse();
+        assertThat(forked.cancellationCause()).isNull();
+    }
+
+    @Test
+    void runCallWrapAndExecutorsPropagateContextWithoutLeakingToWorkerThreads() throws Exception {
+        Context.Key<String> roleKey = Context.key("role");
+        Context context = Context.ROOT.withValue(roleKey, "admin");
+
+        AtomicReference<String> valueSeenByRun = new AtomicReference<>();
+        AtomicReference<Context> currentSeenByRun = new AtomicReference<>();
+        context.run(() -> {
+            valueSeenByRun.set(roleKey.get());
+            currentSeenByRun.set(Context.current());
+        });
+
+        assertThat(valueSeenByRun.get()).isEqualTo("admin");
+        assertThat(currentSeenByRun.get()).isSameAs(context);
+        assertThat(Context.current()).isSameAs(Context.ROOT);
+        String callResult = context.call(() -> roleKey.get());
+        assertThat(callResult).isEqualTo("admin");
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            assertThat(executor.submit(context.wrap(() -> roleKey.get())).get(5, TimeUnit.SECONDS)).isEqualTo("admin");
+
+            AtomicReference<String> wrappedRunnableValue = new AtomicReference<>();
+            AtomicReference<Context> wrappedRunnableCurrent = new AtomicReference<>();
+            executor.submit(context.wrap(() -> {
+                wrappedRunnableValue.set(roleKey.get());
+                wrappedRunnableCurrent.set(Context.current());
+            })).get(5, TimeUnit.SECONDS);
+
+            assertThat(wrappedRunnableValue.get()).isEqualTo("admin");
+            assertThat(wrappedRunnableCurrent.get()).isSameAs(context);
+
+            CountDownLatch fixedExecutorLatch = new CountDownLatch(1);
+            AtomicReference<String> fixedExecutorValue = new AtomicReference<>();
+            AtomicReference<Context> fixedExecutorCurrent = new AtomicReference<>();
+            context.fixedContextExecutor(executor).execute(() -> {
+                fixedExecutorValue.set(roleKey.get());
+                fixedExecutorCurrent.set(Context.current());
+                fixedExecutorLatch.countDown();
+            });
+
+            assertThat(fixedExecutorLatch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(fixedExecutorValue.get()).isEqualTo("admin");
+            assertThat(fixedExecutorCurrent.get()).isSameAs(context);
+
+            CountDownLatch currentExecutorLatch = new CountDownLatch(1);
+            AtomicReference<String> currentExecutorValue = new AtomicReference<>();
+            Context invokingContext = Context.ROOT.withValue(roleKey, "captured-at-execute");
+            Context previous = invokingContext.attach();
+            try {
+                Context.currentContextExecutor(executor).execute(() -> {
+                    currentExecutorValue.set(roleKey.get());
+                    currentExecutorLatch.countDown();
+                });
+            } finally {
+                invokingContext.detach(previous);
+            }
+
+            assertThat(currentExecutorLatch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(currentExecutorValue.get()).isEqualTo("captured-at-execute");
+            assertThat(executor.submit(() -> roleKey.get()).get(5, TimeUnit.SECONDS)).isNull();
+            assertThat(executor.submit(Context::current).get(5, TimeUnit.SECONDS)).isSameAs(Context.ROOT);
+        } finally {
+            shutdown(executor);
+        }
+    }
+
+    @Test
+    void cancellationListenersSeeParentCancellationAndDetachAndCancelRestoresPreviousContext() throws Exception {
+        Context.CancellableContext parent = Context.ROOT.withCancellation();
+        Context child = parent.withValue(Context.key("request"), "req-7");
+
+        CountDownLatch listenerLatch = new CountDownLatch(1);
+        AtomicReference<Context> notifiedContext = new AtomicReference<>();
+        AtomicInteger removedListenerCalls = new AtomicInteger();
+
+        child.addListener(context -> {
+            notifiedContext.set(context);
+            listenerLatch.countDown();
+        }, Runnable::run);
+        Context.CancellationListener removedListener = context -> removedListenerCalls.incrementAndGet();
+        child.addListener(removedListener, Runnable::run);
+        child.removeListener(removedListener);
+
+        IllegalStateException cause = new IllegalStateException("boom");
+
+        assertThat(parent.cancel(cause)).isTrue();
+        assertThat(parent.cancel(new RuntimeException("ignored"))).isFalse();
+        assertThat(listenerLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(child.isCancelled()).isTrue();
+        assertThat(child.cancellationCause()).isSameAs(cause);
+        assertThat(notifiedContext.get()).isSameAs(child);
+        assertThat(removedListenerCalls.get()).isZero();
+
+        Context.CancellableContext attached = Context.ROOT.withCancellation();
+        Context previous = attached.attach();
+        IllegalArgumentException detachedCause = new IllegalArgumentException("done");
+        attached.detachAndCancel(previous, detachedCause);
+
+        assertThat(Context.current()).isSameAs(Context.ROOT);
+        assertThat(attached.isCancelled()).isTrue();
+        assertThat(attached.cancellationCause()).isSameAs(detachedCause);
+    }
+
+    @Test
+    void deadlinesSupportOrderingAndAutomaticallyCancelContexts() throws Exception {
+        MutableTicker ticker = new MutableTicker();
+        Deadline base = Deadline.after(5, TimeUnit.SECONDS, ticker);
+        Deadline later = base.offset(2, TimeUnit.SECONDS);
+        Deadline earlier = later.offset(-3, TimeUnit.SECONDS);
+
+        assertThat(base.timeRemaining(TimeUnit.SECONDS)).isEqualTo(5);
+        assertThat(base.isBefore(later)).isTrue();
+        assertThat(later.minimum(base)).isSameAs(base);
+        assertThat(earlier.compareTo(base)).isLessThan(0);
+        assertThat(base.offset(0, TimeUnit.SECONDS)).isSameAs(base);
+        assertThat(base.toString()).contains("from now").contains("ticker=");
+
+        ticker.advance(6, TimeUnit.SECONDS);
+        assertThat(base.isExpired()).isTrue();
+        assertThat(base.timeRemaining(TimeUnit.SECONDS)).isNegative();
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            CountDownLatch deadlineLatch = new CountDownLatch(1);
+            Deadline expiringDeadline = Deadline.after(50, TimeUnit.MILLISECONDS);
+            expiringDeadline.runOnExpiration(deadlineLatch::countDown, scheduler);
+            assertThat(deadlineLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+            Context.CancellableContext parent = Context.ROOT.withDeadlineAfter(50, TimeUnit.MILLISECONDS, scheduler);
+            Context.CancellableContext child = parent.withDeadlineAfter(500, TimeUnit.MILLISECONDS, scheduler);
+            CountDownLatch childCancelledLatch = new CountDownLatch(1);
+            child.addListener(context -> childCancelledLatch.countDown(), Runnable::run);
+
+            assertThat(child.getDeadline()).isEqualTo(parent.getDeadline());
+            assertThat(childCancelledLatch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(parent.isCancelled()).isTrue();
+            assertThat(child.isCancelled()).isTrue();
+            assertThat(child.cancellationCause()).isInstanceOf(TimeoutException.class).hasMessage("context timed out");
+        } finally {
+            shutdown(scheduler);
+        }
+    }
+
+    @Test
+    void shorterChildDeadlineCancelsOnlyChildAndKeepsParentActive() throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        Context.CancellableContext parent = null;
+        try {
+            parent = Context.ROOT.withDeadlineAfter(500, TimeUnit.MILLISECONDS, scheduler);
+            Context.CancellableContext child = parent.withDeadlineAfter(50, TimeUnit.MILLISECONDS, scheduler);
+            CountDownLatch childCancelledLatch = new CountDownLatch(1);
+            AtomicReference<Context> notifiedContext = new AtomicReference<>();
+
+            child.addListener(context -> {
+                notifiedContext.set(context);
+                childCancelledLatch.countDown();
+            }, Runnable::run);
+
+            assertThat(child.getDeadline().isBefore(parent.getDeadline())).isTrue();
+            assertThat(childCancelledLatch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(notifiedContext.get()).isSameAs(child);
+            assertThat(child.isCancelled()).isTrue();
+            assertThat(child.cancellationCause()).isInstanceOf(TimeoutException.class).hasMessage("context timed out");
+            assertThat(parent.isCancelled()).isFalse();
+            assertThat(parent.cancellationCause()).isNull();
+        } finally {
+            if (parent != null) {
+                parent.cancel(null);
+            }
+            shutdown(scheduler);
+        }
+    }
+
+    @Test
+    void expiredDeadlinesCancelContextsImmediatelyAndNotifyLateListeners() throws Exception {
+        MutableTicker ticker = new MutableTicker();
+        Deadline expiredDeadline = Deadline.after(5, TimeUnit.SECONDS, ticker);
+        ticker.advance(6, TimeUnit.SECONDS);
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            Context.CancellableContext expiredContext = Context.ROOT.withDeadline(expiredDeadline, scheduler);
+            CountDownLatch lateListenerLatch = new CountDownLatch(1);
+            AtomicReference<Context> notifiedContext = new AtomicReference<>();
+
+            expiredContext.addListener(context -> {
+                notifiedContext.set(context);
+                lateListenerLatch.countDown();
+            }, Runnable::run);
+
+            assertThat(expiredContext.getDeadline()).isSameAs(expiredDeadline);
+            assertThat(expiredContext.isCancelled()).isTrue();
+            assertThat(expiredContext.cancellationCause()).isInstanceOf(TimeoutException.class).hasMessage("context timed out");
+            assertThat(lateListenerLatch.getCount()).isZero();
+            assertThat(notifiedContext.get()).isSameAs(expiredContext);
+        } finally {
+            shutdown(scheduler);
+        }
+    }
+
+    private static void shutdown(ExecutorService executor) throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private static final class MutableTicker extends Deadline.Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long nanoTime() {
+            return nanos.get();
+        }
+
+        void advance(long time, TimeUnit unit) {
+            nanos.addAndGet(unit.toNanos(time));
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-context/1.57.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-context/1.57.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.grpc.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #1737

This PR provides test fixes and new metadata for io.grpc:grpc-context:1.57.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.4
- Agent: pi
- Model: gpt-5.4
- Input tokens: 81409
- Cached input tokens: 743808
- Output tokens: 2630
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 76.41

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `a94ae3901e5382e6bcf5a24a1affc5e1a4ef86ae`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.grpc:grpc-context:1.27.2: 0/0 covered calls (100.00%)
- io.grpc:grpc-context:1.57.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.grpc:grpc-context:1.27.2: 1466/2074 (70.68%)
- io.grpc:grpc-context:1.57.0: N/A

**Line:**
- io.grpc:grpc-context:1.27.2: 353/462 (76.41%)
- io.grpc:grpc-context:1.57.0: N/A

**Method:**
- io.grpc:grpc-context:1.27.2: 108/130 (83.08%)
- io.grpc:grpc-context:1.57.0: N/A

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.grpc/grpc-context/1.27.2/build.gradle 2/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
index ade4036733..9cfd4c4ea1 100644
--- 1/tests/src/io.grpc/grpc-context/1.27.2/build.gradle
+++ 2/tests/src/io.grpc/grpc-context/1.57.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "io.grpc:grpc-context:$libraryVersion"
+    testImplementation "io.grpc:grpc-api:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/io.grpc/grpc-context/1.27.2/gradle.properties 2/tests/src/io.grpc/grpc-context/1.57.0/gradle.properties
index a5d540ccaf..94ab869e60 100644
--- 1/tests/src/io.grpc/grpc-context/1.27.2/gradle.properties
+++ 2/tests/src/io.grpc/grpc-context/1.57.0/gradle.properties
@@ -1,6 +1,6 @@
 # Optional explicit tested library coordinates (format: group:artifact:version).
 # If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
 # environment variable GVM_TCK_LC and then this property.
-library.coordinates = io.grpc:grpc-context:1.27.2
-library.version = 1.27.2
-metadata.dir = io.grpc/grpc-context/1.27.2/
+library.coordinates = io.grpc:grpc-context:1.57.0
+library.version = 1.57.0
+metadata.dir = io.grpc/grpc-context/1.57.0/

```
