### PR TITLE
[GenAI] Test fix for org.slf4j:slf4j-simple:1.7.32 using gpt-5.5

### DIFF
--- a/metadata/org.slf4j/slf4j-simple/1.7.32/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-simple/1.7.32/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.SimpleLoggerConfiguration$1"
+      },
+      "glob": "simplelogger.properties"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-simple/index.json
+++ b/metadata/org.slf4j/slf4j-simple/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.7.32",
+    "tested-versions" : [
+      "1.7.32"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.7.25",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/metadata/org.slf4j/slf4j-simple/index.json
+++ b/metadata/org.slf4j/slf4j-simple/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.7.32",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.32/slf4j-simple-1.7.32-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/v_1.7.32/slf4j-simple/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-simple/1.7.32/slf4j-simple-1.7.32-javadoc.jar",
+    "description" : "SLF4J Simple is a lightweight SLF4J binding that routes SLF4J logging calls to a simple logger implementation. It writes log output to System.err by default and is intended as a basic logging backend for applications or tests that do not need a full logging framework.",
     "tested-versions" : [
       "1.7.32"
     ],

--- a/stats/org.slf4j/slf4j-simple/1.7.32/execution-metrics.json
+++ b/stats/org.slf4j/slf4j-simple/1.7.32/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-04-29": {
+    "timestamp": "2026-04-29T16:44:00.654500Z",
+    "library": "org.slf4j:slf4j-simple:1.7.32",
+    "starting_commit": "b6c13d16b04a60eb297bdec45d4681b9582db898",
+    "ending_commit": "6ea0dc7e118af6889a772b4491cde536a6713278",
+    "previous_library": "org.slf4j:slf4j-simple:1.7.25",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.7.32",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 412,
+          "missed": 648,
+          "ratio": 0.388679,
+          "total": 1060
+        },
+        "line": {
+          "covered": 102,
+          "missed": 187,
+          "ratio": 0.352941,
+          "total": 289
+        },
+        "method": {
+          "covered": 23,
+          "missed": 54,
+          "ratio": 0.298701,
+          "total": 77
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.7.25",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 413,
+          "missed": 642,
+          "ratio": 0.391469,
+          "total": 1055
+        },
+        "line": {
+          "covered": 103,
+          "missed": 185,
+          "ratio": 0.357639,
+          "total": 288
+        },
+        "method": {
+          "covered": 23,
+          "missed": 54,
+          "ratio": 0.298701,
+          "total": 77
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 35428,
+      "cached_input_tokens_used": 136704,
+      "output_tokens_used": 3575,
+      "iterations": 1,
+      "cost_usd": 0.1756,
+      "tested_library_loc": 102,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 35.29,
+      "previous_library_coverage_percent": 35.76
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java",
+      "metadata_file": "metadata/org.slf4j/slf4j-simple/1.7.32/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.slf4j/slf4j-simple/1.7.32/stats.json
+++ b/stats/org.slf4j/slf4j-simple/1.7.32/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.7.32",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 412,
+        "missed" : 648,
+        "ratio" : 0.388679,
+        "total" : 1060
+      },
+      "line" : {
+        "covered" : 102,
+        "missed" : 187,
+        "ratio" : 0.352941,
+        "total" : 289
+      },
+      "method" : {
+        "covered" : 23,
+        "missed" : 54,
+        "ratio" : 0.298701,
+        "total" : 77
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/.gitignore
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/build.gradle
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:slf4j-simple:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:slf4j-simple:1.7.32
+library.version = 1.7.32
+metadata.dir = org.slf4j/slf4j-simple/1.7.32/

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/settings.gradle
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.slf4j-simple_tests'

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_simple;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleLoggerConfigurationAnonymous1Test {
+
+    private static final String CONFIGURATION_FILE = "simplelogger.properties";
+    private static final String TRACE_CONFIGURATION = SimpleLogger.DEFAULT_LOG_LEVEL_KEY + "=trace\n";
+
+    @Test
+    void loadsConfigurationUsingContextAndSystemClassLoaders() throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalDefaultLevel = System.getProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+        try {
+            System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(null);
+            Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
+            assertThat(defaultLogger.isInfoEnabled()).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
+            resetSimpleLoggerInitialization();
+        }
+    }
+
+    private static void resetSimpleLoggerInitialization() throws Exception {
+        Field initialized = SimpleLogger.class.getDeclaredField("INITIALIZED");
+        initialized.setAccessible(true);
+        initialized.setBoolean(null, false);
+
+        Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
+        configParams.setAccessible(true);
+        configParams.set(null, null);
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    private static final class PropertiesClassLoader extends ClassLoader {
+        PropertiesClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (CONFIGURATION_FILE.equals(name)) {
+                return new ByteArrayInputStream(TRACE_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -10,10 +10,12 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerConfiguration;
 import org.slf4j.impl.SimpleLoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,14 +33,15 @@ public class SimpleLoggerConfigurationAnonymous1Test {
             System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
 
             resetSimpleLoggerInitialization();
-            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
-            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
-            assertThat(configuredLogger.isTraceEnabled()).isTrue();
-
-            resetSimpleLoggerInitialization();
             Thread.currentThread().setContextClassLoader(null);
             Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
             assertThat(defaultLogger.isInfoEnabled()).isTrue();
+            assertThat(defaultLogger.isTraceEnabled()).isFalse();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
         } finally {
             Thread.currentThread().setContextClassLoader(originalContextClassLoader);
             restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
@@ -51,9 +54,30 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         initialized.setAccessible(true);
         initialized.setBoolean(null, false);
 
+        SimpleLoggerConfiguration configParams = getConfigParams();
+        clearConfigurationProperties(configParams);
+        resetDefaultLogLevel(configParams);
+    }
+
+    private static SimpleLoggerConfiguration getConfigParams() throws Exception {
         Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
         configParams.setAccessible(true);
-        configParams.set(null, null);
+        return (SimpleLoggerConfiguration) configParams.get(null);
+    }
+
+    private static void clearConfigurationProperties(SimpleLoggerConfiguration configParams) throws Exception {
+        Field properties = SimpleLoggerConfiguration.class.getDeclaredField("properties");
+        properties.setAccessible(true);
+        ((Properties) properties.get(configParams)).clear();
+    }
+
+    private static void resetDefaultLogLevel(SimpleLoggerConfiguration configParams) throws Exception {
+        Field defaultLogLevelDefault = SimpleLoggerConfiguration.class.getDeclaredField("DEFAULT_LOG_LEVEL_DEFAULT");
+        defaultLogLevelDefault.setAccessible(true);
+
+        Field defaultLogLevel = SimpleLoggerConfiguration.class.getDeclaredField("defaultLogLevel");
+        defaultLogLevel.setAccessible(true);
+        defaultLogLevel.setInt(configParams, defaultLogLevelDefault.getInt(null));
     }
 
     private static void restoreSystemProperty(String key, String value) {

--- a/tests/src/org.slf4j/slf4j-simple/1.7.32/user-code-filter.json
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.slf4j.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3361

This PR provides test fixes and new metadata for org.slf4j:slf4j-simple:1.7.32, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 35428
- Cached input tokens: 136704
- Output tokens: 3575
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 35.29
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 35.76

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-simple:1.7.25: 2/2 covered calls (100.00%)
- org.slf4j:slf4j-simple:1.7.32: 2/2 covered calls (100.00%)

**Resources:**
- org.slf4j:slf4j-simple:1.7.25: 2/2 covered calls (100.00%)
- org.slf4j:slf4j-simple:1.7.32: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-simple:1.7.25: 413/1055 (39.15%)
- org.slf4j:slf4j-simple:1.7.32: 412/1060 (38.87%)

**Line:**
- org.slf4j:slf4j-simple:1.7.25: 103/288 (35.76%)
- org.slf4j:slf4j-simple:1.7.32: 102/289 (35.29%)

**Method:**
- org.slf4j:slf4j-simple:1.7.25: 23/77 (29.87%)
- org.slf4j:slf4j-simple:1.7.32: 23/77 (29.87%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.slf4j/slf4j-simple/1.7.25/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
index 0ba77a65b..d32bde5b9 100644
--- a/tests/src/org.slf4j/slf4j-simple/1.7.25/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
+++ b/tests/src/org.slf4j/slf4j-simple/1.7.32/src/test/java/org_slf4j/slf4j_simple/SimpleLoggerConfigurationAnonymous1Test.java
@@ -10,10 +10,12 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerConfiguration;
 import org.slf4j.impl.SimpleLoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,15 +32,16 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         try {
             System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
 
-            resetSimpleLoggerInitialization();
-            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
-            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
-            assertThat(configuredLogger.isTraceEnabled()).isTrue();
-
             resetSimpleLoggerInitialization();
             Thread.currentThread().setContextClassLoader(null);
             Logger defaultLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.system");
             assertThat(defaultLogger.isInfoEnabled()).isTrue();
+            assertThat(defaultLogger.isTraceEnabled()).isFalse();
+
+            resetSimpleLoggerInitialization();
+            Thread.currentThread().setContextClassLoader(new PropertiesClassLoader(originalContextClassLoader));
+            Logger configuredLogger = new SimpleLoggerFactory().getLogger("simple.logger.configuration.context");
+            assertThat(configuredLogger.isTraceEnabled()).isTrue();
         } finally {
             Thread.currentThread().setContextClassLoader(originalContextClassLoader);
             restoreSystemProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, originalDefaultLevel);
@@ -51,9 +54,30 @@ public class SimpleLoggerConfigurationAnonymous1Test {
         initialized.setAccessible(true);
         initialized.setBoolean(null, false);
 
+        SimpleLoggerConfiguration configParams = getConfigParams();
+        clearConfigurationProperties(configParams);
+        resetDefaultLogLevel(configParams);
+    }
+
+    private static SimpleLoggerConfiguration getConfigParams() throws Exception {
         Field configParams = SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
         configParams.setAccessible(true);
-        configParams.set(null, null);
+        return (SimpleLoggerConfiguration) configParams.get(null);
+    }
+
+    private static void clearConfigurationProperties(SimpleLoggerConfiguration configParams) throws Exception {
+        Field properties = SimpleLoggerConfiguration.class.getDeclaredField("properties");
+        properties.setAccessible(true);
+        ((Properties) properties.get(configParams)).clear();
+    }
+
+    private static void resetDefaultLogLevel(SimpleLoggerConfiguration configParams) throws Exception {
+        Field defaultLogLevelDefault = SimpleLoggerConfiguration.class.getDeclaredField("DEFAULT_LOG_LEVEL_DEFAULT");
+        defaultLogLevelDefault.setAccessible(true);
+
+        Field defaultLogLevel = SimpleLoggerConfiguration.class.getDeclaredField("defaultLogLevel");
+        defaultLogLevel.setAccessible(true);
+        defaultLogLevel.setInt(configParams, defaultLogLevelDefault.getInt(null));
     }
 
     private static void restoreSystemProperty(String key, String value) {

```
