### PR TITLE
[GenAI] Test fix for redis.clients:jedis:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/redis.clients/jedis/3.0.0/reachability-metadata.json
+++ b/metadata/redis.clients/jedis/3.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.HostAndPort"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/redis.clients/jedis/index.json
+++ b/metadata/redis.clients/jedis/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "redis.clients"
+    ]
+  },
+  {
     "metadata-version" : "2.9.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/2.9.0/jedis-2.9.0-sources.jar",
     "repository-url" : "https://github.com/redis/jedis",

--- a/metadata/redis.clients/jedis/index.json
+++ b/metadata/redis.clients/jedis/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/3.0.0/jedis-3.0.0-sources.jar",
+    "repository-url" : "https://github.com/redis/jedis",
+    "test-code-url" : "https://github.com/redis/jedis/tree/jedis-3.0.0/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/3.0.0/jedis-3.0.0-javadoc.jar",
+    "description" : "Jedis is a Java client library for Redis that provides synchronous APIs for commands, pooling, transactions, pipelining, and Redis cluster usage. It lets Java applications communicate with Redis servers while exposing Redis data structures and operations through a compact client interface.",
     "tested-versions" : [
       "3.0.0"
     ],
     "allowed-packages" : [
-      "redis.clients"
+      "redis.clients.jedis"
     ]
   },
   {

--- a/stats/redis.clients/jedis/3.0.0/execution-metrics.json
+++ b/stats/redis.clients/jedis/3.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T16:35:11.693198Z",
+    "library": "redis.clients:jedis:3.0.0",
+    "starting_commit": "c7407b9588828e00460c13c90c4edb23f9c36ebd",
+    "ending_commit": "21bd21f279f4d1304a6c5be557bd31c37c539657",
+    "previous_library": "redis.clients:jedis:2.9.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7154,
+          "missed": 42752,
+          "ratio": 0.143349,
+          "total": 49906
+        },
+        "line": {
+          "covered": 712,
+          "missed": 7404,
+          "ratio": 0.087728,
+          "total": 8116
+        },
+        "method": {
+          "covered": 218,
+          "missed": 3378,
+          "ratio": 0.060623,
+          "total": 3596
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.9.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7059,
+          "missed": 42828,
+          "ratio": 0.1415,
+          "total": 49887
+        },
+        "line": {
+          "covered": 682,
+          "missed": 7373,
+          "ratio": 0.084668,
+          "total": 8055
+        },
+        "method": {
+          "covered": 212,
+          "missed": 3239,
+          "ratio": 0.061431,
+          "total": 3451
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 46013,
+      "cached_input_tokens_used": 300032,
+      "output_tokens_used": 2287,
+      "iterations": 1,
+      "cost_usd": 0.2186,
+      "tested_library_loc": 712,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 8.77,
+      "previous_library_coverage_percent": 8.47
+    },
+    "artifacts": {
+      "test_file": "tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java",
+      "metadata_file": "metadata/redis.clients/jedis/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/redis.clients/jedis/3.0.0/stats.json
+++ b/stats/redis.clients/jedis/3.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7154,
+        "missed" : 42752,
+        "ratio" : 0.143349,
+        "total" : 49906
+      },
+      "line" : {
+        "covered" : 712,
+        "missed" : 7404,
+        "ratio" : 0.087728,
+        "total" : 8116
+      },
+      "method" : {
+        "covered" : 218,
+        "missed" : 3378,
+        "ratio" : 0.060623,
+        "total" : 3596
+      }
+    }
+  } ]
+}

--- a/tests/src/redis.clients/jedis/3.0.0/.gitignore
+++ b/tests/src/redis.clients/jedis/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/redis.clients/jedis/3.0.0/build.gradle
+++ b/tests/src/redis.clients/jedis/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "redis.clients:jedis:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/redis.clients/jedis/3.0.0/gradle.properties
+++ b/tests/src/redis.clients/jedis/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = redis.clients:jedis:3.0.0
+library.version = 3.0.0
+metadata.dir = redis.clients/jedis/3.0.0/

--- a/tests/src/redis.clients/jedis/3.0.0/settings.gradle
+++ b/tests/src/redis.clients/jedis/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'redis.clients.jedis_tests'

