### PR TITLE
[GenAI] Add support for org.springframework.security:spring-security-crypto:5.7.3 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.security/spring-security-crypto/5.7.3/reachability-metadata.json
+++ b/metadata/org.springframework.security/spring-security-crypto/5.7.3/reachability-metadata.json
@@ -1,0 +1,240 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.AesBytesEncryptor"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.Encryptors"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.apache.logging.log4j.spi.ExtendedLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.slf4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.slf4j.spi.LocationAwareLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCrypt"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.HexEncodingTextEncryptor"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.keygen.SecureRandomBytesKeyGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCrypt"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/org.springframework.security/spring-security-crypto/index.json
+++ b/metadata/org.springframework.security/spring-security-crypto/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.7.3",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/security/spring-security-crypto/5.7.3/spring-security-crypto-5.7.3-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-security",
+    "test-code-url" : "https://github.com/spring-projects/spring-security/tree/5.7.3/crypto/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/security/spring-security-crypto/5.7.3/spring-security-crypto-5.7.3-javadoc.jar",
+    "description" : "Spring Security Crypto provides password encoding, key generation, and cryptographic utility classes used by Spring Security and standalone Java applications. It includes implementations for algorithms such as BCrypt, PBKDF2, SCrypt, Argon2, and symmetric text encryption helpers.",
+    "tested-versions" : [
+      "5.7.3"
+    ],
+    "allowed-packages" : [
+      "org.springframework.security.crypto"
+    ]
+  }
+]

