### PR TITLE
Add Gradle tasks for iterative native metadata tracing

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -200,6 +200,50 @@ Examples:
    ./gradlew generateMetadata -Pcoordinates=org.postgresql:postgresql:42.7.3 --agentAllowedPackages=org.example.app,com.acme.service
    ```
 
+### Native metadata tracing and exact verification
+
+These tasks use Native Image runtime metadata tracing. They require a GraalVM build that supports `-H:+MetadataTracingSupport`, `-XX:TraceMetadata`, and `-XX:TraceMetadataConditionPackages`.
+
+Build a trace-enabled native test image:
+
+```console
+./gradlew nativeTraceImage -Pcoordinates=<group:artifact:version>
+```
+
+Run the trace-enabled binary once and write runtime trace metadata. The native process exit code is informational; this task is expected to complete even if tests fail, so the trace output can still be inspected or merged.
+
+```console
+./gradlew runNativeTraceImage \
+  -Pcoordinates=<group:artifact:version> \
+  -PtraceMetadataPath=<absolute-trace-output-dir> \
+  -PtraceMetadataConditionPackages=<package1,package2,...>
+```
+
+Always write traces to a temporary directory, not to `metadata/<group>/<artifact>/<version>`. The trace output may be partial when the native test fails. Merge one or more trace output directories with:
+
+```console
+./gradlew mergeNativeTraceMetadata \
+  -PinputDirs=<absolute-trace-output-dir-0>,<absolute-trace-output-dir-1>,... \
+  -PoutputDir=<absolute-merged-metadata-dir>
+```
+
+Rebuild with merged metadata for another tracing iteration:
+
+```console
+./gradlew nativeTraceImage \
+  -Pcoordinates=<group:artifact:version> \
+  -PmetadataConfigDirs=<absolute-merged-metadata-dir>
+```
+
+Verify exact reachability metadata for a package prefix:
+
+```console
+./gradlew verifyExactReachabilityMetadata \
+  -Pcoordinates=<group:artifact:version> \
+  -PmetadataConfigDirs=<absolute-metadata-dir-0>,<absolute-metadata-dir-1>,... \
+  -PexactPackages=<package_prefix1,package_prefix2,...>
+```
+
 ### Splitting test-only metadata
 
 Moves test-only entries from library `reachability-metadata.json` in `metadata/`, into the corresponding test resources metadata file.
@@ -271,6 +315,10 @@ These tasks support the scheduled workflow that checks newer upstream library ve
 - Pull images (single lib): `./gradlew pullAllowedDockerImages -Pcoordinates=[group:artifact:version|k/n|all]`
 - Check metadata (single lib): `./gradlew checkMetadataFiles -Pcoordinates=[group:artifact:version|k/n|all]`
 - Generate metadata (single lib): `./gradlew generateMetadata -Pcoordinates=group:artifact:version`
+- Build trace-enabled native image: `./gradlew nativeTraceImage -Pcoordinates=group:artifact:version`
+- Run trace-enabled native image: `./gradlew runNativeTraceImage -Pcoordinates=group:artifact:version -PtraceMetadataPath=<absolute-trace-output-dir> -PtraceMetadataConditionPackages=<package1,package2,...>`
+- Merge native trace metadata: `./gradlew mergeNativeTraceMetadata -PinputDirs=<absolute-trace-output-dir-0>,<absolute-trace-output-dir-1>,... -PoutputDir=<absolute-merged-metadata-dir>`
+- Verify exact reachability metadata: `./gradlew verifyExactReachabilityMetadata -Pcoordinates=group:artifact:version -PmetadataConfigDirs=<absolute-metadata-dir-0>,<absolute-metadata-dir-1>,... -PexactPackages=<package_prefix1,package_prefix2,...>`
 - Split test-only metadata: `./gradlew splitTestOnlyMetadata -Pcoordinates=[group:artifact:version|group:artifact|k/n|all]`
 - Fix test that fails Native Image run for new library version: `./gradlew fixTestNativeImageRun -PtestLibraryCoordinates=group:artifact:version -PnewLibraryVersion=version`
 - Test (single lib): `./gradlew test -Pcoordinates=[group:artifact:version|k/n|all]`

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -25,6 +25,7 @@ import org.graalvm.internal.tck.harness.tasks.CleanInvocationTask
 import org.graalvm.internal.tck.harness.tasks.CompileTestJavaInvocationTask
 import org.graalvm.internal.tck.harness.tasks.JavaTestInvocationTask
 import org.graalvm.internal.tck.harness.tasks.NativeTestCompileInvocationTask
+import org.graalvm.internal.tck.harness.tasks.NativeTraceImageInvocationTask
 import org.graalvm.internal.tck.harness.tasks.FetchExistingLibrariesWithNewerVersionsTask
 import org.gradle.util.internal.VersionNumber
 import org.graalvm.internal.tck.harness.tasks.ComputeAndPullAllowedDockerImagesTask
@@ -43,7 +44,9 @@ import org.graalvm.internal.tck.harness.tasks.GenerateLibraryStatsTask
 import org.graalvm.internal.tck.harness.tasks.ValidateLibraryStatsTask
 import org.graalvm.internal.tck.harness.tasks.AnalyzeExternalLibraryDynamicAccessTask
 import org.graalvm.internal.tck.harness.tasks.GenerateReadmeBadgeSummaryTask
+import org.graalvm.internal.tck.harness.tasks.RunNativeTraceImageInvocationTask
 import org.graalvm.internal.tck.harness.tasks.SplitTestOnlyMetadataTask
+import org.graalvm.internal.tck.harness.tasks.VerifyExactReachabilityMetadataInvocationTask
 import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 
@@ -76,6 +79,66 @@ def writeGithubEnv(String key, String value) {
 
 String coordinateFilter = Objects.requireNonNullElse(project.findProperty("coordinates"), "")
 
+String requiredGradleProperty(String propertyName) {
+    String propertyValue = providers.gradleProperty(propertyName).getOrElse("")
+    if (propertyValue.trim().isEmpty()) {
+        throw new GradleException("Missing '${propertyName}' property! Rerun Gradle with '-P${propertyName}=<value>'")
+    }
+    return propertyValue
+}
+
+List<String> commaSeparatedGradleProperty(String propertyName) {
+    String propertyValue = providers.gradleProperty(propertyName).getOrElse("")
+    if (propertyValue.trim().isEmpty()) {
+        return []
+    }
+    return propertyValue.split(",")
+            .collect { String value -> value.trim() }
+            .findAll { String value -> !value.isEmpty() }
+}
+
+List<File> requiredDirectoryListProperty(String propertyName, boolean requireAbsolute) {
+    List<String> propertyValues = commaSeparatedGradleProperty(propertyName)
+    if (propertyValues.isEmpty()) {
+        requiredGradleProperty(propertyName)
+    }
+    return propertyValues.collect { String propertyValue ->
+        File directory = file(propertyValue)
+        if (requireAbsolute && !new File(propertyValue).isAbsolute()) {
+            throw new GradleException("Property '${propertyName}' must contain absolute paths. Got: ${propertyValue}")
+        }
+        if (!directory.isDirectory()) {
+            throw new GradleException("Property '${propertyName}' must contain existing directories. Missing: ${directory.absolutePath}")
+        }
+        return directory
+    }
+}
+
+String requiredAbsolutePathProperty(String propertyName) {
+    String propertyValue = requiredGradleProperty(propertyName)
+    if (!new File(propertyValue).isAbsolute()) {
+        throw new GradleException("Property '${propertyName}' must contain an absolute path. Got: ${propertyValue}")
+    }
+    return propertyValue
+}
+
+static String nativeImageTool(String toolName) {
+    List<String> toolHomeVariables = ["GRAALVM_HOME", "JAVA_HOME"]
+    for (String toolHomeVariable : toolHomeVariables) {
+        String toolHome = System.getenv(toolHomeVariable)
+        if (toolHome != null && !toolHome.trim().isEmpty()) {
+            List<File> candidates = [
+                    new File(new File(toolHome, "bin"), toolName),
+                    new File(new File(new File(toolHome, "lib"), "svm/bin"), toolName)
+            ]
+            File candidate = candidates.find { File file -> file.isFile() }
+            if (candidate != null) {
+                return candidate.absolutePath
+            }
+        }
+    }
+    return toolName
+}
 
 List<String> matchingCoordinates
 if (CoordinateUtils.isFractionalBatch(coordinateFilter)) {
@@ -110,6 +173,56 @@ tasks.register("javaTest", JavaTestInvocationTask.class) { task ->
 tasks.register("nativeTestCompile", NativeTestCompileInvocationTask.class) { task ->
     task.setDescription("Compiles native tests (nativeTestCompile) for all subprojects")
     task.setGroup(LifecycleBasePlugin.BUILD_GROUP)
+}
+
+// gradle nativeTraceImage -Pcoordinates=<maven-coordinates> [-PmetadataConfigDirs=<dir1,dir2,...>]
+tasks.register("nativeTraceImage", NativeTraceImageInvocationTask.class) { task ->
+    task.setDescription("Builds trace-enabled native tests for matching coordinates")
+    task.setGroup(LifecycleBasePlugin.BUILD_GROUP)
+    task.doFirst {
+        if (project.hasProperty("metadataConfigDirs")) {
+            requiredDirectoryListProperty("metadataConfigDirs", false)
+        }
+    }
+}
+
+// gradle runNativeTraceImage -Pcoordinates=<maven-coordinates> -PtraceMetadataPath=<path>
+//     -PtraceMetadataConditionPackages=<pkg1,pkg2,...>
+tasks.register("runNativeTraceImage", RunNativeTraceImageInvocationTask.class) { task ->
+    task.setDescription("Runs trace-enabled native tests once for matching coordinates")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.doFirst {
+        if (project.hasProperty("metadataConfigDirs")) {
+            requiredDirectoryListProperty("metadataConfigDirs", false)
+        }
+        requiredAbsolutePathProperty("traceMetadataPath")
+        requiredGradleProperty("traceMetadataConditionPackages")
+    }
+}
+
+tasks.register("mergeNativeTraceMetadata", Exec) { Exec task ->
+    task.setDescription("Merges runtime metadata trace output directories with native-image-utils generate")
+    task.setGroup(METADATA_GROUP)
+    task.doFirst {
+        List<File> inputDirs = requiredDirectoryListProperty("inputDirs", false)
+        File outputDir = file(requiredAbsolutePathProperty("outputDir"))
+        delete(outputDir)
+        List<String> commandLineArgs = [nativeImageTool("native-image-utils"), "generate"]
+        commandLineArgs.addAll(inputDirs.collect { File inputDir -> "--input-dir=${inputDir.absolutePath}" })
+        commandLineArgs.add("--output-dir=${outputDir.absolutePath}")
+        task.commandLine(commandLineArgs)
+    }
+}
+
+// gradle verifyExactReachabilityMetadata -Pcoordinates=<maven-coordinates> -PmetadataConfigDirs=<dir>
+//     -PexactPackages=<pkg1,pkg2,...>
+tasks.register("verifyExactReachabilityMetadata", VerifyExactReachabilityMetadataInvocationTask.class) { task ->
+    task.setDescription("Builds native tests with exact reachability metadata for matching coordinates")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.doFirst {
+        requiredDirectoryListProperty("metadataConfigDirs", true)
+        requiredGradleProperty("exactPackages")
+    }
 }
 
 // gradle jacocoTestReport -Pcoordinates=<maven-coordinates>

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -8,6 +8,8 @@ import groovy.json.JsonSlurper
 import org.graalvm.internal.tck.utils.DynamicAccessUtils
 import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
 import org.gradle.api.tasks.PathSensitivity
 
 import java.util.jar.JarFile
@@ -69,6 +71,11 @@ String libraryVersion = System.getenv("GVM_TCK_LV") ?: providers.gradleProperty(
 
 String libraryGAV = System.getenv("GVM_TCK_LC") ?: providers.gradleProperty('library.coordinates').getOrElse(null)
 libraryGAV = libraryGAV ?: ""
+String libraryGA = ""
+def libraryGAVParts = libraryGAV.split(":")
+if (libraryGAVParts.length >= 2) {
+    libraryGA = "${libraryGAVParts[0]}:${libraryGAVParts[1]}"
+}
 
 String overrideVal = System.getenv("GVM_TCK_EXCLUDE") ?: providers.gradleProperty('library.override').getOrElse(null)
 overrideVal = overrideVal ?: "false"
@@ -79,6 +86,93 @@ boolean generateDynamicAccessReportTaskRequested = gradle.startParameter.taskNam
     taskName == "generateDynamicAccessReport" || taskName.endsWith(":generateDynamicAccessReport")
 }
 boolean generateDynamicAccessReport = generateDynamicAccessReportVal.toBoolean() || generateDynamicAccessReportTaskRequested
+
+Closure<Boolean> isTaskRequested = { String taskName ->
+    gradle.startParameter.taskNames.any { String requestedTaskName ->
+        requestedTaskName == taskName || requestedTaskName.endsWith(":${taskName}")
+    }
+}
+
+boolean informationalTaskRequested = isTaskRequested("help") || isTaskRequested("tasks") || isTaskRequested("properties")
+boolean nativeTraceImageTaskRequested = !informationalTaskRequested &&
+        (isTaskRequested("nativeTraceImage") || isTaskRequested("runNativeTraceImage"))
+boolean runNativeTraceImageTaskRequested = !informationalTaskRequested && isTaskRequested("runNativeTraceImage")
+boolean verifyExactReachabilityMetadataTaskRequested = !informationalTaskRequested &&
+        isTaskRequested("verifyExactReachabilityMetadata")
+
+Closure<String> requiredGradleProperty = { String propertyName ->
+    String propertyValue = providers.gradleProperty(propertyName).getOrElse("")
+    if (propertyValue.trim().isEmpty()) {
+        throw new GradleException("Missing '${propertyName}' property! Rerun Gradle with '-P${propertyName}=<value>'")
+    }
+    return propertyValue
+}
+
+Closure<List<String>> commaSeparatedGradleProperty = { String propertyName ->
+    String propertyValue = providers.gradleProperty(propertyName).getOrElse("")
+    if (propertyValue.trim().isEmpty()) {
+        return []
+    }
+    return propertyValue.split(",")
+            .collect { String value -> value.trim() }
+            .findAll { String value -> !value.isEmpty() }
+}
+
+Closure<List<File>> requiredDirectoryListProperty = { String propertyName, boolean requireAbsolute ->
+    List<String> propertyValues = commaSeparatedGradleProperty(propertyName)
+    if (propertyValues.isEmpty()) {
+        requiredGradleProperty(propertyName)
+    }
+    return propertyValues.collect { String propertyValue ->
+        File directory = file(propertyValue)
+        if (requireAbsolute && !new File(propertyValue).isAbsolute()) {
+            throw new GradleException("Property '${propertyName}' must contain absolute paths. Got: ${propertyValue}")
+        }
+        if (!directory.isDirectory()) {
+            throw new GradleException("Property '${propertyName}' must contain existing directories. Missing: ${directory.absolutePath}")
+        }
+        return directory
+    }
+}
+
+Closure<String> requiredAbsolutePathProperty = { String propertyName ->
+    String propertyValue = requiredGradleProperty(propertyName)
+    if (!new File(propertyValue).isAbsolute()) {
+        throw new GradleException("Property '${propertyName}' must contain an absolute path. Got: ${propertyValue}")
+    }
+    return propertyValue
+}
+
+Closure<String> nativeImageTool = { String toolName ->
+    List<String> toolHomeVariables = ["GRAALVM_HOME", "JAVA_HOME"]
+    for (String toolHomeVariable : toolHomeVariables) {
+        String toolHome = System.getenv(toolHomeVariable)
+        if (toolHome != null && !toolHome.trim().isEmpty()) {
+            List<File> candidates = [
+                    new File(new File(toolHome, "bin"), toolName),
+                    new File(new File(new File(toolHome, "lib"), "svm/bin"), toolName)
+            ]
+            File candidate = candidates.find { File file -> file.isFile() }
+            if (candidate != null) {
+                return candidate.absolutePath
+            }
+        }
+    }
+    return toolName
+}
+
+if (runNativeTraceImageTaskRequested) {
+    requiredAbsolutePathProperty("traceMetadataPath")
+    requiredGradleProperty("traceMetadataConditionPackages")
+}
+if (nativeTraceImageTaskRequested && project.hasProperty("metadataConfigDirs")) {
+    requiredDirectoryListProperty("metadataConfigDirs", false)
+}
+if (verifyExactReachabilityMetadataTaskRequested) {
+    requiredGradleProperty("metadataConfigDirs")
+    requiredGradleProperty("exactPackages")
+    requiredDirectoryListProperty("metadataConfigDirs", true)
+}
 
 // Determine native-image build arguments from ci.json.
 def ciJsonFile = tck.repoRoot.file("ci.json").get().asFile
@@ -187,6 +281,93 @@ tasks.register("generateDynamicAccessReport") { task ->
             .withPropertyName("dynamicAccessOutputDir")
 }
 
+Provider<List<String>> nativeTraceBuildArgs = providers.provider {
+    List<String> buildArgs = []
+    if (nativeTraceImageTaskRequested) {
+        buildArgs.add("-H:+UnlockExperimentalVMOptions")
+        buildArgs.add("-H:+MetadataTracingSupport")
+        buildArgs.add("-H:-UnlockExperimentalVMOptions")
+    }
+    List<String> metadataConfigDirs = commaSeparatedGradleProperty("metadataConfigDirs")
+    boolean metadataConfigDirsRequested = nativeTraceImageTaskRequested || verifyExactReachabilityMetadataTaskRequested
+    if (metadataConfigDirsRequested && !metadataConfigDirs.isEmpty()) {
+        buildArgs.add("-H:ConfigurationFileDirectories=${metadataConfigDirs.join(",")}")
+    }
+    if (verifyExactReachabilityMetadataTaskRequested) {
+        buildArgs.add("--exact-reachability-metadata=${requiredGradleProperty("exactPackages")}")
+    }
+    return buildArgs
+}
+
+tasks.named("nativeTestCompile", BuildNativeImageTask).configure { BuildNativeImageTask task ->
+    if (verifyExactReachabilityMetadataTaskRequested) {
+        task.outputs.upToDateWhen { false }
+    }
+    if (runNativeTraceImageTaskRequested) {
+        task.doFirst {
+            requiredGradleProperty("traceMetadataPath")
+            requiredGradleProperty("traceMetadataConditionPackages")
+        }
+    }
+    if (verifyExactReachabilityMetadataTaskRequested) {
+        task.doFirst {
+            requiredDirectoryListProperty("metadataConfigDirs", true)
+            requiredGradleProperty("exactPackages")
+        }
+    }
+}
+
+tasks.register("nativeTraceImage") { task ->
+    task.setDescription("Builds the test native image with runtime metadata tracing support enabled")
+    task.setGroup(LifecycleBasePlugin.BUILD_GROUP)
+    task.dependsOn(tasks.named("nativeTestCompile"))
+}
+
+tasks.register("runNativeTraceImage", Exec) { Exec task ->
+    task.setDescription("Runs the trace-enabled test native image once and writes runtime metadata trace output")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.dependsOn(tasks.named("nativeTraceImage"))
+    task.ignoreExitValue = true
+    task.doFirst {
+        String traceMetadataPath = requiredAbsolutePathProperty("traceMetadataPath")
+        String traceMetadataConditionPackages = requiredGradleProperty("traceMetadataConditionPackages")
+        BuildNativeImageTask nativeTestCompile = tasks.named("nativeTestCompile", BuildNativeImageTask).get()
+        NativeRunTask nativeTest = tasks.named("nativeTest", NativeRunTask).get()
+        File imageFile = nativeTestCompile.outputFile.get().asFile
+        List<String> runtimeArgs = []
+        runtimeArgs.addAll(nativeTest.internalRuntimeArgs.get())
+        runtimeArgs.addAll(nativeTest.runtimeArgs.get())
+        runtimeArgs.add("-XX:TraceMetadata=path=${traceMetadataPath}")
+        runtimeArgs.add("-XX:TraceMetadataConditionPackages=${traceMetadataConditionPackages}")
+        task.executable = imageFile.absolutePath
+        task.args = runtimeArgs
+    }
+}
+
+tasks.register("mergeNativeTraceMetadata", Exec) { Exec task ->
+    task.setDescription("Merges runtime metadata trace output directories with native-image-utils generate")
+    task.setGroup("Metadata")
+    task.doFirst {
+        List<File> inputDirs = requiredDirectoryListProperty("inputDirs", false)
+        File outputDir = file(requiredAbsolutePathProperty("outputDir"))
+        delete(outputDir)
+        List<String> commandLineArgs = [nativeImageTool("native-image-utils"), "generate"]
+        commandLineArgs.addAll(inputDirs.collect { File inputDir -> "--input-dir=${inputDir.absolutePath}" })
+        commandLineArgs.add("--output-dir=${outputDir.absolutePath}")
+        task.commandLine(commandLineArgs)
+    }
+}
+
+tasks.register("verifyExactReachabilityMetadata") { task ->
+    task.setDescription("Builds the test native image with exact reachability metadata for the supplied packages")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.dependsOn(tasks.named("nativeTestCompile"))
+    task.doFirst {
+        requiredDirectoryListProperty("metadataConfigDirs", true)
+        requiredGradleProperty("exactPackages")
+    }
+}
+
 // Ensure detailed exception/stacktrace logging for all Test tasks, including nativeTest
 tasks.withType(Test).configureEach {
     testLogging {
@@ -274,13 +455,17 @@ graalvmNative {
     metadataRepository {
         enabled = true
         uri(tck.metadataRoot.get().asFile)
+        if (verifyExactReachabilityMetadataTaskRequested && !libraryGA.isBlank()) {
+            excludedModules.add(libraryGA)
+        }
     }
     binaries {
         test {
-            if (override) {
+            if (override || verifyExactReachabilityMetadataTaskRequested) {
                 excludeConfig.put(libraryGAV, [".*"])
             }
             buildArgs.addAll(nativeImageArgs)
+            buildArgs.addAll(nativeTraceBuildArgs)
             if (generateDynamicAccessReport) {
                 buildArgs.addAll(providers.provider {
                     DynamicAccessUtils.buildArgsForClasspathEntries(resolveTestedLibraryJars())

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTraceImageInvocationTask.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Task that builds trace-enabled native test images on matching subprojects.
+ */
+@SuppressWarnings("unused")
+public abstract class NativeTraceImageInvocationTask extends AllCoordinatesExecTask {
+
+    @Override
+    public List<String> commandFor(String coordinates) {
+        List<String> command = new ArrayList<>(List.of(
+                tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
+                "nativeTraceImage"
+        ));
+        appendProperty(command, "metadataConfigDirs");
+        return command;
+    }
+
+    @Override
+    protected String errorMessageFor(String coordinates, int exitCode) {
+        return "Native trace image compilation failed for " + coordinates + " with exit code " + exitCode + ".";
+    }
+
+    private void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
+    }
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Task that runs trace-enabled native test images on matching subprojects.
+ */
+@SuppressWarnings("unused")
+public abstract class RunNativeTraceImageInvocationTask extends AllCoordinatesExecTask {
+
+    @Override
+    public List<String> commandFor(String coordinates) {
+        List<String> command = new ArrayList<>(List.of(
+                tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
+                "runNativeTraceImage"
+        ));
+        appendProperty(command, "metadataConfigDirs");
+        appendProperty(command, "traceMetadataPath");
+        appendProperty(command, "traceMetadataConditionPackages");
+        return command;
+    }
+
+    @Override
+    protected String errorMessageFor(String coordinates, int exitCode) {
+        return "Native trace image run failed for " + coordinates + " with exit code " + exitCode + ".";
+    }
+
+    private void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
+    }
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/VerifyExactReachabilityMetadataInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/VerifyExactReachabilityMetadataInvocationTask.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Task that builds native test images with exact reachability metadata enabled.
+ */
+@SuppressWarnings("unused")
+public abstract class VerifyExactReachabilityMetadataInvocationTask extends AllCoordinatesExecTask {
+
+    @Override
+    public List<String> commandFor(String coordinates) {
+        List<String> command = new ArrayList<>(List.of(
+                tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
+                "verifyExactReachabilityMetadata"
+        ));
+        appendProperty(command, "metadataConfigDirs");
+        appendProperty(command, "exactPackages");
+        return command;
+    }
+
+    @Override
+    protected String errorMessageFor(String coordinates, int exitCode) {
+        return "Exact reachability metadata verification failed for "
+                + coordinates
+                + " with exit code "
+                + exitCode
+                + ".";
+    }
+
+    private void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2598.

This adds a small Gradle workflow for iterating on missing reachability metadata from native-image runtime metadata tracing. The workflow is intentionally split into separate tasks so a user can build a trace-enabled native test image once, run it repeatedly to collect trace output, merge one or more trace directories into a normal metadata directory, and then rebuild with that merged metadata for another iteration.

The branch also documents the workflow in `docs/DEVELOPING.md` using templates rather than concrete local paths, so the commands can be copied and filled in for any library coordinate.

## Added commands

### `nativeTraceImage`

```console
./gradlew nativeTraceImage -Pcoordinates=<group:artifact:version>
```

Builds the native test image for the selected coordinate with metadata tracing support enabled. The task adds the native-image build flags needed for runtime tracing:

```text
-H:+UnlockExperimentalVMOptions
-H:+MetadataTracingSupport
-H:-UnlockExperimentalVMOptions
```

It also accepts optional merged metadata from a previous iteration:

```console
./gradlew nativeTraceImage \
  -Pcoordinates=<group:artifact:version> \
  -PmetadataConfigDirs=<absolute-merged-metadata-dir>
