### PR TITLE
[GenAI] Test fix for org.apache.tomcat:tomcat-jdbc:10.1.14 using gpt-5.5

### DIFF
--- a/metadata/org.apache.tomcat/tomcat-jdbc/10.1.14/reachability-metadata.json
+++ b/metadata/org.apache.tomcat/tomcat-jdbc/10.1.14/reachability-metadata.json
@@ -51,5 +51,30 @@
         ]
       }
     }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.interceptor.AbstractQueryReport"
+      },
+      "glob": "META-INF/services/org.apache.juli.logging.Log"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.ConnectionPool"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.ConnectionPool"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
   ]
 }

--- a/metadata/org.apache.tomcat/tomcat-jdbc/10.1.14/reachability-metadata.json
+++ b/metadata/org.apache.tomcat/tomcat-jdbc/10.1.14/reachability-metadata.json
@@ -1,0 +1,55 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.CallableStatement"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.ConnectionPool"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.Connection",
+          "javax.sql.PooledConnection"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.PreparedStatement"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.interceptor.StatementDecoratorInterceptor"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.ResultSet"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.Statement"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.apache.tomcat/tomcat-jdbc/index.json
+++ b/metadata/org.apache.tomcat/tomcat-jdbc/index.json
@@ -1,16 +1,22 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "org.apache.tomcat.jdbc"
+    "latest" : true,
+    "metadata-version" : "10.1.14",
+    "tested-versions" : [
+      "10.1.14"
     ],
-    "metadata-version": "10.1.7",
-    "source-code-url": "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-jdbc/10.1.7/tomcat-jdbc-10.1.7-sources.jar",
-    "repository-url": "https://github.com/apache/tomcat",
-    "test-code-url": "https://github.com/apache/tomcat/tree/10.1.7/modules/jdbc-pool/src/test",
-    "documentation-url": "https://github.com/apache/tomcat/tree/10.1.7/webapps/docs",
-    "description": "Tomcat JDBC is Apache Tomcat's JDBC connection pool implementation for creating, managing, and monitoring pooled database connections. It provides a DataSource API with pooling, validation, JMX integration, and interceptors for Java applications running inside or outside Tomcat.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "org.apache.tomcat.jdbc"
+    ]
+  },
+  {
+    "metadata-version" : "10.1.7",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-jdbc/10.1.7/tomcat-jdbc-10.1.7-sources.jar",
+    "repository-url" : "https://github.com/apache/tomcat",
+    "test-code-url" : "https://github.com/apache/tomcat/tree/10.1.7/modules/jdbc-pool/src/test",
+    "documentation-url" : "https://github.com/apache/tomcat/tree/10.1.7/webapps/docs",
+    "description" : "Tomcat JDBC is Apache Tomcat's JDBC connection pool implementation for creating, managing, and monitoring pooled database connections. It provides a DataSource API with pooling, validation, JMX integration, and interceptors for Java applications running inside or outside Tomcat.",
+    "tested-versions" : [
       "10.1.7",
       "10.1.8",
       "10.1.9",
@@ -18,6 +24,9 @@
       "10.1.11",
       "10.1.12",
       "10.1.13"
+    ],
+    "allowed-packages" : [
+      "org.apache.tomcat.jdbc"
     ]
   }
 ]

--- a/stats/org.apache.tomcat/tomcat-jdbc/10.1.14/stats.json
+++ b/stats/org.apache.tomcat/tomcat-jdbc/10.1.14/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "10.1.14",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.452381,
+          "coveredCalls" : 19,
+          "totalCalls" : 42
+        }
+      },
+      "coverageRatio" : 0.452381,
+      "coveredCalls" : 19,
+      "totalCalls" : 42
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3183,
+        "missed" : 11460,
+        "ratio" : 0.217373,
+        "total" : 14643
+      },
+      "line" : {
+        "covered" : 811,
+        "missed" : 2973,
+        "ratio" : 0.214323,
+        "total" : 3784
+      },
+      "method" : {
+        "covered" : 168,
+        "missed" : 721,
+        "ratio" : 0.188976,
+        "total" : 889
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/.gitignore
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/build.gradle
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.tomcat:tomcat-jdbc:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'com.h2database:h2:2.1.214'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/gradle.properties
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 10.1.14
+metadata.dir = org.apache.tomcat/tomcat-jdbc/10.1.14/

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/metadata-extra-filter.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/metadata-extra-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.tomcat.**"}
+  ]
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/metadata-user-code-filter.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.tomcat.**"}
+  ]
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/settings.gradle
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.tomcat.tomcat-jdbc_tests'

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.interceptor.AbstractQueryReport;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractQueryReportTest {
+
+    @Test
+    void wrapsPreparedStatementsWithQueryReportingProxy() throws Exception {
+        TestQueryReport queryReport = new TestQueryReport();
+        queryReport.setThreshold(Long.MAX_VALUE);
+
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:abstract_query_report");
+                PreparedStatement setupStatement = connection.prepareStatement("""
+                        CREATE TABLE query_report_item (
+                            id INT NOT NULL PRIMARY KEY,
+                            name VARCHAR(255)
+                        )
+                        """)) {
+            setupStatement.executeUpdate();
+
+            insertItem(connection);
+
+            String query = "SELECT name FROM query_report_item WHERE id = ?";
+            try (PreparedStatement delegate = connection.prepareStatement(query);
+                    PreparedStatement statement = queryReport.wrapPreparedStatement(delegate, query)) {
+                statement.setInt(1, 1);
+
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getString(1)).isEqualTo("reported-query");
+                    assertThat(resultSet.next()).isFalse();
+                }
+
+                assertThat(statement.isClosed()).isFalse();
+            }
+        }
+
+        assertThat(queryReport.preparedSql).containsExactly("SELECT name FROM query_report_item WHERE id = ?");
+        assertThat(queryReport.executedSql).containsExactly("SELECT name FROM query_report_item WHERE id = ?");
+        assertThat(queryReport.failedSql).isEmpty();
+    }
+
+    private void insertItem(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                INSERT INTO query_report_item(id, name)
+                VALUES (?, ?)
+                """)) {
+            statement.setInt(1, 1);
+            statement.setString(2, "reported-query");
+            statement.executeUpdate();
+        }
+    }
+
+    private static final class TestQueryReport extends AbstractQueryReport {
+        private final List<String> preparedSql = new ArrayList<>();
+        private final List<String> executedSql = new ArrayList<>();
+        private final List<String> failedSql = new ArrayList<>();
+
+        private PreparedStatement wrapPreparedStatement(PreparedStatement statement, String sql)
+                throws NoSuchMethodException {
+            Method method = Connection.class.getMethod("prepareStatement", String.class);
+            Object[] args = { sql };
+            return (PreparedStatement) createStatement(null, method, args, statement, 0);
+        }
+
+        @Override
+        protected void prepareStatement(String sql, long time) {
+            preparedSql.add(sql);
+        }
+
+        @Override
+        protected void prepareCall(String query, long time) {
+            throw new AssertionError("No callable statements are prepared by this test");
+        }
+
+        @Override
+        protected String reportQuery(String query, Object[] args, String name, long start, long delta) {
+            String sql = super.reportQuery(query, args, name, start, delta);
+            executedSql.add(sql);
+            return sql;
+        }
+
+        @Override
+        protected String reportFailedQuery(String query, Object[] args, String name, long start, Throwable throwable) {
+            String sql = super.reportFailedQuery(query, args, name, start, throwable);
+            failedSql.add(sql);
+            return sql;
+        }
+
+        @Override
+        public void closeInvoked() {
+            // This test wraps statements directly, so connection close events are not observed.
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
@@ -77,7 +77,7 @@ public class AbstractQueryReportTest {
         private PreparedStatement wrapPreparedStatement(PreparedStatement statement, String sql)
                 throws NoSuchMethodException {
             Method method = Connection.class.getMethod("prepareStatement", String.class);
-            Object[] args = { sql };
+            Object[] args = {sql};
             return (PreparedStatement) createStatement(null, method, args, statement, 0);
         }
 

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
@@ -6,7 +6,9 @@
  */
 package org_apache_tomcat.tomcat_jdbc;
 
-import org.apache.tomcat.jdbc.pool.DataSource;
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -20,9 +22,12 @@ public class PooledConnectionTest {
 
     @Test
     void opensConnectionWithConfiguredDriverClass() throws SQLException {
-        DataSource dataSource = createDataSource();
+        PoolProperties poolProperties = createPoolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
         try {
-            try (Connection connection = dataSource.getConnection();
+            pooledConnection.connect();
+            try (Connection connection = pooledConnection.getConnection();
                     Statement statement = connection.createStatement()) {
                 statement.executeUpdate("""
                         CREATE TABLE pooled_connection_item (
@@ -38,19 +43,21 @@ public class PooledConnectionTest {
                 assertInsertedItem(statement);
             }
         } finally {
-            dataSource.close(true);
+            pooledConnection.release();
         }
     }
 
