### PR TITLE
[GenAI] Add support for org.jboss.modules:jboss-modules:2.1.6.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json
+++ b/metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.modules.PathUtils"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    }
+  ]
+}

--- a/metadata/org.jboss.modules/jboss-modules/index.json
+++ b/metadata/org.jboss.modules/jboss-modules/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.1.6.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/modules/jboss-modules/2.1.6.Final/jboss-modules-2.1.6.Final-sources.jar",
+    "repository-url" : "https://github.com/jboss-modules/jboss-modules",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/modules/jboss-modules/2.1.6.Final/jboss-modules-2.1.6.Final-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/modules/jboss-modules/2.1.6.Final/jboss-modules-2.1.6.Final-javadoc.jar",
+    "description" : "JBoss Modules is a standalone modular class loading and execution environment for Java applications. It lets applications run with isolated modules, explicit dependencies, and an extensible module resolution system instead of one flat application class path.",
+    "tested-versions" : [
+      "2.1.6.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.modules"
+    ]
+  }
+]

--- a/stats/org.jboss.modules/jboss-modules/2.1.6.Final/execution-metrics.json
+++ b/stats/org.jboss.modules/jboss-modules/2.1.6.Final/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-04-29": {
+    "timestamp": "2026-04-29T17:32:31.762309Z",
+    "library": "org.jboss.modules:jboss-modules:2.1.6.Final",
+    "starting_commit": "47fc5496e784630fd7fab0cd7ac054c8c590b036",
+    "ending_commit": "c5a257c3cb4d898a4279379a8487b8ad22e2d317",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.6.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 46
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 11
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 57
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1686,
+          "missed": 37108,
+          "ratio": 0.04346,
+          "total": 38794
+        },
+        "line": {
+          "covered": 367,
+          "missed": 8614,
+          "ratio": 0.040864,
+          "total": 8981
+        },
+        "method": {
+          "covered": 86,
+          "missed": 1488,
+          "ratio": 0.054638,
+          "total": 1574
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 416680,
+      "cached_input_tokens_used": 4320256,
+      "output_tokens_used": 34622,
+      "iterations": 11,
+      "cost_usd": 3.1988,
+      "generated_loc": 131,
+      "tested_library_loc": 367,
+      "metadata_entries": 2,
+      "code_coverage_percent": 4.09
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/JbossModulesPathUtilsTest.java",
+      "metadata_file": "metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.modules/jboss-modules/2.1.6.Final/stats.json
+++ b/stats/org.jboss.modules/jboss-modules/2.1.6.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.1.6.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 46
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 11
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 57
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1686,
+        "missed" : 37108,
+        "ratio" : 0.04346,
+        "total" : 38794
+      },
+      "line" : {
+        "covered" : 367,
+        "missed" : 8614,
+        "ratio" : 0.040864,
+        "total" : 8981
+      },
+      "method" : {
+        "covered" : 86,
+        "missed" : 1488,
+        "ratio" : 0.054638,
+        "total" : 1574
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/.gitignore
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
@@ -16,6 +16,13 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('-H:+UnlockExperimentalVMOptions')
+            buildArgs.add('-H:ServiceLoaderFeatureExcludeServiceProviders=org.jboss.modules.ModuleLoggerFinder')
+            buildArgs.add('--initialize-at-build-time=org.jboss.modules.ModuleLoggerFinder,org.jboss.modules.ModuleLoggerFinder$1,org.jboss.modules.ModuleLoggerFinder$2,org.jboss.modules.ModuleLoggerFinder$DelegatingSystemLogger,org.jboss.modules.ModuleLoggerFinder$QueueingSystemLogger,org.jboss.modules.ModuleLoggerFinder$SystemLogRecord')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.modules:jboss-modules:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/gradle.properties
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.modules:jboss-modules:2.1.6.Final
+library.version = 2.1.6.Final
+metadata.dir = org.jboss.modules/jboss-modules/2.1.6.Final/

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/settings.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.modules.jboss-modules_tests'

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/JbossModulesPathUtilsTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/JbossModulesPathUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_modules.jboss_modules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.jboss.modules.PathUtils;
+import org.jboss.modules.filter.PathFilters;
+import org.junit.jupiter.api.Test;
+
+public class JbossModulesPathUtilsTest {
+    @Test
+    void canonicalPathOperationsNormalizeRelativeSegmentsAndClassifyChildren() {
+        assertEquals("alpha/gamma/delta", PathUtils.canonicalize("alpha/beta/../gamma/./delta"));
+        assertEquals("var/log", PathUtils.relativize("///var/log"));
+        assertEquals("archive.jar", PathUtils.fileNameOfPath("/tmp/archive.jar"));
+        assertEquals("alpha/beta", PathUtils.toGenericSeparators("alpha/beta"));
+
+        assertTrue(PathUtils.isRelative("alpha/beta"));
+        assertFalse(PathUtils.isRelative("/alpha/beta"));
+        assertTrue(PathUtils.isSeparator('/'));
+
+        assertTrue(PathUtils.isChild("alpha", "alpha/beta/gamma"));
+        assertTrue(PathUtils.isDirectChild("alpha", "alpha/beta"));
+        assertFalse(PathUtils.isDirectChild("alpha", "alpha/beta/gamma"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.isChild("alpha", "/alpha/beta"));
+    }
+
+    @Test
+    void filterPathsAddsAcceptedPathsToTheSuppliedCollection() {
+        List<String> paths = List.of("api/Foo.class", "api/internal/Secret.class", "META-INF/services/app.Plugin");
+        LinkedHashSet<String> acceptedPaths = new LinkedHashSet<>();
+
+        LinkedHashSet<String> returnedPaths = PathUtils.filterPaths(
+                paths,
+                PathFilters.all(
+                        PathFilters.isChildOf("api"),
+                        PathFilters.not(PathFilters.isChildOf("api/internal"))),
+                acceptedPaths);
+
+        assertSame(acceptedPaths, returnedPaths);
+        assertIterableEquals(List.of("api/Foo.class"), new ArrayList<>(acceptedPaths));
+    }
+
+    @Test
+    void basicModuleNamesAreConvertedToModulePathSegments() {
+        assertEquals("org/jboss/modules/main", PathUtils.basicModuleNameToPath("org.jboss.modules"));
+        assertEquals("org/jboss/modules/test-slot", PathUtils.basicModuleNameToPath("org.jboss.modules:test-slot"));
+        assertEquals("org/jboss/modules/test.slot", PathUtils.basicModuleNameToPath("org.jboss.modules:test/slot"));
+
+        assertNull(PathUtils.basicModuleNameToPath(".leading"));
+        assertNull(PathUtils.basicModuleNameToPath("org..example"));
+        assertNull(PathUtils.basicModuleNameToPath("org.example:"));
+        assertNull(PathUtils.basicModuleNameToPath("org.example\\"));
+    }
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -6,11 +6,64 @@
  */
 package org_jboss_modules.jboss_modules;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.jboss.modules.IterableResourceLoader;
+import org.jboss.modules.Resource;
+import org.jboss.modules.ResourceLoaders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class Jboss_modulesTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void pathResourceLoaderReadsAndIteratesFileSystemResources(@TempDir Path resourceRoot) throws Exception {
+        Path configDirectory = Files.createDirectories(resourceRoot.resolve("config"));
+        Path nestedDirectory = Files.createDirectories(configDirectory.resolve("nested"));
+        Files.writeString(configDirectory.resolve("settings.properties"), "feature.enabled=true\n", UTF_8);
+        Files.writeString(nestedDirectory.resolve("details.txt"), "nested-resource\n", UTF_8);
+
+        IterableResourceLoader resourceLoader = ResourceLoaders.createPathResourceLoader(resourceRoot);
+
+        Resource settingsResource = resourceLoader.getResource("config/settings.properties");
+        assertNotNull(settingsResource);
+        assertEquals("config/settings.properties", settingsResource.getName());
+        assertEquals("feature.enabled=true\n".getBytes(UTF_8).length, settingsResource.getSize());
+        assertEquals("feature.enabled=true\n", readResource(settingsResource));
+        assertNull(resourceLoader.getResource("config/missing.properties"));
+
+        assertIterableEquals(
+                List.of("config/settings.properties"),
+                resourceNames(resourceLoader.iterateResources("config", false)));
+        assertIterableEquals(
+                List.of("config/nested/details.txt", "config/settings.properties"),
+                resourceNames(resourceLoader.iterateResources("config", true)));
+        assertTrue(resourceLoader.getPaths().contains("config/nested"));
+    }
+
+    private static String readResource(Resource resource) throws IOException {
+        try (InputStream inputStream = resource.openStream()) {
+            return new String(inputStream.readAllBytes(), UTF_8);
+        }
+    }
+
+    private static List<String> resourceNames(Iterator<Resource> resources) {
+        List<String> names = new ArrayList<>();
+        while (resources.hasNext()) {
+            names.add(resources.next().getName());
+        }
+        names.sort(String::compareTo);
+        return names;
     }
 }

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_modules.jboss_modules;
+
+import org.junit.jupiter.api.Test;
+
+class Jboss_modulesTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -23,10 +23,23 @@ import java.util.List;
 import org.jboss.modules.IterableResourceLoader;
 import org.jboss.modules.Resource;
 import org.jboss.modules.ResourceLoaders;
+import org.jboss.modules.Version;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class Jboss_modulesTest {
+    @Test
+    void versionsParseAndCompareNumericAndQualifiedParts() {
+        Version betaVersion = Version.parse("1.0.0.Beta1");
+        Version finalVersion = Version.parse("1.0.0.Final");
+        Version nextMinorVersion = Version.parse("1.1.0");
+
+        assertTrue(finalVersion.compareTo(betaVersion) > 0);
+        assertTrue(nextMinorVersion.compareTo(finalVersion) > 0);
+        assertEquals(Version.parse("1.0.0.Final"), finalVersion);
+        assertEquals("1.0.0.Final", finalVersion.toString());
+    }
+
     @Test
     void pathResourceLoaderReadsAndIteratesFileSystemResources(@TempDir Path resourceRoot) throws Exception {
         Path configDirectory = Files.createDirectories(resourceRoot.resolve("config"));

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.modules.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.modules.**"
+      "includeClasses" : "org.jboss.modules.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3283

This PR introduces tests and metadata for org.jboss.modules:jboss-modules:2.1.6.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 416680
- Cached input tokens: 4320256
- Output tokens: 34622
- Entries: 2
- Iterations: 11
- Library coverage percentage: 4.09
- Generated lines of code: 131
- Tested library lines of code: 367

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/57 covered calls (0.00%)
- Reflection: 0/46 covered calls (0.00%)
- Resources: 0/11 covered calls (0.00%)

Library coverage:
- Instruction: 1686/38794 (4.35%)
- Line: 367/8981 (4.09%)
- Method: 86/1574 (5.46%)
