### PR TITLE
Use call-weighted dynamic access coverage

### DIFF
--- a/.github/workflows/publish-scheduled-coverage.yml
+++ b/.github/workflows/publish-scheduled-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
 
       - name: "🔧 Setup Java"
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
@@ -97,7 +97,7 @@ public final class ReadmeBadgeSummarySupport {
                 snapshotDate.toString(),
                 new BadgeValues(
                         formatInteger(metadataIndexMetrics.metadataIndexes()),
-                        formatPercent(statsMetrics.avgDynamicAccessCoveragePercent()),
+                        formatPercent(statsMetrics.dynamicAccessCallCoveragePercent()),
                         formatInteger(metadataIndexMetrics.testedVersions()),
                         formatInteger(statsMetrics.testedLinesOfCode())
                 ),
@@ -199,8 +199,8 @@ public final class ReadmeBadgeSummarySupport {
     private static StatsMetrics buildStatsMetrics(LibraryStatsModels.LibraryStats libraryStats) {
         int coverageStatsArtifacts = libraryStats.entries() == null ? 0 : libraryStats.entries().size();
 
-        BigDecimal dynamicAccessRatioSum = BigDecimal.ZERO;
-        long dynamicAccessRatioCount = 0;
+        long dynamicAccessCoveredCalls = 0;
+        long dynamicAccessTotalCalls = 0;
         int testedLinesOfCode = 0;
         if (libraryStats.entries() != null) {
             for (LibraryStatsModels.ArtifactStats artifactStats : libraryStats.entries().values()) {
@@ -216,8 +216,11 @@ public final class ReadmeBadgeSummarySupport {
                             continue;
                         }
                         if (versionStats.dynamicAccess() != null && versionStats.dynamicAccess().isAvailable()) {
-                            dynamicAccessRatioSum = dynamicAccessRatioSum.add(versionStats.dynamicAccess().coverageRatio());
-                            dynamicAccessRatioCount++;
+                            long totalCalls = versionStats.dynamicAccess().totalCalls();
+                            if (totalCalls > 0) {
+                                dynamicAccessCoveredCalls += versionStats.dynamicAccess().coveredCalls();
+                                dynamicAccessTotalCalls += totalCalls;
+                            }
                         }
                         if (versionStats.libraryCoverage() != null
                                 && versionStats.libraryCoverage().line() != null
@@ -229,15 +232,15 @@ public final class ReadmeBadgeSummarySupport {
             }
         }
 
-        BigDecimal avgDynamicAccessCoveragePercent = BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
-        if (dynamicAccessRatioCount > 0) {
-            avgDynamicAccessCoveragePercent = dynamicAccessRatioSum
-                    .divide(BigDecimal.valueOf(dynamicAccessRatioCount), AVERAGE_SCALE, RoundingMode.HALF_UP)
+        BigDecimal dynamicAccessCallCoveragePercent = BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+        if (dynamicAccessTotalCalls > 0) {
+            dynamicAccessCallCoveragePercent = BigDecimal.valueOf(dynamicAccessCoveredCalls)
+                    .divide(BigDecimal.valueOf(dynamicAccessTotalCalls), AVERAGE_SCALE, RoundingMode.HALF_UP)
                     .multiply(HUNDRED)
                     .setScale(1, RoundingMode.HALF_UP);
         }
 
-        return new StatsMetrics(avgDynamicAccessCoveragePercent, coverageStatsArtifacts, testedLinesOfCode);
+        return new StatsMetrics(dynamicAccessCallCoveragePercent, coverageStatsArtifacts, testedLinesOfCode);
     }
 
     private static MetadataIndexMetrics buildMetadataIndexMetrics(Path metadataRoot) {
@@ -413,12 +416,12 @@ public final class ReadmeBadgeSummarySupport {
                 new PanelSpec(
                         "dynamic-access",
                         "Dynamic access coverage",
-                        "Average dynamic-access call coverage across repository metadata",
+                        "Dynamic-access call coverage across repository metadata",
                         true,
                         "percent",
                         "#1f9d55",
                         "#34d399",
-                        extractMetricPoints(history, entry -> entry.metrics().stats().avgDynamicAccessCoveragePercent())
+                        extractMetricPoints(history, entry -> entry.metrics().stats().dynamicAccessCallCoveragePercent())
                 ),
                 new PanelSpec(
                         "tested-lines-of-code",
@@ -988,7 +991,7 @@ public final class ReadmeBadgeSummarySupport {
     }
 
     public record StatsMetrics(
-            BigDecimal avgDynamicAccessCoveragePercent,
+            BigDecimal dynamicAccessCallCoveragePercent,
             int coverageStatsArtifacts,
             int testedLinesOfCode
     ) {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
@@ -67,6 +67,26 @@ class ReadmeBadgeSummarySupportTests {
                         }
                       },
                       "version": "1.0.0"
+                    },
+                    {
+                      "dynamicAccess": {
+                        "breakdown": {
+                          "reflection": {
+                            "coveredCalls": 1,
+                            "coverageRatio": 0.125,
+                            "totalCalls": 8
+                          }
+                        },
+                        "coveredCalls": 1,
+                        "coverageRatio": 0.125,
+                        "totalCalls": 8
+                      },
+                      "libraryCoverage": {
+                        "instruction": "N/A",
+                        "line": "N/A",
+                        "method": "N/A"
+                      },
+                      "version": "1.0.1"
                     }
 	                  ]
 	                }
@@ -185,12 +205,12 @@ class ReadmeBadgeSummarySupportTests {
 
         assertThat(summary.date()).isEqualTo("2026-04-07");
         assertThat(summary.badges().librariesSupported()).isEqualTo("2");
-        assertThat(summary.badges().dynamicAccessCoverage()).isEqualTo("75.0%");
+        assertThat(summary.badges().dynamicAccessCoverage()).isEqualTo("20.0%");
         assertThat(summary.badges().testedLibraryVersions()).isEqualTo("4");
         assertThat(summary.badges().testedLinesOfCode()).isEqualTo("1");
 
         assertThat(summary.metrics().stats().coverageStatsArtifacts()).isEqualTo(2);
-        assertThat(summary.metrics().stats().avgDynamicAccessCoveragePercent()).isEqualByComparingTo("75.0");
+        assertThat(summary.metrics().stats().dynamicAccessCallCoveragePercent()).isEqualByComparingTo("20.0");
         assertThat(summary.metrics().stats().testedLinesOfCode()).isEqualTo(1);
         assertThat(summary.metrics().metadataIndexes().metadataIndexes()).isEqualTo(2);
         assertThat(summary.metrics().metadataIndexes().metadataBaselines()).isEqualTo(3);
@@ -203,7 +223,7 @@ class ReadmeBadgeSummarySupportTests {
         );
         assertThat(updatedHistory.history()).hasSize(1);
         assertThat(updatedHistory.history().get(0).date()).isEqualTo("2026-04-07");
-        assertThat(updatedHistory.history().get(0).metrics().stats().avgDynamicAccessCoveragePercent()).isEqualByComparingTo("75.0");
+        assertThat(updatedHistory.history().get(0).metrics().stats().dynamicAccessCallCoveragePercent()).isEqualByComparingTo("20.0");
     }
 
     @Test
@@ -230,7 +250,7 @@ class ReadmeBadgeSummarySupportTests {
 
         ReadmeBadgeSummarySupport.ReadmeMetricsHistory updatedHistory = ReadmeBadgeSummarySupport.withSnapshot(history, summary);
         assertThat(updatedHistory.history()).hasSize(1);
-        assertThat(updatedHistory.history().get(0).metrics().stats().avgDynamicAccessCoveragePercent()).isEqualByComparingTo("25.0");
+        assertThat(updatedHistory.history().get(0).metrics().stats().dynamicAccessCallCoveragePercent()).isEqualByComparingTo("25.0");
         assertThat(updatedHistory.history().get(0).metrics().metadataIndexes().testedVersions()).isEqualTo(24);
     }
 
@@ -271,7 +291,7 @@ class ReadmeBadgeSummarySupportTests {
         assertThat(svg).contains("Supported libraries");
         assertThat(svg).contains("Libraries with reachability metadata in the repository");
         assertThat(svg).contains("Dynamic access coverage");
-        assertThat(svg).contains("Average dynamic-access call coverage across repository metadata");
+        assertThat(svg).contains("Dynamic-access call coverage across repository metadata");
         assertThat(svg).contains("Tested library versions");
         assertThat(svg).contains("Tested library versions recorded across metadata indexes");
         assertThat(svg).contains("Tested lines of code");


### PR DESCRIPTION
Closes #3334

## Summary
- calculate repository dynamic access coverage as covered dynamic-access calls divided by detected dynamic-access calls
- skip entries with no detected dynamic-access calls\n- rename the stored stats metric to dynamicAccessCallCoveragePercent
- update the coverage graph subtitle and tests for the weighted calculation

- ## Testing
- ./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.stats.ReadmeBadgeSummarySupportTests --stacktrace