### PR TITLE
[GenAI] Test fix for org.awaitility:awaitility:4.2.1 using gpt-5.5

### DIFF
--- a/metadata/org.awaitility/awaitility/4.2.1/reachability-metadata.json
+++ b/metadata/org.awaitility/awaitility/4.2.1/reachability-metadata.json
@@ -1,0 +1,73 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.CallableCondition"
+      },
+      "type" : "java.lang.management.ManagementFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.CallableCondition"
+      },
+      "type" : "java.lang.management.ThreadMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.CallableHamcrestCondition"
+      },
+      "type" : "org.awaitility.core.FieldSupplierBuilder$AnnotationFieldSupplier",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.CallableCondition"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.LambdaErrorMessageGenerator"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org_awaitility.awaitility.LambdaErrorMessageGeneratorTest",
+          "interfaces" : [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/metadata/org.awaitility/awaitility/index.json
+++ b/metadata/org.awaitility/awaitility/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.2.1",
+    "tested-versions" : [
+      "4.2.1"
+    ],
+    "allowed-packages" : [
+      "org.awaitility"
+    ]
+  },
+  {
     "metadata-version" : "4.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/awaitility/awaitility/4.2.0/awaitility-4.2.0-sources.jar",
     "repository-url" : "https://github.com/awaitility/awaitility",

--- a/metadata/org.awaitility/awaitility/index.json
+++ b/metadata/org.awaitility/awaitility/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.2.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/awaitility/awaitility/4.2.1/awaitility-4.2.1-sources.jar",
+    "repository-url" : "https://github.com/awaitility/awaitility",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/awaitility/awaitility/4.2.1/awaitility-4.2.1-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/awaitility/awaitility/4.2.1/awaitility-4.2.1-javadoc.jar",
+    "description" : "Awaitility is a Java DSL for waiting on asynchronous operations in tests without manual sleeps or polling loops. It lets assertions poll until conditions are satisfied or time out, making concurrent and eventually consistent behavior easier to verify.",
     "tested-versions" : [
       "4.2.1"
     ],

--- a/stats/org.awaitility/awaitility/4.2.1/stats.json
+++ b/stats/org.awaitility/awaitility/4.2.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.2.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1992,
+        "missed" : 4121,
+        "ratio" : 0.325863,
+        "total" : 6113
+      },
+      "line" : {
+        "covered" : 482,
+        "missed" : 768,
+        "ratio" : 0.3856,
+        "total" : 1250
+      },
+      "method" : {
+        "covered" : 149,
+        "missed" : 282,
+        "ratio" : 0.345708,
+        "total" : 431
+      }
+    }
+  } ]
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/.gitignore
+++ b/tests/src/org.awaitility/awaitility/4.2.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.awaitility/awaitility/4.2.1/build.gradle
+++ b/tests/src/org.awaitility/awaitility/4.2.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.awaitility:awaitility:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/gradle.properties
+++ b/tests/src/org.awaitility/awaitility/4.2.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.awaitility:awaitility:4.2.1
+library.version = 4.2.1
+metadata.dir = org.awaitility/awaitility/4.2.1/