--- a/stats/org.springframework.security/spring-security-crypto/5.7.3/stats.json
+++ b/stats/org.springframework.security/spring-security-crypto/5.7.3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.7.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7429,
+        "missed" : 8177,
+        "ratio" : 0.476035,
+        "total" : 15606
+      },
+      "line" : {
+        "covered" : 450,
+        "missed" : 774,
+        "ratio" : 0.367647,
+        "total" : 1224
+      },
+      "method" : {
+        "covered" : 103,
+        "missed" : 136,
+        "ratio" : 0.430962,
+        "total" : 239
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/.gitignore
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.security:spring-security-crypto:$libraryVersion"
+    testImplementation 'org.springframework:spring-jcl:5.3.22'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.security:spring-security-crypto:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/gradle.properties
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.security:spring-security-crypto:5.7.3
+library.version = 5.7.3
+metadata.dir = org.springframework.security/spring-security-crypto/5.7.3/

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/settings.gradle
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.security.spring-security-crypto_tests'

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -55,7 +55,7 @@ public class Spring_security_cryptoTest {
 
     @Test
     void bcryptStaticApiGeneratesSaltHashesStringsAndHashesBytes() {
-        SecureRandom random = new SecureRandom(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        SecureRandom random = new SecureRandom(new byte[] {1, 2, 3, 4, 5, 6, 7, 8 });
         String salt = BCrypt.gensalt("$2a", 4, random);
 
         String stringHash = BCrypt.hashpw(PASSWORD, salt);
@@ -151,12 +151,12 @@ public class Spring_security_cryptoTest {
         byte[] utf8 = Utf8.encode(text);
 
         assertThat(Utf8.decode(utf8)).isEqualTo(text);
-        assertThat(Hex.encode(new byte[] { 0x00, 0x0f, (byte) 0xff }))
+        assertThat(Hex.encode(new byte[] {0x00, 0x0f, (byte) 0xff }))
                 .containsExactly('0', '0', '0', 'f', 'f', 'f');
         assertThat(Hex.decode("000fff")).containsExactly(0x00, 0x0f, (byte) 0xff);
-        assertThat(EncodingUtils.concatenate(new byte[] { 1, 2 }, new byte[] { 3 }, new byte[] { 4, 5 }))
+        assertThat(EncodingUtils.concatenate(new byte[] {1, 2 }, new byte[] {3 }, new byte[] {4, 5 }))
                 .containsExactly(1, 2, 3, 4, 5);
-        assertThat(EncodingUtils.subArray(new byte[] { 10, 20, 30, 40, 50 }, 1, 4)).containsExactly(20, 30, 40);
+        assertThat(EncodingUtils.subArray(new byte[] {10, 20, 30, 40, 50 }, 1, 4)).containsExactly(20, 30, 40);
         assertThatThrownBy(() -> Hex.decode("abc")).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -198,7 +198,7 @@ public class Spring_security_cryptoTest {
     void bytesEncryptorsRoundTripBinaryPayloadsWithCbcAndGcm() {
         BytesEncryptor standard = Encryptors.standard("bytes-password", SALT);
         BytesEncryptor stronger = Encryptors.stronger("bytes-password", SALT);
-        byte[] payload = new byte[] { 0, 1, 2, 3, 4, 5, 127, (byte) 128, (byte) 255 };
+        byte[] payload = new byte[] {0, 1, 2, 3, 4, 5, 127, (byte) 128, (byte) 255 };
 
         byte[] standardCiphertext = standard.encrypt(payload);
         byte[] strongerCiphertext = stronger.encrypt(payload);

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.codec.Utf8;
 import org.springframework.security.crypto.encrypt.BytesEncryptor;
 import org.springframework.security.crypto.encrypt.Encryptors;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
 import org.springframework.security.crypto.keygen.BytesKeyGenerator;
 import org.springframework.security.crypto.keygen.KeyGenerators;
 import org.springframework.security.crypto.keygen.StringKeyGenerator;
@@ -132,6 +134,15 @@ public class Spring_security_cryptoTest {
         StringKeyGenerator stringGenerator = KeyGenerators.string();
 
         assertThat(stringGenerator.generateKey()).matches("[0-9a-f]{16}");
+    }
+
+    @Test
+    void base64StringKeyGeneratorProducesUrlSafeKeysWithoutPadding() {
+        Base64StringKeyGenerator generator = new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding(), 32);
+
+        String key = generator.generateKey();
+
+        assertThat(key).hasSize(43).matches("[A-Za-z0-9_-]+");
     }
 
     @Test

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_security.spring_security_crypto;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_security_cryptoTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -177,6 +177,24 @@ public class Spring_security_cryptoTest {
     }
 
     @Test
+    void queryableTextEncryptorProducesStableCiphertextForLookupValues() {
+        TextEncryptor firstEncryptor = Encryptors.queryableText("lookup-password", SALT);
+        TextEncryptor secondEncryptor = Encryptors.queryableText("lookup-password", SALT);
+        String lookupValue = "customer-12345";
+
+        String firstCiphertext = firstEncryptor.encrypt(lookupValue);
+        String repeatedCiphertext = firstEncryptor.encrypt(lookupValue);
+        String secondEncryptorCiphertext = secondEncryptor.encrypt(lookupValue);
+        String differentCiphertext = firstEncryptor.encrypt("customer-67890");
+
+        assertThat(firstCiphertext).isNotEqualTo(lookupValue).matches("[0-9a-f]+");
+        assertThat(repeatedCiphertext).isEqualTo(firstCiphertext);
+        assertThat(secondEncryptorCiphertext).isEqualTo(firstCiphertext);
+        assertThat(differentCiphertext).isNotEqualTo(firstCiphertext);
+        assertThat(secondEncryptor.decrypt(firstCiphertext)).isEqualTo(lookupValue);
+    }
+
+    @Test
     void bytesEncryptorsRoundTripBinaryPayloadsWithCbcAndGcm() {
         BytesEncryptor standard = Encryptors.standard("bytes-password", SALT);
         BytesEncryptor stronger = Encryptors.stronger("bytes-password", SALT);

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -6,11 +6,180 @@
  */
 package org_springframework_security.spring_security_crypto;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Spring_security_cryptoTest {
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.BCryptVersion;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.security.crypto.keygen.BytesKeyGenerator;
+import org.springframework.security.crypto.keygen.KeyGenerators;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm;
+import org.springframework.security.crypto.util.EncodingUtils;
+
+public class Spring_security_cryptoTest {
+    private static final String PASSWORD = "correct horse battery staple";
+    private static final String WRONG_PASSWORD = "correct horse battery staple?";
+    private static final String SALT = "5c0744940b5c369b";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void bcryptPasswordEncoderEncodesMatchesAndDetectsWeakCost() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(BCryptVersion.$2B, 4);
+
+        String encoded = encoder.encode(PASSWORD);
+
+        assertThat(encoded).startsWith("$2b$04$").hasSize(60);
+        assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+        assertThat(encoder.matches(WRONG_PASSWORD, encoded)).isFalse();
+        assertThat(encoder.upgradeEncoding(encoded)).isFalse();
+        assertThat(new BCryptPasswordEncoder(BCryptVersion.$2B, 10).upgradeEncoding(encoded)).isTrue();
+    }
+
+    @Test
+    void bcryptStaticApiGeneratesSaltHashesStringsAndHashesBytes() {
+        SecureRandom random = new SecureRandom(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        String salt = BCrypt.gensalt("$2a", 4, random);
+
+        String stringHash = BCrypt.hashpw(PASSWORD, salt);
+        String byteHash = BCrypt.hashpw(PASSWORD.getBytes(StandardCharsets.UTF_8), salt);
+
+        assertThat(salt).startsWith("$2a$04$").hasSize(29);
+        assertThat(stringHash).startsWith(salt).hasSize(60);
+        assertThat(byteHash).isEqualTo(stringHash);
+        assertThat(BCrypt.checkpw(PASSWORD, stringHash)).isTrue();
+        assertThat(BCrypt.checkpw(PASSWORD.getBytes(StandardCharsets.UTF_8), stringHash)).isTrue();
+        assertThat(BCrypt.checkpw(WRONG_PASSWORD, stringHash)).isFalse();
+    }
+
+    @Test
+    void pbkdf2PasswordEncoderSupportsHexAndBase64EncodedHashes() {
+        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
+        hexEncoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+
+        String hexEncoded = hexEncoder.encode(PASSWORD);
+
+        assertThat(hexEncoded).matches("[0-9a-f]+");
+        assertThat(hexEncoder.matches(PASSWORD, hexEncoded)).isTrue();
+        assertThat(hexEncoder.matches(WRONG_PASSWORD, hexEncoded)).isFalse();
+
+        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
+        base64Encoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
+        base64Encoder.setEncodeHashAsBase64(true);
+
+        String base64Encoded = base64Encoder.encode(PASSWORD);
+
+        assertThat(base64Encoded).matches("[A-Za-z0-9+/]+={0,2}");
+        assertThat(base64Encoder.matches(PASSWORD, base64Encoded)).isTrue();
+        assertThat(base64Encoder.matches(PASSWORD, hexEncoded)).isFalse();
+    }
+
+    @Test
+    void delegatingPasswordEncoderUsesCurrentIdAndVerifiesExplicitLegacyId() {
+        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 64, 1_000);
+        pbkdf2.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Map<String, PasswordEncoder> encoders = new HashMap<>();
+        encoders.put("bcrypt", new BCryptPasswordEncoder(4));
+        encoders.put("pbkdf2", pbkdf2);
+        DelegatingPasswordEncoder delegating = new DelegatingPasswordEncoder("bcrypt", encoders);
+
+        String currentEncoded = delegating.encode(PASSWORD);
+        String legacyEncoded = "{pbkdf2}" + pbkdf2.encode(PASSWORD);
+
+        assertThat(currentEncoded).startsWith("{bcrypt}$2a$04$");
+        assertThat(delegating.matches(PASSWORD, currentEncoded)).isTrue();
+        assertThat(delegating.matches(PASSWORD, legacyEncoded)).isTrue();
+        assertThat(delegating.matches(WRONG_PASSWORD, legacyEncoded)).isFalse();
+        assertThat(delegating.upgradeEncoding(legacyEncoded)).isTrue();
+        assertThatThrownBy(() -> delegating.matches(PASSWORD, "{unknown}" + currentEncoded))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("PasswordEncoder mapped for the id \"unknown\"");
+    }
+
+    @Test
+    void keyGeneratorsCreateRandomSharedAndHexStringKeys() {
+        BytesKeyGenerator randomGenerator = KeyGenerators.secureRandom(32);
+        byte[] firstRandomKey = randomGenerator.generateKey();
+        byte[] secondRandomKey = randomGenerator.generateKey();
+
+        assertThat(randomGenerator.getKeyLength()).isEqualTo(32);
+        assertThat(firstRandomKey).hasSize(32);
+        assertThat(secondRandomKey).hasSize(32);
+        assertThat(Arrays.equals(firstRandomKey, secondRandomKey)).isFalse();
+
+        BytesKeyGenerator sharedGenerator = KeyGenerators.shared(16);
+        byte[] sharedKey = sharedGenerator.generateKey();
+
+        assertThat(sharedGenerator.getKeyLength()).isEqualTo(16);
+        assertThat(sharedKey).hasSize(16);
+        assertThat(sharedGenerator.generateKey()).containsExactly(sharedKey);
+
+        StringKeyGenerator stringGenerator = KeyGenerators.string();
+
+        assertThat(stringGenerator.generateKey()).matches("[0-9a-f]{16}");
+    }
+
+    @Test
+    void codecAndEncodingUtilitiesRoundTripTextAndByteRanges() {
+        String text = "Spring Security crypto \u2615";
+        byte[] utf8 = Utf8.encode(text);
+
+        assertThat(Utf8.decode(utf8)).isEqualTo(text);
+        assertThat(Hex.encode(new byte[] { 0x00, 0x0f, (byte) 0xff }))
+                .containsExactly('0', '0', '0', 'f', 'f', 'f');
+        assertThat(Hex.decode("000fff")).containsExactly(0x00, 0x0f, (byte) 0xff);
+        assertThat(EncodingUtils.concatenate(new byte[] { 1, 2 }, new byte[] { 3 }, new byte[] { 4, 5 }))
+                .containsExactly(1, 2, 3, 4, 5);
+        assertThat(EncodingUtils.subArray(new byte[] { 10, 20, 30, 40, 50 }, 1, 4)).containsExactly(20, 30, 40);
+        assertThatThrownBy(() -> Hex.decode("abc")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void textEncryptorsEncryptDecryptAndUseAuthenticatedMode() {
+        TextEncryptor standardText = Encryptors.text("text-password", SALT);
+        TextEncryptor authenticatedText = Encryptors.delux("text-password", SALT);
+        String message = "token=abc123&scope=read write";
+
+        String standardCiphertext = standardText.encrypt(message);
+        String authenticatedCiphertext = authenticatedText.encrypt(message);
+
+        assertThat(standardCiphertext).isNotEqualTo(message).matches("[0-9a-f]+");
+        assertThat(authenticatedCiphertext).isNotEqualTo(message).matches("[0-9a-f]+");
+        assertThat(standardText.decrypt(standardCiphertext)).isEqualTo(message);
+        assertThat(authenticatedText.decrypt(authenticatedCiphertext)).isEqualTo(message);
+        assertThatThrownBy(() -> authenticatedText.decrypt(standardCiphertext)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void bytesEncryptorsRoundTripBinaryPayloadsWithCbcAndGcm() {
+        BytesEncryptor standard = Encryptors.standard("bytes-password", SALT);
+        BytesEncryptor stronger = Encryptors.stronger("bytes-password", SALT);
+        byte[] payload = new byte[] { 0, 1, 2, 3, 4, 5, 127, (byte) 128, (byte) 255 };
+
+        byte[] standardCiphertext = standard.encrypt(payload);
+        byte[] strongerCiphertext = stronger.encrypt(payload);
+
+        assertThat(Arrays.equals(standardCiphertext, payload)).isFalse();
+        assertThat(Arrays.equals(strongerCiphertext, payload)).isFalse();
+        assertThat(standardCiphertext).hasSizeGreaterThan(payload.length);
+        assertThat(strongerCiphertext).hasSizeGreaterThan(payload.length);
+        assertThat(standard.decrypt(standardCiphertext)).containsExactly(payload);
+        assertThat(stronger.decrypt(strongerCiphertext)).containsExactly(payload);
+        assertThatThrownBy(() -> stronger.decrypt(standardCiphertext)).isInstanceOf(RuntimeException.class);
     }
 }

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.security.crypto.**"
+      "includeClasses" : "org.springframework.security.crypto.**"
     }
   ]
 }

--- a/tests/src/org.springframework.security/spring-security-crypto/5.7.3/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-crypto/5.7.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.security.crypto.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2690

This PR introduces tests and metadata for org.springframework.security:spring-security-crypto:5.7.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 190502
- Cached input tokens: 1277952
- Output tokens: 17264
- Entries: 38
- Iterations: 4
- Library coverage percentage: 36.76
- Generated lines of code: 175
- Tested library lines of code: 450

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1493d9b2a2352ac1b4252980d1b88df550676d18`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 7429/15606 (47.60%)
- Line: 450/1224 (36.76%)
- Method: 103/239 (43.10%)
