### PR TITLE
[GenAI] Test fix for org.slf4j:slf4j-simple:1.7.32 using gpt-5.5

### DIFF
--- a/metadata/org.slf4j/slf4j-simple/1.7.32/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-simple/1.7.32/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.SimpleLoggerConfiguration$1"
+      },
+      "glob": "simplelogger.properties"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-simple/index.json
+++ b/metadata/org.slf4j/slf4j-simple/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.7.32",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.32/slf4j-simple-1.7.32-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/v_1.7.32/slf4j-simple/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.32/slf4j-simple-1.7.32-javadoc.jar",
+    "description" : "SLF4J Simple is a lightweight SLF4J binding that routes SLF4J logging calls to a basic logger implementation. It writes log output to System.err by default and is intended for applications or tests that need a minimal logging backend without a full logging framework.",
     "tested-versions" : [
       "1.7.32"
     ],

--- a/metadata/org.slf4j/slf4j-simple/index.json
+++ b/metadata/org.slf4j/slf4j-simple/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.7.32",
+    "tested-versions" : [
+      "1.7.32"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.7.25",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/stats/org.slf4j/slf4j-simple/1.7.32/stats.json
+++ b/stats/org.slf4j/slf4j-simple/1.7.32/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.7.32",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 422,
+        "missed" : 638,
+        "ratio" : 0.398113,
+        "total" : 1060
+      },
+      "line" : {
+        "covered" : 105,
+        "missed" : 184,
+        "ratio" : 0.363322,
+        "total" : 289
+      },
+      "method" : {
+        "covered" : 23,
+        "missed" : 54,
+        "ratio" : 0.298701,
+        "total" : 77
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/.gitignore
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/build.gradle
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:slf4j-simple:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:slf4j-simple:1.7.32
+library.version = 1.7.32
+metadata.dir = org.slf4j/slf4j-simple/1.7.32/

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/settings.gradle
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.slf4j-simple_tests'

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_simple;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleLoggerConfigurationAnonymous1Test {
+
+    private static final String CONFIGURATION_FILE = "simplelogger.properties";
+    private static final String TRACE_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=trace\n";
+
+    @Test
+    void loadsConfigurationUsingContextAndSystemClassLoaders() throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalDefaultLevel = System.getProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+        try {
+            System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(null);
+            Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
+            assertThat(defaultLogger.isInfoEnabled()).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
+            resetSimpleLoggerInitialization();
+        }
+    }
+
+    private static void resetSimpleLoggerInitialization() throws Exception {
+        Field initialized = SimpleLogger.class.getDeclaredField("INITIALIZED");
+        initialized.setAccessible(true);
+        initialized.setBoolean(null, false);
+
+        Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
+        configParams.setAccessible(true);
+        configParams.set(null, null);
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    private static final class PropertiesClassLoader extends ClassLoader {
+        PropertiesClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (CONFIGURATION_FILE.equals(name)) {
+                return new ByteArrayInputStream(TRACE_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -22,6 +22,7 @@ public class SimpleLoggerConfigurationAnonymous1Test {
 
     private static final String CONFIGURATION_FILE = "simplelogger.properties";
     private static final String TRACE_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=trace\n";
+    private static final String INFO_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=info\n";
 
     @Test
     void loadsConfigurationUsingContextAndSystemClassLoaders() throws Exception {
@@ -31,18 +32,20 @@ public class SimpleLoggerConfigurationAnonymous1Test {
             System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
 
             resetSimpleLoggerInitialization();
-            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
-            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
-            assertThat(configuredLogger.isTraceEnabled()).isTrue();
-
-            resetSimpleLoggerInitialization();
             Thread.currentThread().setContextClassLoader(null);
             Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
             assertThat(defaultLogger.isInfoEnabled()).isTrue();
+            assertThat(defaultLogger.isTraceEnabled()).isFalse();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread()
+                    .setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader, TRACE_CONFIGURATION));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
         } finally {
+            restoreSimpleLoggerConfiguration(originalContextClassLoader, originalDefaultLevel);
             Thread.currentThread().setContextClassLoader(originalContextClassLoader);
             restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
-            resetSimpleLoggerInitialization();
         }
     }
 
@@ -50,10 +53,15 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         Field initialized = SimpleLogger.class.getDeclaredField("INITIALIZED");
         initialized.setAccessible(true);
         initialized.setBoolean(null, false);
+    }
 
-        Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
-        configParams.setAccessible(true);
-        configParams.set(null, null);
+    private static void restoreSimpleLoggerConfiguration(
+            ClassLoader classLoader,
+            String defaultLevel) throws Exception {
+        restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, defaultLevel);
+        Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(classLoader, INFO_CONFIGURATION));
+        resetSimpleLoggerInitialization();
+        new SimpleLoggerFactory().getLogger("simple.logger.configuration.restore");
     }
 
     private static void restoreSystemProperty(String key, String value) {
@@ -65,14 +73,17 @@ public class SimpleLoggerConfigurationAnonymous1Test {
     }
 
     private static final class PropertiesClassLoader extends ClassLoader {
-        PropertiesClassLoader(ClassLoader parent) {
+        private final String configuration;
+
+        PropertiesClassLoader(ClassLoader parent, String configuration) {
             super(parent);
+            this.configuration = configuration;
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
             if (CONFIGURATION_FILE.equals(name)) {
-                return new ByteArrayInputStream(TRACE_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+                return new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8));
             }
             return super.getResourceAsStream(name);
         }

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/user-code-filter.json
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.slf4j.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3361

This PR provides test fixes and new metadata for org.slf4j:slf4j-simple:1.7.32, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71391
- Cached input tokens: 964096
- Output tokens: 10023
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 36.33
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 35.76

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4fc96062b20fa40ca2d8e225514294b35b2373d4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-simple:1.7.25: 2/2 covered calls (100.00%)
- org.slf4j:slf4j-simple:1.7.32: 2/2 covered calls (100.00%)

**Resources:**
- org.slf4j:slf4j-simple:1.7.25: 2/2 covered calls (100.00%)
- org.slf4j:slf4j-simple:1.7.32: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-simple:1.7.25: 413/1055 (39.15%)
- org.slf4j:slf4j-simple:1.7.32: 422/1060 (39.81%)

**Line:**
- org.slf4j:slf4j-simple:1.7.25: 103/288 (35.76%)
- org.slf4j:slf4j-simple:1.7.32: 105/289 (36.33%)

**Method:**
- org.slf4j:slf4j-simple:1.7.25: 23/77 (29.87%)
- org.slf4j:slf4j-simple:1.7.32: 23/77 (29.87%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.slf4j/slf4j-simple/1.7.25/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java 2/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
index 0ba77a65bd..a6bd7c460a 100644
--- 1/tests/src/org.slf4j/slf4j-simple/1.7.25/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ 2/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -22,6 +22,7 @@ public class SimpleLoggerConfigurationAnonymous1Test {
 
     private static final String CONFIGURATION_FILE = "simplelogger.properties";
     private static final String TRACE_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=trace\n";
+    private static final String INFO_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=info\n";
 
     @Test
     void loadsConfigurationUsingContextAndSystemClassLoaders() throws Exception {
@@ -30,19 +31,21 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         try {
             System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
 
-            resetSimpleLoggerInitialization();
-            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
-            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
-            assertThat(configuredLogger.isTraceEnabled()).isTrue();
-
             resetSimpleLoggerInitialization();
             Thread.currentThread().setContextClassLoader(null);
             Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
             assertThat(defaultLogger.isInfoEnabled()).isTrue();
+            assertThat(defaultLogger.isTraceEnabled()).isFalse();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread()
+                    .setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader, TRACE_CONFIGURATION));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
         } finally {
+            restoreSimpleLoggerConfiguration(originalContextClassLoader, originalDefaultLevel);
             Thread.currentThread().setContextClassLoader(originalContextClassLoader);
             restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
-            resetSimpleLoggerInitialization();
         }
     }
 
@@ -50,10 +53,15 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         Field initialized = SimpleLogger.class.getDeclaredField("INITIALIZED");
         initialized.setAccessible(true);
         initialized.setBoolean(null, false);
+    }
 
-        Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
-        configParams.setAccessible(true);
-        configParams.set(null, null);
+    private static void restoreSimpleLoggerConfiguration(
+            ClassLoader classLoader,
+            String defaultLevel) throws Exception {
+        restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, defaultLevel);
+        Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(classLoader, INFO_CONFIGURATION));
+        resetSimpleLoggerInitialization();
+        new SimpleLoggerFactory().getLogger("simple.logger.configuration.restore");
     }
 
     private static void restoreSystemProperty(String key, String value) {
@@ -65,14 +73,17 @@ public class SimpleLoggerConfigurationAnonymous1Test {
     }
 
     private static final class PropertiesClassLoader extends ClassLoader {
-        PropertiesClassLoader(ClassLoader parent) {
+        private final String configuration;
+
+        PropertiesClassLoader(ClassLoader parent, String configuration) {
             super(parent);
+            this.configuration = configuration;
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
             if (CONFIGURATION_FILE.equals(name)) {
-                return new ByteArrayInputStream(TRACE_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+                return new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8));
             }
             return super.getResourceAsStream(name);
         }

```
