### PR TITLE
Run test-all-metadata weekly

### DIFF
--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -1,6 +1,8 @@
 name: "Test all metadata (one version per test suite)"
 
 on:
+  schedule:
+    - cron: "0 2 * * 0"
   workflow_dispatch:
   pull_request:
     branches:


### PR DESCRIPTION
Closes #3329

Adds a weekly schedule to the test-all-metadata workflow so the full metadata suite runs regularly without requiring manual dispatch.