-    private DataSource createDataSource() {
-        DataSource dataSource = new DataSource();
-        dataSource.setDriverClassName("org.h2.Driver");
-        dataSource.setUrl("jdbc:h2:mem:pooled_connection");
-        dataSource.setUsername("sa");
-        dataSource.setPassword("");
-        dataSource.setInitialSize(0);
-        dataSource.setMaxActive(1);
-        return dataSource;
+    private PoolProperties createPoolProperties() {
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDriverClassName("org.h2.Driver");
+        poolProperties.setUrl("jdbc:h2:mem:pooled_connection");
+        poolProperties.setUsername("sa");
+        poolProperties.setPassword("");
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
     }
 
     private void assertInsertedItem(Statement statement) throws SQLException {

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.DataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PooledConnectionTest {
+
+    @Test
+    void opensConnectionWithConfiguredDriverClass() throws SQLException {
+        DataSource dataSource = createDataSource();
+        try {
+            try (Connection connection = dataSource.getConnection();
+                    Statement statement = connection.createStatement()) {
+                statement.executeUpdate("""
+                        CREATE TABLE pooled_connection_item (
+                            id INT NOT NULL PRIMARY KEY,
+                            name VARCHAR(255)
+                        )
+                        """);
+                statement.executeUpdate("""
+                        INSERT INTO pooled_connection_item(id, name)
+                        VALUES (1, 'driver-connection')
+                        """);
+
+                assertInsertedItem(statement);
+            }
+        } finally {
+            dataSource.close(true);
+        }
+    }
+
+    private DataSource createDataSource() {
+        DataSource dataSource = new DataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:pooled_connection");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        dataSource.setInitialSize(0);
+        dataSource.setMaxActive(1);
+        return dataSource;
+    }
+
+    private void assertInsertedItem(Statement statement) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery("SELECT name FROM pooled_connection_item WHERE id = 1")) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("driver-connection");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.ProxyConnection;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyConnectionTest {
+
+    @Test
+    void delegatesXaAndJdbcMethodsToWrappedConnection() throws SQLException {
+        PoolProperties poolProperties = createPoolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
+        try {
+            pooledConnection.connect();
+            TestProxyConnection proxyConnection = new TestProxyConnection(connectionPool, pooledConnection);
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    ProxyConnectionTest.class.getClassLoader(),
+                    new Class<?>[] { Connection.class, XAConnection.class },
+                    proxyConnection);
+
+            XAResource xaResource = ((XAConnection) connection).getXAResource();
+            boolean autoCommit = connection.getAutoCommit();
+
+            assertThat(xaResource).isNotNull();
+            assertThat(autoCommit).isTrue();
+        } finally {
+            pooledConnection.release();
+        }
+    }
+
+    private PoolProperties createPoolProperties() {
+        JdbcDataSource h2DataSource = new JdbcDataSource();
+        h2DataSource.setURL("jdbc:h2:mem:proxy_connection;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        h2DataSource.setUser("sa");
+        h2DataSource.setPassword("");
+
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDataSource(h2DataSource);
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
+    }
+
+    private static final class TestProxyConnection extends ProxyConnection {
+        private TestProxyConnection(ConnectionPool parent, PooledConnection connection) {
+            super(parent, connection, true);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
@@ -34,7 +34,7 @@ public class ProxyConnectionTest {
             TestProxyConnection proxyConnection = new TestProxyConnection(connectionPool, pooledConnection);
             Connection connection = (Connection) Proxy.newProxyInstance(
                     ProxyConnectionTest.class.getClassLoader(),
-                    new Class<?>[] { Connection.class, XAConnection.class },
+                    new Class<?>[] {Connection.class, XAConnection.class},
                     proxyConnection);
 
             XAResource xaResource = ((XAConnection) connection).getXAResource();

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.interceptor.StatementCache;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementCacheInnerCachedStatementTest {
+    private static final String SELECT_NAME_BY_ID = "SELECT name FROM cached_statement_item WHERE id = ?";
+
+    @Test
+    void closeRebuildsProxyFacadeBeforeCachingStatement() throws SQLException {
+        StatementCache statementCache = new StatementCache();
+        statementCache.setProperties(statementCacheProperties());
+        PoolProperties poolProperties = poolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
+        statementCache.poolStarted(connectionPool);
+        statementCache.reset(connectionPool, pooledConnection);
+
+        try (Connection delegate = DriverManager.getConnection(
+                "jdbc:h2:mem:statement_cache_inner_cached_statement;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE")) {
+            createTestData(delegate);
+            statementCache.setNext(new TerminalConnectionInterceptor(delegate));
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    StatementCacheInnerCachedStatementTest.class.getClassLoader(),
+                    new Class<?>[] { Connection.class },
+                    statementCache);
+            try {
+                PreparedStatement firstStatement = connection.prepareStatement(SELECT_NAME_BY_ID);
+                firstStatement.setInt(1, 1);
+                assertPreparedStatementQuery(firstStatement, "first-cached-statement");
+
+                firstStatement.close();
+                assertThat(firstStatement.isClosed()).isTrue();
+                assertThat(statementCache.getCacheSizePerConnection()).isEqualTo(1);
+
+                PreparedStatement cachedStatement = connection.prepareStatement(SELECT_NAME_BY_ID);
+                cachedStatement.setInt(1, 2);
+                try {
+                    assertThat(cachedStatement.isClosed()).isFalse();
+                    assertThat(statementCache.getCacheSizePerConnection()).isZero();
+                    assertPreparedStatementQuery(cachedStatement, "second-cached-statement");
+                } finally {
+                    cachedStatement.close();
+                }
+            } finally {
+                connection.close();
+            }
+        } finally {
+            statementCache.reset(null, null);
+            statementCache.poolClosed(connectionPool);
+        }
+    }
+
+    private Map<String, PoolProperties.InterceptorProperty> statementCacheProperties() {
+        Map<String, PoolProperties.InterceptorProperty> properties = new HashMap<>();
+        properties.put("prepared", new PoolProperties.InterceptorProperty("prepared", "true"));
+        properties.put("callable", new PoolProperties.InterceptorProperty("callable", "false"));
+        properties.put("max", new PoolProperties.InterceptorProperty("max", "4"));
+        return properties;
+    }
+
+    private PoolProperties poolProperties() {
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
+    }
+
+    private void createTestData(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE cached_statement_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO cached_statement_item(id, name)
+                    VALUES (1, 'first-cached-statement')
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO cached_statement_item(id, name)
+                    VALUES (2, 'second-cached-statement')
+                    """);
+        }
+    }
+
+    private void assertPreparedStatementQuery(PreparedStatement statement, String expectedName) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo(expectedName);
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TerminalConnectionInterceptor extends JdbcInterceptor {
+        private final Connection delegate;
+
+        private TerminalConnectionInterceptor(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (compare("prepareStatement", method)) {
+                return delegate.prepareStatement((String) args[0]);
+            }
+            if (compare("close", method)) {
+                delegate.close();
+                return null;
+            }
+            if (compare("isClosed", method)) {
+                return delegate.isClosed();
+            }
+            if (compare("toString", method)) {
+                return delegate.toString();
+            }
+            throw new UnsupportedOperationException(method.getName());
+        }
+
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection con) {
+            // This terminal interceptor keeps no pool state.
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
@@ -45,7 +45,7 @@ public class StatementCacheInnerCachedStatementTest {
             statementCache.setNext(new TerminalConnectionInterceptor(delegate));
             Connection connection = (Connection) Proxy.newProxyInstance(
                     StatementCacheInnerCachedStatementTest.class.getClassLoader(),
-                    new Class<?>[] { Connection.class },
+                    new Class<?>[] {Connection.class},
                     statementCache);
             try {
                 PreparedStatement firstStatement = connection.prepareStatement(SELECT_NAME_BY_ID);

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
@@ -38,7 +38,7 @@ public class StatementCacheTest {
             statementCache.setNext(new TerminalConnectionInterceptor(delegate));
             Connection connection = (Connection) Proxy.newProxyInstance(
                     StatementCacheTest.class.getClassLoader(),
-                    new Class<?>[] { Connection.class },
+                    new Class<?>[] {Connection.class},
                     statementCache);
             try {
                 assertPreparedStatementQuery(connection, 1, "cached-first");

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.interceptor.StatementCache;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementCacheTest {
+
+    @Test
+    void preparesStatementsThroughStatementCacheDecorator() throws SQLException {
+        StatementCache statementCache = new StatementCache();
+        statementCache.setProperties(statementCacheProperties());
+
+        try (Connection delegate = DriverManager.getConnection("jdbc:h2:mem:statement_cache")) {
+            createTestData(delegate);
+            statementCache.setNext(new TerminalConnectionInterceptor(delegate));
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    StatementCacheTest.class.getClassLoader(),
+                    new Class<?>[] { Connection.class },
+                    statementCache);
+            try {
+                assertPreparedStatementQuery(connection, 1, "cached-first");
+                assertPreparedStatementQuery(connection, 2, "cached-second");
+            } finally {
+                connection.close();
+            }
+        }
+    }
+
+    private Map<String, PoolProperties.InterceptorProperty> statementCacheProperties() {
+        Map<String, PoolProperties.InterceptorProperty> properties = new HashMap<>();
+        properties.put("prepared", new PoolProperties.InterceptorProperty("prepared", "true"));
+        properties.put("callable", new PoolProperties.InterceptorProperty("callable", "false"));
+        properties.put("max", new PoolProperties.InterceptorProperty("max", "2"));
+        return properties;
+    }
+
+    private void createTestData(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE statement_cache_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("INSERT INTO statement_cache_item(id, name) VALUES (1, 'cached-first')");
+            statement.executeUpdate("INSERT INTO statement_cache_item(id, name) VALUES (2, 'cached-second')");
+        }
+    }
+
+    private void assertPreparedStatementQuery(Connection connection, int id, String expectedName) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement("SELECT name FROM statement_cache_item WHERE id = ?");
+        statement.setInt(1, id);
+
+        try (ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.getStatement()).isSameAs(statement);
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo(expectedName);
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TerminalConnectionInterceptor extends JdbcInterceptor {
+        private final Connection delegate;
+
+        private TerminalConnectionInterceptor(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (compare("prepareStatement", method)) {
+                return delegate.prepareStatement((String) args[0]);
+            }
+            if (compare("close", method)) {
+                delegate.close();
+                return null;
+            }
+            if (compare("isClosed", method)) {
+                return delegate.isClosed();
+            }
+            if (compare("toString", method)) {
+                return delegate.toString();
+            }
+            throw new UnsupportedOperationException(method.getName());
+        }
+
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection con) {
+            // This terminal interceptor keeps no pool state.
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementDecoratorInterceptorTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementDecoratorInterceptorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.interceptor.StatementDecoratorInterceptor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementDecoratorInterceptorTest {
+
+    @Test
+    void statementDecoratorWrapsStatementResultSets() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:statement_decorator");
+                Statement statement = connection.createStatement()) {
+            createTestTable(statement);
+
+            Statement decoratedStatement = decorateStatement(connection, statement);
+            assertDecoratedResultSet(decoratedStatement);
+        }
+    }
+
+    private Statement decorateStatement(Connection connection, Statement statement) throws Exception {
+        TestStatementDecoratorInterceptor interceptor = new TestStatementDecoratorInterceptor();
+        return interceptor.decorate(connection, statement);
+    }
+
+    private void createTestTable(Statement statement) throws SQLException {
+        statement.executeUpdate("CREATE TABLE decorated_item (id INT NOT NULL PRIMARY KEY, name VARCHAR(255))");
+        statement.executeUpdate("INSERT INTO decorated_item(id, name) VALUES (1, 'proxy-result')");
+    }
+
+    private void assertDecoratedResultSet(Statement statement) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery("SELECT name FROM decorated_item WHERE id = 1")) {
+            assertThat(resultSet.getStatement()).isSameAs(statement);
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("proxy-result");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TestStatementDecoratorInterceptor extends StatementDecoratorInterceptor {
+        private Statement decorate(Connection connection, Statement statement)
+                throws InstantiationException, IllegalAccessException, InvocationTargetException,
+                NoSuchMethodException {
+            return (Statement) createDecorator(
+                    connection,
+                    null,
+                    null,
+                    statement,
+                    getConstructor(CREATE_STATEMENT_IDX, Statement.class),
+                    null);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
@@ -6,11 +6,15 @@
  */
 package org_apache_tomcat.tomcat_jdbc;
 
-import org.apache.tomcat.jdbc.pool.DataSource;
-import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.StatementFacade;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -20,10 +24,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StatementFacadeTest {
 
     @Test
-    void wrapsCreatedStatementsWithStatementFacadeProxy() throws SQLException {
-        DataSource dataSource = new DataSource(createPoolProperties());
-        try (Connection connection = dataSource.getConnection();
-                Statement statement = connection.createStatement()) {
+    void wrapsCreatedStatementsWithStatementFacadeProxy() throws Exception {
+        TestStatementFacade statementFacade = new TestStatementFacade();
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:statement_facade");
+                Statement delegate = connection.createStatement()) {
+            Statement statement = statementFacade.wrapCreatedStatement(delegate);
             statement.executeUpdate("""
                     CREATE TABLE statement_facade_item (
                         id INT NOT NULL PRIMARY KEY,
@@ -37,23 +42,7 @@ public class StatementFacadeTest {
 
             assertInsertedItem(statement);
             assertThat(statement.toString()).contains("StatementFacade");
-        } finally {
-            dataSource.close(true);
         }
-    }
-
-    private PoolProperties createPoolProperties() {
-        PoolProperties poolProperties = new PoolProperties();
-        poolProperties.setDriverClassName("org.h2.Driver");
-        poolProperties.setUrl("jdbc:h2:mem:statement_facade;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
-        poolProperties.setUsername("sa");
-        poolProperties.setPassword("");
-        poolProperties.setInitialSize(0);
-        poolProperties.setMaxActive(1);
-        poolProperties.setJmxEnabled(false);
-        poolProperties.setTimeBetweenEvictionRunsMillis(0);
-        poolProperties.setUseStatementFacade(true);
-        return poolProperties;
     }
 
     private void assertInsertedItem(Statement statement) throws SQLException {
@@ -62,6 +51,24 @@ public class StatementFacadeTest {
             assertThat(resultSet.next()).isTrue();
             assertThat(resultSet.getString(1)).isEqualTo("facade-statement");
             assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TestStatementFacade extends StatementFacade {
+        private TestStatementFacade() {
+            super(new TerminalJdbcInterceptor());
+        }
+
+        private Statement wrapCreatedStatement(Statement statement) throws NoSuchMethodException {
+            Method method = Connection.class.getMethod("createStatement");
+            return (Statement) createStatement(null, method, new Object[0], statement, 0);
+        }
+    }
+
+    private static final class TerminalJdbcInterceptor extends JdbcInterceptor {
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection connection) {
+            // No state is held by this terminal interceptor.
         }
     }
 }

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.DataSource;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementFacadeTest {
+
+    @Test
+    void wrapsCreatedStatementsWithStatementFacadeProxy() throws SQLException {
+        DataSource dataSource = new DataSource(createPoolProperties());
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE statement_facade_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO statement_facade_item(id, name)
+                    VALUES (1, 'facade-statement')
+                    """);
+
+            assertInsertedItem(statement);
+            assertThat(statement.toString()).contains("StatementFacade");
+        } finally {
+            dataSource.close(true);
+        }
+    }
+
+    private PoolProperties createPoolProperties() {
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDriverClassName("org.h2.Driver");
+        poolProperties.setUrl("jdbc:h2:mem:statement_facade;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        poolProperties.setUsername("sa");
+        poolProperties.setPassword("");
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        poolProperties.setUseStatementFacade(true);
+        return poolProperties;
+    }
+
+    private void assertInsertedItem(Statement statement) throws SQLException {
+        String query = "SELECT name FROM statement_facade_item WHERE id = 1";
+        try (ResultSet resultSet = statement.executeQuery(query)) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("facade-statement");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.DataSourceFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.sql.DataSource;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TomcatJdbcTest {
+
+    private DataSource dataSource;
+    private Connection connection;
+
+    @BeforeAll
+    public void init() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("driverClassName", "org.h2.Driver");
+        properties.setProperty("url", "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        properties.setProperty("username", "fred");
+        properties.setProperty("password", "secret");
+        properties.setProperty("initialSize", "2");
+        properties.setProperty("minIdle", "1");
+        properties.setProperty("testOnBorrow", "true");
+        properties.setProperty("testOnConnect", "true");
+        properties.setProperty("validationQuery", "select 1");
+        DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSource = dataSourceFactory.createDataSource(properties);
+    }
+
+    @AfterAll
+    public void close() throws Exception {
+        ((org.apache.tomcat.jdbc.pool.DataSource) dataSource).close(true);
+    }
+
+    @BeforeEach
+    public void setConnection() throws SQLException {
+        connection = dataSource.getConnection();
+    }
+
+    @AfterEach
+    public void removeConnection() throws SQLException {
+        if (connection != null) {
+            connection.close();
+            connection = null;
+        }
+    }
+
+    @Test
+    void testPreparedStatement() throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE foo (id INT NOT NULL, name VARCHAR(255), PRIMARY KEY (id))");
+        }
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO foo(id, name) VALUES( ?, ?)")) {
+            preparedStatement.setInt(1, 1);
+            preparedStatement.setString(2, "test1");
+            int count = preparedStatement.executeUpdate();
+            assertThat(count).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testCallableStatement() throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE ALIAS my_round FOR 'java.lang.Math.round(double)'");
+        }
+        try (CallableStatement callableStatement = connection.prepareCall("CALL my_round(?)")) {
+            callableStatement.setFloat(1, 4567.9874f);
+            ResultSet resultSet = callableStatement.executeQuery();
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getInt(1)).isEqualTo(4568);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
@@ -6,33 +6,33 @@
  */
 package org_apache_tomcat.tomcat_jdbc;
 
+import org.apache.tomcat.jdbc.pool.DataSource;
 import org.apache.tomcat.jdbc.pool.DataSourceFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
-import javax.sql.DataSource;
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TomcatJdbcTest {
+public class TomcatJdbcTest {
 
-    private DataSource dataSource;
-    private Connection connection;
+    @Test
+    void createsConfiguredDataSource() {
+        PoolConfiguration poolConfiguration = DataSourceFactory.parsePoolProperties(createProperties());
+        DataSource dataSource = new DataSource(poolConfiguration);
 
-    @BeforeAll
-    public void init() throws Exception {
+        assertThat(dataSource.getDriverClassName()).isEqualTo("org.h2.Driver");
+        assertThat(dataSource.getUrl()).isEqualTo("jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        assertThat(dataSource.getUsername()).isEqualTo("fred");
+        assertThat(dataSource.getInitialSize()).isEqualTo(2);
+        assertThat(dataSource.getMinIdle()).isEqualTo(1);
+        assertThat(dataSource.isTestOnBorrow()).isTrue();
+        assertThat(dataSource.isTestOnConnect()).isTrue();
+        assertThat(dataSource.getValidationQuery()).isEqualTo("select 1");
+    }
+
+    private Properties createProperties() {
         Properties properties = new Properties();
         properties.setProperty("driverClassName", "org.h2.Driver");
         properties.setProperty("url", "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
@@ -43,52 +43,6 @@ class TomcatJdbcTest {
         properties.setProperty("testOnBorrow", "true");
         properties.setProperty("testOnConnect", "true");
         properties.setProperty("validationQuery", "select 1");
-        DataSourceFactory dataSourceFactory = new DataSourceFactory();
-        dataSource = dataSourceFactory.createDataSource(properties);
-    }
-
-    @AfterAll
-    public void close() throws Exception {
-        ((org.apache.tomcat.jdbc.pool.DataSource) dataSource).close(true);
-    }
-
-    @BeforeEach
-    public void setConnection() throws SQLException {
-        connection = dataSource.getConnection();
-    }
-
-    @AfterEach
-    public void removeConnection() throws SQLException {
-        if (connection != null) {
-            connection.close();
-            connection = null;
-        }
-    }
-
-    @Test
-    void testPreparedStatement() throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE TABLE foo (id INT NOT NULL, name VARCHAR(255), PRIMARY KEY (id))");
-        }
-
-        try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO foo(id, name) VALUES( ?, ?)")) {
-            preparedStatement.setInt(1, 1);
-            preparedStatement.setString(2, "test1");
-            int count = preparedStatement.executeUpdate();
-            assertThat(count).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void testCallableStatement() throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE ALIAS my_round FOR 'java.lang.Math.round(double)'");
-        }
-        try (CallableStatement callableStatement = connection.prepareCall("CALL my_round(?)")) {
-            callableStatement.setFloat(1, 4567.9874f);
-            ResultSet resultSet = callableStatement.executeQuery();
-            assertThat(resultSet.next()).isTrue();
-            assertThat(resultSet.getInt(1)).isEqualTo(4568);
-        }
+        return properties;
     }
 }

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.ProxyConnectionTest"
+    },
+    "interfaces": [
+      "java.sql.Connection",
+      "javax.sql.XAConnection"
+    ]
+  }
+]

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
@@ -7,5 +7,22 @@
       "java.sql.Connection",
       "javax.sql.XAConnection"
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementFacadeTest"
+    },
+    "interfaces": [
+      "java.sql.Connection",
+      "javax.sql.PooledConnection"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementFacadeTest"
+    },
+    "interfaces": [
+      "java.sql.Statement"
+    ]
   }
 ]

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
@@ -13,15 +13,6 @@
       "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementFacadeTest"
     },
     "interfaces": [
-      "java.sql.Connection",
-      "javax.sql.PooledConnection"
-    ]
-  },
-  {
-    "condition": {
-      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementFacadeTest"
-    },
-    "interfaces": [
       "java.sql.Statement"
     ]
   }

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
@@ -15,5 +15,13 @@
     "interfaces": [
       "java.sql.Statement"
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementCacheTest"
+    },
+    "interfaces": [
+      "java.sql.Connection"
+    ]
   }
 ]

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "java.lang.Math",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.h2.schema.FunctionAlias"
+    }
+  },
+  {
+    "name": "java.lang.Math",
+    "condition": {
+      "typeReachable": "org.h2.schema.FunctionAlias$JavaMethod"
+    },
+    "methods": [
+      {
+        "name": "round",
+        "parameterTypes": [
+          "double"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "org.h2.Driver",
+    "condition": {
+      "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "java.lang.Math",
     "queryAllPublicMethods": true,
     "condition": {

--- a/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/user-code-filter.json
+++ b/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.tomcat.jdbc.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #740

This PR provides test fixes and new metadata for org.apache.tomcat:tomcat-jdbc:10.1.14, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 988761
- Cached input tokens: 14390784
- Output tokens: 122950
- Entries found: 11
- Iterations: 23
- Library coverage percentage: 21.43
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 21.72

### Metadata Forge

- Forge monitored branch: `origin/ai/forge-current-changes-20260428`
- Forge branch: `ai/forge-current-changes-20260428`
- Forge commit hash: `a94ae3901e5382e6bcf5a24a1affc5e1a4ef86ae`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.tomcat:tomcat-jdbc:10.1.7: 11/42 covered calls (26.19%)
- org.apache.tomcat:tomcat-jdbc:10.1.14: 19/42 covered calls (45.24%)

**Reflection:**
- org.apache.tomcat:tomcat-jdbc:10.1.7: 11/42 covered calls (26.19%)
- org.apache.tomcat:tomcat-jdbc:10.1.14: 19/42 covered calls (45.24%)

#### Library coverage

**Instruction:**
- org.apache.tomcat:tomcat-jdbc:10.1.7: 3130/14583 (21.46%)
- org.apache.tomcat:tomcat-jdbc:10.1.14: 3183/14643 (21.74%)

**Line:**
- org.apache.tomcat:tomcat-jdbc:10.1.7: 819/3770 (21.72%)
- org.apache.tomcat:tomcat-jdbc:10.1.14: 811/3784 (21.43%)

**Method:**
- org.apache.tomcat:tomcat-jdbc:10.1.7: 170/889 (19.12%)
- org.apache.tomcat:tomcat-jdbc:10.1.14: 168/889 (18.90%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/gradle.properties 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/gradle.properties
index 7209585a2a..194c2f7fa1 100644
--- 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/gradle.properties
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/gradle.properties
@@ -1,2 +1,2 @@
-library.version = 10.1.7
-metadata.dir = org.apache.tomcat/tomcat-jdbc/10.1.7/
+library.version = 10.1.14
+metadata.dir = org.apache.tomcat/tomcat-jdbc/10.1.14/
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
new file mode 100644
index 0000000000..7b9e5c7fb4
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/AbstractQueryReportTest.java
@@ -0,0 +1,113 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.interceptor.AbstractQueryReport;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractQueryReportTest {
+
+    @Test
+    void wrapsPreparedStatementsWithQueryReportingProxy() throws Exception {
+        TestQueryReport queryReport = new TestQueryReport();
+        queryReport.setThreshold(Long.MAX_VALUE);
+
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:abstract_query_report");
+                PreparedStatement setupStatement = connection.prepareStatement("""
+                        CREATE TABLE query_report_item (
+                            id INT NOT NULL PRIMARY KEY,
+                            name VARCHAR(255)
+                        )
+                        """)) {
+            setupStatement.executeUpdate();
+
+            insertItem(connection);
+
+            String query = "SELECT name FROM query_report_item WHERE id = ?";
+            try (PreparedStatement delegate = connection.prepareStatement(query);
+                    PreparedStatement statement = queryReport.wrapPreparedStatement(delegate, query)) {
+                statement.setInt(1, 1);
+
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getString(1)).isEqualTo("reported-query");
+                    assertThat(resultSet.next()).isFalse();
+                }
+
+                assertThat(statement.isClosed()).isFalse();
+            }
+        }
+
+        assertThat(queryReport.preparedSql).containsExactly("SELECT name FROM query_report_item WHERE id = ?");
+        assertThat(queryReport.executedSql).containsExactly("SELECT name FROM query_report_item WHERE id = ?");
+        assertThat(queryReport.failedSql).isEmpty();
+    }
+
+    private void insertItem(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                INSERT INTO query_report_item(id, name)
+                VALUES (?, ?)
+                """)) {
+            statement.setInt(1, 1);
+            statement.setString(2, "reported-query");
+            statement.executeUpdate();
+        }
+    }
+
+    private static final class TestQueryReport extends AbstractQueryReport {
+        private final List<String> preparedSql = new ArrayList<>();
+        private final List<String> executedSql = new ArrayList<>();
+        private final List<String> failedSql = new ArrayList<>();
+
+        private PreparedStatement wrapPreparedStatement(PreparedStatement statement, String sql)
+                throws NoSuchMethodException {
+            Method method = Connection.class.getMethod("prepareStatement", String.class);
+            Object[] args = {sql};
+            return (PreparedStatement) createStatement(null, method, args, statement, 0);
+        }
+
+        @Override
+        protected void prepareStatement(String sql, long time) {
+            preparedSql.add(sql);
+        }
+
+        @Override
+        protected void prepareCall(String query, long time) {
+            throw new AssertionError("No callable statements are prepared by this test");
+        }
+
+        @Override
+        protected String reportQuery(String query, Object[] args, String name, long start, long delta) {
+            String sql = super.reportQuery(query, args, name, start, delta);
+            executedSql.add(sql);
+            return sql;
+        }
+
+        @Override
+        protected String reportFailedQuery(String query, Object[] args, String name, long start, Throwable throwable) {
+            String sql = super.reportFailedQuery(query, args, name, start, throwable);
+            failedSql.add(sql);
+            return sql;
+        }
+
+        @Override
+        public void closeInvoked() {
+            // This test wraps statements directly, so connection close events are not observed.
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
new file mode 100644
index 0000000000..dc7538e257
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/PooledConnectionTest.java
@@ -0,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PooledConnectionTest {
+
+    @Test
+    void opensConnectionWithConfiguredDriverClass() throws SQLException {
+        PoolProperties poolProperties = createPoolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
+        try {
+            pooledConnection.connect();
+            try (Connection connection = pooledConnection.getConnection();
+                    Statement statement = connection.createStatement()) {
+                statement.executeUpdate("""
+                        CREATE TABLE pooled_connection_item (
+                            id INT NOT NULL PRIMARY KEY,
+                            name VARCHAR(255)
+                        )
+                        """);
+                statement.executeUpdate("""
+                        INSERT INTO pooled_connection_item(id, name)
+                        VALUES (1, 'driver-connection')
+                        """);
+
+                assertInsertedItem(statement);
+            }
+        } finally {
+            pooledConnection.release();
+        }
+    }
+
+    private PoolProperties createPoolProperties() {
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDriverClassName("org.h2.Driver");
+        poolProperties.setUrl("jdbc:h2:mem:pooled_connection");
+        poolProperties.setUsername("sa");
+        poolProperties.setPassword("");
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
+    }
+
+    private void assertInsertedItem(Statement statement) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery("SELECT name FROM pooled_connection_item WHERE id = 1")) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("driver-connection");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
new file mode 100644
index 0000000000..7abb64bc03
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/ProxyConnectionTest.java
@@ -0,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.ProxyConnection;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyConnectionTest {
+
+    @Test
+    void delegatesXaAndJdbcMethodsToWrappedConnection() throws SQLException {
+        PoolProperties poolProperties = createPoolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
+        try {
+            pooledConnection.connect();
+            TestProxyConnection proxyConnection = new TestProxyConnection(connectionPool, pooledConnection);
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    ProxyConnectionTest.class.getClassLoader(),
+                    new Class<?>[] {Connection.class, XAConnection.class},
+                    proxyConnection);
+
+            XAResource xaResource = ((XAConnection) connection).getXAResource();
+            boolean autoCommit = connection.getAutoCommit();
+
+            assertThat(xaResource).isNotNull();
+            assertThat(autoCommit).isTrue();
+        } finally {
+            pooledConnection.release();
+        }
+    }
+
+    private PoolProperties createPoolProperties() {
+        JdbcDataSource h2DataSource = new JdbcDataSource();
+        h2DataSource.setURL("jdbc:h2:mem:proxy_connection;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        h2DataSource.setUser("sa");
+        h2DataSource.setPassword("");
+
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDataSource(h2DataSource);
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
+    }
+
+    private static final class TestProxyConnection extends ProxyConnection {
+        private TestProxyConnection(ConnectionPool parent, PooledConnection connection) {
+            super(parent, connection, true);
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
new file mode 100644
index 0000000000..8bcb5b097f
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheInnerCachedStatementTest.java
@@ -0,0 +1,151 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.interceptor.StatementCache;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementCacheInnerCachedStatementTest {
+    private static final String SELECT_NAME_BY_ID = "SELECT name FROM cached_statement_item WHERE id = ?";
+
+    @Test
+    void closeRebuildsProxyFacadeBeforeCachingStatement() throws SQLException {
+        StatementCache statementCache = new StatementCache();
+        statementCache.setProperties(statementCacheProperties());
+        PoolProperties poolProperties = poolProperties();
+        ConnectionPool connectionPool = new ConnectionPool(poolProperties);
+        PooledConnection pooledConnection = new PooledConnection(poolProperties, connectionPool);
+        statementCache.poolStarted(connectionPool);
+        statementCache.reset(connectionPool, pooledConnection);
+
+        try (Connection delegate = DriverManager.getConnection(
+                "jdbc:h2:mem:statement_cache_inner_cached_statement;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE")) {
+            createTestData(delegate);
+            statementCache.setNext(new TerminalConnectionInterceptor(delegate));
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    StatementCacheInnerCachedStatementTest.class.getClassLoader(),
+                    new Class<?>[] {Connection.class},
+                    statementCache);
+            try {
+                PreparedStatement firstStatement = connection.prepareStatement(SELECT_NAME_BY_ID);
+                firstStatement.setInt(1, 1);
+                assertPreparedStatementQuery(firstStatement, "first-cached-statement");
+
+                firstStatement.close();
+                assertThat(firstStatement.isClosed()).isTrue();
+                assertThat(statementCache.getCacheSizePerConnection()).isEqualTo(1);
+
+                PreparedStatement cachedStatement = connection.prepareStatement(SELECT_NAME_BY_ID);
+                cachedStatement.setInt(1, 2);
+                try {
+                    assertThat(cachedStatement.isClosed()).isFalse();
+                    assertThat(statementCache.getCacheSizePerConnection()).isZero();
+                    assertPreparedStatementQuery(cachedStatement, "second-cached-statement");
+                } finally {
+                    cachedStatement.close();
+                }
+            } finally {
+                connection.close();
+            }
+        } finally {
+            statementCache.reset(null, null);
+            statementCache.poolClosed(connectionPool);
+        }
+    }
+
+    private Map<String, PoolProperties.InterceptorProperty> statementCacheProperties() {
+        Map<String, PoolProperties.InterceptorProperty> properties = new HashMap<>();
+        properties.put("prepared", new PoolProperties.InterceptorProperty("prepared", "true"));
+        properties.put("callable", new PoolProperties.InterceptorProperty("callable", "false"));
+        properties.put("max", new PoolProperties.InterceptorProperty("max", "4"));
+        return properties;
+    }
+
+    private PoolProperties poolProperties() {
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setInitialSize(0);
+        poolProperties.setMaxActive(1);
+        poolProperties.setJmxEnabled(false);
+        poolProperties.setTimeBetweenEvictionRunsMillis(0);
+        return poolProperties;
+    }
+
+    private void createTestData(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE cached_statement_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO cached_statement_item(id, name)
+                    VALUES (1, 'first-cached-statement')
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO cached_statement_item(id, name)
+                    VALUES (2, 'second-cached-statement')
+                    """);
+        }
+    }
+
+    private void assertPreparedStatementQuery(PreparedStatement statement, String expectedName) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo(expectedName);
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TerminalConnectionInterceptor extends JdbcInterceptor {
+        private final Connection delegate;
+
+        private TerminalConnectionInterceptor(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (compare("prepareStatement", method)) {
+                return delegate.prepareStatement((String) args[0]);
+            }
+            if (compare("close", method)) {
+                delegate.close();
+                return null;
+            }
+            if (compare("isClosed", method)) {
+                return delegate.isClosed();
+            }
+            if (compare("toString", method)) {
+                return delegate.toString();
+            }
+            throw new UnsupportedOperationException(method.getName());
+        }
+
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection con) {
+            // This terminal interceptor keeps no pool state.
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
new file mode 100644
index 0000000000..347765c7c9
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementCacheTest.java
@@ -0,0 +1,115 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.interceptor.StatementCache;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementCacheTest {
+
+    @Test
+    void preparesStatementsThroughStatementCacheDecorator() throws SQLException {
+        StatementCache statementCache = new StatementCache();
+        statementCache.setProperties(statementCacheProperties());
+
+        try (Connection delegate = DriverManager.getConnection("jdbc:h2:mem:statement_cache")) {
+            createTestData(delegate);
+            statementCache.setNext(new TerminalConnectionInterceptor(delegate));
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    StatementCacheTest.class.getClassLoader(),
+                    new Class<?>[] {Connection.class},
+                    statementCache);
+            try {
+                assertPreparedStatementQuery(connection, 1, "cached-first");
+                assertPreparedStatementQuery(connection, 2, "cached-second");
+            } finally {
+                connection.close();
+            }
+        }
+    }
+
+    private Map<String, PoolProperties.InterceptorProperty> statementCacheProperties() {
+        Map<String, PoolProperties.InterceptorProperty> properties = new HashMap<>();
+        properties.put("prepared", new PoolProperties.InterceptorProperty("prepared", "true"));
+        properties.put("callable", new PoolProperties.InterceptorProperty("callable", "false"));
+        properties.put("max", new PoolProperties.InterceptorProperty("max", "2"));
+        return properties;
+    }
+
+    private void createTestData(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE statement_cache_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("INSERT INTO statement_cache_item(id, name) VALUES (1, 'cached-first')");
+            statement.executeUpdate("INSERT INTO statement_cache_item(id, name) VALUES (2, 'cached-second')");
+        }
+    }
+
+    private void assertPreparedStatementQuery(Connection connection, int id, String expectedName) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement("SELECT name FROM statement_cache_item WHERE id = ?");
+        statement.setInt(1, id);
+
+        try (ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.getStatement()).isSameAs(statement);
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo(expectedName);
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TerminalConnectionInterceptor extends JdbcInterceptor {
+        private final Connection delegate;
+
+        private TerminalConnectionInterceptor(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (compare("prepareStatement", method)) {
+                return delegate.prepareStatement((String) args[0]);
+            }
+            if (compare("close", method)) {
+                delegate.close();
+                return null;
+            }
+            if (compare("isClosed", method)) {
+                return delegate.isClosed();
+            }
+            if (compare("toString", method)) {
+                return delegate.toString();
+            }
+            throw new UnsupportedOperationException(method.getName());
+        }
+
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection con) {
+            // This terminal interceptor keeps no pool state.
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementDecoratorInterceptorTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementDecoratorInterceptorTest.java
new file mode 100644
index 0000000000..09db284bfa
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementDecoratorInterceptorTest.java
@@ -0,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.interceptor.StatementDecoratorInterceptor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementDecoratorInterceptorTest {
+
+    @Test
+    void statementDecoratorWrapsStatementResultSets() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:statement_decorator");
+                Statement statement = connection.createStatement()) {
+            createTestTable(statement);
+
+            Statement decoratedStatement = decorateStatement(connection, statement);
+            assertDecoratedResultSet(decoratedStatement);
+        }
+    }
+
+    private Statement decorateStatement(Connection connection, Statement statement) throws Exception {
+        TestStatementDecoratorInterceptor interceptor = new TestStatementDecoratorInterceptor();
+        return interceptor.decorate(connection, statement);
+    }
+
+    private void createTestTable(Statement statement) throws SQLException {
+        statement.executeUpdate("CREATE TABLE decorated_item (id INT NOT NULL PRIMARY KEY, name VARCHAR(255))");
+        statement.executeUpdate("INSERT INTO decorated_item(id, name) VALUES (1, 'proxy-result')");
+    }
+
+    private void assertDecoratedResultSet(Statement statement) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery("SELECT name FROM decorated_item WHERE id = 1")) {
+            assertThat(resultSet.getStatement()).isSameAs(statement);
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("proxy-result");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TestStatementDecoratorInterceptor extends StatementDecoratorInterceptor {
+        private Statement decorate(Connection connection, Statement statement)
+                throws InstantiationException, IllegalAccessException, InvocationTargetException,
+                NoSuchMethodException {
+            return (Statement) createDecorator(
+                    connection,
+                    null,
+                    null,
+                    statement,
+                    getConstructor(CREATE_STATEMENT_IDX, Statement.class),
+                    null);
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
new file mode 100644
index 0000000000..2b8aa3d593
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/StatementFacadeTest.java
@@ -0,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_jdbc;
+
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.apache.tomcat.jdbc.pool.JdbcInterceptor;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
+import org.apache.tomcat.jdbc.pool.StatementFacade;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatementFacadeTest {
+
+    @Test
+    void wrapsCreatedStatementsWithStatementFacadeProxy() throws Exception {
+        TestStatementFacade statementFacade = new TestStatementFacade();
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:statement_facade");
+                Statement delegate = connection.createStatement()) {
+            Statement statement = statementFacade.wrapCreatedStatement(delegate);
+            statement.executeUpdate("""
+                    CREATE TABLE statement_facade_item (
+                        id INT NOT NULL PRIMARY KEY,
+                        name VARCHAR(255)
+                    )
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO statement_facade_item(id, name)
+                    VALUES (1, 'facade-statement')
+                    """);
+
+            assertInsertedItem(statement);
+            assertThat(statement.toString()).contains("StatementFacade");
+        }
+    }
+
+    private void assertInsertedItem(Statement statement) throws SQLException {
+        String query = "SELECT name FROM statement_facade_item WHERE id = 1";
+        try (ResultSet resultSet = statement.executeQuery(query)) {
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo("facade-statement");
+            assertThat(resultSet.next()).isFalse();
+        }
+    }
+
+    private static final class TestStatementFacade extends StatementFacade {
+        private TestStatementFacade() {
+            super(new TerminalJdbcInterceptor());
+        }
+
+        private Statement wrapCreatedStatement(Statement statement) throws NoSuchMethodException {
+            Method method = Connection.class.getMethod("createStatement");
+            return (Statement) createStatement(null, method, new Object[0], statement, 0);
+        }
+    }
+
+    private static final class TerminalJdbcInterceptor extends JdbcInterceptor {
+        @Override
+        public void reset(ConnectionPool parent, PooledConnection connection) {
+            // No state is held by this terminal interceptor.
+        }
+    }
+}
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
index 0d8af15a5c..06399f7a05 100644
--- 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/java/org_apache_tomcat/tomcat_jdbc/TomcatJdbcTest.java
@@ -6,33 +6,33 @@
  */
 package org_apache_tomcat.tomcat_jdbc;
 
+import org.apache.tomcat.jdbc.pool.DataSource;
 import org.apache.tomcat.jdbc.pool.DataSourceFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
-import javax.sql.DataSource;
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TomcatJdbcTest {
+public class TomcatJdbcTest {
 
-    private DataSource dataSource;
-    private Connection connection;
+    @Test
+    void createsConfiguredDataSource() {
+        PoolConfiguration poolConfiguration = DataSourceFactory.parsePoolProperties(createProperties());
+        DataSource dataSource = new DataSource(poolConfiguration);
+
+        assertThat(dataSource.getDriverClassName()).isEqualTo("org.h2.Driver");
+        assertThat(dataSource.getUrl()).isEqualTo("jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        assertThat(dataSource.getUsername()).isEqualTo("fred");
+        assertThat(dataSource.getInitialSize()).isEqualTo(2);
+        assertThat(dataSource.getMinIdle()).isEqualTo(1);
+        assertThat(dataSource.isTestOnBorrow()).isTrue();
+        assertThat(dataSource.isTestOnConnect()).isTrue();
+        assertThat(dataSource.getValidationQuery()).isEqualTo("select 1");
+    }
 
-    @BeforeAll
-    public void init() throws Exception {
+    private Properties createProperties() {
         Properties properties = new Properties();
         properties.setProperty("driverClassName", "org.h2.Driver");
         properties.setProperty("url", "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
@@ -43,52 +43,6 @@ class TomcatJdbcTest {
         properties.setProperty("testOnBorrow", "true");
         properties.setProperty("testOnConnect", "true");
         properties.setProperty("validationQuery", "select 1");
-        DataSourceFactory dataSourceFactory = new DataSourceFactory();
-        dataSource = dataSourceFactory.createDataSource(properties);
-    }
-
-    @AfterAll
-    public void close() throws Exception {
-        ((org.apache.tomcat.jdbc.pool.DataSource) dataSource).close(true);
-    }
-
-    @BeforeEach
-    public void setConnection() throws SQLException {
-        connection = dataSource.getConnection();
-    }
-
-    @AfterEach
-    public void removeConnection() throws SQLException {
-        if (connection != null) {
-            connection.close();
-            connection = null;
-        }
-    }
-
-    @Test
-    void testPreparedStatement() throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE TABLE foo (id INT NOT NULL, name VARCHAR(255), PRIMARY KEY (id))");
-        }
-
-        try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO foo(id, name) VALUES( ?, ?)")) {
-            preparedStatement.setInt(1, 1);
-            preparedStatement.setString(2, "test1");
-            int count = preparedStatement.executeUpdate();
-            assertThat(count).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void testCallableStatement() throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE ALIAS my_round FOR 'java.lang.Math.round(double)'");
-        }
-        try (CallableStatement callableStatement = connection.prepareCall("CALL my_round(?)")) {
-            callableStatement.setFloat(1, 4567.9874f);
-            ResultSet resultSet = callableStatement.executeQuery();
-            assertThat(resultSet.next()).isTrue();
-            assertThat(resultSet.getInt(1)).isEqualTo(4568);
-        }
+        return properties;
     }
 }
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
new file mode 100644
index 0000000000..ab28fee5f0
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/proxy-config.json
@@ -0,0 +1,27 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.ProxyConnectionTest"
+    },
+    "interfaces": [
+      "java.sql.Connection",
+      "javax.sql.XAConnection"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementFacadeTest"
+    },
+    "interfaces": [
+      "java.sql.Statement"
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "org_apache_tomcat.tomcat_jdbc.StatementCacheTest"
+    },
+    "interfaces": [
+      "java.sql.Connection"
+    ]
+  }
+]
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/src/test/resources/META-INF/native-image/tests-only/reflect-config.json 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
index e039c621b8..229c818c89 100644
--- 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.7/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/src/test/resources/META-INF/native-image/tests-only/reflect-config.json
@@ -1,4 +1,16 @@
 [
+  {
+    "name": "org.h2.Driver",
+    "condition": {
+      "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
   {
     "name": "java.lang.Math",
     "queryAllPublicMethods": true,
diff --git 1/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/user-code-filter.json 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/user-code-filter.json
new file mode 100644
index 0000000000..41e8ffb1a4
--- /dev/null
+++ 2/tests/src/org.apache.tomcat/tomcat-jdbc/10.1.14/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.tomcat.jdbc.**"
+    }
+  ]
+}

```
