### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-metrics:1.59.0 using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/reachability-metadata.json
@@ -1,0 +1,81 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.SdkMeter"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.SdkMeterProvider"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProvider",
+      "methods": [
+        {
+          "name": "resetForTest",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.common.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "addMeterConfiguratorCondition",
+          "parameterTypes": [
+            "java.util.function.Predicate",
+            "io.opentelemetry.sdk.metrics.internal.MeterConfig"
+          ]
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.common.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.ViewBuilder",
+      "methods": [
+        {
+          "name": "addAttributesProcessor",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.DoubleAdder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.59.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.59.0/opentelemetry-sdk-metrics-1.59.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.59.0/sdk/metrics/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.59.0/opentelemetry-sdk-metrics-1.59.0-javadoc.jar",
+    "description" : "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
     "tested-versions" : [
       "1.59.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,17 +1,23 @@
 [
   {
-    "latest": true,
-    "override": true,
-    "allowed-packages": [
-      "io.opentelemetry"
+    "latest" : true,
+    "metadata-version" : "1.59.0",
+    "tested-versions" : [
+      "1.59.0"
     ],
-    "metadata-version": "1.19.0",
-    "source-code-url": "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
-    "repository-url": "https://github.com/open-telemetry/opentelemetry-java",
-    "test-code-url": "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
-    "documentation-url": "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
-    "description": "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
+    "override" : true,
+    "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.19.0/opentelemetry-sdk-metrics-1.19.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.19.0/sdk/metrics/src/test",
+    "documentation-url" : "https://github.com/open-telemetry/opentelemetry-java/blob/v1.19.0/sdk/metrics/README.md",
+    "description" : "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider and the pipeline components that produce metric data. Applications and instrumentation use it to configure, collect, and export metrics through OpenTelemetry.",
+    "tested-versions" : [
       "1.19.0",
       "1.20.0",
       "1.20.1",
@@ -56,11 +62,14 @@
       "1.54.1",
       "1.55.0"
     ],
-    "skipped-versions": [
+    "skipped-versions" : [
       {
-        "version": "1.34.0",
-        "reason": "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
+        "version" : "1.34.0",
+        "reason" : "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse."
       }
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
     ]
   }
 ]

--- a/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.59.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3231,
+        "missed" : 15463,
+        "ratio" : 0.172836,
+        "total" : 18694
+      },
+      "line" : {
+        "covered" : 864,
+        "missed" : 3396,
+        "ratio" : 0.202817,
+        "total" : 4260
+      },
+      "method" : {
+        "covered" : 279,
+        "missed" : 928,
+        "ratio" : 0.231152,
+        "total" : 1207
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-metrics:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--allow-incomplete-classpath')
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version=1.59.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.59.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'opentelemetry-sdk-metrics-test'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+
+public class OpenTelemetrySdkMetricsTest {
+
+    @Test
+    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
+
+        Method method =
+                SdkMeterProviderBuilder.class.getDeclaredMethod(
+                        "setExemplarFilter", ExemplarFilter.class);
+        method.setAccessible(true);
+        method.invoke(sdkMeterProvider, new ExemplarFilter() {
+            @Override
+            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
+                return false;
+            }
+        });
+
+        try (SdkMeterProvider provider = sdkMeterProvider.build()) {
+            provider.meterBuilder("test");
+        }
+
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,42 +6,20 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder()
+                .setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");
         }
-
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -12,7 +12,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.common.internal.ScopeConfigurator;
 import io.opentelemetry.sdk.common.internal.ScopeConfiguratorBuilder;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.common.internal.ScopeConfiguratorBuilder;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.MeterConfig;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SdkMeterProviderUtilTest {
+
+    private static final AttributeKey<String> EXISTING_ATTRIBUTE = AttributeKey.stringKey("existing");
+    private static final AttributeKey<String> TENANT_ATTRIBUTE = AttributeKey.stringKey("tenant.id");
+    private static final AttributeKey<String> IGNORED_ATTRIBUTE = AttributeKey.stringKey("ignored.id");
+
+    @Test
+    public void builderConfiguratorAndConditionDisableMatchingMeters() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder()
+                .registerMetricReader(reader);
+        ScopeConfigurator<MeterConfig> configurator = MeterConfig.configuratorBuilder()
+                .addCondition(ScopeConfiguratorBuilder.nameEquals("blocked-by-configurator"), MeterConfig.disabled())
+                .build();
+
+        SdkMeterProviderUtil.setMeterConfigurator(builder, configurator);
+        SdkMeterProviderUtil.addMeterConfiguratorCondition(
+                builder,
+                ScopeConfiguratorBuilder.nameEquals("blocked-by-condition"),
+                MeterConfig.disabled());
+
+        try (SdkMeterProvider provider = builder.build()) {
+            provider.get("allowed").counterBuilder("allowed.counter").build().add(1);
+            provider.get("blocked-by-configurator").counterBuilder("blocked.configurator.counter").build().add(1);
+            provider.get("blocked-by-condition").counterBuilder("blocked.condition.counter").build().add(1);
+
+            Collection<MetricData> metrics = reader.collect();
+
+            Assertions.assertTrue(metricNamed(metrics, "allowed.counter").isPresent());
+            Assertions.assertFalse(metricNamed(metrics, "blocked.configurator.counter").isPresent());
+            Assertions.assertFalse(metricNamed(metrics, "blocked.condition.counter").isPresent());
+        }
+    }
+
+    @Test
+    public void providerConfiguratorUpdatesExistingMetersAndResetClearsInstruments() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .build()) {
+            Meter meter = provider.get("configurable");
+            meter.counterBuilder("reset.counter").build().add(1);
+            Assertions.assertTrue(metricNamed(reader.collect(), "reset.counter").isPresent());
+
+            ScopeConfigurator<MeterConfig> disabledConfigurator = MeterConfig.configuratorBuilder()
+                    .addCondition(ScopeConfiguratorBuilder.nameEquals("configurable"), MeterConfig.disabled())
+                    .build();
+            SdkMeterProviderUtil.setMeterConfigurator(provider, disabledConfigurator);
+            meter.counterBuilder("disabled.after.update.counter").build().add(1);
+            Assertions.assertFalse(metricNamed(reader.collect(), "disabled.after.update.counter").isPresent());
+
+            SdkMeterProviderUtil.setMeterConfigurator(provider, MeterConfig.configuratorBuilder().build());
+            meter.counterBuilder("after.reenable.counter").build().add(1);
+            Assertions.assertTrue(metricNamed(reader.collect(), "after.reenable.counter").isPresent());
+
+            SdkMeterProviderUtil.resetForTest(provider);
+            Assertions.assertFalse(metricNamed(reader.collect(), "after.reenable.counter").isPresent());
+        }
+    }
+
+    @Test
+    public void baggageAttributesAreAppendedToViewMeasurements() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        ViewBuilder viewBuilder = View.builder().setAttributeFilter(key -> EXISTING_ATTRIBUTE.getKey().equals(key));
+        Predicate<String> baggageKeyFilter = key -> TENANT_ATTRIBUTE.getKey().equals(key);
+        SdkMeterProviderUtil.appendFilteredBaggageAttributes(viewBuilder, baggageKeyFilter);
+        View view = viewBuilder.build();
+
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .registerView(InstrumentSelector.builder().setName("baggage.counter").build(), view)
+                .build()) {
+            Context context = Baggage.builder()
+                    .put(TENANT_ATTRIBUTE.getKey(), "tenant-a")
+                    .put(IGNORED_ATTRIBUTE.getKey(), "ignored")
+                    .put(EXISTING_ATTRIBUTE.getKey(), "from-baggage")
+                    .build()
+                    .storeInContext(Context.root());
+
+            provider.get("baggage-meter").counterBuilder("baggage.counter").build()
+                    .add(1, Attributes.of(EXISTING_ATTRIBUTE, "from-measurement"), context);
+
+            MetricData metric = metricNamed(reader.collect(), "baggage.counter").orElseThrow(AssertionError::new);
+            LongPointData point = metric.getLongSumData().getPoints().iterator().next();
+
+            Assertions.assertEquals("from-measurement", point.getAttributes().get(EXISTING_ATTRIBUTE));
+            Assertions.assertEquals("tenant-a", point.getAttributes().get(TENANT_ATTRIBUTE));
+            Assertions.assertNull(point.getAttributes().get(IGNORED_ATTRIBUTE));
+        }
+    }
+
+    private static Optional<MetricData> metricNamed(Collection<MetricData> metrics, String name) {
+        return metrics.stream()
+                .filter(metric -> name.equals(metric.getName()))
+                .findFirst();
+    }
+
+    private static final class RecordingMetricReader implements MetricReader {
+        private CollectionRegistration registration = CollectionRegistration.noop();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            this.registration = registration;
+        }
+
+        Collection<MetricData> collect() {
+            return registration.collectAllMetrics();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.sdk.metrics.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3341

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-metrics:1.59.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 156712
- Cached input tokens: 1686016
- Output tokens: 11593
- Entries found: 12
- Iterations: 3
- Library coverage percentage: 20.28
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 1.29

### Metadata Forge

- Forge monitored branch: `origin/vj/gh-ready`
- Forge branch: `vj/gh-ready`
- Forge commit hash: `1e4f1a8284ebf9f67d0f22a6bb041b58600142b6`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 5/5 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 0/3 covered calls (0.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 165/15046 (1.10%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 3231/18694 (17.28%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 45/3480 (1.29%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 864/4260 (20.28%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.19.0: 15/999 (1.50%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 279/1207 (23.12%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
index 399b536ee4..b5ab761610 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/build.gradle
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
@@ -22,3 +22,14 @@ graalvmNative {
         }
     }
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
index c50a968cdb..8e3492c78b 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.19.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -6,42 +6,20 @@
  */
 package opentelemetry;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-
 public class OpenTelemetrySdkMetricsTest {
 
     @Test
-    public void sdkMetricsTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder();
-
-        Method method =
-                SdkMeterProviderBuilder.class.getDeclaredMethod(
-                        "setExemplarFilter", ExemplarFilter.class);
-        method.setAccessible(true);
-        method.invoke(sdkMeterProvider, new ExemplarFilter() {
-            @Override
-            public boolean shouldSampleMeasurement(long value, Attributes attributes, Context context) {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSampleMeasurement(double value, Attributes attributes, Context context) {
-                return false;
-            }
-        });
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider = SdkMeterProvider.builder()
+                .setExemplarFilter(ExemplarFilter.alwaysOff());
 
         try (SdkMeterProvider provider = sdkMeterProvider.build()) {
             provider.meterBuilder("test");
         }
-
     }
 }
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
new file mode 100644
index 0000000000..34d97b5280
--- /dev/null
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -0,0 +1,160 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.common.internal.ScopeConfiguratorBuilder;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.MeterConfig;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SdkMeterProviderUtilTest {
+
+    private static final AttributeKey<String> EXISTING_ATTRIBUTE = AttributeKey.stringKey("existing");
+    private static final AttributeKey<String> TENANT_ATTRIBUTE = AttributeKey.stringKey("tenant.id");
+    private static final AttributeKey<String> IGNORED_ATTRIBUTE = AttributeKey.stringKey("ignored.id");
+
+    @Test
+    public void builderConfiguratorAndConditionDisableMatchingMeters() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder()
+                .registerMetricReader(reader);
+        ScopeConfigurator<MeterConfig> configurator = MeterConfig.configuratorBuilder()
+                .addCondition(ScopeConfiguratorBuilder.nameEquals("blocked-by-configurator"), MeterConfig.disabled())
+                .build();
+
+        SdkMeterProviderUtil.setMeterConfigurator(builder, configurator);
+        SdkMeterProviderUtil.addMeterConfiguratorCondition(
+                builder,
+                ScopeConfiguratorBuilder.nameEquals("blocked-by-condition"),
+                MeterConfig.disabled());
+
+        try (SdkMeterProvider provider = builder.build()) {
+            provider.get("allowed").counterBuilder("allowed.counter").build().add(1);
+            provider.get("blocked-by-configurator").counterBuilder("blocked.configurator.counter").build().add(1);
+            provider.get("blocked-by-condition").counterBuilder("blocked.condition.counter").build().add(1);
+
+            Collection<MetricData> metrics = reader.collect();
+
+            Assertions.assertTrue(metricNamed(metrics, "allowed.counter").isPresent());
+            Assertions.assertFalse(metricNamed(metrics, "blocked.configurator.counter").isPresent());
+            Assertions.assertFalse(metricNamed(metrics, "blocked.condition.counter").isPresent());
+        }
+    }
+
+    @Test
+    public void providerConfiguratorUpdatesExistingMetersAndResetClearsInstruments() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .build()) {
+            Meter meter = provider.get("configurable");
+            meter.counterBuilder("reset.counter").build().add(1);
+            Assertions.assertTrue(metricNamed(reader.collect(), "reset.counter").isPresent());
+
+            ScopeConfigurator<MeterConfig> disabledConfigurator = MeterConfig.configuratorBuilder()
+                    .addCondition(ScopeConfiguratorBuilder.nameEquals("configurable"), MeterConfig.disabled())
+                    .build();
+            SdkMeterProviderUtil.setMeterConfigurator(provider, disabledConfigurator);
+            meter.counterBuilder("disabled.after.update.counter").build().add(1);
+            Assertions.assertFalse(metricNamed(reader.collect(), "disabled.after.update.counter").isPresent());
+
+            SdkMeterProviderUtil.setMeterConfigurator(provider, MeterConfig.configuratorBuilder().build());
+            meter.counterBuilder("after.reenable.counter").build().add(1);
+            Assertions.assertTrue(metricNamed(reader.collect(), "after.reenable.counter").isPresent());
+
+            SdkMeterProviderUtil.resetForTest(provider);
+            Assertions.assertFalse(metricNamed(reader.collect(), "after.reenable.counter").isPresent());
+        }
+    }
+
+    @Test
+    public void baggageAttributesAreAppendedToViewMeasurements() {
+        RecordingMetricReader reader = new RecordingMetricReader();
+        ViewBuilder viewBuilder = View.builder().setAttributeFilter(key -> EXISTING_ATTRIBUTE.getKey().equals(key));
+        Predicate<String> baggageKeyFilter = key -> TENANT_ATTRIBUTE.getKey().equals(key);
+        SdkMeterProviderUtil.appendFilteredBaggageAttributes(viewBuilder, baggageKeyFilter);
+        View view = viewBuilder.build();
+
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .registerView(InstrumentSelector.builder().setName("baggage.counter").build(), view)
+                .build()) {
+            Context context = Baggage.builder()
+                    .put(TENANT_ATTRIBUTE.getKey(), "tenant-a")
+                    .put(IGNORED_ATTRIBUTE.getKey(), "ignored")
+                    .put(EXISTING_ATTRIBUTE.getKey(), "from-baggage")
+                    .build()
+                    .storeInContext(Context.root());
+
+            provider.get("baggage-meter").counterBuilder("baggage.counter").build()
+                    .add(1, Attributes.of(EXISTING_ATTRIBUTE, "from-measurement"), context);
+
+            MetricData metric = metricNamed(reader.collect(), "baggage.counter").orElseThrow(AssertionError::new);
+            LongPointData point = metric.getLongSumData().getPoints().iterator().next();
+
+            Assertions.assertEquals("from-measurement", point.getAttributes().get(EXISTING_ATTRIBUTE));
+            Assertions.assertEquals("tenant-a", point.getAttributes().get(TENANT_ATTRIBUTE));
+            Assertions.assertNull(point.getAttributes().get(IGNORED_ATTRIBUTE));
+        }
+    }
+
+    private static Optional<MetricData> metricNamed(Collection<MetricData> metrics, String name) {
+        return metrics.stream()
+                .filter(metric -> name.equals(metric.getName()))
+                .findFirst();
+    }
+
+    private static final class RecordingMetricReader implements MetricReader {
+        private CollectionRegistration registration = CollectionRegistration.noop();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            this.registration = registration;
+        }
+
+        Collection<MetricData> collect() {
+            return registration.collectAllMetrics();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
new file mode 100644
index 0000000000..8d10356eed
--- /dev/null
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.sdk.metrics.**"
+    }
+  ]
+}

```