```

### `runNativeTraceImage`

```console
./gradlew runNativeTraceImage \
  -Pcoordinates=<group:artifact:version> \
  -PtraceMetadataPath=<absolute-trace-output-dir> \
  -PtraceMetadataConditionPackages=<package1,package2,...>
```

Runs the trace-enabled native test binary once and passes the runtime tracing flags:

```text
-XX:TraceMetadata=path=<absolute-trace-output-dir>
-XX:TraceMetadataConditionPackages=<package1,package2,...>
```

This task depends on `nativeTraceImage`, so users do not need to invoke the build task separately. If the image was just built with the same inputs, Gradle can reuse it. The native process exit code is intentionally informational: tests may fail while still producing useful metadata, so test failures should not prevent inspecting or merging the trace output. The task still validates required arguments before running.

### `mergeNativeTraceMetadata`

```console
./gradlew mergeNativeTraceMetadata \
  -PinputDirs=<absolute-trace-output-dir-0>,<absolute-trace-output-dir-1>,... \
  -PoutputDir=<absolute-merged-metadata-dir>
```

Wraps `native-image-utils generate` and converts one or more trace output directories into a standard reachability metadata directory. The output directory is deleted before each merge so it represents the supplied input directories exactly.

### `verifyExactReachabilityMetadata`

```console
./gradlew verifyExactReachabilityMetadata \
  -Pcoordinates=<group:artifact:version> \
  -PmetadataConfigDirs=<absolute-metadata-dir-0>,<absolute-metadata-dir-1>,... \
  -PexactPackages=<package_prefix1,package_prefix2,...>
