### PR TITLE
[GenAI] Test fix for org.apache.tomcat:tomcat-juli:11.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.tomcat/tomcat-juli/11.0.0/reachability-metadata.json
+++ b/metadata/org.apache.tomcat/tomcat-juli/11.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.ClassLoaderLogManager"
+      },
+      "glob" : "logging.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.tomcat/tomcat-juli/index.json
+++ b/metadata/org.apache.tomcat/tomcat-juli/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "11.0.0"
     ],
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-juli/11.0.0/tomcat-juli-11.0.0-sources.jar",
+    "repository-url" : "https://github.com/apache/tomcat",
+    "test-code-url" : "https://github.com/apache/tomcat/tree/11.0.0/test/org/apache/juli",
+    "documentation-url" : "https://github.com/apache/tomcat/blob/11.0.0/webapps/docs/logging.xml",
+    "description" : "Apache Tomcat JULI is Tomcat's packaged logging implementation built around java.util.logging and a renamed Commons Logging API. It provides class-loader-aware log management, handlers, and formatters so Tomcat and deployed web applications can keep logging configuration and output separated.",
     "allowed-packages" : [
       "org.apache.juli"
     ]

--- a/metadata/org.apache.tomcat/tomcat-juli/index.json
+++ b/metadata/org.apache.tomcat/tomcat-juli/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "11.0.0",
+    "tested-versions" : [
+      "11.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.juli"
+    ]
+  },
+  {
     "metadata-version" : "10.1.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-juli/10.1.7/tomcat-juli-10.1.7-sources.jar",
     "repository-url" : "https://github.com/apache/tomcat",

--- a/stats/org.apache.tomcat/tomcat-juli/11.0.0/stats.json
+++ b/stats/org.apache.tomcat/tomcat-juli/11.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "11.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.785714,
+          "coveredCalls" : 11,
+          "totalCalls" : 14
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.8,
+      "coveredCalls" : 12,
+      "totalCalls" : 15
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1097,
+        "missed" : 2309,
+        "ratio" : 0.322079,
+        "total" : 3406
+      },
+      "line" : {
+        "covered" : 295,
+        "missed" : 600,
+        "ratio" : 0.329609,
+        "total" : 895
+      },
+      "method" : {
+        "covered" : 42,
+        "missed" : 85,
+        "ratio" : 0.330709,
+        "total" : 127
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/.gitignore
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/build.gradle
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.tomcat:tomcat-juli:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/gradle.properties
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.tomcat:tomcat-juli:11.0.0
+library.version = 11.0.0
+metadata.dir = org.apache.tomcat/tomcat-juli/11.0.0/

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/settings.gradle
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.tomcat.tomcat-juli_tests'

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_juli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.apache.juli.ClassLoaderLogManager;
+import org.apache.juli.WebappProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ClassLoaderLogManagerTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void readsUrlClassLoaderConfigurationAndCreatesConfiguredHandler() throws Exception {
+        Path loggingProperties = temporaryDirectory.resolve("logging.properties");
+        Files.writeString(loggingProperties, loggingProperties(), StandardCharsets.UTF_8);
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        URL[] urls = {temporaryDirectory.toUri().toURL()};
+        try (URLClassLoader configurationClassLoader = new URLClassLoader(urls, getClass().getClassLoader())) {
+            Thread.currentThread().setContextClassLoader(configurationClassLoader);
+            ClassLoaderLogManager logManager = newLogManager();
+            try {
+                logManager.readConfiguration();
+
+                Logger rootLogger = logManager.getLogger("");
+                RecordingHandler handler = findRecordingHandler(rootLogger);
+                rootLogger.info("message from URL class loader configuration");
+
+                assertThat(handler.getPublishedRecords()).isEqualTo(1);
+            } finally {
+                logManager.shutdown();
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
+            }
+        }
+    }
+
+    @Test
+    void readsWebappClassLoaderConfigurationResource() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        WebappLoggingClassLoader webappClassLoader = new WebappLoggingClassLoader(getClass().getClassLoader(),
+                loggingProperties());
+        Thread.currentThread().setContextClassLoader(webappClassLoader);
+        ClassLoaderLogManager logManager = newLogManager();
+        try {
+            logManager.readConfiguration();
+
+            Logger rootLogger = logManager.getLogger("");
+            RecordingHandler handler = findRecordingHandler(rootLogger);
+            rootLogger.info("message from webapp class loader configuration");
+
+            assertThat(webappClassLoader.wasLoggingConfigurationRequested()).isTrue();
+            assertThat(handler.getPublishedRecords()).isEqualTo(1);
+        } finally {
+            logManager.shutdown();
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static ClassLoaderLogManager newLogManager() {
+        ClassLoaderLogManager logManager = new ClassLoaderLogManager();
+        logManager.setUseShutdownHook(false);
+        return logManager;
+    }
+
+    private static RecordingHandler findRecordingHandler(Logger logger) {
+        for (Handler handler : logger.getHandlers()) {
+            if (handler instanceof RecordingHandler recordingHandler) {
+                return recordingHandler;
+            }
+        }
+        throw new AssertionError("Expected a RecordingHandler to be configured");
+    }
+
+    private static String loggingProperties() {
+        return """
+                handlers = %s
+                .level = FINE
+                sample.category.level = FINEST
+                """.formatted(RecordingHandler.class.getName());
+    }
+
+    public static final class RecordingHandler extends Handler {
+        private int publishedRecords;
+
+        public RecordingHandler() {
+            setLevel(Level.ALL);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            publishedRecords++;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        int getPublishedRecords() {
+            return publishedRecords;
+        }
+    }
+
+    public static final class WebappLoggingClassLoader extends ClassLoader implements WebappProperties {
+        private final byte[] loggingProperties;
+        private boolean loggingConfigurationRequested;
+
+        WebappLoggingClassLoader(ClassLoader parent, String loggingProperties) {
+            super(parent);
+            this.loggingProperties = loggingProperties.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if ("logging.properties".equals(name)) {
+                loggingConfigurationRequested = true;
+                return new ByteArrayInputStream(loggingProperties);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        @Override
+        public boolean hasLoggingConfig() {
+            return true;
+        }
+
+        @Override
+        public String getWebappName() {
+            return "coverage-webapp";
+        }
+
+        @Override
+        public String getHostName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getServiceName() {
+            return "coverage-service";
+        }
+
+        boolean wasLoggingConfigurationRequested() {
+            return loggingConfigurationRequested;
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
@@ -8,7 +8,6 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -55,24 +54,31 @@ public class ClassLoaderLogManagerTest {
     }
 
     @Test
-    void readsWebappClassLoaderConfigurationResource() throws Exception {
+    void readsWebappUrlClassLoaderConfigurationResource() throws Exception {
+        Path loggingProperties = temporaryDirectory.resolve("logging.properties");
+        Files.writeString(loggingProperties, loggingProperties(), StandardCharsets.UTF_8);
+
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        WebappLoggingClassLoader webappClassLoader = new WebappLoggingClassLoader(getClass().getClassLoader(),
-                loggingProperties());
-        Thread.currentThread().setContextClassLoader(webappClassLoader);
-        ClassLoaderLogManager logManager = newLogManager();
-        try {
-            logManager.readConfiguration();
+        URL[] urls = {temporaryDirectory.toUri().toURL()};
+        try (WebappLoggingClassLoader webappClassLoader = new WebappLoggingClassLoader(urls,
+                getClass().getClassLoader())) {
+            Thread.currentThread().setContextClassLoader(webappClassLoader);
+            ClassLoaderLogManager logManager = newLogManager();
+            try {
+                logManager.readConfiguration();
 
-            Logger rootLogger = logManager.getLogger("");
-            RecordingHandler handler = findRecordingHandler(rootLogger);
-            rootLogger.info("message from webapp class loader configuration");
+                Logger rootLogger = logManager.getLogger("");
+                RecordingHandler handler = findRecordingHandler(rootLogger);
+                rootLogger.info("message from webapp class loader configuration");
 
-            assertThat(webappClassLoader.wasLoggingConfigurationRequested()).isTrue();
-            assertThat(handler.getPublishedRecords()).isEqualTo(1);
-        } finally {
-            logManager.shutdown();
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
+                assertThat(webappClassLoader.wasLoggingConfigurationRequested()).isTrue();
+                assertThat(logManager.getProperty("coverage.webapp"))
+                        .isEqualTo("coverage-webapp@localhost/coverage-service");
+                assertThat(handler.getPublishedRecords()).isEqualTo(1);
+            } finally {
+                logManager.shutdown();
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
+            }
         }
     }
 
@@ -96,6 +102,7 @@ public class ClassLoaderLogManagerTest {
                 handlers = %s
                 .level = FINE
                 sample.category.level = FINEST
+                coverage.webapp = ${classloader.webappName}@${classloader.hostName}/${classloader.serviceName}
                 """.formatted(RecordingHandler.class.getName());
     }
 
@@ -124,20 +131,18 @@ public class ClassLoaderLogManagerTest {
         }
     }
 
-    public static final class WebappLoggingClassLoader extends ClassLoader implements WebappProperties {
-        private final byte[] loggingProperties;
+    @SuppressWarnings("deprecation")
+    public static final class WebappLoggingClassLoader extends URLClassLoader implements WebappProperties {
         private boolean loggingConfigurationRequested;
 
-        WebappLoggingClassLoader(ClassLoader parent, String loggingProperties) {
-            super(parent);
-            this.loggingProperties = loggingProperties.getBytes(StandardCharsets.UTF_8);
+        WebappLoggingClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
             if ("logging.properties".equals(name)) {
                 loggingConfigurationRequested = true;
-                return new ByteArrayInputStream(loggingProperties);
             }
             return super.getResourceAsStream(name);
         }

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_juli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+
+public class DirectJDKLogTest {
+    private static final String LOGGING_CONFIG_CLASS_PROPERTY = "java.util.logging.config.class";
+    private static final String LOGGING_CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
+
+    @Test
+    void createsDefaultLogAndPublishesMessagesThroughJdkLogging() {
+        String previousConfigClass = System.clearProperty(LOGGING_CONFIG_CLASS_PROPERTY);
+        String previousConfigFile = System.clearProperty(LOGGING_CONFIG_FILE_PROPERTY);
+        List<HandlerFormatter> rootHandlerFormatters = captureRootConsoleFormatterState();
+        try {
+            Log log = LogFactory.getLog("coverage.direct-jdk-log");
+
+            exerciseLoggingMethods(log);
+        } finally {
+            restoreProperty(LOGGING_CONFIG_CLASS_PROPERTY, previousConfigClass);
+            restoreProperty(LOGGING_CONFIG_FILE_PROPERTY, previousConfigFile);
+            restoreRootConsoleFormatterState(rootHandlerFormatters);
+        }
+    }
+
+    private static void exerciseLoggingMethods(Log log) {
+        String loggerName = "coverage.direct-jdk-log";
+        Logger logger = Logger.getLogger(loggerName);
+        Level previousLevel = logger.getLevel();
+        boolean previousUseParentHandlers = logger.getUseParentHandlers();
+        RecordingHandler handler = new RecordingHandler();
+        logger.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        try {
+            log.trace("trace message");
+            log.debug("debug message");
+            log.info("info message");
+            log.warn("warn message");
+            log.error("error message", new IllegalStateException("error cause"));
+            log.fatal("fatal message", new IllegalArgumentException("fatal cause"));
+
+            assertThat(log.isTraceEnabled()).isTrue();
+            assertThat(log.isDebugEnabled()).isTrue();
+            assertThat(log.isInfoEnabled()).isTrue();
+            assertThat(log.isWarnEnabled()).isTrue();
+            assertThat(log.isErrorEnabled()).isTrue();
+            assertThat(log.isFatalEnabled()).isTrue();
+            assertThat(handler.getPublishedMessages()).containsExactly(
+                    "trace message",
+                    "debug message",
+                    "info message",
+                    "warn message",
+                    "error message",
+                    "fatal message");
+        } finally {
+            logger.removeHandler(handler);
+            handler.close();
+            logger.setUseParentHandlers(previousUseParentHandlers);
+            logger.setLevel(previousLevel);
+        }
+    }
+
+    private static List<HandlerFormatter> captureRootConsoleFormatterState() {
+        List<HandlerFormatter> states = new ArrayList<>();
+        for (Handler handler : Logger.getLogger("").getHandlers()) {
+            if (handler instanceof ConsoleHandler) {
+                states.add(new HandlerFormatter(handler, handler.getFormatter()));
+            }
+        }
+        return states;
+    }
+
+    private static void restoreRootConsoleFormatterState(List<HandlerFormatter> states) {
+        for (HandlerFormatter state : states) {
+            state.handler.setFormatter(state.formatter);
+        }
+    }
+
+    private static void restoreProperty(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+
+    private static final class HandlerFormatter {
+        private final Handler handler;
+        private final Formatter formatter;
+
+        private HandlerFormatter(Handler handler, Formatter formatter) {
+            this.handler = handler;
+            this.formatter = formatter;
+        }
+    }
+
+    private static final class RecordingHandler extends Handler {
+        private final List<String> publishedMessages = new ArrayList<>();
+
+        RecordingHandler() {
+            setLevel(Level.ALL);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            publishedMessages.add(record.getMessage());
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        List<String> getPublishedMessages() {
+            return publishedMessages;
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
@@ -8,8 +8,13 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -24,19 +29,28 @@ import org.junit.jupiter.api.Test;
 public class DirectJDKLogTest {
     private static final String LOGGING_CONFIG_CLASS_PROPERTY = "java.util.logging.config.class";
     private static final String LOGGING_CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
+    private static final String JULI_FORMATTER_PROPERTY = "org.apache.juli.formatter";
+    private static final String LOG_SERVICE_RESOURCE = "META-INF/services/org.apache.juli.logging.Log";
 
     @Test
     void createsDefaultLogAndPublishesMessagesThroughJdkLogging() {
         String previousConfigClass = System.clearProperty(LOGGING_CONFIG_CLASS_PROPERTY);
         String previousConfigFile = System.clearProperty(LOGGING_CONFIG_FILE_PROPERTY);
+        String previousFormatter = System.setProperty(JULI_FORMATTER_PROPERTY, TrackingFormatter.class.getName());
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(new ServiceResourceFilteringClassLoader(previousContextClassLoader));
+        int formatterCreations = TrackingFormatter.getCreations();
         List<HandlerFormatter> rootHandlerFormatters = captureRootConsoleFormatterState();
         try {
             Log log = LogFactory.getLog("coverage.direct-jdk-log");
 
+            assertThat(TrackingFormatter.getCreations()).isGreaterThan(formatterCreations);
             exerciseLoggingMethods(log);
         } finally {
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
             restoreProperty(LOGGING_CONFIG_CLASS_PROPERTY, previousConfigClass);
             restoreProperty(LOGGING_CONFIG_FILE_PROPERTY, previousConfigFile);
+            restoreProperty(JULI_FORMATTER_PROPERTY, previousFormatter);
             restoreRootConsoleFormatterState(rootHandlerFormatters);
         }
     }
@@ -110,6 +124,45 @@ public class DirectJDKLogTest {
         private HandlerFormatter(Handler handler, Formatter formatter) {
             this.handler = handler;
             this.formatter = formatter;
+        }
+    }
+
+    public static final class TrackingFormatter extends Formatter {
+        private static final AtomicInteger CREATIONS = new AtomicInteger();
+
+        public TrackingFormatter() {
+            CREATIONS.incrementAndGet();
+        }
+
+        static int getCreations() {
+            return CREATIONS.get();
+        }
+
+        @Override
+        public String format(LogRecord record) {
+            return record.getMessage() + System.lineSeparator();
+        }
+    }
+
+    private static final class ServiceResourceFilteringClassLoader extends ClassLoader {
+        private ServiceResourceFilteringClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (LOG_SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (LOG_SERVICE_RESOURCE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
         }
     }
 

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
@@ -8,15 +8,8 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -27,32 +20,11 @@ import org.apache.juli.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 public class DirectJDKLogTest {
-    private static final String LOGGING_CONFIG_CLASS_PROPERTY = "java.util.logging.config.class";
-    private static final String LOGGING_CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
-    private static final String JULI_FORMATTER_PROPERTY = "org.apache.juli.formatter";
-    private static final String LOG_SERVICE_RESOURCE = "META-INF/services/org.apache.juli.logging.Log";
-
     @Test
-    void createsDefaultLogAndPublishesMessagesThroughJdkLogging() {
-        String previousConfigClass = System.clearProperty(LOGGING_CONFIG_CLASS_PROPERTY);
-        String previousConfigFile = System.clearProperty(LOGGING_CONFIG_FILE_PROPERTY);
-        String previousFormatter = System.setProperty(JULI_FORMATTER_PROPERTY, TrackingFormatter.class.getName());
-        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(new ServiceResourceFilteringClassLoader(previousContextClassLoader));
-        int formatterCreations = TrackingFormatter.getCreations();
-        List<HandlerFormatter> rootHandlerFormatters = captureRootConsoleFormatterState();
-        try {
-            Log log = LogFactory.getLog("coverage.direct-jdk-log");
+    void createsLogAndPublishesMessagesThroughJdkLogging() {
+        Log log = LogFactory.getLog("coverage.direct-jdk-log");
 
-            assertThat(TrackingFormatter.getCreations()).isGreaterThan(formatterCreations);
-            exerciseLoggingMethods(log);
-        } finally {
-            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
-            restoreProperty(LOGGING_CONFIG_CLASS_PROPERTY, previousConfigClass);
-            restoreProperty(LOGGING_CONFIG_FILE_PROPERTY, previousConfigFile);
-            restoreProperty(JULI_FORMATTER_PROPERTY, previousFormatter);
-            restoreRootConsoleFormatterState(rootHandlerFormatters);
-        }
+        exerciseLoggingMethods(log);
     }
 
     private static void exerciseLoggingMethods(Log log) {
@@ -90,79 +62,6 @@ public class DirectJDKLogTest {
             handler.close();
             logger.setUseParentHandlers(previousUseParentHandlers);
             logger.setLevel(previousLevel);
-        }
-    }
-
-    private static List<HandlerFormatter> captureRootConsoleFormatterState() {
-        List<HandlerFormatter> states = new ArrayList<>();
-        for (Handler handler : Logger.getLogger("").getHandlers()) {
-            if (handler instanceof ConsoleHandler) {
-                states.add(new HandlerFormatter(handler, handler.getFormatter()));
-            }
-        }
-        return states;
-    }
-
-    private static void restoreRootConsoleFormatterState(List<HandlerFormatter> states) {
-        for (HandlerFormatter state : states) {
-            state.handler.setFormatter(state.formatter);
-        }
-    }
-
-    private static void restoreProperty(String property, String value) {
-        if (value == null) {
-            System.clearProperty(property);
-        } else {
-            System.setProperty(property, value);
-        }
-    }
-
-    private static final class HandlerFormatter {
-        private final Handler handler;
-        private final Formatter formatter;
-
-        private HandlerFormatter(Handler handler, Formatter formatter) {
-            this.handler = handler;
-            this.formatter = formatter;
-        }
-    }
-
-    public static final class TrackingFormatter extends Formatter {
-        private static final AtomicInteger CREATIONS = new AtomicInteger();
-
-        public TrackingFormatter() {
-            CREATIONS.incrementAndGet();
-        }
-
-        static int getCreations() {
-            return CREATIONS.get();
-        }
-
-        @Override
-        public String format(LogRecord record) {
-            return record.getMessage() + System.lineSeparator();
-        }
-    }
-
-    private static final class ServiceResourceFilteringClassLoader extends ClassLoader {
-        private ServiceResourceFilteringClassLoader(ClassLoader parent) {
-            super(parent);
-        }
-
-        @Override
-        public URL getResource(String name) {
-            if (LOG_SERVICE_RESOURCE.equals(name)) {
-                return null;
-            }
-            return super.getResource(name);
-        }
-
-        @Override
-        public Enumeration<URL> getResources(String name) throws IOException {
-            if (LOG_SERVICE_RESOURCE.equals(name)) {
-                return Collections.emptyEnumeration();
-            }
-            return super.getResources(name);
         }
     }
 

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/FileHandlerTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/FileHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_juli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+import org.apache.juli.FileHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FileHandlerTest {
+    @TempDir
+    Path logDirectory;
+
+    @AfterEach
+    void resetLogManager() {
+        LogManager.getLogManager().reset();
+    }
+
+    @Test
+    void configuresCustomFilterAndFormatterFromLogManagerProperties() throws Exception {
+        loadLoggingProperties("""
+                org.apache.juli.FileHandler.filter=%s
+                org.apache.juli.FileHandler.formatter=%s
+                org.apache.juli.FileHandler.level=ALL
+                """.formatted(RecordingFilter.class.getName(), RecordingFormatter.class.getName()));
+
+        FileHandler handler = new FileHandler(logDirectory.toString(), "coverage-", ".log", 0, false, -1);
+        try {
+            assertThat(handler.getFilter()).isInstanceOf(RecordingFilter.class);
+            assertThat(handler.getFormatter()).isInstanceOf(RecordingFormatter.class);
+
+            LogRecord record = new LogRecord(Level.INFO, "message from FileHandler");
+            handler.publish(record);
+            handler.flush();
+
+            RecordingFilter filter = (RecordingFilter) handler.getFilter();
+            RecordingFormatter formatter = (RecordingFormatter) handler.getFormatter();
+            assertThat(filter.acceptedRecords).isEqualTo(1);
+            assertThat(formatter.formattedRecords).isEqualTo(1);
+            assertThat(Files.readString(logDirectory.resolve("coverage-.log")))
+                    .contains("formatted: message from FileHandler");
+        } finally {
+            handler.close();
+        }
+    }
+
+    private static void loadLoggingProperties(String properties) throws Exception {
+        byte[] bytes = properties.getBytes(StandardCharsets.UTF_8);
+        LogManager.getLogManager().readConfiguration(new ByteArrayInputStream(bytes));
+    }
+
+    public static final class RecordingFilter implements Filter {
+        private int acceptedRecords;
+
+        public RecordingFilter() {
+        }
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            acceptedRecords++;
+            return true;
+        }
+    }
+
+    public static final class RecordingFormatter extends Formatter {
+        private int formattedRecords;
+
+        public RecordingFormatter() {
+        }
+
+        @Override
+        public String format(LogRecord record) {
+            formattedRecords++;
+            return "formatted: " + record.getMessage() + System.lineSeparator();
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_tomcat.tomcat_juli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+
+public class LogFactoryTest {
+    @Test
+    void createsServiceLoadedLogByName() {
+        Log log = LogFactory.getLog("coverage.service-loaded-log");
+
+        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
+        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo("coverage.service-loaded-log");
+    }
+
+    @Test
+    void createsServiceLoadedLogFromClassName() {
+        Log log = LogFactory.getFactory().getInstance(LogFactoryTest.class);
+
+        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
+        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo(LogFactoryTest.class.getName());
+    }
+
+    public static final class ServiceLoadedLog implements Log {
+        private final String name;
+        private final Logger logger;
+
+        public ServiceLoadedLog() {
+            this(ServiceLoadedLog.class.getName());
+        }
+
+        public ServiceLoadedLog(String name) {
+            this.name = name;
+            logger = Logger.getLogger(name);
+        }
+
+        String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return logger.isLoggable(Level.FINE);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return logger.isLoggable(Level.SEVERE);
+        }
+
+        @Override
+        public boolean isFatalEnabled() {
+            return logger.isLoggable(Level.SEVERE);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return logger.isLoggable(Level.INFO);
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return logger.isLoggable(Level.FINER);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return logger.isLoggable(Level.WARNING);
+        }
+
+        @Override
+        public void trace(Object message) {
+            trace(message, null);
+        }
+
+        @Override
+        public void trace(Object message, Throwable throwable) {
+            log(Level.FINER, message, throwable);
+        }
+
+        @Override
+        public void debug(Object message) {
+            debug(message, null);
+        }
+
+        @Override
+        public void debug(Object message, Throwable throwable) {
+            log(Level.FINE, message, throwable);
+        }
+
+        @Override
+        public void info(Object message) {
+            info(message, null);
+        }
+
+        @Override
+        public void info(Object message, Throwable throwable) {
+            log(Level.INFO, message, throwable);
+        }
+
+        @Override
+        public void warn(Object message) {
+            warn(message, null);
+        }
+
+        @Override
+        public void warn(Object message, Throwable throwable) {
+            log(Level.WARNING, message, throwable);
+        }
+
+        @Override
+        public void error(Object message) {
+            error(message, null);
+        }
+
+        @Override
+        public void error(Object message, Throwable throwable) {
+            log(Level.SEVERE, message, throwable);
+        }
+
+        @Override
+        public void fatal(Object message) {
+            fatal(message, null);
+        }
+
+        @Override
+        public void fatal(Object message, Throwable throwable) {
+            log(Level.SEVERE, message, throwable);
+        }
+
+        private void log(Level level, Object message, Throwable throwable) {
+            if (throwable == null) {
+                logger.log(level, String.valueOf(message));
+            } else {
+                logger.log(level, String.valueOf(message), throwable);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
@@ -8,22 +8,143 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 public class LogFactoryTest {
     @Test
-    void createsLogByName() {
-        Log log = LogFactory.getLog("coverage.log-factory");
+    void createsServiceLoadedLogByName() {
+        Log log = LogFactory.getLog("coverage.service-loaded-log");
 
-        assertThat(log.isInfoEnabled()).isTrue();
+        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
+        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo("coverage.service-loaded-log");
     }
 
     @Test
-    void createsLogFromClassName() {
+    void createsServiceLoadedLogFromClassName() {
         Log log = LogFactory.getFactory().getInstance(LogFactoryTest.class);
 
-        assertThat(log.isInfoEnabled()).isTrue();
+        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
+        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo(LogFactoryTest.class.getName());
+    }
+
+    public static final class ServiceLoadedLog implements Log {
+        private final String name;
+        private final Logger logger;
+
+        public ServiceLoadedLog() {
+            this(ServiceLoadedLog.class.getName());
+        }
+
+        public ServiceLoadedLog(String name) {
+            this.name = name;
+            logger = Logger.getLogger(name);
+        }
+
+        String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return logger.isLoggable(Level.FINE);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return logger.isLoggable(Level.SEVERE);
+        }
+
+        @Override
+        public boolean isFatalEnabled() {
+            return logger.isLoggable(Level.SEVERE);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return logger.isLoggable(Level.INFO);
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return logger.isLoggable(Level.FINER);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return logger.isLoggable(Level.WARNING);
+        }
+
+        @Override
+        public void trace(Object message) {
+            trace(message, null);
+        }
+
+        @Override
+        public void trace(Object message, Throwable throwable) {
+            log(Level.FINER, message, throwable);
+        }
+
+        @Override
+        public void debug(Object message) {
+            debug(message, null);
+        }
+
+        @Override
+        public void debug(Object message, Throwable throwable) {
+            log(Level.FINE, message, throwable);
+        }
+
+        @Override
+        public void info(Object message) {
+            info(message, null);
+        }
+
+        @Override
+        public void info(Object message, Throwable throwable) {
+            log(Level.INFO, message, throwable);
+        }
+
+        @Override
+        public void warn(Object message) {
+            warn(message, null);
+        }
+
+        @Override
+        public void warn(Object message, Throwable throwable) {
+            log(Level.WARNING, message, throwable);
+        }
+
+        @Override
+        public void error(Object message) {
+            error(message, null);
+        }
+
+        @Override
+        public void error(Object message, Throwable throwable) {
+            log(Level.SEVERE, message, throwable);
+        }
+
+        @Override
+        public void fatal(Object message) {
+            fatal(message, null);
+        }
+
+        @Override
+        public void fatal(Object message, Throwable throwable) {
+            log(Level.SEVERE, message, throwable);
+        }
+
+        private void log(Level level, Object message, Throwable throwable) {
+            if (throwable == null) {
+                logger.log(level, String.valueOf(message));
+            } else {
+                logger.log(level, String.valueOf(message), throwable);
+            }
+        }
     }
 }

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/LogFactoryTest.java
@@ -8,143 +8,22 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 public class LogFactoryTest {
     @Test
-    void createsServiceLoadedLogByName() {
-        Log log = LogFactory.getLog("coverage.service-loaded-log");
+    void createsLogByName() {
+        Log log = LogFactory.getLog("coverage.log-factory");
 
-        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
-        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo("coverage.service-loaded-log");
+        assertThat(log.isInfoEnabled()).isTrue();
     }
 
     @Test
-    void createsServiceLoadedLogFromClassName() {
+    void createsLogFromClassName() {
         Log log = LogFactory.getFactory().getInstance(LogFactoryTest.class);
 
-        assertThat(log).isInstanceOf(ServiceLoadedLog.class);
-        assertThat(((ServiceLoadedLog) log).getName()).isEqualTo(LogFactoryTest.class.getName());
-    }
-
-    public static final class ServiceLoadedLog implements Log {
-        private final String name;
-        private final Logger logger;
-
-        public ServiceLoadedLog() {
-            this(ServiceLoadedLog.class.getName());
-        }
-
-        public ServiceLoadedLog(String name) {
-            this.name = name;
-            logger = Logger.getLogger(name);
-        }
-
-        String getName() {
-            return name;
-        }
-
-        @Override
-        public boolean isDebugEnabled() {
-            return logger.isLoggable(Level.FINE);
-        }
-
-        @Override
-        public boolean isErrorEnabled() {
-            return logger.isLoggable(Level.SEVERE);
-        }
-
-        @Override
-        public boolean isFatalEnabled() {
-            return logger.isLoggable(Level.SEVERE);
-        }
-
-        @Override
-        public boolean isInfoEnabled() {
-            return logger.isLoggable(Level.INFO);
-        }
-
-        @Override
-        public boolean isTraceEnabled() {
-            return logger.isLoggable(Level.FINER);
-        }
-
-        @Override
-        public boolean isWarnEnabled() {
-            return logger.isLoggable(Level.WARNING);
-        }
-
-        @Override
-        public void trace(Object message) {
-            trace(message, null);
-        }
-
-        @Override
-        public void trace(Object message, Throwable throwable) {
-            log(Level.FINER, message, throwable);
-        }
-
-        @Override
-        public void debug(Object message) {
-            debug(message, null);
-        }
-
-        @Override
-        public void debug(Object message, Throwable throwable) {
-            log(Level.FINE, message, throwable);
-        }
-
-        @Override
-        public void info(Object message) {
-            info(message, null);
-        }
-
-        @Override
-        public void info(Object message, Throwable throwable) {
-            log(Level.INFO, message, throwable);
-        }
-
-        @Override
-        public void warn(Object message) {
-            warn(message, null);
-        }
-
-        @Override
-        public void warn(Object message, Throwable throwable) {
-            log(Level.WARNING, message, throwable);
-        }
-
-        @Override
-        public void error(Object message) {
-            error(message, null);
-        }
-
-        @Override
-        public void error(Object message, Throwable throwable) {
-            log(Level.SEVERE, message, throwable);
-        }
-
-        @Override
-        public void fatal(Object message) {
-            fatal(message, null);
-        }
-
-        @Override
-        public void fatal(Object message, Throwable throwable) {
-            log(Level.SEVERE, message, throwable);
-        }
-
-        private void log(Level level, Object message, Throwable throwable) {
-            if (throwable == null) {
-                logger.log(level, String.valueOf(message));
-            } else {
-                logger.log(level, String.valueOf(message), throwable);
-            }
-        }
+        assertThat(log.isInfoEnabled()).isTrue();
     }
 }

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,62 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.ClassLoaderLogManager"
+      },
+      "type" : "org_apache_tomcat.tomcat_juli.ClassLoaderLogManagerTest$RecordingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "org_apache_tomcat.tomcat_juli.FileHandlerTest$RecordingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "org_apache_tomcat.tomcat_juli.FileHandlerTest$RecordingFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.LogFactory"
+      },
+      "type" : "org_apache_tomcat.tomcat_juli.LogFactoryTest$ServiceLoadedLog",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.LogFactory"
+      },
+      "glob" : "META-INF/services/org.apache.juli.logging.Log"
+    }
+  ]
+}

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/native-image/tomcat-juli-test-metadata/reflect-config.json
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/native-image/tomcat-juli-test-metadata/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "org_apache_tomcat.tomcat_juli.LogFactoryTest$ServiceLoadedLog",
+    "allPublicConstructors": true
+  }
+]

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/services/org.apache.juli.logging.Log
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/services/org.apache.juli.logging.Log
@@ -1,0 +1,1 @@
+org_apache_tomcat.tomcat_juli.LogFactoryTest$ServiceLoadedLog

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/services/org.apache.juli.logging.Log
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/resources/META-INF/services/org.apache.juli.logging.Log
@@ -1,1 +1,0 @@
-org_apache_tomcat.tomcat_juli.LogFactoryTest$ServiceLoadedLog

--- a/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/user-code-filter.json
+++ b/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.juli.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3349

This PR provides test fixes and new metadata for org.apache.tomcat:tomcat-juli:11.0.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 178829
- Cached input tokens: 1792000
- Output tokens: 25405
- Entries found: 1
- Iterations: 4
- Library coverage percentage: 32.96
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 30.34

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4fc96062b20fa40ca2d8e225514294b35b2373d4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.tomcat:tomcat-juli:10.1.7: 13/16 covered calls (81.25%)
- org.apache.tomcat:tomcat-juli:11.0.0: 12/15 covered calls (80.00%)

**Reflection:**
- org.apache.tomcat:tomcat-juli:10.1.7: 11/14 covered calls (78.57%)
- org.apache.tomcat:tomcat-juli:11.0.0: 11/14 covered calls (78.57%)

**Resources:**
- org.apache.tomcat:tomcat-juli:10.1.7: 2/2 covered calls (100.00%)
- org.apache.tomcat:tomcat-juli:11.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.tomcat:tomcat-juli:10.1.7: 1040/3556 (29.25%)
- org.apache.tomcat:tomcat-juli:11.0.0: 1097/3406 (32.21%)

**Line:**
- org.apache.tomcat:tomcat-juli:10.1.7: 284/936 (30.34%)
- org.apache.tomcat:tomcat-juli:11.0.0: 295/895 (32.96%)

**Method:**
- org.apache.tomcat:tomcat-juli:10.1.7: 42/132 (31.82%)
- org.apache.tomcat:tomcat-juli:11.0.0: 42/127 (33.07%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.tomcat/tomcat-juli/10.1.7/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java 2/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
index c476ea549f..b423295e31 100644
--- 1/tests/src/org.apache.tomcat/tomcat-juli/10.1.7/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
+++ 2/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/ClassLoaderLogManagerTest.java
@@ -8,7 +8,6 @@ package org_apache_tomcat.tomcat_juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -55,24 +54,31 @@ public class ClassLoaderLogManagerTest {
     }
 
     @Test
-    void readsWebappClassLoaderConfigurationResource() throws Exception {
+    void readsWebappUrlClassLoaderConfigurationResource() throws Exception {
+        Path loggingProperties = temporaryDirectory.resolve("logging.properties");
+        Files.writeString(loggingProperties, loggingProperties(), StandardCharsets.UTF_8);
+
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        WebappLoggingClassLoader webappClassLoader = new WebappLoggingClassLoader(getClass().getClassLoader(),
-                loggingProperties());
-        Thread.currentThread().setContextClassLoader(webappClassLoader);
-        ClassLoaderLogManager logManager = newLogManager();
-        try {
-            logManager.readConfiguration();
-
-            Logger rootLogger = logManager.getLogger("");
-            RecordingHandler handler = findRecordingHandler(rootLogger);
-            rootLogger.info("message from webapp class loader configuration");
-
-            assertThat(webappClassLoader.wasLoggingConfigurationRequested()).isTrue();
-            assertThat(handler.getPublishedRecords()).isEqualTo(1);
-        } finally {
-            logManager.shutdown();
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        URL[] urls = {temporaryDirectory.toUri().toURL()};
+        try (WebappLoggingClassLoader webappClassLoader = new WebappLoggingClassLoader(urls,
+                getClass().getClassLoader())) {
+            Thread.currentThread().setContextClassLoader(webappClassLoader);
+            ClassLoaderLogManager logManager = newLogManager();
+            try {
+                logManager.readConfiguration();
+
+                Logger rootLogger = logManager.getLogger("");
+                RecordingHandler handler = findRecordingHandler(rootLogger);
+                rootLogger.info("message from webapp class loader configuration");
+
+                assertThat(webappClassLoader.wasLoggingConfigurationRequested()).isTrue();
+                assertThat(logManager.getProperty("coverage.webapp"))
+                        .isEqualTo("coverage-webapp@localhost/coverage-service");
+                assertThat(handler.getPublishedRecords()).isEqualTo(1);
+            } finally {
+                logManager.shutdown();
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
+            }
         }
     }
 
@@ -96,6 +102,7 @@ public class ClassLoaderLogManagerTest {
                 handlers = %s
                 .level = FINE
                 sample.category.level = FINEST
+                coverage.webapp = ${classloader.webappName}@${classloader.hostName}/${classloader.serviceName}
                 """.formatted(RecordingHandler.class.getName());
     }
 
@@ -124,20 +131,18 @@ public class ClassLoaderLogManagerTest {
         }
     }
 
-    public static final class WebappLoggingClassLoader extends ClassLoader implements WebappProperties {
-        private final byte[] loggingProperties;
+    @SuppressWarnings("deprecation")
+    public static final class WebappLoggingClassLoader extends URLClassLoader implements WebappProperties {
         private boolean loggingConfigurationRequested;
 
-        WebappLoggingClassLoader(ClassLoader parent, String loggingProperties) {
-            super(parent);
-            this.loggingProperties = loggingProperties.getBytes(StandardCharsets.UTF_8);
+        WebappLoggingClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
             if ("logging.properties".equals(name)) {
                 loggingConfigurationRequested = true;
-                return new ByteArrayInputStream(loggingProperties);
             }
             return super.getResourceAsStream(name);
         }
diff --git 1/tests/src/org.apache.tomcat/tomcat-juli/10.1.7/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java 2/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
index 169da53861..4ef3b1e0ab 100644
--- 1/tests/src/org.apache.tomcat/tomcat-juli/10.1.7/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
+++ 2/tests/src/org.apache.tomcat/tomcat-juli/11.0.0/src/test/java/org_apache_tomcat/tomcat_juli/DirectJDKLogTest.java
@@ -10,8 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -22,23 +20,11 @@ import org.apache.juli.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 public class DirectJDKLogTest {
-    private static final String LOGGING_CONFIG_CLASS_PROPERTY = "java.util.logging.config.class";
-    private static final String LOGGING_CONFIG_FILE_PROPERTY = "java.util.logging.config.file";
-
     @Test
-    void createsDefaultLogAndPublishesMessagesThroughJdkLogging() {
-        String previousConfigClass = System.clearProperty(LOGGING_CONFIG_CLASS_PROPERTY);
-        String previousConfigFile = System.clearProperty(LOGGING_CONFIG_FILE_PROPERTY);
-        List<HandlerFormatter> rootHandlerFormatters = captureRootConsoleFormatterState();
-        try {
-            Log log = LogFactory.getLog("coverage.direct-jdk-log");
+    void createsLogAndPublishesMessagesThroughJdkLogging() {
+        Log log = LogFactory.getLog("coverage.direct-jdk-log");
 
-            exerciseLoggingMethods(log);
-        } finally {
-            restoreProperty(LOGGING_CONFIG_CLASS_PROPERTY, previousConfigClass);
-            restoreProperty(LOGGING_CONFIG_FILE_PROPERTY, previousConfigFile);
-            restoreRootConsoleFormatterState(rootHandlerFormatters);
-        }
+        exerciseLoggingMethods(log);
     }
 
     private static void exerciseLoggingMethods(Log log) {
@@ -79,40 +65,6 @@ public class DirectJDKLogTest {
         }
     }
 
-    private static List<HandlerFormatter> captureRootConsoleFormatterState() {
-        List<HandlerFormatter> states = new ArrayList<>();
-        for (Handler handler : Logger.getLogger("").getHandlers()) {
-            if (handler instanceof ConsoleHandler) {
-                states.add(new HandlerFormatter(handler, handler.getFormatter()));
-            }
-        }
-        return states;
-    }
-
-    private static void restoreRootConsoleFormatterState(List<HandlerFormatter> states) {
-        for (HandlerFormatter state : states) {
-            state.handler.setFormatter(state.formatter);
-        }
-    }
-
-    private static void restoreProperty(String property, String value) {
-        if (value == null) {
-            System.clearProperty(property);
-        } else {
-            System.setProperty(property, value);
-        }
-    }
-
-    private static final class HandlerFormatter {
-        private final Handler handler;
-        private final Formatter formatter;
-
-        private HandlerFormatter(Handler handler, Formatter formatter) {
-            this.handler = handler;
-            this.formatter = formatter;
-        }
-    }
-
     private static final class RecordingHandler extends Handler {
         private final List<String> publishedMessages = new ArrayList<>();
 

```
