### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java:19.7 using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
@@ -1,0 +1,83 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.com.google.common.collect.Platform"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "19.7",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.7/graphql-java-19.7-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v19.7/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.7/graphql-java-19.7-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of the GraphQL specification. It provides APIs for building schemas, executing GraphQL queries, and integrating GraphQL behavior into JVM applications.",
     "tested-versions" : [
       "19.7"
     ],

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -1,21 +1,30 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "graphql"
+    "latest" : true,
+    "metadata-version" : "19.7",
+    "tested-versions" : [
+      "19.7"
     ],
-    "metadata-version": "19.2",
-    "source-code-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-sources.jar",
-    "repository-url": "https://github.com/graphql-java/graphql-java",
-    "test-code-url": "https://github.com/graphql-java/graphql-java/tree/v19.2/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-javadoc.jar",
-    "description": "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "graphql"
+    ]
+  },
+  {
+    "metadata-version" : "19.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v19.2/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
+    "tested-versions" : [
       "19.2",
       "19.3",
       "19.4",
       "19.5",
       "19.6"
+    ],
+    "allowed-packages" : [
+      "graphql"
     ]
   }
 ]

--- a/stats/com.graphql-java/graphql-java/19.7/stats.json
+++ b/stats/com.graphql-java/graphql-java/19.7/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "19.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 11,
+          "totalCalls" : 11
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 12,
+      "totalCalls" : 12
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 42429,
+        "missed" : 107068,
+        "ratio" : 0.283812,
+        "total" : 149497
+      },
+      "line" : {
+        "covered" : 10223,
+        "missed" : 22881,
+        "ratio" : 0.308815,
+        "total" : 33104
+      },
+      "method" : {
+        "covered" : 2957,
+        "missed" : 6765,
+        "ratio" : 0.304156,
+        "total" : 9722
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -6,12 +6,25 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
+    id "com.gradleup.shadow" version "9.2.2"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations {
+    relocatedGuava
+}
+
+tasks.register("relocatedGuavaJar", com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveClassifier = "relocated-guava"
+    configurations = [project.configurations.relocatedGuava]
+    relocate "com.google.common", "graphql.com.google.common"
+}
+
 dependencies {
     testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testImplementation files(tasks.named("relocatedGuavaJar"))
+    relocatedGuava "com.google.guava:guava:31.0.1-jre"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -28,3 +28,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.7
+metadata.dir = com.graphql-java/graphql-java/19.7/

--- a/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-tests'

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.Scalars;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcherHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GraphqlJavaPropertyFetchingImplTest {
+
+  @BeforeEach
+  void clearCacheBeforeTest() {
+    PropertyDataFetcherHelper.clearReflectionCache();
+  }
+
+  @AfterEach
+  void clearCacheAfterTest() {
+    PropertyDataFetcherHelper.clearReflectionCache();
+    PropertyDataFetcherHelper.setUseSetAccessible(true);
+    PropertyDataFetcherHelper.setUseNegativeCache(true);
+  }
+
+  @Test
+  void fetchesPublicGetterAcceptingDataFetchingEnvironment() {
+    DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .fieldType(Scalars.GraphQLString)
+            .build();
+    EnvironmentAwareProperty source = new EnvironmentAwareProperty();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("message", source, Scalars.GraphQLString, environment);
+
+    assertThat(value).isEqualTo("message:true");
+  }
+
+  @Test
+  void fetchesPrivateGetterUsingSetAccessible() {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("secret", source, Scalars.GraphQLString);
+
+    assertThat(value).isEqualTo("private-getter");
+  }
+
+  @Test
+  void fetchesPublicFieldAndCachedPublicField() {
+    PublicFieldSource source = new PublicFieldSource();
+
+    Object firstValue = PropertyDataFetcherHelper.getPropertyValue("publicName", source, Scalars.GraphQLString);
+    source.publicName = "cached-public-field";
+    Object cachedValue = PropertyDataFetcherHelper.getPropertyValue("publicName", source, Scalars.GraphQLString);
+
+    assertThat(firstValue).isEqualTo("public-field");
+    assertThat(cachedValue).isEqualTo("cached-public-field");
+  }
+
+  @Test
+  void fetchesPrivateFieldUsingSetAccessible() {
+    PrivateFieldSource source = new PrivateFieldSource();
+
+    Object firstValue = PropertyDataFetcherHelper.getPropertyValue("hiddenName", source, Scalars.GraphQLString);
+    source.hiddenName = "cached-private-field";
+    Object cachedValue = PropertyDataFetcherHelper.getPropertyValue("hiddenName", source, Scalars.GraphQLString);
+
+    assertThat(firstValue).isEqualTo("private-field");
+    assertThat(cachedValue).isEqualTo("cached-private-field");
+  }
+
+  @Test
+  void fetchesPublicGetterFromNonPublicClassAfterPublicSearchFallback() {
+    NonPublicGetterSource source = new NonPublicGetterSource();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("fallback", source, Scalars.GraphQLString);
+
+    assertThat(value).isEqualTo("fallback");
+  }
+
+  public static final class EnvironmentAwareProperty {
+
+    public String getMessage(DataFetchingEnvironment environment) {
+      return "message:" + (environment.getFieldType() == Scalars.GraphQLString);
+    }
+  }
+
+  private static final class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private-getter";
+    }
+  }
+
+  public static final class PublicFieldSource {
+
+    public String publicName = "public-field";
+  }
+
+  private static final class PrivateFieldSource {
+
+    private String hiddenName = "private-field";
+  }
+
+  private static final class NonPublicGetterSource {
+
+    public String getFallback() {
+      return "fallback";
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
@@ -6,10 +6,13 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.lang.reflect.Method;
+
 import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.PropertyDataFetcherHelper;
+import graphql.schema.PropertyFetchingImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +87,29 @@ public class GraphqlJavaPropertyFetchingImplTest {
     assertThat(value).isEqualTo("fallback");
   }
 
+  @Test
+  void findsGetterDeclaredOnNonPublicInterfaceRoot() throws Exception {
+    PropertyFetchingImpl propertyFetching = new PropertyFetchingImpl(DataFetchingEnvironment.class);
+    Class<?> cacheKeyClass = Class.forName("graphql.schema.PropertyFetchingImpl$CacheKey");
+    Method findMethod = PropertyFetchingImpl.class.getDeclaredMethod(
+            "findPubliclyAccessibleMethod",
+            cacheKeyClass,
+            Class.class,
+            String.class,
+            boolean.class);
+    findMethod.setAccessible(true);
+
+    Method getter = (Method) findMethod.invoke(
+            propertyFetching,
+            null,
+            InterfaceOnlyProperty.class,
+            "getInterfaceOnly",
+            false);
+
+    assertThat(getter.getName()).isEqualTo("getInterfaceOnly");
+    assertThat(getter.getDeclaringClass()).isEqualTo(InterfaceOnlyProperty.class);
+  }
+
   public static final class EnvironmentAwareProperty {
 
     public String getMessage(DataFetchingEnvironment environment) {
@@ -113,5 +139,10 @@ public class GraphqlJavaPropertyFetchingImplTest {
     public String getFallback() {
       return "fallback";
     }
+  }
+
+  private interface InterfaceOnlyProperty {
+
+    String getInterfaceOnly();
   }
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import graphql.introspection.IntrospectionQuery;
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.starwars.Droid;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlTests {
+
+
+  @Test
+  void greetingQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("greeting", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("greeting", new StaticDataFetcher("Hello GraphQL"))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ greeting }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{greeting=Hello GraphQL}");
+  }
+
+  @Test
+  void introspectionQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder -> {
+      runtimeWiringBuilder.type("Query", builder -> builder.typeName("Character").typeResolver(characterTypeResolver()));
+    });
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).contains("{__schema={queryType={name=QueryType}");
+  }
+
+  @Test
+  void paginatedQuery() throws Exception {
+    PageInfo pageInfo = new DefaultPageInfo(new DefaultConnectionCursor("start"),
+            new DefaultConnectionCursor("end"), true, true);
+    Edge<Human> edge = new DefaultEdge<>(new Human(), new DefaultConnectionCursor("current"));
+    Connection<Human> connection = new DefaultConnection<>(List.of(edge), pageInfo);
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder ->
+            runtimeWiringBuilder.type("QueryType", builder ->
+                    builder.dataFetcher("humans", new StaticDataFetcher(connection)))
+                    .type("Character", typeBuilder -> typeBuilder.typeResolver(characterTypeResolver())));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ humans { edges { node { id name } } pageInfo { startCursor } } }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{humans={edges=[{node={id=42, name=GraalVM}}], pageInfo={startCursor=start}}}");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+  private TypeResolver characterTypeResolver() {
+    return env -> {
+      Object javaObject = env.getObject();
+      if (javaObject instanceof Droid) {
+        return env.getSchema().getObjectType("Droid");
+      } else if (javaObject instanceof Human) {
+        return env.getSchema().getObjectType("Human");
+      } else {
+        throw new IllegalStateException("Unknown Character type");
+      }
+    };
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Droid implements Character {
+
+  @Override
+  public Long getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getPrimaryFunction() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+/**
+ * @author Brian Clozel
+ */
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Human implements Character {
+
+  @Override
+  public Long getId() {
+    return 42L;
+  }
+
+  @Override
+  public String getName() {
+    return "GraalVM";
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getHomePlanet() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -2,5 +2,25 @@
   {
     "name": "graphql.starwars.Human",
     "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$EnvironmentAwareProperty",
+    "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource",
+    "allPublicFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateFieldSource",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource",
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,5 +1,33 @@
 [
   {
+    "name": "graphql.schema.GraphQLAppliedDirectiveArgument",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLArgument",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultConnection",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultEdge",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultPageInfo",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLFieldDefinition",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLInputObjectField",
+    "allPublicMethods": true
+  },
+  {
     "name": "graphql.starwars.Human",
     "allPublicMethods": true
   },

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -50,5 +50,13 @@
   {
     "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource",
     "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$InterfaceOnlyProperty",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.PropertyFetchingImpl",
+    "allDeclaredMethods": true
   }
 ]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "graphql.starwars.Human",
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
@@ -1,0 +1,19 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/greeting.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      },
+      {
+        "pattern": "\\Qgraphql/starwars.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
@@ -1,5 +1,15 @@
 {
-  "bundles": [],
+  "bundles": [
+    {
+      "name": "i18n.Execution"
+    },
+    {
+      "name": "i18n.General"
+    },
+    {
+      "name": "i18n.Validation"
+    }
+  ],
   "resources": {
     "includes": [
       {

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,82 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource",
+      "methods" : [
+        {
+          "name" : "getFallback",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateFieldSource",
+      "fields" : [
+        {
+          "name" : "hiddenName"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource",
+      "methods" : [
+        {
+          "name" : "getSecret",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource",
+      "fields" : [
+        {
+          "name" : "publicName"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    greeting: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
@@ -1,0 +1,63 @@
+schema {
+    query: QueryType
+    mutation: Mutation
+}
+
+type Mutation {
+    addFriend(characterId: ID!, newFriend: NewCharacter!) : Character!
+}
+
+type QueryType {
+    hero(episode: Episode): Character!
+    human(id : String) : Human
+    droid(id: ID!): Droid
+    humans: HumanConnection
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]
+    homePlanet: String
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+}
+
+interface Character {
+    id: ID!
+    name: String!
+}
+
+input NewCharacter {
+    name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #737

This PR provides test fixes and new metadata for com.graphql-java:graphql-java:19.7, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 216063
- Cached input tokens: 3424768
- Output tokens: 27193
- Entries found: 13
- Iterations: 4
- Library coverage percentage: 30.88
- Previous library version metadata entries: 24
- Previous library version coverage percentage: 22.18

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `a94ae3901e5382e6bcf5a24a1affc5e1a4ef86ae`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java:19.2: 4/66 covered calls (6.06%)
- com.graphql-java:graphql-java:19.7: 12/12 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java:19.2: 3/65 covered calls (4.62%)
- com.graphql-java:graphql-java:19.7: 11/11 covered calls (100.00%)

**Resources:**
- com.graphql-java:graphql-java:19.2: 1/1 covered calls (100.00%)
- com.graphql-java:graphql-java:19.7: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java:19.2: 44403/220088 (20.18%)
- com.graphql-java:graphql-java:19.7: 42429/149497 (28.38%)

**Line:**
- com.graphql-java:graphql-java:19.2: 10623/47902 (22.18%)
- com.graphql-java:graphql-java:19.7: 10223/33104 (30.88%)

**Method:**
- com.graphql-java:graphql-java:19.2: 3126/15518 (20.14%)
- com.graphql-java:graphql-java:19.7: 2957/9722 (30.42%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
index 2b200a3cb1..02f94e88ca 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -6,12 +6,36 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
+    id "com.gradleup.shadow" version "9.2.2"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations {
+    relocatedGuava
+}
+
+tasks.register("relocatedGuavaJar", com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveClassifier = "relocated-guava"
+    configurations = [project.configurations.relocatedGuava]
+    relocate "com.google.common", "graphql.com.google.common"
+}
+
 dependencies {
     testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testImplementation files(tasks.named("relocatedGuavaJar"))
+    relocatedGuava "com.google.guava:guava:31.0.1-jre"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/gradle.properties 2/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
index 535b5eed75..6697bfa241 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/gradle.properties
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
@@ -1,2 +1,2 @@
-library.version = 19.2
-metadata.dir = com.graphql-java/graphql-java/19.2/
+library.version = 19.7
+metadata.dir = com.graphql-java/graphql-java/19.7/
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
new file mode 100644
index 0000000000..b47ed82b62
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphqlJavaPropertyFetchingImplTest.java
@@ -0,0 +1,148 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.lang.reflect.Method;
+
+import graphql.Scalars;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcherHelper;
+import graphql.schema.PropertyFetchingImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GraphqlJavaPropertyFetchingImplTest {
+
+  @BeforeEach
+  void clearCacheBeforeTest() {
+    PropertyDataFetcherHelper.clearReflectionCache();
+  }
+
+  @AfterEach
+  void clearCacheAfterTest() {
+    PropertyDataFetcherHelper.clearReflectionCache();
+    PropertyDataFetcherHelper.setUseSetAccessible(true);
+    PropertyDataFetcherHelper.setUseNegativeCache(true);
+  }
+
+  @Test
+  void fetchesPublicGetterAcceptingDataFetchingEnvironment() {
+    DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .fieldType(Scalars.GraphQLString)
+            .build();
+    EnvironmentAwareProperty source = new EnvironmentAwareProperty();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("message", source, Scalars.GraphQLString, environment);
+
+    assertThat(value).isEqualTo("message:true");
+  }
+
+  @Test
+  void fetchesPrivateGetterUsingSetAccessible() {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("secret", source, Scalars.GraphQLString);
+
+    assertThat(value).isEqualTo("private-getter");
+  }
+
+  @Test
+  void fetchesPublicFieldAndCachedPublicField() {
+    PublicFieldSource source = new PublicFieldSource();
+
+    Object firstValue = PropertyDataFetcherHelper.getPropertyValue("publicName", source, Scalars.GraphQLString);
+    source.publicName = "cached-public-field";
+    Object cachedValue = PropertyDataFetcherHelper.getPropertyValue("publicName", source, Scalars.GraphQLString);
+
+    assertThat(firstValue).isEqualTo("public-field");
+    assertThat(cachedValue).isEqualTo("cached-public-field");
+  }
+
+  @Test
+  void fetchesPrivateFieldUsingSetAccessible() {
+    PrivateFieldSource source = new PrivateFieldSource();
+
+    Object firstValue = PropertyDataFetcherHelper.getPropertyValue("hiddenName", source, Scalars.GraphQLString);
+    source.hiddenName = "cached-private-field";
+    Object cachedValue = PropertyDataFetcherHelper.getPropertyValue("hiddenName", source, Scalars.GraphQLString);
+
+    assertThat(firstValue).isEqualTo("private-field");
+    assertThat(cachedValue).isEqualTo("cached-private-field");
+  }
+
+  @Test
+  void fetchesPublicGetterFromNonPublicClassAfterPublicSearchFallback() {
+    NonPublicGetterSource source = new NonPublicGetterSource();
+
+    Object value = PropertyDataFetcherHelper.getPropertyValue("fallback", source, Scalars.GraphQLString);
+
+    assertThat(value).isEqualTo("fallback");
+  }
+
+  @Test
+  void findsGetterDeclaredOnNonPublicInterfaceRoot() throws Exception {
+    PropertyFetchingImpl propertyFetching = new PropertyFetchingImpl(DataFetchingEnvironment.class);
+    Class<?> cacheKeyClass = Class.forName("graphql.schema.PropertyFetchingImpl$CacheKey");
+    Method findMethod = PropertyFetchingImpl.class.getDeclaredMethod(
+            "findPubliclyAccessibleMethod",
+            cacheKeyClass,
+            Class.class,
+            String.class,
+            boolean.class);
+    findMethod.setAccessible(true);
+
+    Method getter = (Method) findMethod.invoke(
+            propertyFetching,
+            null,
+            InterfaceOnlyProperty.class,
+            "getInterfaceOnly",
+            false);
+
+    assertThat(getter.getName()).isEqualTo("getInterfaceOnly");
+    assertThat(getter.getDeclaringClass()).isEqualTo(InterfaceOnlyProperty.class);
+  }
+
+  public static final class EnvironmentAwareProperty {
+
+    public String getMessage(DataFetchingEnvironment environment) {
+      return "message:" + (environment.getFieldType() == Scalars.GraphQLString);
+    }
+  }
+
+  private static final class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private-getter";
+    }
+  }
+
+  public static final class PublicFieldSource {
+
+    public String publicName = "public-field";
+  }
+
+  private static final class PrivateFieldSource {
+
+    private String hiddenName = "private-field";
+  }
+
+  private static final class NonPublicGetterSource {
+
+    public String getFallback() {
+      return "fallback";
+    }
+  }
+
+  private interface InterfaceOnlyProperty {
+
+    String getInterfaceOnly();
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
index bda5e60815..ab07c58d21 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,6 +1,62 @@
 [
+  {
+    "name": "graphql.schema.GraphQLAppliedDirectiveArgument",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLArgument",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultConnection",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultEdge",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.relay.DefaultPageInfo",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLFieldDefinition",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.GraphQLInputObjectField",
+    "allPublicMethods": true
+  },
   {
     "name": "graphql.starwars.Human",
     "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$EnvironmentAwareProperty",
+    "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource",
+    "allPublicFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateFieldSource",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource",
+    "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$InterfaceOnlyProperty",
+    "allPublicMethods": true
+  },
+  {
+    "name": "graphql.schema.PropertyFetchingImpl",
+    "allDeclaredMethods": true
   }
 ]
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
index 20d2bf52b5..c1f83186d8 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
@@ -1,5 +1,15 @@
 {
-  "bundles": [],
+  "bundles": [
+    {
+      "name": "i18n.Execution"
+    },
+    {
+      "name": "i18n.General"
+    },
+    {
+      "name": "i18n.Validation"
+    }
+  ],
   "resources": {
     "includes": [
       {
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
new file mode 100644
index 0000000000..5dff892c67
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -0,0 +1,82 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource",
+      "methods" : [
+        {
+          "name" : "getFallback",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$NonPublicGetterSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateFieldSource",
+      "fields" : [
+        {
+          "name" : "hiddenName"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource",
+      "methods" : [
+        {
+          "name" : "getSecret",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PrivateGetterSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyDataFetcherHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.GraphqlJavaPropertyFetchingImplTest$PublicFieldSource",
+      "fields" : [
+        {
+          "name" : "publicName"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    }
+  ]
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
new file mode 100644
index 0000000000..b154f38b11
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}

```