```

Builds the native test image with `--exact-reachability-metadata=<package_prefixes>` and the supplied metadata directories. This is useful for checking whether the selected package prefixes still rely on missing or overly broad metadata.

## Notes from manual exploration

All tracing experiments were run with a local GraalVM build that contains the new tracing flags:

```console
export GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_8860390CA7_JAVA25/graalvm-8860390ca7-java25-25.1.0-dev
```

### `com.fasterxml:classmate:1.5.1`

The exact metadata verification command completed successfully even when pointed at an empty metadata directory:

```console
./gradlew verifyExactReachabilityMetadata \
  -Pcoordinates=com.fasterxml:classmate:1.5.1 \
  -PmetadataConfigDirs=/home/jovan/Work/graalvm-reachability-metadata/empty \
  -PexactPackages=com_fasterxml \
  --stacktrace
```

This was useful as a sanity check for the exact-metadata task wiring, but it also showed that an empty metadata directory is not necessarily a failure by itself: the selected tests may not exercise missing dynamic metadata under the requested package prefix.

### `org.hibernate.orm:hibernate-core:7.0.0.Final`

A `runNativeTraceImage` invocation failed before the tracing workflow was usable because the binary was not built with the required tracing support / runtime flag combination:

```console
./gradlew runNativeTraceImage \
  -Pcoordinates=org.hibernate.orm:hibernate-core:7.0.0.Final \
  -PtraceMetadataPath=/tmp/gvm-trace-classmate-run-0 \
  -PtraceMetadataConditionPackages=com_fasterxml
