### PR TITLE
Fix Netty 4.1.79 metadata for grpc-netty

### DIFF
--- a/metadata/io.netty/netty-common/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-common/4.1.79.Final/reachability-metadata.json
@@ -25,6 +25,13 @@
     },
     {
       "condition" : {
+        "typeReached" : "io.netty.util.ResourceLeakDetector"
+      },
+      "type" : "io.netty.util.ReferenceCountUtil",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "io.netty.util.internal.NativeLibraryLoader"
       },
       "type" : "io.netty.util.internal.NativeLibraryUtil"
@@ -305,6 +312,105 @@
         {
           "name" : "<init>",
           "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueConsumerNodeRef"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueConsumerNodeRef",
+      "fields" : [
+        {
+          "name" : "consumerNode"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueProducerNodeRef"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseLinkedQueueProducerNodeRef",
+      "fields" : [
+        {
+          "name" : "producerNode"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields" : [
+        {
+          "name" : "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields" : [
+        {
+          "name" : "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields" : [
+        {
+          "name" : "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.LinkedQueueNode"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.LinkedQueueNode",
+      "fields" : [
+        {
+          "name" : "next"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields" : [
+        {
+          "name" : "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields" : [
+        {
+          "name" : "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields" : [
+        {
+          "name" : "producerLimit"
         }
       ]
     },


### PR DESCRIPTION
Fixes #3322.

## Summary

- add missing shaded JCTools queue field metadata for `io.netty:netty-common:4.1.79.Final`
- add `ReferenceCountUtil` declared-method metadata needed by `ResourceLeakDetector.addExclusions`

## Testing

```bash
./gradlew checkMetadataFiles -Pcoordinates=io.netty:netty-common:4.1.79.Final
./gradlew test -Pcoordinates=io.grpc:grpc-netty:1.51.0 --stacktrace
```