### PR TITLE
[GenAI] Test fix for org.jboss.logmanager:jboss-logmanager:1.3.0.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/reachability-metadata.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/reachability-metadata.json
@@ -1,0 +1,260 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "com.sun.jmx.trace.Trace"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.Enum",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.Level"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "type" : "org.jboss.logmanager.formatters.Formatters$12$2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logmanager.formatters.Formatters$12",
+            "java.lang.ClassLoader",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "type" : "javax.crypto.Cipher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogContext"
+      },
+      "type" : "org.jboss.logmanager.LogContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LoggerNode"
+      },
+      "type" : "org.jboss.logmanager.LoggerNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtLogRecord"
+      },
+      "glob" : "org/jboss/logmanager/ExtLogRecord$FormatStyle.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "glob" : "org/jboss/logmanager/ExtLogRecord.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.NDC"
+      },
+      "glob" : "org/jboss/logmanager/NDC$Holder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.NDC$Holder"
+      },
+      "glob" : "org/jboss/logmanager/NDC$Stack.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtLogRecord"
+      },
+      "glob" : "org/jboss/logmanager/NDC.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "glob" : "org/jboss/logmanager/WrappedExtLogRecord.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.MultistepFormatter"
+      },
+      "glob" : "org/jboss/logmanager/formatters/FormatStep.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.PatternFormatter"
+      },
+      "glob" : "org/jboss/logmanager/formatters/FormatStringParser.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.FormatStringParser"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$1.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$11.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$12.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$12$1.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$12$2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$15.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$JustifyingFormatStep.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.FormatStringParser"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters.class"
+    },
+    {
+      "glob" : "org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12DefinedClass.class"
+    },
+    {
+      "glob" : "org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test$BootstrapFormattingInvoker.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12$2"
+      },
+      "glob" : "org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.class"
+    }
+  ]
+}

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.3.0.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.3.0.Final/jboss-logmanager-1.3.0.Final-sources.jar",
+    "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",
+    "test-code-url" : "https://github.com/jboss-logging/jboss-logmanager/tree/1.3.0.Final/src/test",
+    "documentation-url" : "N/A",
+    "description" : "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
     "tested-versions" : [
       "1.3.0.Final"
     ],

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -1,15 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "org.jboss.logmanager" ],
-    "metadata-version": "1.2.0.GA",
-    "source-code-url": "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.2.0.GA/jboss-logmanager-1.2.0.GA-sources.jar",
-    "repository-url": "https://github.com/jboss-logging/jboss-logmanager",
-    "test-code-url": "https://github.com/jboss-logging/jboss-logmanager/tree/1.2.0.GA/src/test",
-    "documentation-url": "N/A",
-    "description": "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "1.3.0.Final",
+    "tested-versions" : [
+      "1.3.0.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.logmanager"
+    ]
+  },
+  {
+    "metadata-version" : "1.2.0.GA",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.2.0.GA/jboss-logmanager-1.2.0.GA-sources.jar",
+    "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",
+    "test-code-url" : "https://github.com/jboss-logging/jboss-logmanager/tree/1.2.0.GA/src/test",
+    "documentation-url" : "N/A",
+    "description" : "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
+    "tested-versions" : [
       "1.2.0.GA"
+    ],
+    "allowed-packages" : [
+      "org.jboss.logmanager"
     ]
   }
 ]

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/stats.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.3.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.958333,
+          "coveredCalls" : 23,
+          "totalCalls" : 24
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.965517,
+      "coveredCalls" : 28,
+      "totalCalls" : 29
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5368,
+        "missed" : 14467,
+        "ratio" : 0.270633,
+        "total" : 19835
+      },
+      "line" : {
+        "covered" : 1220,
+        "missed" : 3388,
+        "ratio" : 0.264757,
+        "total" : 4608
+      },
+      "method" : {
+        "covered" : 305,
+        "missed" : 778,
+        "ratio" : 0.281625,
+        "total" : 1083
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/.gitignore
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/build.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.logmanager:jboss-logmanager:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/gradle.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.logmanager:jboss-logmanager:1.3.0.Final
+library.version = 1.3.0.Final
+metadata.dir = org.jboss.logmanager/jboss-logmanager/1.3.0.Final/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/settings.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.logmanager.jboss-logmanager_tests'

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.FormatterConfiguration;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void constructorPropertyTypeCanBeDiscoveredFromPublicGetter() {
+        String loggerName = AbstractPropertyConfigurationTest.class.getName() + ".constructorProperty";
+        LogContext logContext = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(logContext);
+
+        FormatterConfiguration formatter = configuration.addFormatterConfiguration(
+                null,
+                PrefixFormatter.class.getName(),
+                "prefixFormatter",
+                "prefix"
+        );
+        formatter.setPropertyValueString("prefix", "constructed:");
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                CapturingHandler.class.getName(),
+                "capturingHandler"
+        );
+        handler.setFormatterName("prefixFormatter");
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.setHandlerNames("capturingHandler");
+        configuration.commit();
+
+        Logger logger = logContext.getLogger(loggerName);
+        logger.info("message");
+
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(CapturingHandler.class, capturing -> {
+            assertThat(capturing.getFormatter()).isInstanceOfSatisfying(PrefixFormatter.class,
+                    formatterInstance -> assertThat(formatterInstance.getPrefix()).isEqualTo("constructed:"));
+            assertThat(capturing.getLastPublishedMessage()).isEqualTo("constructed:message");
+        });
+    }
+
+    public static final class PrefixFormatter extends Formatter {
+        private final String prefix;
+
+        public PrefixFormatter(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class CapturingHandler extends Handler {
+        private String lastPublishedMessage;
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AtomicArrayTest {
+
+    @Test
+    void addAndRemoveSupportNonHandlerComponentTypes() throws Exception {
+        Holder holder = new Holder();
+        AtomicReferenceFieldUpdater<Holder, String[]> updater =
+                AtomicReferenceFieldUpdater.newUpdater(Holder.class, String[].class, "values");
+        Object atomicArray = newAtomicArray(updater, String.class);
+
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "console");
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "file");
+
+        assertThat(holder.values).containsExactly("console", "file");
+        assertThat(invokeMethod(
+                atomicArray,
+                "remove",
+                new Class<?>[] {Object.class, Object.class, boolean.class },
+                holder,
+                "console",
+                false
+        )).isEqualTo(Boolean.TRUE);
+        assertThat(holder.values).containsExactly("file");
+
+        invokeMethod(atomicArray, "clear", new Class<?>[] {Object.class }, holder);
+        assertThat(holder.values).isEmpty();
+    }
+
+    private static Object newAtomicArray(
+            final AtomicReferenceFieldUpdater<Holder, String[]> updater,
+            final Class<String> componentType
+    ) throws Exception {
+        Class<?> atomicArrayType = Class.forName("org.jboss.logmanager.AtomicArray");
+        Constructor<?> constructor = atomicArrayType.getDeclaredConstructor(AtomicReferenceFieldUpdater.class, Class.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(updater, componentType);
+    }
+
+    private static Object invokeMethod(
+            final Object target,
+            final String methodName,
+            final Class<?>[] parameterTypes,
+            final Object... arguments
+    ) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static final class Holder {
+        volatile String[] values = new String[0];
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentReferenceHashMapTest {
+
+    @Test
+    void serializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> map = newConcurrentReferenceHashMap();
+        Map<String, String> expectedEntries = new LinkedHashMap<>();
+        expectedEntries.put("logger", "main");
+        expectedEntries.put("handler", "console");
+        map.putAll(expectedEntries);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(map);
+            objectOutputStream.flush();
+            serialized = outputStream.toByteArray();
+        }
+
+        Object restored;
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            restored = objectInputStream.readObject();
+        }
+
+        assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        @SuppressWarnings("unchecked")
+        Map<String, String> restoredMap = (Map<String, String>) restored;
+        assertThat(restoredMap)
+                .hasSize(expectedEntries.size())
+                .containsAllEntriesOf(expectedEntries);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Map<String, String> newConcurrentReferenceHashMap() throws Exception {
+        Class<?> mapType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        Class enumType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType");
+        Object strongReference = Enum.valueOf(enumType, "STRONG");
+        Constructor<?> constructor = mapType.getDeclaredConstructor(int.class, enumType, enumType);
+        constructor.setAccessible(true);
+        return (Map<String, String>) constructor.newInstance(4, strongReference, strongReference);
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class ConcurrentReferenceHashMapTest {
 
     @Test
     void serializationRoundTripPreservesEntries() throws Exception {
+        assumeFalse(isNativeImageRuntime(), "ConcurrentReferenceHashMap serializes JDK lock internals");
+
         Map<String, String> map = newConcurrentReferenceHashMap();
         Map<String, String> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put("logger", "main");
@@ -47,6 +50,10 @@ public class ConcurrentReferenceHashMapTest {
         assertThat(restoredMap)
                 .hasSize(expectedEntries.size())
                 .containsAllEntriesOf(expectedEntries);
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.logmanager.DefaultConfigurationLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultConfigurationLocatorTest {
+
+    @Test
+    void findConfigurationLoadsLoggingPropertiesFromThreadContextClassLoader() throws Exception {
+        String originalConfiguration = System.getProperty("logging.configuration");
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            System.clearProperty("logging.configuration");
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+            DefaultConfigurationLocator locator = new DefaultConfigurationLocator();
+            try (InputStream stream = locator.findConfiguration()) {
+                assertThat(stream).isNotNull();
+                assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+                        .contains("test.resource=thread-context-class-loader");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalConfiguration == null) {
+                System.clearProperty("logging.configuration");
+            } else {
+                System.setProperty("logging.configuration", originalConfiguration);
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.logmanager.MDC;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastCopyHashMapTest {
+
+    @Test
+    void mdcCopySerializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> originalMdc = MDC.copy();
+        try {
+            MDC.clear();
+            Map<String, String> expectedEntries = new LinkedHashMap<>();
+            expectedEntries.put("logger", "main");
+            expectedEntries.put("handler", "console");
+            expectedEntries.forEach(MDC::put);
+
+            Map<String, String> map = MDC.copy();
+            assertThat(map.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+
+            byte[] serialized = serialize(map);
+            Object restored = deserialize(serialized);
+
+            assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+            assertThat(restored).isInstanceOf(Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> restoredMap = (Map<String, String>) restored;
+            assertThat(restoredMap).isEqualTo(expectedEntries);
+        } finally {
+            MDC.clear();
+            originalMdc.forEach(MDC::put);
+        }
+    }
+
+    private static byte[] serialize(final Object value) throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+            objectOutputStream.flush();
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static Object deserialize(final byte[] serialized) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return objectInputStream.readObject();
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/Formatters12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/Formatters12Test.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.CodeSource;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
+import java.util.Objects;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.Formatters;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+public class Formatters12Test {
+
+    @Test
+    void extendedExceptionFormattingUsesTcclDefinedClassAndResourceLookupWhenCodeSourceLocationIsMissing()
+            throws Exception {
+        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+
+        String className = Formatters12DefinedClass.class.getName();
+        TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
+
+        String formatted = formatWithTccl(trackingLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        assertThat(trackingLoader.wasResourceRequested()).isTrue();
+    }
+
+    @Test
+    void privilegedExtendedExceptionResourceLookupMatchesDirectClassLoaderLookup() throws Throwable {
+        assumeFalse(System.getProperty("java.vm.name", "").contains("Substrate VM"),
+                "Anonymous privileged-action construction is only needed for JVM dynamic-access coverage");
+
+        Object exceptionFormatStep = Formatters.exceptionFormatStep(true, 0, 0, true);
+        Class<?> privilegedActionClass = exceptionFormatStep.getClass().getClassLoader()
+                .loadClass(exceptionFormatStep.getClass().getName() + "$2");
+        MethodHandles.Lookup actionLookup = MethodHandles.privateLookupIn(privilegedActionClass, MethodHandles.lookup());
+        MethodHandle constructor = actionLookup.findConstructor(
+                privilegedActionClass,
+                MethodType.methodType(void.class, exceptionFormatStep.getClass(), Class.class, String.class)
+        );
+        String classResourceName = Formatters12Test.class.getName().replace('.', '/') + ".class";
+        URL expectedResource = Formatters12Test.class.getClassLoader().getResource(classResourceName);
+
+        @SuppressWarnings("unchecked")
+        PrivilegedAction<URL> privilegedAction = (PrivilegedAction<URL>) constructor.invoke(
+                exceptionFormatStep,
+                Formatters12Test.class,
+                classResourceName
+        );
+
+        assertThat(AccessController.doPrivileged(privilegedAction)).isEqualTo(expectedResource);
+    }
+
+    @Test
+    void extendedExceptionFormattingUsesBootstrapFallbackWhenTheLibraryLoaderRejectsTheClass() throws Throwable {
+        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+
+        String className = "java.util.HexFormat";
+        BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
+        BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
+
+        String formatted = formattingAction.format(newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        assertThat(bootstrapFallbackClassLoader.wasRejected()).isTrue();
+    }
+
+    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            PatternFormatter formatter = new PatternFormatter("%E");
+            ExtLogRecord record = new ExtLogRecord(Level.SEVERE, "coverage", Formatters12Test.class.getName());
+            record.setThrown(thrown);
+            return formatter.format(record);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static IllegalStateException newFailure(final String className) {
+        IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
+        });
+        return failure;
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+
+    private static final class TrackingDefinedClassLoader extends ClassLoader {
+        private final String definedClassName;
+        private final byte[] definedClassBytes;
+        private final String resourceName;
+        private boolean resourceRequested;
+
+        private TrackingDefinedClassLoader(final String definedClassName) throws IOException {
+            super(Formatters12Test.class.getClassLoader());
+            this.definedClassName = definedClassName;
+            this.resourceName = definedClassName.replace('.', '/') + ".class";
+            this.definedClassBytes = loadClassBytes(resourceName);
+        }
+
+        boolean wasResourceRequested() {
+            return resourceRequested;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (!definedClassName.equals(name)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> alreadyLoaded = findLoadedClass(name);
+                if (alreadyLoaded != null) {
+                    return alreadyLoaded;
+                }
+                Class<?> definedClass = defineClass(
+                        name,
+                        definedClassBytes,
+                        0,
+                        definedClassBytes.length,
+                        new ProtectionDomain(new CodeSource(null, (Certificate[]) null), null)
+                );
+                if (resolve) {
+                    resolveClass(definedClass);
+                }
+                return definedClass;
+            }
+        }
+
+        @Override
+        public java.net.URL getResource(final String name) {
+            if (resourceName.equals(name)) {
+                resourceRequested = true;
+            }
+            return super.getResource(name);
+        }
+
+        private static byte[] loadClassBytes(final String resourceName) throws IOException {
+            try (InputStream inputStream = Formatters12DefinedClass.class.getClassLoader().getResourceAsStream(resourceName)) {
+                return Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+            }
+        }
+    }
+
+    public interface BootstrapFormattingAction {
+        String format(Throwable thrown);
+    }
+
+    public static final class BootstrapFormattingInvoker implements BootstrapFormattingAction {
+        public static final BootstrapFormattingAction INSTANCE = new BootstrapFormattingInvoker();
+
+        private BootstrapFormattingInvoker() {
+        }
+
+        @Override
+        public String format(final Throwable thrown) {
+            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                PatternFormatter formatter = new PatternFormatter("%E");
+                java.util.logging.LogRecord record = new java.util.logging.LogRecord(Level.SEVERE, "coverage");
+                record.setThrown(thrown);
+                return formatter.format(record);
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalTccl);
+            }
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private boolean rejected;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        boolean wasRejected() {
+            return rejected;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                rejected = true;
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class BootstrapFallbackClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private boolean rejected;
+
+        private BootstrapFallbackClassLoader(final String rejectedClassName) {
+            super(Formatters12Test.class.getClassLoader());
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        BootstrapFormattingAction loadFormattingAction() throws Throwable {
+            Class<?> actionClass = Class.forName(BootstrapFormattingInvoker.class.getName(), true, this);
+            VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
+                    actionClass,
+                    "INSTANCE",
+                    BootstrapFormattingAction.class
+            );
+            return BootstrapFormattingAction.class.cast(instanceHandle.get());
+        }
+
+        boolean wasRejected() {
+            return rejected;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> alreadyLoaded = findLoadedClass(name);
+                if (alreadyLoaded != null) {
+                    return alreadyLoaded;
+                }
+                if (rejectedClassName.equals(name)) {
+                    rejected = true;
+                    throw new ClassNotFoundException(name);
+                }
+                if (shouldDefineLocally(name)) {
+                    Class<?> localClass = findClass(name);
+                    if (resolve) {
+                        resolveClass(localClass);
+                    }
+                    return localClass;
+                }
+                return super.loadClass(name, resolve);
+            }
+        }
+
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream inputStream = Formatters12Test.class.getClassLoader().getResourceAsStream(resourceName)) {
+                byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+                return defineClass(name, classBytes, 0, classBytes.length);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+
+        private boolean shouldDefineLocally(final String name) {
+            return name.startsWith("org.jboss.logmanager.")
+                    || BootstrapFormattingInvoker.class.getName().equals(name);
+        }
+    }
+}
+
+final class Formatters12DefinedClass {
+}
+
+final class Formatters12FallbackMarker {
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.security.PrivilegedAction;
+
+import org.jboss.logmanager.formatters.FormatStep;
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Anonymous2Test {
+
+    @Test
+    void resourceLookupUsesSuppliedClassLoader() throws Throwable {
+        final String resourceName = FormattersAnonymous12Anonymous2Test.class.getName().replace('.', '/') + ".class";
+        final ClassLoader classLoader = FormattersAnonymous12Anonymous2Test.class.getClassLoader();
+        final URL expectedResource = classLoader.getResource(resourceName);
+
+        final URL resource = newResourceLookupAction(classLoader, resourceName).run();
+
+        assertThat(resource).isEqualTo(expectedResource);
+    }
+
+    @Test
+    void resourceLookupUsesSystemClassLoaderWhenSuppliedClassLoaderIsNull() throws Throwable {
+        final String resourceName = String.class.getName().replace('.', '/') + ".class";
+        final URL expectedResource = ClassLoader.getSystemResource(resourceName);
+
+        final URL resource = newResourceLookupAction(null, resourceName).run();
+
+        assertThat(resource).isEqualTo(expectedResource);
+    }
+
+    private static PrivilegedAction<URL> newResourceLookupAction(final ClassLoader classLoader, final String resourceName)
+            throws Throwable {
+        final FormatStep exceptionFormatStep = Formatters.exceptionFormatStep(true, 0, 0, true);
+        final Class<?> actionClass = exceptionFormatStep.getClass().getClassLoader()
+                .loadClass(exceptionFormatStep.getClass().getName() + "$2");
+        final MethodHandles.Lookup actionLookup = MethodHandles.privateLookupIn(actionClass, MethodHandles.lookup());
+        final MethodHandle constructor = actionLookup.findConstructor(
+                actionClass,
+                MethodType.methodType(void.class, exceptionFormatStep.getClass(), ClassLoader.class, String.class)
+        );
+
+        @SuppressWarnings("unchecked")
+        final PrivilegedAction<URL> action = (PrivilegedAction<URL>) constructor.invoke(
+                exceptionFormatStep,
+                classLoader,
+                resourceName
+        );
+        return action;
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -8,89 +8,71 @@ package org_jboss_logmanager.jboss_logmanager;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.net.URL;
-import java.security.AccessController;
 import java.security.CodeSource;
-import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.Objects;
 import java.util.logging.Level;
 
 import org.jboss.logmanager.ExtLogRecord;
-import org.jboss.logmanager.formatters.Formatters;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class Formatters12Test {
+public class FormattersAnonymous12Test {
 
     @Test
     void extendedExceptionFormattingUsesTcclDefinedClassAndResourceLookupWhenCodeSourceLocationIsMissing()
             throws Exception {
-        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+        final String className = FormattersAnonymous12DefinedClass.class.getName();
+        final TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
 
-        String className = Formatters12DefinedClass.class.getName();
-        TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
-
-        String formatted = formatWithTccl(trackingLoader, newFailure(className));
+        final String formatted = formatWithTccl(trackingLoader, newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
         assertThat(trackingLoader.wasResourceRequested()).isTrue();
     }
 
     @Test
-    void privilegedExtendedExceptionResourceLookupMatchesDirectClassLoaderLookup() throws Throwable {
-        assumeFalse(System.getProperty("java.vm.name", "").contains("Substrate VM"),
-                "Anonymous privileged-action construction is only needed for JVM dynamic-access coverage");
-
-        Object exceptionFormatStep = Formatters.exceptionFormatStep(true, 0, 0, true);
-        Class<?> privilegedActionClass = exceptionFormatStep.getClass().getClassLoader()
-                .loadClass(exceptionFormatStep.getClass().getName() + "$2");
-        MethodHandles.Lookup actionLookup = MethodHandles.privateLookupIn(privilegedActionClass, MethodHandles.lookup());
-        MethodHandle constructor = actionLookup.findConstructor(
-                privilegedActionClass,
-                MethodType.methodType(void.class, exceptionFormatStep.getClass(), Class.class, String.class)
-        );
-        String classResourceName = Formatters12Test.class.getName().replace('.', '/') + ".class";
-        URL expectedResource = Formatters12Test.class.getClassLoader().getResource(classResourceName);
-
-        @SuppressWarnings("unchecked")
-        PrivilegedAction<URL> privilegedAction = (PrivilegedAction<URL>) constructor.invoke(
-                exceptionFormatStep,
-                Formatters12Test.class,
-                classResourceName
+    void oneArgumentClassForNameIsUsedWhenTheContextClassLoaderRejectsTheFrameClass() {
+        final String className = String.class.getName();
+        final RejectingClassLoader rejectingLoader = new RejectingClassLoader(
+                Thread.currentThread().getContextClassLoader(),
+                className
         );
 
-        assertThat(AccessController.doPrivileged(privilegedAction)).isEqualTo(expectedResource);
+        final String formatted = formatWithTccl(rejectingLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        assertThat(rejectingLoader.wasRejected()).isTrue();
     }
 
     @Test
-    void extendedExceptionFormattingUsesBootstrapFallbackWhenTheLibraryLoaderRejectsTheClass() throws Throwable {
-        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+    void bootstrapClassLoaderFallbackIsUsedWhenTheLibraryLoaderRejectsTheFrameClass() throws Throwable {
+        final String className = "java.util.HexFormat";
+        final BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
+        final BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
 
-        String className = "java.util.HexFormat";
-        BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
-        BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
-
-        String formatted = formattingAction.format(newFailure(className));
+        final String formatted = formattingAction.format(newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
         assertThat(bootstrapFallbackClassLoader.wasRejected()).isTrue();
     }
 
     private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
-        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
-            PatternFormatter formatter = new PatternFormatter("%E");
-            ExtLogRecord record = new ExtLogRecord(Level.SEVERE, "coverage", Formatters12Test.class.getName());
+            final PatternFormatter formatter = new PatternFormatter("%E");
+            final ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous12Test.class.getName()
+            );
             record.setThrown(thrown);
             return formatter.format(record);
         } finally {
@@ -99,15 +81,11 @@ public class Formatters12Test {
     }
 
     private static IllegalStateException newFailure(final String className) {
-        IllegalStateException failure = new IllegalStateException("boom");
+        final IllegalStateException failure = new IllegalStateException("boom");
         failure.setStackTrace(new StackTraceElement[] {
                 new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
         });
         return failure;
-    }
-
-    private static boolean isNativeImageRuntime() {
-        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 
     private static final class TrackingDefinedClassLoader extends ClassLoader {
@@ -117,7 +95,7 @@ public class Formatters12Test {
         private boolean resourceRequested;
 
         private TrackingDefinedClassLoader(final String definedClassName) throws IOException {
-            super(Formatters12Test.class.getClassLoader());
+            super(FormattersAnonymous12Test.class.getClassLoader());
             this.definedClassName = definedClassName;
             this.resourceName = definedClassName.replace('.', '/') + ".class";
             this.definedClassBytes = loadClassBytes(resourceName);
@@ -133,11 +111,11 @@ public class Formatters12Test {
                 return super.loadClass(name, resolve);
             }
             synchronized (getClassLoadingLock(name)) {
-                Class<?> alreadyLoaded = findLoadedClass(name);
+                final Class<?> alreadyLoaded = findLoadedClass(name);
                 if (alreadyLoaded != null) {
                     return alreadyLoaded;
                 }
-                Class<?> definedClass = defineClass(
+                final Class<?> definedClass = defineClass(
                         name,
                         definedClassBytes,
                         0,
@@ -152,7 +130,7 @@ public class Formatters12Test {
         }
 
         @Override
-        public java.net.URL getResource(final String name) {
+        public URL getResource(final String name) {
             if (resourceName.equals(name)) {
                 resourceRequested = true;
             }
@@ -160,7 +138,8 @@ public class Formatters12Test {
         }
 
         private static byte[] loadClassBytes(final String resourceName) throws IOException {
-            try (InputStream inputStream = Formatters12DefinedClass.class.getClassLoader().getResourceAsStream(resourceName)) {
+            try (InputStream inputStream = FormattersAnonymous12DefinedClass.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
                 return Objects.requireNonNull(inputStream, resourceName).readAllBytes();
             }
         }
@@ -178,11 +157,11 @@ public class Formatters12Test {
 
         @Override
         public String format(final Throwable thrown) {
-            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
             try {
                 Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-                PatternFormatter formatter = new PatternFormatter("%E");
-                java.util.logging.LogRecord record = new java.util.logging.LogRecord(Level.SEVERE, "coverage");
+                final PatternFormatter formatter = new PatternFormatter("%E");
+                final java.util.logging.LogRecord record = new java.util.logging.LogRecord(Level.SEVERE, "coverage");
                 record.setThrown(thrown);
                 return formatter.format(record);
             } finally {
@@ -219,13 +198,13 @@ public class Formatters12Test {
         private boolean rejected;
 
         private BootstrapFallbackClassLoader(final String rejectedClassName) {
-            super(Formatters12Test.class.getClassLoader());
+            super(FormattersAnonymous12Test.class.getClassLoader());
             this.rejectedClassName = rejectedClassName;
         }
 
         BootstrapFormattingAction loadFormattingAction() throws Throwable {
-            Class<?> actionClass = Class.forName(BootstrapFormattingInvoker.class.getName(), true, this);
-            VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
+            final Class<?> actionClass = loadClass(BootstrapFormattingInvoker.class.getName());
+            final VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
                     actionClass,
                     "INSTANCE",
                     BootstrapFormattingAction.class
@@ -240,7 +219,7 @@ public class Formatters12Test {
         @Override
         protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
             synchronized (getClassLoadingLock(name)) {
-                Class<?> alreadyLoaded = findLoadedClass(name);
+                final Class<?> alreadyLoaded = findLoadedClass(name);
                 if (alreadyLoaded != null) {
                     return alreadyLoaded;
                 }
@@ -249,7 +228,7 @@ public class Formatters12Test {
                     throw new ClassNotFoundException(name);
                 }
                 if (shouldDefineLocally(name)) {
-                    Class<?> localClass = findClass(name);
+                    final Class<?> localClass = findClass(name);
                     if (resolve) {
                         resolveClass(localClass);
                     }
@@ -261,9 +240,10 @@ public class Formatters12Test {
 
         @Override
         protected Class<?> findClass(final String name) throws ClassNotFoundException {
-            String resourceName = name.replace('.', '/') + ".class";
-            try (InputStream inputStream = Formatters12Test.class.getClassLoader().getResourceAsStream(resourceName)) {
-                byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+            final String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream inputStream = FormattersAnonymous12Test.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
+                final byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
                 return defineClass(name, classBytes, 0, classBytes.length);
             } catch (IOException e) {
                 throw new ClassNotFoundException(name, e);
@@ -277,8 +257,5 @@ public class Formatters12Test {
     }
 }
 
-final class Formatters12DefinedClass {
-}
-
-final class Formatters12FallbackMarker {
+final class FormattersAnonymous12DefinedClass {
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -53,7 +53,7 @@ public class FormattersAnonymous12Test {
 
     @Test
     void bootstrapClassLoaderFallbackIsUsedWhenTheLibraryLoaderRejectsTheFrameClass() throws Throwable {
-        final String className = "java.util.HexFormat";
+        final String className = "javax.crypto.Cipher";
         final BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
         final BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
 

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -22,12 +22,15 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class FormattersAnonymous12Test {
 
     @Test
     void extendedExceptionFormattingUsesTcclDefinedClassAndResourceLookupWhenCodeSourceLocationIsMissing()
             throws Exception {
+        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+
         final String className = FormattersAnonymous12DefinedClass.class.getName();
         final TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
 
@@ -39,6 +42,11 @@ public class FormattersAnonymous12Test {
 
     @Test
     void oneArgumentClassForNameIsUsedWhenTheContextClassLoaderRejectsTheFrameClass() {
+        assumeFalse(
+                isNativeImageRuntime(),
+                "Native image does not preserve JVM class-loader fallback observability for linked classes"
+        );
+
         final String className = String.class.getName();
         final RejectingClassLoader rejectingLoader = new RejectingClassLoader(
                 Thread.currentThread().getContextClassLoader(),
@@ -53,6 +61,8 @@ public class FormattersAnonymous12Test {
 
     @Test
     void bootstrapClassLoaderFallbackIsUsedWhenTheLibraryLoaderRejectsTheFrameClass() throws Throwable {
+        assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
+
         final String className = "javax.crypto.Cipher";
         final BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
         final BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
@@ -86,6 +96,10 @@ public class FormattersAnonymous12Test {
                 new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
         });
         return failure;
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 
     private static final class TrackingDefinedClassLoader extends ClassLoader {

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.logmanager.ConfigurationLocator;
+import org.jboss.logmanager.LogManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogManagerTest {
+
+    @Test
+    void readConfigurationLoadsLocatorFromThreadContextClassLoader() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        TcclConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, TcclConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(TcclConfigurationLocator.class.getClassLoader());
+
+            new LogManager().readConfiguration();
+
+            assertThat(TcclConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(TcclConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            TcclConfigurationLocator.reset();
+        }
+    }
+
+    @Test
+    void readConfigurationFallsBackToLogManagerClassLoaderWhenTcclCannotLoadLocator() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        FallbackConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, FallbackConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(
+                    new RejectingClassLoader(originalTccl, FallbackConfigurationLocator.class.getName())
+            );
+
+            new LogManager().readConfiguration();
+
+            assertThat(FallbackConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(FallbackConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            FallbackConfigurationLocator.reset();
+        }
+    }
+
+    public static final class TcclConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public TcclConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    public static final class FallbackConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public FallbackConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyConfiguratorTest {
+
+    @Test
+    void configureInstantiatesAndConfiguresNamedComponents() throws IOException {
+        String loggerName = PropertyConfiguratorTest.class.getName() + ".configured";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    logger.%1$s.level=INFO
+                    logger.%1$s.filter=coverageFilter
+                    logger.%1$s.handlers=coverageHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.coverageHandler=%2$s
+                    handler.coverageHandler.level=INFO
+                    handler.coverageHandler.encoding=UTF-8
+                    handler.coverageHandler.errorManager=coverageErrorManager
+                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.formatter=coverageFormatter
+                    handler.coverageHandler.properties=label
+                    handler.coverageHandler.label=primary
+                    filter.coverageFilter=%3$s
+                    filter.coverageFilter.properties=enabled
+                    filter.coverageFilter.enabled=true
+                    formatter.coverageFormatter=%4$s
+                    formatter.coverageFormatter.properties=prefix
+                    formatter.coverageFormatter.prefix=formatted:
+                    errorManager.coverageErrorManager=%5$s
+                    errorManager.coverageErrorManager.properties=name
+                    errorManager.coverageErrorManager.name=once
+                    """.formatted(
+                    loggerName,
+                    TrackingHandler.class.getName(),
+                    TrackingFilter.class.getName(),
+                    TrackingFormatter.class.getName(),
+                    TrackingErrorManager.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
+                assertThat(handler.getLevel()).isEqualTo(Level.INFO);
+                assertThat(handler.getEncoding()).isEqualTo("UTF-8");
+                assertThat(handler.getLabel()).isEqualTo("primary");
+                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
+                assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,
+                        errorManager -> assertThat(errorManager.getName()).isEqualTo("once"));
+            });
+
+            TrackingHandler handler = (TrackingHandler) logger.getHandlers()[0];
+            logger.info("hello");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("formatted:hello");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class TrackingHandler extends Handler {
+        private String label;
+        private String lastPublishedMessage;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(final String label) {
+            this.label = label;
+        }
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        public ErrorManager getConfiguredErrorManager() {
+            return getErrorManager();
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    public static final class TrackingFilter implements Filter {
+        private boolean enabled;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean isLoggable(final LogRecord record) {
+            return enabled;
+        }
+    }
+
+    public static final class TrackingFormatter extends Formatter {
+        private String prefix = "";
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class TrackingErrorManager extends ErrorManager {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -33,15 +33,15 @@ public class PropertyConfiguratorTest {
         try {
             String configuration = """
                     loggers=%1$s
+                    filters=coverageFilter
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
                     handler.coverageHandler.level=INFO
                     handler.coverageHandler.encoding=UTF-8
                     handler.coverageHandler.errorManager=coverageErrorManager
-                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.filter=filter coverageFilter
                     handler.coverageHandler.formatter=coverageFormatter
                     handler.coverageHandler.properties=label
                     handler.coverageHandler.label=primary
@@ -68,13 +68,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
+      },
+      "glob" : "logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,10 +1,42 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "org.jboss.logmanager.AtomicArray",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        },
+        {
+          "name" : "serialPersistentFields"
+        }
+      ]
+    }
+  ],
   "resources" : [
     {
       "condition" : {
         "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
       },
       "glob" : "logging.properties"
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "org.jboss.logmanager.FastCopyHashMap"
     }
   ]
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,28 +1,4 @@
 {
-  "reflection" : [
-    {
-      "condition" : {
-        "typeReached" : "org.jboss.logmanager.AtomicArray"
-      },
-      "type" : "org.jboss.logmanager.AtomicArray",
-      "allDeclaredConstructors" : true,
-      "allDeclaredMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
-      },
-      "type" : "java.lang.String",
-      "fields" : [
-        {
-          "name" : "serialVersionUID"
-        },
-        {
-          "name" : "serialPersistentFields"
-        }
-      ]
-    }
-  ],
   "resources" : [
     {
       "condition" : {
@@ -31,12 +7,182 @@
       "glob" : "logging.properties"
     }
   ],
-  "serialization" : [
+  "reflection" : [
     {
       "condition" : {
-        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
       },
-      "type" : "org.jboss.logmanager.FastCopyHashMap"
+      "type" : "org_jboss_logmanager.jboss_logmanager.FormattersAnonymous12DefinedClass"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$PrefixFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.ErrorManagerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FilterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "setPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/logging.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+test.resource=thread-context-class-loader

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.logmanager.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.logmanager.**"
+      "includeClasses" : "org.jboss.logmanager.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3356

This PR provides test fixes and new metadata for org.jboss.logmanager:jboss-logmanager:1.3.0.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 393702
- Cached input tokens: 5863424
- Output tokens: 43589
- Entries found: 51
- Iterations: 6
- Library coverage percentage: 26.48
- Previous library version metadata entries: 17
- Previous library version coverage percentage: 26.04

### Metadata Forge

- Forge monitored branch: `origin/vj/gh-ready`
- Forge branch: `master`
- Forge commit hash: `72d24b607766bede0d0f70fffa0606acaaaecc6f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 33/35 covered calls (94.29%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 28/29 covered calls (96.55%)

**Reflection:**
- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 30/32 covered calls (93.75%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 23/24 covered calls (95.83%)

**Resources:**
- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 3/3 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 3653/14184 (25.75%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5368/19835 (27.06%)

**Line:**
- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 903/3468 (26.04%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 1220/4608 (26.48%)

**Method:**
- org.jboss.logmanager:jboss-logmanager:1.2.0.GA: 185/786 (23.54%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 305/1083 (28.16%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
new file mode 100644
index 0000000000..986b739d33
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -0,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.FormatterConfiguration;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void constructorPropertyTypeCanBeDiscoveredFromPublicGetter() {
+        String loggerName = AbstractPropertyConfigurationTest.class.getName() + ".constructorProperty";
+        LogContext logContext = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(logContext);
+
+        FormatterConfiguration formatter = configuration.addFormatterConfiguration(
+                null,
+                PrefixFormatter.class.getName(),
+                "prefixFormatter",
+                "prefix"
+        );
+        formatter.setPropertyValueString("prefix", "constructed:");
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                CapturingHandler.class.getName(),
+                "capturingHandler"
+        );
+        handler.setFormatterName("prefixFormatter");
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.setHandlerNames("capturingHandler");
+        configuration.commit();
+
+        Logger logger = logContext.getLogger(loggerName);
+        logger.info("message");
+
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(CapturingHandler.class, capturing -> {
+            assertThat(capturing.getFormatter()).isInstanceOfSatisfying(PrefixFormatter.class,
+                    formatterInstance -> assertThat(formatterInstance.getPrefix()).isEqualTo("constructed:"));
+            assertThat(capturing.getLastPublishedMessage()).isEqualTo("constructed:message");
+        });
+    }
+
+    public static final class PrefixFormatter extends Formatter {
+        private final String prefix;
+
+        public PrefixFormatter(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class CapturingHandler extends Handler {
+        private String lastPublishedMessage;
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
index 08bf3cc740..62219f6122 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class ConcurrentReferenceHashMapTest {
 
     @Test
     void serializationRoundTripPreservesEntries() throws Exception {
+        assumeFalse(isNativeImageRuntime(), "ConcurrentReferenceHashMap serializes JDK lock internals");
+
         Map<String, String> map = newConcurrentReferenceHashMap();
         Map<String, String> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put("logger", "main");
@@ -49,6 +52,10 @@ public class ConcurrentReferenceHashMapTest {
                 .containsAllEntriesOf(expectedEntries);
     }
 
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private static Map<String, String> newConcurrentReferenceHashMap() throws Exception {
         Class<?> mapType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap");
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
new file mode 100644
index 0000000000..4409419ca9
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -0,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.security.PrivilegedAction;
+
+import org.jboss.logmanager.formatters.FormatStep;
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Anonymous2Test {
+
+    @Test
+    void resourceLookupUsesSuppliedClassLoader() throws Throwable {
+        final String resourceName = FormattersAnonymous12Anonymous2Test.class.getName().replace('.', '/') + ".class";
+        final ClassLoader classLoader = FormattersAnonymous12Anonymous2Test.class.getClassLoader();
+        final URL expectedResource = classLoader.getResource(resourceName);
+
+        final URL resource = newResourceLookupAction(classLoader, resourceName).run();
+
+        assertThat(resource).isEqualTo(expectedResource);
+    }
+
+    @Test
+    void resourceLookupUsesSystemClassLoaderWhenSuppliedClassLoaderIsNull() throws Throwable {
+        final String resourceName = String.class.getName().replace('.', '/') + ".class";
+        final URL expectedResource = ClassLoader.getSystemResource(resourceName);
+
+        final URL resource = newResourceLookupAction(null, resourceName).run();
+
+        assertThat(resource).isEqualTo(expectedResource);
+    }
+
+    private static PrivilegedAction<URL> newResourceLookupAction(final ClassLoader classLoader, final String resourceName)
+            throws Throwable {
+        final FormatStep exceptionFormatStep = Formatters.exceptionFormatStep(true, 0, 0, true);
+        final Class<?> actionClass = exceptionFormatStep.getClass().getClassLoader()
+                .loadClass(exceptionFormatStep.getClass().getName() + "$2");
+        final MethodHandles.Lookup actionLookup = MethodHandles.privateLookupIn(actionClass, MethodHandles.lookup());
+        final MethodHandle constructor = actionLookup.findConstructor(
+                actionClass,
+                MethodType.methodType(void.class, exceptionFormatStep.getClass(), ClassLoader.class, String.class)
+        );
+
+        @SuppressWarnings("unchecked")
+        final PrivilegedAction<URL> action = (PrivilegedAction<URL>) constructor.invoke(
+                exceptionFormatStep,
+                classLoader,
+                resourceName
+        );
+        return action;
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/Formatters12Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
similarity index 65%
rename from /tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/Formatters12Test.java
rename to /tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
index b2f643b45f..57edbeaade 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/Formatters12Test.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -8,89 +8,81 @@ package org_jboss_logmanager.jboss_logmanager;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.net.URL;
-import java.security.AccessController;
 import java.security.CodeSource;
-import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.Objects;
 import java.util.logging.Level;
 
 import org.jboss.logmanager.ExtLogRecord;
-import org.jboss.logmanager.formatters.Formatters;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class Formatters12Test {
+public class FormattersAnonymous12Test {
 
     @Test
     void extendedExceptionFormattingUsesTcclDefinedClassAndResourceLookupWhenCodeSourceLocationIsMissing()
             throws Exception {
         assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
 
-        String className = Formatters12DefinedClass.class.getName();
-        TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
+        final String className = FormattersAnonymous12DefinedClass.class.getName();
+        final TrackingDefinedClassLoader trackingLoader = new TrackingDefinedClassLoader(className);
 
-        String formatted = formatWithTccl(trackingLoader, newFailure(className));
+        final String formatted = formatWithTccl(trackingLoader, newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
         assertThat(trackingLoader.wasResourceRequested()).isTrue();
     }
 
     @Test
-    void privilegedExtendedExceptionResourceLookupMatchesDirectClassLoaderLookup() throws Throwable {
-        assumeFalse(System.getProperty("java.vm.name", "").contains("Substrate VM"),
-                "Anonymous privileged-action construction is only needed for JVM dynamic-access coverage");
-
-        Object exceptionFormatStep = Formatters.exceptionFormatStep(true, 0, 0, true);
-        Class<?> privilegedActionClass = exceptionFormatStep.getClass().getClassLoader()
-                .loadClass(exceptionFormatStep.getClass().getName() + "$2");
-        MethodHandles.Lookup actionLookup = MethodHandles.privateLookupIn(privilegedActionClass, MethodHandles.lookup());
-        MethodHandle constructor = actionLookup.findConstructor(
-                privilegedActionClass,
-                MethodType.methodType(void.class, exceptionFormatStep.getClass(), Class.class, String.class)
+    void oneArgumentClassForNameIsUsedWhenTheContextClassLoaderRejectsTheFrameClass() {
+        assumeFalse(
+                isNativeImageRuntime(),
+                "Native image does not preserve JVM class-loader fallback observability for linked classes"
         );
-        String classResourceName = Formatters12Test.class.getName().replace('.', '/') + ".class";
-        URL expectedResource = Formatters12Test.class.getClassLoader().getResource(classResourceName);
-
-        @SuppressWarnings("unchecked")
-        PrivilegedAction<URL> privilegedAction = (PrivilegedAction<URL>) constructor.invoke(
-                exceptionFormatStep,
-                Formatters12Test.class,
-                classResourceName
+
+        final String className = String.class.getName();
+        final RejectingClassLoader rejectingLoader = new RejectingClassLoader(
+                Thread.currentThread().getContextClassLoader(),
+                className
         );
 
-        assertThat(AccessController.doPrivileged(privilegedAction)).isEqualTo(expectedResource);
+        final String formatted = formatWithTccl(rejectingLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        assertThat(rejectingLoader.wasRejected()).isTrue();
     }
 
     @Test
-    void extendedExceptionFormattingUsesBootstrapFallbackWhenTheLibraryLoaderRejectsTheClass() throws Throwable {
+    void bootstrapClassLoaderFallbackIsUsedWhenTheLibraryLoaderRejectsTheFrameClass() throws Throwable {
         assumeFalse(isNativeImageRuntime(), "Runtime class definition is not supported in native-image tests");
 
-        String className = "java.util.HexFormat";
-        BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
-        BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
+        final String className = "javax.crypto.Cipher";
+        final BootstrapFallbackClassLoader bootstrapFallbackClassLoader = new BootstrapFallbackClassLoader(className);
+        final BootstrapFormattingAction formattingAction = bootstrapFallbackClassLoader.loadFormattingAction();
 
-        String formatted = formattingAction.format(newFailure(className));
+        final String formatted = formattingAction.format(newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
         assertThat(bootstrapFallbackClassLoader.wasRejected()).isTrue();
     }
 
     private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
-        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
-            PatternFormatter formatter = new PatternFormatter("%E");
-            ExtLogRecord record = new ExtLogRecord(Level.SEVERE, "coverage", Formatters12Test.class.getName());
+            final PatternFormatter formatter = new PatternFormatter("%E");
+            final ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous12Test.class.getName()
+            );
             record.setThrown(thrown);
             return formatter.format(record);
         } finally {
@@ -99,7 +91,7 @@ public class Formatters12Test {
     }
 
     private static IllegalStateException newFailure(final String className) {
-        IllegalStateException failure = new IllegalStateException("boom");
+        final IllegalStateException failure = new IllegalStateException("boom");
         failure.setStackTrace(new StackTraceElement[] {
                 new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
         });
@@ -117,7 +109,7 @@ public class Formatters12Test {
         private boolean resourceRequested;
 
         private TrackingDefinedClassLoader(final String definedClassName) throws IOException {
-            super(Formatters12Test.class.getClassLoader());
+            super(FormattersAnonymous12Test.class.getClassLoader());
             this.definedClassName = definedClassName;
             this.resourceName = definedClassName.replace('.', '/') + ".class";
             this.definedClassBytes = loadClassBytes(resourceName);
@@ -133,11 +125,11 @@ public class Formatters12Test {
                 return super.loadClass(name, resolve);
             }
             synchronized (getClassLoadingLock(name)) {
-                Class<?> alreadyLoaded = findLoadedClass(name);
+                final Class<?> alreadyLoaded = findLoadedClass(name);
                 if (alreadyLoaded != null) {
                     return alreadyLoaded;
                 }
-                Class<?> definedClass = defineClass(
+                final Class<?> definedClass = defineClass(
                         name,
                         definedClassBytes,
                         0,
@@ -152,7 +144,7 @@ public class Formatters12Test {
         }
 
         @Override
-        public java.net.URL getResource(final String name) {
+        public URL getResource(final String name) {
             if (resourceName.equals(name)) {
                 resourceRequested = true;
             }
@@ -160,7 +152,8 @@ public class Formatters12Test {
         }
 
         private static byte[] loadClassBytes(final String resourceName) throws IOException {
-            try (InputStream inputStream = Formatters12DefinedClass.class.getClassLoader().getResourceAsStream(resourceName)) {
+            try (InputStream inputStream = FormattersAnonymous12DefinedClass.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
                 return Objects.requireNonNull(inputStream, resourceName).readAllBytes();
             }
         }
@@ -178,11 +171,11 @@ public class Formatters12Test {
 
         @Override
         public String format(final Throwable thrown) {
-            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
             try {
                 Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-                PatternFormatter formatter = new PatternFormatter("%E");
-                java.util.logging.LogRecord record = new java.util.logging.LogRecord(Level.SEVERE, "coverage");
+                final PatternFormatter formatter = new PatternFormatter("%E");
+                final java.util.logging.LogRecord record = new java.util.logging.LogRecord(Level.SEVERE, "coverage");
                 record.setThrown(thrown);
                 return formatter.format(record);
             } finally {
@@ -219,13 +212,13 @@ public class Formatters12Test {
         private boolean rejected;
 
         private BootstrapFallbackClassLoader(final String rejectedClassName) {
-            super(Formatters12Test.class.getClassLoader());
+            super(FormattersAnonymous12Test.class.getClassLoader());
             this.rejectedClassName = rejectedClassName;
         }
 
         BootstrapFormattingAction loadFormattingAction() throws Throwable {
-            Class<?> actionClass = Class.forName(BootstrapFormattingInvoker.class.getName(), true, this);
-            VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
+            final Class<?> actionClass = loadClass(BootstrapFormattingInvoker.class.getName());
+            final VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
                     actionClass,
                     "INSTANCE",
                     BootstrapFormattingAction.class
@@ -240,7 +233,7 @@ public class Formatters12Test {
         @Override
         protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
             synchronized (getClassLoadingLock(name)) {
-                Class<?> alreadyLoaded = findLoadedClass(name);
+                final Class<?> alreadyLoaded = findLoadedClass(name);
                 if (alreadyLoaded != null) {
                     return alreadyLoaded;
                 }
@@ -249,7 +242,7 @@ public class Formatters12Test {
                     throw new ClassNotFoundException(name);
                 }
                 if (shouldDefineLocally(name)) {
-                    Class<?> localClass = findClass(name);
+                    final Class<?> localClass = findClass(name);
                     if (resolve) {
                         resolveClass(localClass);
                     }
@@ -261,9 +254,10 @@ public class Formatters12Test {
 
         @Override
         protected Class<?> findClass(final String name) throws ClassNotFoundException {
-            String resourceName = name.replace('.', '/') + ".class";
-            try (InputStream inputStream = Formatters12Test.class.getClassLoader().getResourceAsStream(resourceName)) {
-                byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+            final String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream inputStream = FormattersAnonymous12Test.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
+                final byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
                 return defineClass(name, classBytes, 0, classBytes.length);
             } catch (IOException e) {
                 throw new ClassNotFoundException(name, e);
@@ -277,8 +271,5 @@ public class Formatters12Test {
     }
 }
 
-final class Formatters12DefinedClass {
-}
-
-final class Formatters12FallbackMarker {
+final class FormattersAnonymous12DefinedClass {
 }
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
index c9014d0ca0..a684de3feb 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -33,15 +33,15 @@ public class PropertyConfiguratorTest {
         try {
             String configuration = """
                     loggers=%1$s
+                    filters=coverageFilter
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
                     handler.coverageHandler.level=INFO
                     handler.coverageHandler.encoding=UTF-8
                     handler.coverageHandler.errorManager=coverageErrorManager
-                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.filter=filter coverageFilter
                     handler.coverageHandler.formatter=coverageFormatter
                     handler.coverageHandler.properties=label
                     handler.coverageHandler.label=primary
@@ -68,13 +68,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/user-code-filter.json 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
index abb519b85d..013f719e78 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/user-code-filter.json
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.logmanager.**"
+      "includeClasses" : "org.jboss.logmanager.**"
     }
   ]
 }

```