```

The native process reported:

```text
error: Could not find option 'TraceMetadataConditionPackages'. Use -XX:PrintFlags= to list all available options.
```

That drove the task dependency shape: `runNativeTraceImage` now depends on `nativeTraceImage`, so the run task builds the trace-enabled image first instead of attempting to run an ordinary native test image.

### `commons-codec:commons-codec:1.10`

Deleting the library metadata caused native tests to fail with missing bundled resources such as:

```text
org/apache/commons/codec/language/dmrules.txt
org/apache/commons/codec/language/bm/ash_languages.txt
```

The trace workflow did not produce useful replacement metadata for this case. That is expected for this kind of failure: runtime metadata tracing helps with dynamic metadata such as reflection/serialization/JNI-style registrations, but it does not infer resource include patterns from failed resource lookups.

### `org.apache.commons:commons-collections4:4.4`

Deleting metadata for this library broke native tests with many serialization-related failures, including `InvalidClassException` / no valid constructor style failures. This was the successful iterative case: running the trace-enabled image produced additional metadata, merging it, and rebuilding with the merged metadata allowed subsequent iterations to get further through the test suite and collect more missing dynamic metadata.

The intended loop from that experiment is:

```console
./gradlew nativeTraceImage \
  -Pcoordinates=org.apache.commons:commons-collections4:4.4