--- a/tests/src/org.awaitility/awaitility/4.2.1/settings.gradle
+++ b/tests/src/org.awaitility/awaitility/4.2.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.awaitility.awaitility_tests'

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/CallableHamcrestConditionTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/CallableHamcrestConditionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.fieldIn;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CallableHamcrestConditionTest {
+
+    @Test
+    void describesNamedFieldSupplierWhenMatched() {
+        FieldBackedService service = new FieldBackedService("ready");
+
+        String result = await()
+                .pollDelay(Duration.ZERO)
+                .pollInterval(Duration.ofMillis(1))
+                .atMost(Duration.ofMillis(100))
+                .until(fieldIn(service).ofType(String.class).andWithName("state"), equalTo("ready"));
+
+        assertThat(result).isEqualTo("ready");
+    }
+
+    private static final class FieldBackedService {
+        private final String state;
+
+        private FieldBackedService(String state) {
+            this.state = state;
+        }
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/ClassPathResolverTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/ClassPathResolverTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import org.awaitility.classpath.ClassPathResolver;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassPathResolverTest {
+
+    @Test
+    void reportsAwaitilityClassAsPresentOnClasspath() {
+        boolean present = ClassPathResolver.existInCP(ClassPathResolver.class.getName());
+
+        assertThat(present).isTrue();
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/FieldSupplierBuilderInnerNameAndTypeFieldSupplierTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/FieldSupplierBuilderInnerNameAndTypeFieldSupplierTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.awaitility.core.FieldSupplierBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.fieldIn;
+
+public class FieldSupplierBuilderInnerNameAndTypeFieldSupplierTest {
+
+    @Test
+    void readsPrivateFieldSelectedByAnnotation() throws Exception {
+        AnnotatedFieldHolder holder = new AnnotatedFieldHolder("dynamic value");
+        FieldSupplierBuilder builder = fieldIn(holder);
+        builder.ofType(String.class).andAnnotatedWith(SelectedField.class);
+
+        FieldSupplierBuilder.NameAndTypeFieldSupplier<String> supplier = builder.new NameAndTypeFieldSupplier<>();
+
+        assertThat(supplier.call()).isEqualTo("dynamic value");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface SelectedField {
+    }
+
+    private static final class AnnotatedFieldHolder {
+
+        @SelectedField
+        private final String value;
+
+        private AnnotatedFieldHolder(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/FieldSupplierBuilderInnerNameFieldSupplierTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/FieldSupplierBuilderInnerNameFieldSupplierTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.fieldIn;
+
+public class FieldSupplierBuilderInnerNameFieldSupplierTest {
+
+    @Test
+    void readsPrivateFieldSelectedByTypeAndAnnotation() throws Exception {
+        AnnotatedFieldHolder holder = new AnnotatedFieldHolder("ready");
+
+        Callable<String> supplier = fieldIn(holder).ofType(String.class).andAnnotatedWith(SelectedField.class);
+
+        assertThat(supplier.call()).isEqualTo("ready");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface SelectedField {
+    }
+
+    private static final class AnnotatedFieldHolder {
+
+        @SelectedField
+        private final String value;
+
+        private AnnotatedFieldHolder(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LambdaErrorMessageGeneratorTest {
+
+    @Test
+    void describesTimedOutCallableLambdaCondition() {
+        ConditionTimeoutException timeout = assertThrows(
+                ConditionTimeoutException.class,
+                () -> await()
+                        .pollDelay(Duration.ZERO)
+                        .pollInterval(Duration.ofMillis(1))
+                        .atMost(Duration.ofMillis(20))
+                        .until(new Synthetic$$Lambda$Condition()));
+
+        assertThat(timeout.getMessage())
+                .contains("Condition with")
+                .contains("Synthetic")
+                .contains("was not fulfilled");
+    }
+
+    @SuppressWarnings("checkstyle:TypeName")
+    private static final class Synthetic$$Lambda$Condition implements Callable<Boolean> {
+        @Override
+        public Boolean call() {
+            return false;
+        }
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
@@ -20,25 +20,19 @@ public class LambdaErrorMessageGeneratorTest {
 
     @Test
     void describesTimedOutCallableLambdaCondition() {
+        Callable<Boolean> condition = () -> false;
         ConditionTimeoutException timeout = assertThrows(
                 ConditionTimeoutException.class,
                 () -> await()
                         .pollDelay(Duration.ZERO)
                         .pollInterval(Duration.ofMillis(1))
                         .atMost(Duration.ofMillis(20))
-                        .until(new Synthetic$$Lambda$Condition()));
+                        .until(condition));
 
         assertThat(timeout.getMessage())
                 .contains("Condition with")
-                .contains("Synthetic")
+                .contains("Lambda expression")
+                .contains("LambdaErrorMessageGeneratorTest")
                 .contains("was not fulfilled");
-    }
-
-    @SuppressWarnings("checkstyle:TypeName")
-    private static final class Synthetic$$Lambda$Condition implements Callable<Boolean> {
-        @Override
-        public Boolean call() {
-            return false;
-        }
     }
 }

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/WhiteboxImplTest.java
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/WhiteboxImplTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_awaitility.awaitility;
+
+import java.util.concurrent.Callable;
+
+import org.awaitility.reflect.WhiteboxImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.fieldIn;
+
+public class WhiteboxImplTest {
+
+    @Test
+    void readsPrivateInstanceFieldByName() {
+        WhiteboxSubject subject = new WhiteboxSubject("Awaitility", 4, "tested");
+
+        String name = WhiteboxImpl.getInternalState(subject, "name");
+
+        assertThat(name).isEqualTo("Awaitility");
+    }
+
+    @Test
+    void readsPrivateInstanceFieldByTypeThroughFieldSupplier() throws Exception {
+        WhiteboxSubject subject = new WhiteboxSubject("Awaitility", 4, "tested");
+
+        Callable<Integer> releaseLine = fieldIn(subject).ofType(Integer.class);
+
+        assertThat(releaseLine.call()).isEqualTo(4);
+    }
+
+    @Test
+    void readsPrivateInstanceFieldByNameAndTypeThroughFieldSupplier() throws Exception {
+        WhiteboxSubject subject = new WhiteboxSubject("Awaitility", 4, "tested");
+
+        Callable<String> status = fieldIn(subject).ofType(String.class).andWithName("status");
+
+        assertThat(status.call()).isEqualTo("tested");
+    }
+}
+
+class WhiteboxSubject {
+
+    private final String name;
+
+    private final Integer releaseLine;
+
+    private final String status;
+
+    WhiteboxSubject(String name, Integer releaseLine, String status) {
+        this.name = name;
+        this.releaseLine = releaseLine;
+        this.status = status;
+    }
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,66 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.AbstractHamcrestCondition"
+      },
+      "type" : "org_awaitility.awaitility.CallableHamcrestConditionTest$FieldBackedService",
+      "fields" : [
+        {
+          "name" : "state"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.CallableHamcrestCondition"
+      },
+      "type" : "org_awaitility.awaitility.CallableHamcrestConditionTest$FieldBackedService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.FieldSupplierBuilder$NameAndTypeFieldSupplier"
+      },
+      "type" : "org_awaitility.awaitility.FieldSupplierBuilderInnerNameAndTypeFieldSupplierTest$AnnotatedFieldHolder",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.reflect.WhiteboxImpl"
+      },
+      "type" : "org_awaitility.awaitility.FieldSupplierBuilderInnerNameAndTypeFieldSupplierTest$AnnotatedFieldHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.core.FieldSupplierBuilder$NameFieldSupplier"
+      },
+      "type" : "org_awaitility.awaitility.FieldSupplierBuilderInnerNameFieldSupplierTest$AnnotatedFieldHolder",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.reflect.WhiteboxImpl"
+      },
+      "type" : "org_awaitility.awaitility.WhiteboxSubject",
+      "fields" : [
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "releaseLine"
+        },
+        {
+          "name" : "status"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.awaitility/awaitility/4.2.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.awaitility/awaitility/4.2.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -61,6 +61,17 @@
           "name" : "status"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.awaitility.reflect.WhiteboxImpl"
+      },
+      "type" : "org_awaitility.awaitility.WhiteboxSubject",
+      "fields" : [
+        {
+          "name" : "releaseLine"
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.awaitility/awaitility/4.2.1/user-code-filter.json
+++ b/tests/src/org.awaitility/awaitility/4.2.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.awaitility.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3350

This PR provides test fixes and new metadata for org.awaitility:awaitility:4.2.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 81380
- Cached input tokens: 1012224
- Output tokens: 7602
- Entries found: 15
- Iterations: 1
- Library coverage percentage: 38.56
- Previous library version metadata entries: 15
- Previous library version coverage percentage: 38.32

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4fc96062b20fa40ca2d8e225514294b35b2373d4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.awaitility:awaitility:4.2.0: 9/9 covered calls (100.00%)
- org.awaitility:awaitility:4.2.1: 9/9 covered calls (100.00%)

**Reflection:**
- org.awaitility:awaitility:4.2.0: 9/9 covered calls (100.00%)
- org.awaitility:awaitility:4.2.1: 9/9 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.awaitility:awaitility:4.2.0: 1953/5992 (32.59%)
- org.awaitility:awaitility:4.2.1: 1992/6113 (32.59%)

**Line:**
- org.awaitility:awaitility:4.2.0: 469/1224 (38.32%)
- org.awaitility:awaitility:4.2.1: 482/1250 (38.56%)

**Method:**
- org.awaitility:awaitility:4.2.0: 146/422 (34.60%)
- org.awaitility:awaitility:4.2.1: 149/431 (34.57%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.awaitility/awaitility/4.2.0/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java 2/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
index 710c3b1e63..6cb0b455a5 100644
--- 1/tests/src/org.awaitility/awaitility/4.2.0/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
+++ 2/tests/src/org.awaitility/awaitility/4.2.1/src/test/java/org_awaitility/awaitility/LambdaErrorMessageGeneratorTest.java
@@ -20,25 +20,19 @@ public class LambdaErrorMessageGeneratorTest {
 
     @Test
     void describesTimedOutCallableLambdaCondition() {
+        Callable<Boolean> condition = () -> false;
         ConditionTimeoutException timeout = assertThrows(
                 ConditionTimeoutException.class,
                 () -> await()
                         .pollDelay(Duration.ZERO)
                         .pollInterval(Duration.ofMillis(1))
                         .atMost(Duration.ofMillis(20))
-                        .until(new Synthetic$$Lambda$Condition()));
+                        .until(condition));
 
         assertThat(timeout.getMessage())
                 .contains("Condition with")
-                .contains("Synthetic")
+                .contains("Lambda expression")
+                .contains("LambdaErrorMessageGeneratorTest")
                 .contains("was not fulfilled");
     }
-
-    @SuppressWarnings("checkstyle:TypeName")
-    private static final class Synthetic$$Lambda$Condition implements Callable<Boolean> {
-        @Override
-        public Boolean call() {
-            return false;
-        }
-    }
 }

```
