### PR TITLE
[GenAI] Add support for org.slf4j:log4j-over-slf4j:1.7.25 using gpt-5.5

### DIFF
--- a/metadata/org.slf4j/log4j-over-slf4j/1.7.25/reachability-metadata.json
+++ b/metadata/org.slf4j/log4j-over-slf4j/1.7.25/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.log4j.Category"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.slf4j/log4j-over-slf4j/index.json
+++ b/metadata/org.slf4j/log4j-over-slf4j/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.7.25",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/v_1.7.25/log4j-over-slf4j/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25-javadoc.jar",
+    "description" : "log4j-over-slf4j provides replacement classes for the Log4j version 1 API that route logging calls to SLF4J. It lets applications and dependencies written against Log4j use the SLF4J binding selected by the application without keeping a Log4j version 1 runtime implementation on the classpath.",
+    "tested-versions" : [
+      "1.7.25"
+    ],
+    "allowed-packages" : [
+      "org.apache.log4j"
+    ]
+  }
+]

--- a/stats/org.slf4j/log4j-over-slf4j/1.7.25/stats.json
+++ b/stats/org.slf4j/log4j-over-slf4j/1.7.25/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.7.25",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 717,
+        "missed" : 439,
+        "ratio" : 0.620242,
+        "total" : 1156
+      },
+      "line" : {
+        "covered" : 221,
+        "missed" : 147,
+        "ratio" : 0.600543,
+        "total" : 368
+      },
+      "method" : {
+        "covered" : 100,
+        "missed" : 61,
+        "ratio" : 0.621118,
+        "total" : 161
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/.gitignore
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/build.gradle
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.slf4j:log4j-over-slf4j:$libraryVersion"
+    testRuntimeOnly "org.slf4j:slf4j-jdk14:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/build.gradle
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:log4j-over-slf4j:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/gradle.properties
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:log4j-over-slf4j:1.7.25
+library.version = 1.7.25
+metadata.dir = org.slf4j/log4j-over-slf4j/1.7.25/

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/settings.gradle
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.log4j-over-slf4j_tests'

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
@@ -22,6 +22,7 @@ import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.RollingFileAppender;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
+import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.helpers.NullEnumeration;
 import org.apache.log4j.spi.ErrorHandler;
 import org.apache.log4j.spi.Filter;
@@ -30,8 +31,11 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.xml.DOMConfigurator;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -182,6 +186,53 @@ public class Log4j_over_slf4jTest {
 
         MDC.clear();
         assertThat(MDC.get("user")).isNull();
+    }
+
+    @Test
+    void logLogEmitsInternalStatusMessagesAndHonorsFlags() {
+        PrintStream previousOut = System.out;
+        PrintStream previousErr = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        try (PrintStream capturedOut = new PrintStream(out, true, StandardCharsets.UTF_8);
+                PrintStream capturedErr = new PrintStream(err, true, StandardCharsets.UTF_8)) {
+            System.setOut(capturedOut);
+            System.setErr(capturedErr);
+            LogLog.setQuietMode(false);
+            LogLog.setInternalDebugging(false);
+
+            LogLog.debug("debug disabled");
+            LogLog.warn("warning");
+            LogLog.error("error");
+
+            assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+            assertThat(err.toString(StandardCharsets.UTF_8))
+                    .contains("log4j:WARN warning", "log4j:ERROR error");
+
+            out.reset();
+            err.reset();
+            LogLog.setInternalDebugging(true);
+            LogLog.debug("debug enabled");
+
+            assertThat(out.toString(StandardCharsets.UTF_8)).contains("log4j: debug enabled");
+            assertThat(err.toString(StandardCharsets.UTF_8)).isEmpty();
+
+            out.reset();
+            err.reset();
+            LogLog.setQuietMode(true);
+            LogLog.debug("quiet debug");
+            LogLog.warn(" quiet warn");
+            LogLog.error(" quiet error");
+
+            assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+            assertThat(err.toString(StandardCharsets.UTF_8)).isEmpty();
+        } finally {
+            LogLog.setQuietMode(false);
+            LogLog.setInternalDebugging(false);
+            System.setOut(previousOut);
+            System.setErr(previousErr);
+        }
     }
 
     @Test

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
@@ -95,6 +95,26 @@ public class Log4j_over_slf4jTest {
     }
 
     @Test
+    void logManagerFactoryLookupDoesNotPopulateTheSharedLoggerCache() {
+        String loggerName = uniqueLoggerName("log-manager-factory");
+        AtomicInteger factoryInvocations = new AtomicInteger();
+        CountingLoggerFactory factory = new CountingLoggerFactory(factoryInvocations);
+
+        Logger first = LogManager.getLogger(loggerName, factory);
+        Logger second = LogManager.getLogger(loggerName, factory);
+        Logger cached = LogManager.getLogger(loggerName);
+
+        assertThat(first).isInstanceOf(CountingLogger.class);
+        assertThat(second).isInstanceOf(CountingLogger.class);
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.getName()).isEqualTo(loggerName);
+        assertThat(second.getName()).isEqualTo(loggerName);
+        assertThat(factoryInvocations).hasValue(2);
+        assertThat(cached).isNotInstanceOf(CountingLogger.class);
+        assertThat(LogManager.getLogger(loggerName)).isSameAs(cached);
+    }
+
+    @Test
     void loggingMethodsDelegateMessagesLevelsAndThrowablesToSlf4jBinding() {
         String loggerName = uniqueLoggerName("delegation");
         RecordingHandler handler = new RecordingHandler();

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
@@ -6,11 +6,379 @@
  */
 package org_slf4j.log4j_over_slf4j;
 
+import org.apache.log4j.Appender;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Category;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
+import org.apache.log4j.NDC;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.RollingFileAppender;
+import org.apache.log4j.SimpleLayout;
+import org.apache.log4j.WriterAppender;
+import org.apache.log4j.helpers.NullEnumeration;
+import org.apache.log4j.spi.ErrorHandler;
+import org.apache.log4j.spi.Filter;
+import org.apache.log4j.spi.LoggerFactory;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.xml.DOMConfigurator;
 import org.junit.jupiter.api.Test;
 
-class Log4j_over_slf4jTest {
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import static java.util.logging.Level.ALL;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Log4j_over_slf4jTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void loggerLookupUsesLog4jCompatibleNamesAndCaching() {
+        String loggerName = uniqueLoggerName("lookup");
+
+        Logger first = Logger.getLogger(loggerName);
+        Logger second = Logger.getLogger(loggerName);
+        Category category = Category.getInstance(loggerName);
+
+        assertThat(second).isSameAs(first);
+        assertThat(LogManager.getLogger(loggerName)).isSameAs(first);
+        assertThat(category).isSameAs(first);
+        assertThat(first.getName()).isEqualTo(loggerName);
+        assertThat(Logger.getLogger(Log4j_over_slf4jTest.class).getName())
+                .isEqualTo(Log4j_over_slf4jTest.class.getName());
+        assertThat(Logger.getRootLogger()).isSameAs(LogManager.getRootLogger());
+        assertThat(Logger.getRootLogger().getName()).isEqualTo("ROOT");
+        assertThat(first.getParent()).isNull();
+        assertThat(first.getAppender("missing")).isNull();
+        assertThat(first.getAllAppenders()).isSameAs(NullEnumeration.getInstance());
+        assertThat(first.getAllAppenders().hasMoreElements()).isFalse();
+        assertThatThrownBy(() -> first.getAllAppenders().nextElement())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void customLoggerFactoryIsUsedForUncachedNamesOnly() {
+        String loggerName = uniqueLoggerName("factory");
+        AtomicInteger firstFactoryInvocations = new AtomicInteger();
+        AtomicInteger secondFactoryInvocations = new AtomicInteger();
+
+        Logger logger = Logger.getLogger(loggerName, new CountingLoggerFactory(firstFactoryInvocations));
+        Logger cached = Logger.getLogger(loggerName, new CountingLoggerFactory(secondFactoryInvocations));
+
+        assertThat(logger).isInstanceOf(CountingLogger.class);
+        assertThat(cached).isSameAs(logger);
+        assertThat(firstFactoryInvocations).hasValue(1);
+        assertThat(secondFactoryInvocations).hasValue(0);
+    }
+
+    @Test
+    void loggingMethodsDelegateMessagesLevelsAndThrowablesToSlf4jBinding() {
+        String loggerName = uniqueLoggerName("delegation");
+        RecordingHandler handler = new RecordingHandler();
+
+        withJulLogger(loggerName, handler, () -> {
+            Logger logger = Logger.getLogger(loggerName);
+            RuntimeException infoFailure = new RuntimeException("info failure");
+            IllegalStateException fqcnFailure = new IllegalStateException("fqcn failure");
+
+            assertThat(logger.isTraceEnabled()).isTrue();
+            assertThat(logger.isDebugEnabled()).isTrue();
+            assertThat(logger.isInfoEnabled()).isTrue();
+            assertThat(logger.isWarnEnabled()).isTrue();
+            assertThat(logger.isErrorEnabled()).isTrue();
+            assertThat(logger.isEnabledFor(Level.TRACE)).isTrue();
+            assertThat(logger.getEffectiveLevel()).isEqualTo(Level.TRACE);
+
+            logger.trace("trace message");
+            logger.debug(new Message("debug message"));
+            logger.info("info message", infoFailure);
+            logger.warn("warn message");
+            logger.error("error message");
+            logger.fatal("fatal message");
+            logger.log(Level.INFO, "generic info");
+            logger.log("custom.fqcn", Level.WARN, "fqcn warn", fqcnFailure);
+
+            assertThat(handler.records())
+                    .extracting(LogRecord::getLevel)
+                    .containsExactly(FINEST, FINE, INFO, WARNING, SEVERE, SEVERE, INFO, WARNING);
+            assertThat(handler.records())
+                    .extracting(LogRecord::getMessage)
+                    .containsExactly(
+                            "trace message",
+                            "debug message",
+                            "info message",
+                            "warn message",
+                            "error message",
+                            "fatal message",
+                            "generic info",
+                            "fqcn warn");
+            assertThat(handler.records().get(2).getThrown()).isSameAs(infoFailure);
+            assertThat(handler.records().get(7).getThrown()).isSameAs(fqcnFailure);
+        });
+    }
+
+    @Test
+    void levelConversionsFollowLog4jSemantics() {
+        assertThat(Level.toLevel("trace")).isEqualTo(Level.TRACE);
+        assertThat(Level.toLevel("DEBUG")).isEqualTo(Level.DEBUG);
+        assertThat(Level.toLevel("info")).isEqualTo(Level.INFO);
+        assertThat(Level.toLevel("WARN")).isEqualTo(Level.WARN);
+        assertThat(Level.toLevel("error")).isEqualTo(Level.ERROR);
+        assertThat(Level.toLevel("fatal")).isEqualTo(Level.FATAL);
+        assertThat(Level.toLevel("off")).isEqualTo(Level.OFF);
+        assertThat(Level.toLevel("all")).isEqualTo(Level.ALL);
+        assertThat(Level.toLevel("unknown", Level.ERROR)).isEqualTo(Level.ERROR);
+        assertThat(Level.toLevel(5000)).isEqualTo(Level.TRACE);
+        assertThat(Level.toLevel(12345, Level.WARN)).isEqualTo(Level.WARN);
+
+        assertThat(Level.INFO.isGreaterOrEqual(Level.DEBUG)).isTrue();
+        assertThat(Level.DEBUG.isGreaterOrEqual(Level.ERROR)).isFalse();
+        assertThat(Level.WARN.toString()).isEqualTo("WARN");
+        assertThat(Level.WARN.toInt()).isEqualTo(Level.WARN_INT);
+        assertThat(Level.WARN.getSyslogEquivalent()).isEqualTo(4);
+    }
+
+    @Test
+    void mdcAndNdcBridgeToSlf4jDiagnosticContext() {
+        MDC.clear();
+        NDC.clear();
+
+        MDC.put("requestId", 42);
+        MDC.put("user", "alice");
+
+        assertThat(MDC.get("requestId")).isEqualTo("42");
+        assertThat(MDC.get("user")).isEqualTo("alice");
+        MDC.remove("requestId");
+        assertThat(MDC.get("requestId")).isNull();
+
+        NDC.push("outer");
+        NDC.push("inner");
+        assertThat(NDC.getDepth()).isEqualTo(2);
+        assertThat(NDC.peek()).isEqualTo("inner");
+        assertThat(NDC.pop()).isEqualTo("inner");
+        assertThat(NDC.peek()).isEqualTo("outer");
+        NDC.clear();
+        assertThat(NDC.getDepth()).isZero();
+        assertThat(NDC.pop()).isEmpty();
+
+        MDC.clear();
+        assertThat(MDC.get("user")).isNull();
+    }
+
+    @Test
+    void configurationLayoutAndAppenderCompatibilityTypesAreSafeNoOps() throws IOException {
+        Appender appender = new TestAppender("compatibility-appender");
+        Layout layout = new PatternLayout("%p %c - %m%n");
+        SimpleLayout simpleLayout = new SimpleLayout();
+        URL configurationUrl = new URL("file:/tmp/log4j-over-slf4j.properties");
+        Properties properties = new Properties();
+        properties.setProperty("log4j.rootLogger", "INFO, stdout");
+
+        assertThatCode(BasicConfigurator::configure).doesNotThrowAnyException();
+        assertThatCode(() -> BasicConfigurator.configure(appender)).doesNotThrowAnyException();
+        assertThatCode(BasicConfigurator::resetConfiguration).doesNotThrowAnyException();
+        assertThatCode(() -> PropertyConfigurator.configure(properties)).doesNotThrowAnyException();
+        assertThatCode(() -> PropertyConfigurator.configure("log4j.properties")).doesNotThrowAnyException();
+        assertThatCode(() -> PropertyConfigurator.configure(configurationUrl)).doesNotThrowAnyException();
+        assertThatCode(() -> PropertyConfigurator.configureAndWatch("log4j.properties", 10L))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> DOMConfigurator.configure("log4j.xml")).doesNotThrowAnyException();
+        assertThatCode(() -> DOMConfigurator.configure(configurationUrl)).doesNotThrowAnyException();
+        assertThat(DOMConfigurator.subst("${unchanged}", properties)).isEqualTo("${unchanged}");
+
+        assertThatCode(ConsoleAppender::new).doesNotThrowAnyException();
+        assertThatCode(WriterAppender::new).doesNotThrowAnyException();
+        assertThatCode(() -> new FileAppender(layout, "ignored.log")).doesNotThrowAnyException();
+        assertThatCode(() -> new FileAppender(simpleLayout, "ignored.log", true)).doesNotThrowAnyException();
+        assertThatCode(() -> new FileAppender(layout, "ignored.log", true, false, 8192)).doesNotThrowAnyException();
+        assertThatCode(() -> new RollingFileAppender(layout, "ignored.log")).doesNotThrowAnyException();
+        assertThatCode(() -> new RollingFileAppender(layout, "ignored.log", true)).doesNotThrowAnyException();
+
+        RollingFileAppender rollingFileAppender = new RollingFileAppender();
+        rollingFileAppender.setMaxBackupIndex(3);
+        rollingFileAppender.setMaximumFileSize(1024L);
+
+        Logger logger = Logger.getLogger(uniqueLoggerName("configuration"));
+        logger.addAppender(appender);
+        logger.setAdditivity(true);
+        logger.setLevel(Level.INFO);
+        logger.assertLog(true, "not logged");
+
+        assertThat(logger.getAdditivity()).isFalse();
+        assertThat(logger.getLevel()).isNull();
+        assertThat(logger.getAllAppenders().hasMoreElements()).isFalse();
+    }
+
+    private static String uniqueLoggerName(String suffix) {
+        return Log4j_over_slf4jTest.class.getName() + "." + suffix + "." + System.nanoTime();
+    }
+
+    private static void withJulLogger(String name, RecordingHandler handler, Runnable action) {
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
+        boolean previousUseParentHandlers = logger.getUseParentHandlers();
+        java.util.logging.Level previousLevel = logger.getLevel();
+        Handler[] previousHandlers = logger.getHandlers();
+        for (Handler previousHandler : previousHandlers) {
+            logger.removeHandler(previousHandler);
+        }
+        logger.setUseParentHandlers(false);
+        logger.setLevel(ALL);
+        handler.setLevel(ALL);
+        logger.addHandler(handler);
+        try {
+            action.run();
+        } finally {
+            logger.removeHandler(handler);
+            for (Handler previousHandler : previousHandlers) {
+                logger.addHandler(previousHandler);
+            }
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
+        }
+    }
+
+    private static final class CountingLogger extends Logger {
+        private CountingLogger(String name) {
+            super(name);
+        }
+    }
+
+    private static final class CountingLoggerFactory implements LoggerFactory {
+        private final AtomicInteger invocations;
+
+        private CountingLoggerFactory(AtomicInteger invocations) {
+            this.invocations = invocations;
+        }
+
+        @Override
+        public Logger makeNewLoggerInstance(String name) {
+            invocations.incrementAndGet();
+            return new CountingLogger(name);
+        }
+    }
+
+    private static final class Message {
+        private final String text;
+
+        private Message(String text) {
+            this.text = text;
+        }
+
+        @Override
+        public String toString() {
+            return text;
+        }
+    }
+
+    private static final class RecordingHandler extends Handler {
+        private final List<LogRecord> records = new ArrayList<>();
+
+        private List<LogRecord> records() {
+            return records;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class TestAppender implements Appender {
+        private String name;
+        private Layout layout;
+        private ErrorHandler errorHandler;
+        private Filter filter;
+        private final List<LoggingEvent> events = new ArrayList<>();
+
+        private TestAppender(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void addFilter(Filter filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public Filter getFilter() {
+            return filter;
+        }
+
+        @Override
+        public void clearFilters() {
+            filter = null;
+        }
+
+        @Override
+        public void close() {
+            events.clear();
+        }
+
+        @Override
+        public void doAppend(LoggingEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void setErrorHandler(ErrorHandler errorHandler) {
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public ErrorHandler getErrorHandler() {
+            return errorHandler;
+        }
+
+        @Override
+        public void setLayout(Layout layout) {
+            this.layout = layout;
+        }
+
+        @Override
+        public Layout getLayout() {
+            return layout;
+        }
+
+        @Override
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean requiresLayout() {
+            return true;
+        }
     }
 }

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/src/test/java/org_slf4j/log4j_over_slf4j/Log4j_over_slf4jTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.log4j_over_slf4j;
+
+import org.junit.jupiter.api.Test;
+
+class Log4j_over_slf4jTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/user-code-filter.json
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.log4j.**"
+      "includeClasses" : "org.apache.log4j.**"
     }
   ]
 }

--- a/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/user-code-filter.json
+++ b/tests/src/org.slf4j/log4j-over-slf4j/1.7.25/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.log4j.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2643

This PR introduces tests and metadata for org.slf4j:log4j-over-slf4j:1.7.25, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 219787
- Cached input tokens: 2656256
- Output tokens: 25799
- Entries: 1
- Iterations: 3
- Library coverage percentage: 60.05
- Generated lines of code: 389
- Tested library lines of code: 221

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1493d9b2a2352ac1b4252980d1b88df550676d18`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 717/1156 (62.02%)
- Line: 221/368 (60.05%)
- Method: 100/161 (62.11%)