./gradlew runNativeTraceImage \
  -Pcoordinates=org.apache.commons:commons-collections4:4.4 \
  -PtraceMetadataPath=<absolute-trace-output-dir-0> \
  -PtraceMetadataConditionPackages=org.apache.commons.collections4

./gradlew mergeNativeTraceMetadata \
  -PinputDirs=<absolute-trace-output-dir-0> \
  -PoutputDir=<absolute-merged-metadata-dir>

./gradlew nativeTraceImage \
  -Pcoordinates=org.apache.commons:commons-collections4:4.4 \
  -PmetadataConfigDirs=<absolute-merged-metadata-dir>

./gradlew runNativeTraceImage \
  -Pcoordinates=org.apache.commons:commons-collections4:4.4 \
  -PmetadataConfigDirs=<absolute-merged-metadata-dir> \
  -PtraceMetadataPath=<absolute-trace-output-dir-1> \
  -PtraceMetadataConditionPackages=org.apache.commons.collections4

./gradlew mergeNativeTraceMetadata \
  -PinputDirs=<absolute-trace-output-dir-0>,<absolute-trace-output-dir-1> \
  -PoutputDir=<absolute-merged-metadata-dir>
```

## Documentation

`docs/DEVELOPING.md` now includes a dedicated “Native metadata tracing and exact verification” section plus quick-reference entries for all four tasks. The docs intentionally use placeholders such as `<group:artifact:version>` and `<absolute-trace-output-dir>` instead of local example paths.

## Verification

Manual command exploration covered:

- exact metadata verification with empty metadata for `com.fasterxml:classmate:1.5.1`
- the unsupported runtime-flag failure mode for `org.hibernate.orm:hibernate-core:7.0.0.Final`
- a resource-metadata failure case for `commons-codec:commons-codec:1.10`, which tracing does not fix
- a serialization/dynamic-metadata failure case for `org.apache.commons:commons-collections4:4.4`, where iterative trace/merge/rebuild can add useful metadata across runs

This PR is draft because the workflow should still be reviewed against the exact desired semantics for task caching and the native trace run exit code before merging.