### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.el.ELSupport"
+      },
+      "type" : "com.sun.el.ExpressionFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "com.sun.el.ExpressionFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getModule",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "java.lang.Module",
+      "methods" : [
+        {
+          "name" : "isNamed",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.LanguageTraversal"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.rules.TargetedValidationRules"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "javax.money.MonetaryAmount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.apache.log4j.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.joda.time.ReadableInstant"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.el.ELSupport"
+      },
+      "glob" : "META-INF/services/javax.el.ExpressionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "META-INF/services/javax.el.ExpressionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_fr.properties"
+    },
+    {
+      "bundle" : "ContributorValidationMessages"
+    },
+    {
+      "bundle" : "ValidationMessages"
+    },
+    {
+      "bundle" : "graphql.validation.ValidationMessages"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    },
+    {
+      "bundle" : "org.hibernate.validator.ValidationMessages"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -1,32 +1,45 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
+    "latest" : true,
+    "metadata-version" : "19.1-hibernate-validator-6.2.0.Final",
+    "tested-versions" : [
+      "19.1-hibernate-validator-6.2.0.Final"
+    ],
+    "allowed-packages" : [
       "graphql"
     ],
-    "metadata-version": "19.1",
-    "source-code-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1/graphql-java-extended-validation-19.1-sources.jar",
-    "repository-url": "https://github.com/graphql-java/graphql-java-extended-validation",
-    "test-code-url": "https://github.com/graphql-java/graphql-java-extended-validation/tree/v19.1/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1/graphql-java-extended-validation-19.1-javadoc.jar",
-    "description": "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
-    "tested-versions": [
-      "19.1"
-    ],
-    "requires": [
+    "requires" : [
       "com.graphql-java:graphql-java",
       "org.hibernate.validator:hibernate-validator"
     ]
   },
   {
-    "allowed-packages": [
+    "metadata-version" : "19.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1/graphql-java-extended-validation-19.1-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java-extended-validation",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java-extended-validation/tree/v19.1/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1/graphql-java-extended-validation-19.1-javadoc.jar",
+    "description" : "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
+    "tested-versions" : [
+      "19.1"
+    ],
+    "allowed-packages" : [
       "graphql"
     ],
-    "metadata-version": "19.2",
-    "tested-versions": [
+    "requires" : [
+      "com.graphql-java:graphql-java",
+      "org.hibernate.validator:hibernate-validator"
+    ]
+  },
+  {
+    "metadata-version" : "19.2",
+    "tested-versions" : [
       "19.2"
     ],
-    "requires": [
+    "allowed-packages" : [
+      "graphql"
+    ],
+    "requires" : [
       "com.graphql-java:graphql-java",
       "org.hibernate.validator:hibernate-validator",
       "org.hibernate.orm:hibernate-core"

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "19.1-hibernate-validator-6.2.0.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/graphql-java-extended-validation-19.1-hibernate-validator-6.2.0.Final-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java-extended-validation",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java-extended-validation/tree/v19.1-validator-6.2.0.Final/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/graphql-java-extended-validation-19.1-hibernate-validator-6.2.0.Final-javadoc.jar",
+    "description" : "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
     "tested-versions" : [
       "19.1-hibernate-validator-6.2.0.Final"
     ],

--- a/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/stats.json
+++ b/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "19.1-hibernate-validator-6.2.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2189,
+        "missed" : 2679,
+        "ratio" : 0.449671,
+        "total" : 4868
+      },
+      "line" : {
+        "covered" : 522,
+        "missed" : 626,
+        "ratio" : 0.454704,
+        "total" : 1148
+      },
+      "method" : {
+        "covered" : 158,
+        "missed" : 159,
+        "ratio" : 0.498423,
+        "total" : 317
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -25,3 +25,14 @@ graalvmNative {
 		}
 	}
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
+    implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
+    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+	binaries {
+		test {
+			buildArgs.add('--no-fallback')
+			buildArgs.add('-H:IncludeLocales=fr')
+		}
+	}
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -13,7 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
     implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
-    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
+    implementation "org.hibernate.validator:hibernate-validator:6.2.0.Final"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.1-hibernate-validator-6.2.0.Final
+metadata.dir = com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-extended-validation-tests'

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/com_graphql_java/graphql_java_extended_validation/ELSupportTest.java
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/com_graphql_java/graphql_java_extended_validation/ELSupportTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java_extended_validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+
+import graphql.validation.el.ELSupport;
+import org.junit.jupiter.api.Test;
+
+public class ELSupportTest {
+    @Test
+    public void loadMethodResolvesPublicMethodsForExpressionSupport() throws Throwable {
+        ELSupport elSupport = new ELSupport(Locale.US);
+
+        Method method = loadMethod(elSupport, "evaluate", String.class, Map.class);
+
+        assertThat(method.getDeclaringClass()).isEqualTo(ELSupport.class);
+        assertThat(method.getName()).isEqualTo("evaluate");
+        assertThat(method.getParameterTypes()).containsExactly(String.class, Map.class);
+    }
+
+    private Method loadMethod(ELSupport elSupport, String name, Class<?>... parameterTypes) throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(ELSupport.class, MethodHandles.lookup());
+        MethodHandle loadMethod = lookup.findVirtual(
+            ELSupport.class,
+            "loadMethod",
+            MethodType.methodType(Method.class, String.class, Class[].class)
+        );
+        return (Method) loadMethod.invoke(elSupport, name, parameterTypes);
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/graphql/GraphQlValidationTests.java
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/graphql/GraphQlValidationTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.schemawiring.ValidationSchemaWiring;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlValidationTests {
+
+
+  @Test
+  void validationErrorQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ hired(application: {name: \"p\"}) }");
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name size must be between 3 and 100");
+  }
+
+  @Test
+  void validationErrorQueryInFrench() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(ExecutionInput.newExecutionInput("{ hired(application: {name: \"p\"}) }").locale(Locale.FRENCH).build());
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name la taille doit etre comprise entre 3 et 100");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlValidationTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+    ValidationRules validationRules = ValidationRules.newValidationRules()
+        .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
+        .build();
+    ValidationSchemaWiring schemaWiring = new ValidationSchemaWiring(validationRules);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+    runtimeWiringBuilder.directiveWiring(schemaWiring);
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/validation.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.locale.LocaleUtil"
+      },
+      "type" : "graphql.schema.DataFetchingEnvironmentImpl",
+      "methods" : [
+        {
+          "name" : "getLocale",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.el.ELSupport"
+      },
+      "type" : "graphql.validation.el.ELSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : {
+        "proxy" : [
+          "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_fr.properties"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation.graphqls
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation.graphqls
@@ -1,0 +1,10 @@
+type Query {
+    hired (application : Application!) : Boolean
+}
+
+directive @Size(min : Int = 0, max : Int = 2147483647, message : String = "graphql.validation.Size.message")
+on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+input Application {
+    name : String @Size(min : 3, max : 100)
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation/ValidationMessages_fr.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation/ValidationMessages_fr.properties
@@ -1,0 +1,1 @@
+graphql.validation.Size.message={path} la taille doit etre comprise entre {min} et {max}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.validation.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #718

This PR provides test fixes and new metadata for com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 86564
- Cached input tokens: 933888
- Output tokens: 9149
- Entries found: 52
- Iterations: 2
- Library coverage percentage: 45.47
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 44.43

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `a94ae3901e5382e6bcf5a24a1affc5e1a4ef86ae`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java-extended-validation:19.1: 2/3 covered calls (66.67%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 3/3 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java-extended-validation:19.1: 2/3 covered calls (66.67%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java-extended-validation:19.1: 2136/4868 (43.88%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 2189/4868 (44.97%)

**Line:**
- com.graphql-java:graphql-java-extended-validation:19.1: 510/1148 (44.43%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 522/1148 (45.47%)

**Method:**
- com.graphql-java:graphql-java-extended-validation:19.1: 152/317 (47.95%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 158/317 (49.84%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
index f45c59c71a..486882cce1 100644
--- 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -13,7 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
     implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
-    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
+    implementation "org.hibernate.validator:hibernate-validator:6.2.0.Final"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
@@ -25,3 +25,14 @@ graalvmNative {
 		}
 	}
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/gradle.properties 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
index caabcfca44..e2cfc70e49 100644
--- 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/gradle.properties
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
@@ -1,2 +1,2 @@
-library.version = 19.1
-metadata.dir = com.graphql-java/graphql-java-extended-validation/19.1/
+library.version = 19.1-hibernate-validator-6.2.0.Final
+metadata.dir = com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/com_graphql_java/graphql_java_extended_validation/ELSupportTest.java 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/com_graphql_java/graphql_java_extended_validation/ELSupportTest.java
new file mode 100644
index 0000000000..ebd815ebc0
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/com_graphql_java/graphql_java_extended_validation/ELSupportTest.java
@@ -0,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java_extended_validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+
+import graphql.validation.el.ELSupport;
+import org.junit.jupiter.api.Test;
+
+public class ELSupportTest {
+    @Test
+    public void loadMethodResolvesPublicMethodsForExpressionSupport() throws Throwable {
+        ELSupport elSupport = new ELSupport(Locale.US);
+
+        Method method = loadMethod(elSupport, "evaluate", String.class, Map.class);
+
+        assertThat(method.getDeclaringClass()).isEqualTo(ELSupport.class);
+        assertThat(method.getName()).isEqualTo("evaluate");
+        assertThat(method.getParameterTypes()).containsExactly(String.class, Map.class);
+    }
+
+    private Method loadMethod(ELSupport elSupport, String name, Class<?>... parameterTypes) throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(ELSupport.class, MethodHandles.lookup());
+        MethodHandle loadMethod = lookup.findVirtual(
+            ELSupport.class,
+            "loadMethod",
+            MethodType.methodType(Method.class, String.class, Class[].class)
+        );
+        return (Method) loadMethod.invoke(elSupport, name, parameterTypes);
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
new file mode 100644
index 0000000000..5b68e1eefe
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -0,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.locale.LocaleUtil"
+      },
+      "type" : "graphql.schema.DataFetchingEnvironmentImpl",
+      "methods" : [
+        {
+          "name" : "getLocale",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.el.ELSupport"
+      },
+      "type" : "graphql.validation.el.ELSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : {
+        "proxy" : [
+          "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_fr.properties"
+    }
+  ]
+}
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
new file mode 100644
index 0000000000..a10f61d6ff
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.validation.**"
+    }
+  ]
+}

```