--- a/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ b/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package redis_clients.jedis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.BitPosParams;
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.GeoCoordinate;
+import redis.clients.jedis.GeoRadiusResponse;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisShardInfo;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.SortingParams;
+import redis.clients.jedis.Tuple;
+import redis.clients.jedis.ZParams;
+import redis.clients.jedis.exceptions.JedisAskDataException;
+import redis.clients.jedis.exceptions.JedisBusyException;
+import redis.clients.jedis.exceptions.JedisClusterException;
+import redis.clients.jedis.exceptions.JedisMovedDataException;
+import redis.clients.jedis.exceptions.JedisNoScriptException;
+import redis.clients.jedis.params.geo.GeoRadiusParam;
+import redis.clients.jedis.params.sortedset.ZAddParams;
+import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.util.Hashing;
+import redis.clients.util.JedisClusterCRC16;
+import redis.clients.util.JedisClusterHashTagUtil;
+import redis.clients.util.RedisInputStream;
+import redis.clients.util.RedisOutputStream;
+import redis.clients.util.ShardInfo;
+import redis.clients.util.Sharded;
+import redis.clients.util.Slowlog;
+
+public class JedisTest {
+    @Test
+    void writesRedisProtocolCommandsAndReadsAllReplyTypes() throws Exception {
+        ByteArrayOutputStream commandBytes = new ByteArrayOutputStream();
+        RedisOutputStream outputStream = new RedisOutputStream(commandBytes);
+
+        Protocol.sendCommand(outputStream, Protocol.Command.SET, bytes("client:key"), bytes("value"));
+        outputStream.flush();
+
+        assertThat(asString(commandBytes.toByteArray()))
+                .isEqualTo("*3\r\n$3\r\nSET\r\n$10\r\nclient:key\r\n$5\r\nvalue\r\n");
+        assertThat(asString((byte[]) Protocol.read(input("+OK\r\n")))).isEqualTo("OK");
+        assertThat(Protocol.read(input(":42\r\n"))).isEqualTo(42L);
+        assertThat(asString((byte[]) Protocol.read(input("$5\r\nhello\r\n")))).isEqualTo("hello");
+        assertThat(Protocol.read(input("$-1\r\n"))).isNull();
+
+        Object multiBulk = Protocol.read(input("*4\r\n+PONG\r\n:7\r\n$5\r\nworld\r\n$-1\r\n"));
+
+        assertThat(multiBulk).isInstanceOf(List.class);
+        List<?> replies = (List<?>) multiBulk;
+        assertThat(asString((byte[]) replies.get(0))).isEqualTo("PONG");
+        assertThat(replies.get(1)).isEqualTo(7L);
+        assertThat(asString((byte[]) replies.get(2))).isEqualTo("world");
+        assertThat(replies.get(3)).isNull();
+    }
+
+    @Test
+    void mapsRedisErrorRepliesToSpecificJedisExceptions() {
+        assertThatThrownBy(() -> Protocol.read(input("-MOVED 3999 127.0.0.1:6381\r\n")))
+                .isInstanceOfSatisfying(JedisMovedDataException.class, exception -> {
+                    assertThat(exception.getSlot()).isEqualTo(3999);
+                    assertThat(exception.getTargetNode()).isEqualTo(new HostAndPort("127.0.0.1", 6381));
+                });
+        assertThatThrownBy(() -> Protocol.read(input("-ASK 4000 redis.example.test:6382\r\n")))
+                .isInstanceOfSatisfying(JedisAskDataException.class, exception -> {
+                    assertThat(exception.getSlot()).isEqualTo(4000);
+                    assertThat(exception.getTargetNode()).isEqualTo(new HostAndPort("redis.example.test", 6382));
+                });
+        assertThatThrownBy(() -> Protocol.read(input("-CLUSTERDOWN Hash slot not served\r\n")))
+                .isInstanceOf(JedisClusterException.class);
+        assertThatThrownBy(() -> Protocol.read(input("-BUSY Redis is busy running a script\r\n")))
+                .isInstanceOf(JedisBusyException.class);
+        assertThatThrownBy(() -> Protocol.read(input("-NOSCRIPT No matching script\r\n")))
+                .isInstanceOf(JedisNoScriptException.class);
+
+        assertThat(Protocol.readErrorLineIfPossible(input("-ERR invalid command\r\n")))
+                .isEqualTo("ERR invalid command");
+        assertThat(Protocol.readErrorLineIfPossible(input("+OK\r\n"))).isNull();
+    }
+
+    @Test
+    void buildsCommandParameterObjectsInRedisArgumentOrder() {
+        SortingParams sortingParams = new SortingParams()
+                .by("weight_*")
+                .limit(2, 5)
+                .get("object_*", "#")
+                .desc()
+                .alpha();
+        assertThat(strings(sortingParams.getParams()))
+                .containsExactly("by", "weight_*", "limit", "2", "5", "get", "object_*", "get", "#", "desc", "alpha");
+
+        ScanParams scanParams = new ScanParams().match("user:*").count(25);
+        assertThat(strings(scanParams.getParams())).containsExactly("match", "user:*", "count", "25");
+        assertThat(asString(ScanParams.SCAN_POINTER_START_BINARY)).isEqualTo("0");
+
+        ZParams zParams = new ZParams().weightsByDouble(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
+        assertThat(strings(zParams.getParams())).containsExactly("weights", "1.5", "2.0", "0.25", "aggregate", "MAX");
+
+        BitPosParams bitPosParams = new BitPosParams(3L, 14L);
+        assertThat(strings(bitPosParams.getParams())).containsExactly("3", "14");
+    }
+
+    @Test
+    void buildsSortedSetAndGeoParameterObjects() {
+        byte[][] zaddParams = ZAddParams.zAddParams().nx().ch()
+                .getByteParams(bytes("leaders"), bytes("9.5"), bytes("alice"));
+        assertThat(strings(zaddParams)).containsExactly("leaders", "nx", "ch", "9.5", "alice");
+
+        byte[][] zincrByParams = ZIncrByParams.zIncrByParams().xx()
+                .getByteParams(bytes("leaders"), bytes("2.0"), bytes("bob"));
+        assertThat(strings(zincrByParams)).containsExactly("leaders", "xx", "incr", "2.0", "bob");
+
+        byte[][] geoRadiusParams = GeoRadiusParam.geoRadiusParam()
+                .withCoord()
+                .withDist()
+                .count(3)
+                .sortDescending()
+                .getByteParams(bytes("Sicily"), bytes("15"), bytes("37"), bytes("200"), bytes("km"));
+        assertThat(strings(geoRadiusParams))
+                .containsExactly("Sicily", "15", "37", "200", "km", "withcoord", "withdist", "count", "3", "desc");
+    }
+
+    @Test
+    void convertsRawRedisResponsesWithBuilderFactory() {
+        assertThat(BuilderFactory.STRING.build(bytes("plain"))).isEqualTo("plain");
+        assertThat(BuilderFactory.BOOLEAN.build(1L)).isTrue();
+        assertThat(BuilderFactory.DOUBLE.build(bytes("12.75"))).isEqualTo(12.75D);
+        assertThat(BuilderFactory.STRING_LIST.build(Arrays.asList(bytes("first"), null, bytes("second"))))
+                .containsExactly("first", null, "second");
+
+        Map<String, String> stringMap = BuilderFactory.STRING_MAP.build(Arrays.asList(
+                bytes("field-one"), bytes("value-one"), bytes("field-two"), bytes("value-two")));
+        assertThat(stringMap).containsEntry("field-one", "value-one").containsEntry("field-two", "value-two");
+
+        Set<Tuple> scoredMembers = BuilderFactory.TUPLE_ZSET.build(Arrays.asList(
+                bytes("alice"), bytes("8.5"), bytes("bob"), bytes("9.25")));
+        assertThat(scoredMembers)
+                .extracting(Tuple::getElement)
+                .containsExactly("alice", "bob");
+        assertThat(scoredMembers)
+                .extracting(Tuple::getScore)
+                .containsExactly(8.5D, 9.25D);
+
+        Object evalResult = BuilderFactory.EVAL_RESULT.build(Arrays.asList(
+                bytes("root"), Arrays.asList(bytes("nested"), 5L)));
+        assertThat(evalResult).isEqualTo(Arrays.asList("root", Arrays.asList("nested", 5L)));
+    }
+
+    @Test
+    void convertsGeoResponsesAndValueObjects() {
+        GeoCoordinate coordinate = new GeoCoordinate(13.361389D, 38.115556D);
+        GeoCoordinate sameCoordinate = new GeoCoordinate(13.361389D, 38.115556D);
+        assertThat(coordinate).isEqualTo(sameCoordinate);
+        assertThat(coordinate.toString()).isEqualTo("(13.361389,38.115556)");
+
+        List<GeoCoordinate> coordinates = BuilderFactory.GEO_COORDINATE_LIST.build(Arrays.asList(
+                Arrays.asList(bytes("13.361389"), bytes("38.115556")),
+                null,
+                Arrays.asList(bytes("15.087269"), bytes("37.502669"))));
+        assertThat(coordinates).containsExactly(
+                new GeoCoordinate(13.361389D, 38.115556D),
+                null,
+                new GeoCoordinate(15.087269D, 37.502669D));
+
+        List<GeoRadiusResponse> responses = BuilderFactory.GEORADIUS_WITH_PARAMS_RESULT.build(Arrays.asList(
+                Arrays.asList(
+                        bytes("Palermo"),
+                        bytes("190.4424"),
+                        Arrays.asList(bytes("13.361389"), bytes("38.115556"))),
+                Arrays.asList(
+                        bytes("Catania"),
+                        bytes("56.4413"),
+                        Arrays.asList(bytes("15.087269"), bytes("37.502669")))));
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getMemberByString()).isEqualTo("Palermo");
+        assertThat(responses.get(0).getDistance()).isEqualTo(190.4424D);
+        assertThat(responses.get(0).getCoordinate()).isEqualTo(new GeoCoordinate(13.361389D, 38.115556D));
+        assertThat(responses.get(1).getMemberByString()).isEqualTo("Catania");
+    }
+
+    @Test
+    void convertsSlowlogRepliesIntoDomainObjects() {
+        List<Object> rawEntries = Arrays.<Object>asList(
+                Arrays.<Object>asList(
+                        7L,
+                        1_460_000_000L,
+                        321L,
+                        Arrays.asList(bytes("SET"), bytes("slowlog:key"), bytes("value"))),
+                Arrays.<Object>asList(
+                        8L,
+                        1_460_000_001L,
+                        42L,
+                        Arrays.asList(bytes("GET"), bytes("slowlog:key"))));
+
+        List<Slowlog> entries = Slowlog.from(rawEntries);
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).getId()).isEqualTo(7L);
+        assertThat(entries.get(0).getTimeStamp()).isEqualTo(1_460_000_000L);
+        assertThat(entries.get(0).getExecutionTime()).isEqualTo(321L);
+        assertThat(entries.get(0).getArgs()).containsExactly("SET", "slowlog:key", "value");
+        assertThat(entries.get(0).toString()).isEqualTo("7,1460000000,321,[SET, slowlog:key, value]");
+        assertThat(entries.get(1).getId()).isEqualTo(8L);
+        assertThat(entries.get(1).getArgs()).containsExactly("GET", "slowlog:key");
+    }
+
+    @Test
+    void parsesShardInfoUriAndCreatesUnconnectedJedisResource() {
+        JedisShardInfo redisUri = new JedisShardInfo(URI.create("redis://:secret@cache.example.test:6380/3"));
+        assertThat(redisUri.getHost()).isEqualTo("cache.example.test");
+        assertThat(redisUri.getPort()).isEqualTo(6380);
+        assertThat(redisUri.getPassword()).isEqualTo("secret");
+        assertThat(redisUri.getDb()).isEqualTo(3);
+        assertThat(redisUri.getSsl()).isFalse();
+
+        JedisShardInfo redissUri = new JedisShardInfo("rediss://:tls-secret@secure.example.test:6381/4");
+        assertThat(redissUri.getHost()).isEqualTo("secure.example.test");
+        assertThat(redissUri.getPort()).isEqualTo(6381);
+        assertThat(redissUri.getPassword()).isEqualTo("tls-secret");
+        assertThat(redissUri.getDb()).isEqualTo(4);
+        assertThat(redissUri.getSsl()).isTrue();
+
+        JedisShardInfo shardInfo = new JedisShardInfo("localhost", 6382, 500, "primary", true);
+        shardInfo.setConnectionTimeout(700);
+        shardInfo.setSoTimeout(900);
+        shardInfo.setPassword("changed");
+        assertThat(shardInfo.getName()).isEqualTo("primary");
+        assertThat(shardInfo.getConnectionTimeout()).isEqualTo(700);
+        assertThat(shardInfo.getSoTimeout()).isEqualTo(900);
+        assertThat(shardInfo.getPassword()).isEqualTo("changed");
+        assertThat(shardInfo.toString()).contains("localhost").contains("6382");
+
+        Jedis jedis = shardInfo.createResource();
+        assertThat(jedis).isNotNull();
+        assertThat(jedis.isConnected()).isFalse();
+        jedis.close();
+    }
+
+    @Test
+    void routesKeysAcrossClientSideShardsUsingConsistentHashRing() {
+        TestShardInfo primary = new TestShardInfo("primary", "primary-resource");
+        TestShardInfo secondary = new TestShardInfo("secondary", "secondary-resource");
+        Sharded<String, TestShardInfo> sharded = new Sharded<>(
+                Arrays.asList(primary, secondary), new PredictableHashing());
+
+        assertThat(sharded.getAllShards()).containsExactly("primary-resource", "secondary-resource");
+        assertThat(sharded.getShard("before-primary")).isEqualTo("primary-resource");
+        assertThat(sharded.getShard("between-shards")).isEqualTo("secondary-resource");
+        assertThat(sharded.getShard("after-secondary")).isEqualTo("primary-resource");
+        assertThat(sharded.getShardInfo("between-shards")).isSameAs(secondary);
+    }
+
+    @Test
+    void handlesHostAndPortParsingAndClusterHashSlots() {
+        HostAndPort parsed = HostAndPort.parseString("redis.example.test:7001");
+        assertThat(parsed.getHost()).isEqualTo("redis.example.test");
+        assertThat(parsed.getPort()).isEqualTo(7001);
+        assertThat(parsed.toString()).isEqualTo("redis.example.test:7001");
+        assertThat(HostAndPort.extractParts("2001:db8::10:7002"))
+                .containsExactly("2001:db8::10", "7002");
+        assertThat(new HostAndPort("127.0.0.1", 6379)).isEqualTo(new HostAndPort("localhost", 6379));
+
+        String taggedKey = "cart:{user-42}:items";
+        assertThat(JedisClusterHashTagUtil.getHashTag(taggedKey)).isEqualTo("user-42");
+        assertThat(JedisClusterCRC16.getSlot(taggedKey)).isEqualTo(JedisClusterCRC16.getSlot("profile:{user-42}"));
+        assertThat(JedisClusterHashTagUtil.isClusterCompliantMatchPattern("cart:{user-42}:*")).isTrue();
+        assertThat(JedisClusterHashTagUtil.isClusterCompliantMatchPattern("cart:user-*"))
+                .isFalse();
+        assertThat(JedisClusterCRC16.getCRC16("123456789")).isEqualTo(12739);
+    }
+
+    private static final class TestShardInfo extends ShardInfo<String> {
+        private final String name;
+        private final String resource;
+
+        private TestShardInfo(String name, String resource) {
+            super(Sharded.DEFAULT_WEIGHT);
+            this.name = name;
+            this.resource = resource;
+        }
+
+        @Override
+        protected String createResource() {
+            return resource;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static final class PredictableHashing implements Hashing {
+        @Override
+        public long hash(String key) {
+            if (key.startsWith("primary*")) {
+                return 100L;
+            }
+            if (key.startsWith("secondary*")) {
+                return 200L;
+            }
+            throw new IllegalArgumentException(key);
+        }
+
+        @Override
+        public long hash(byte[] key) {
+            String keyText = asString(key);
+            switch (keyText) {
+                case "before-primary":
+                    return 50L;
+                case "between-shards":
+                    return 150L;
+                case "after-secondary":
+                    return 250L;
+                default:
+                    throw new IllegalArgumentException(keyText);
+            }
+        }
+    }
+
+    private static RedisInputStream input(String data) {
+        return new RedisInputStream(new ByteArrayInputStream(bytes(data)));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String asString(byte[] value) {
+        return new String(value, StandardCharsets.UTF_8);
+    }
+
+    private static List<String> strings(Collection<byte[]> values) {
+        return values.stream().map(JedisTest::asString).collect(Collectors.toList());
+    }
+
+    private static List<String> strings(byte[][] values) {
+        return Arrays.stream(values).map(JedisTest::asString).collect(Collectors.toList());
+    }
+}

--- a/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ b/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -39,17 +39,17 @@ import redis.clients.jedis.exceptions.JedisBusyException;
 import redis.clients.jedis.exceptions.JedisClusterException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoScriptException;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
-import redis.clients.util.Hashing;
-import redis.clients.util.JedisClusterCRC16;
-import redis.clients.util.JedisClusterHashTagUtil;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
-import redis.clients.util.ShardInfo;
-import redis.clients.util.Sharded;
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
+import redis.clients.jedis.util.Hashing;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterHashTagUtil;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+import redis.clients.jedis.util.ShardInfo;
+import redis.clients.jedis.util.Sharded;
+import redis.clients.jedis.util.Slowlog;
 
 public class JedisTest {
     @Test
@@ -116,7 +116,7 @@ public class JedisTest {
         assertThat(strings(scanParams.getParams())).containsExactly("match", "user:*", "count", "25");
         assertThat(asString(ScanParams.SCAN_POINTER_START_BINARY)).isEqualTo("0");
 
-        ZParams zParams = new ZParams().weightsByDouble(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
+        ZParams zParams = new ZParams().weights(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
         assertThat(strings(zParams.getParams())).containsExactly("weights", "1.5", "2.0", "0.25", "aggregate", "MAX");
 
         BitPosParams bitPosParams = new BitPosParams(3L, 14L);

--- a/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
+++ b/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "redis.clients.**"
+      "includeClasses" : "redis.clients.jedis.**"
     }
   ]
 }

--- a/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
+++ b/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "redis.clients.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3366

This PR provides test fixes and new metadata for redis.clients:jedis:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 46013
- Cached input tokens: 300032
- Output tokens: 2287
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 8.77
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 8.47

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- redis.clients:jedis:2.9.0: 0/0 covered calls (100.00%)
- redis.clients:jedis:3.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- redis.clients:jedis:2.9.0: 7059/49887 (14.15%)
- redis.clients:jedis:3.0.0: 7154/49906 (14.33%)

**Line:**
- redis.clients:jedis:2.9.0: 682/8055 (8.47%)
- redis.clients:jedis:3.0.0: 712/8116 (8.77%)

**Method:**
- redis.clients:jedis:2.9.0: 212/3451 (6.14%)
- redis.clients:jedis:3.0.0: 218/3596 (6.06%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/redis.clients/jedis/2.9.0/src/test/java/redis_clients/jedis/JedisTest.java b/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
index 0fc212eec..4bb28ebd8 100644
--- a/tests/src/redis.clients/jedis/2.9.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ b/tests/src/redis.clients/jedis/3.0.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -39,17 +39,17 @@ import redis.clients.jedis.exceptions.JedisBusyException;
 import redis.clients.jedis.exceptions.JedisClusterException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoScriptException;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
-import redis.clients.util.Hashing;
-import redis.clients.util.JedisClusterCRC16;
-import redis.clients.util.JedisClusterHashTagUtil;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
-import redis.clients.util.ShardInfo;
-import redis.clients.util.Sharded;
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
+import redis.clients.jedis.util.Hashing;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterHashTagUtil;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+import redis.clients.jedis.util.ShardInfo;
+import redis.clients.jedis.util.Sharded;
+import redis.clients.jedis.util.Slowlog;
 
 public class JedisTest {
     @Test
@@ -116,7 +116,7 @@ public class JedisTest {
         assertThat(strings(scanParams.getParams())).containsExactly("match", "user:*", "count", "25");
         assertThat(asString(ScanParams.SCAN_POINTER_START_BINARY)).isEqualTo("0");
 
-        ZParams zParams = new ZParams().weightsByDouble(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
+        ZParams zParams = new ZParams().weights(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
         assertThat(strings(zParams.getParams())).containsExactly("weights", "1.5", "2.0", "0.25", "aggregate", "MAX");
 
         BitPosParams bitPosParams = new BitPosParams(3L, 14L);
diff --git a/tests/src/redis.clients/jedis/2.9.0/user-code-filter.json b/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
index 4e5c6780c..510fabf6c 100644
--- a/tests/src/redis.clients/jedis/2.9.0/user-code-filter.json
+++ b/tests/src/redis.clients/jedis/3.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "redis.clients.**"
+      "includeClasses" : "redis.clients.jedis.**"
     }
   ]
 }

```
