### PR TITLE
[GenAI] Test fix for org.springframework.security:spring-security-crypto:6.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.security/spring-security-crypto/6.0.0/reachability-metadata.json
+++ b/metadata/org.springframework.security/spring-security-crypto/6.0.0/reachability-metadata.json
@@ -1,0 +1,240 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.AesBytesEncryptor"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.Encryptors"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.apache.logging.log4j.spi.ExtendedLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.slf4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"
+      },
+      "type": "org.slf4j.spi.LocationAwareLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCrypt"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.HexEncodingTextEncryptor"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.keygen.SecureRandomBytesKeyGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.bcrypt.BCrypt"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.encrypt.CipherUtils"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.security.crypto.password.Pbkdf2PasswordEncoder"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/org.springframework.security/spring-security-crypto/index.json
+++ b/metadata/org.springframework.security/spring-security-crypto/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/security/spring-security-crypto/6.0.0/spring-security-crypto-6.0.0-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-security",
+    "test-code-url" : "https://github.com/spring-projects/spring-security/tree/6.0.0/crypto/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/security/spring-security-crypto/6.0.0/spring-security-crypto-6.0.0-javadoc.jar",
+    "description" : "Spring Security Crypto provides password encoding, key generation, and cryptographic utility classes used by Spring Security and standalone Java applications. It includes implementations for algorithms such as BCrypt, PBKDF2, SCrypt, Argon2, and symmetric text encryption helpers.",
     "tested-versions" : [
       "6.0.0"
     ],

--- a/metadata/org.springframework.security/spring-security-crypto/index.json
+++ b/metadata/org.springframework.security/spring-security-crypto/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.0.0",
+    "tested-versions" : [
+      "6.0.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.security.crypto"
+    ]
+  },
+  {
     "metadata-version" : "5.7.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/security/spring-security-crypto/5.7.3/spring-security-crypto-5.7.3-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-security",

--- a/stats/org.springframework.security/spring-security-crypto/6.0.0/execution-metrics.json
+++ b/stats/org.springframework.security/spring-security-crypto/6.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T17:50:00.329317Z",
+    "library": "org.springframework.security:spring-security-crypto:6.0.0",
+    "starting_commit": "4a674aed5d80a020edcc19a5a7a52968c42fa27f",
+    "ending_commit": "8e6c2b6914cdaa315ce9ce8e23afd01b16a5a75d",
+    "previous_library": "org.springframework.security:spring-security-crypto:5.7.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7386,
+          "missed": 8083,
+          "ratio": 0.477471,
+          "total": 15469
+        },
+        "line": {
+          "covered": 454,
+          "missed": 780,
+          "ratio": 0.367909,
+          "total": 1234
+        },
+        "method": {
+          "covered": 104,
+          "missed": 136,
+          "ratio": 0.433333,
+          "total": 240
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.7.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7429,
+          "missed": 8177,
+          "ratio": 0.476035,
+          "total": 15606
+        },
+        "line": {
+          "covered": 450,
+          "missed": 774,
+          "ratio": 0.367647,
+          "total": 1224
+        },
+        "method": {
+          "covered": 103,
+          "missed": 136,
+          "ratio": 0.430962,
+          "total": 239
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 55681,
+      "cached_input_tokens_used": 342016,
+      "output_tokens_used": 4367,
+      "iterations": 1,
+      "cost_usd": 0.302,
+      "tested_library_loc": 454,
+      "metadata_entries": 38,
+      "previous_library_metadata_entries": 38,
+      "code_coverage_percent": 36.79,
+      "previous_library_coverage_percent": 36.76
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java",
+      "metadata_file": "metadata/org.springframework.security/spring-security-crypto/6.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.security/spring-security-crypto/6.0.0/stats.json
+++ b/stats/org.springframework.security/spring-security-crypto/6.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7386,
+        "missed" : 8083,
+        "ratio" : 0.477471,
+        "total" : 15469
+      },
+      "line" : {
+        "covered" : 454,
+        "missed" : 780,
+        "ratio" : 0.367909,
+        "total" : 1234
+      },
+      "method" : {
+        "covered" : 104,
+        "missed" : 136,
+        "ratio" : 0.433333,
+        "total" : 240
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/.gitignore
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.security:spring-security-crypto:$libraryVersion"
+    testImplementation 'org.springframework:spring-jcl:5.3.22'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/gradle.properties
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.security:spring-security-crypto:6.0.0
+library.version = 6.0.0
+metadata.dir = org.springframework.security/spring-security-crypto/6.0.0/

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/settings.gradle
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.security.spring-security-crypto_tests'

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_security.spring_security_crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.BCryptVersion;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
+import org.springframework.security.crypto.keygen.BytesKeyGenerator;
+import org.springframework.security.crypto.keygen.KeyGenerators;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm;
+import org.springframework.security.crypto.util.EncodingUtils;
+
+public class Spring_security_cryptoTest {
+    private static final String PASSWORD = "correct horse battery staple";
+    private static final String WRONG_PASSWORD = "correct horse battery staple?";
+    private static final String SALT = "5c0744940b5c369b";
+
+    @Test
+    void bcryptPasswordEncoderEncodesMatchesAndDetectsWeakCost() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(BCryptVersion.$2B, 4);
+
+        String encoded = encoder.encode(PASSWORD);
+
+        assertThat(encoded).startsWith("$2b$04$").hasSize(60);
+        assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+        assertThat(encoder.matches(WRONG_PASSWORD, encoded)).isFalse();
+        assertThat(encoder.upgradeEncoding(encoded)).isFalse();
+        assertThat(new BCryptPasswordEncoder(BCryptVersion.$2B, 10).upgradeEncoding(encoded)).isTrue();
+    }
+
+    @Test
+    void bcryptStaticApiGeneratesSaltHashesStringsAndHashesBytes() {
+        SecureRandom random = new SecureRandom(new byte[] {1, 2, 3, 4, 5, 6, 7, 8 });
+        String salt = BCrypt.gensalt("$2a", 4, random);
+
+        String stringHash = BCrypt.hashpw(PASSWORD, salt);
+        String byteHash = BCrypt.hashpw(PASSWORD.getBytes(StandardCharsets.UTF_8), salt);
+
+        assertThat(salt).startsWith("$2a$04$").hasSize(29);
+        assertThat(stringHash).startsWith(salt).hasSize(60);
+        assertThat(byteHash).isEqualTo(stringHash);
+        assertThat(BCrypt.checkpw(PASSWORD, stringHash)).isTrue();
+        assertThat(BCrypt.checkpw(PASSWORD.getBytes(StandardCharsets.UTF_8), stringHash)).isTrue();
+        assertThat(BCrypt.checkpw(WRONG_PASSWORD, stringHash)).isFalse();
+    }
+
+    @Test
+    void pbkdf2PasswordEncoderSupportsHexAndBase64EncodedHashes() {
+        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
+        hexEncoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+
+        String hexEncoded = hexEncoder.encode(PASSWORD);
+
+        assertThat(hexEncoded).matches("[0-9a-f]+");
+        assertThat(hexEncoder.matches(PASSWORD, hexEncoded)).isTrue();
+        assertThat(hexEncoder.matches(WRONG_PASSWORD, hexEncoded)).isFalse();
+
+        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
+        base64Encoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
+        base64Encoder.setEncodeHashAsBase64(true);
+
+        String base64Encoded = base64Encoder.encode(PASSWORD);
+
+        assertThat(base64Encoded).matches("[A-Za-z0-9+/]+={0,2}");
+        assertThat(base64Encoder.matches(PASSWORD, base64Encoded)).isTrue();
+        assertThat(base64Encoder.matches(PASSWORD, hexEncoded)).isFalse();
+    }
+
+    @Test
+    void delegatingPasswordEncoderUsesCurrentIdAndVerifiesExplicitLegacyId() {
+        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 64, 1_000);
+        pbkdf2.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Map<String, PasswordEncoder> encoders = new HashMap<>();
+        encoders.put("bcrypt", new BCryptPasswordEncoder(4));
+        encoders.put("pbkdf2", pbkdf2);
+        DelegatingPasswordEncoder delegating = new DelegatingPasswordEncoder("bcrypt", encoders);
+
+        String currentEncoded = delegating.encode(PASSWORD);
+        String legacyEncoded = "{pbkdf2}" + pbkdf2.encode(PASSWORD);
+
+        assertThat(currentEncoded).startsWith("{bcrypt}$2a$04$");
+        assertThat(delegating.matches(PASSWORD, currentEncoded)).isTrue();
+        assertThat(delegating.matches(PASSWORD, legacyEncoded)).isTrue();
+        assertThat(delegating.matches(WRONG_PASSWORD, legacyEncoded)).isFalse();
+        assertThat(delegating.upgradeEncoding(legacyEncoded)).isTrue();
+        assertThatThrownBy(() -> delegating.matches(PASSWORD, "{unknown}" + currentEncoded))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("PasswordEncoder mapped for the id \"unknown\"");
+    }
+
+    @Test
+    void keyGeneratorsCreateRandomSharedAndHexStringKeys() {
+        BytesKeyGenerator randomGenerator = KeyGenerators.secureRandom(32);
+        byte[] firstRandomKey = randomGenerator.generateKey();
+        byte[] secondRandomKey = randomGenerator.generateKey();
+
+        assertThat(randomGenerator.getKeyLength()).isEqualTo(32);
+        assertThat(firstRandomKey).hasSize(32);
+        assertThat(secondRandomKey).hasSize(32);
+        assertThat(Arrays.equals(firstRandomKey, secondRandomKey)).isFalse();
+
+        BytesKeyGenerator sharedGenerator = KeyGenerators.shared(16);
+        byte[] sharedKey = sharedGenerator.generateKey();
+
+        assertThat(sharedGenerator.getKeyLength()).isEqualTo(16);
+        assertThat(sharedKey).hasSize(16);
+        assertThat(sharedGenerator.generateKey()).containsExactly(sharedKey);
+
+        StringKeyGenerator stringGenerator = KeyGenerators.string();
+
+        assertThat(stringGenerator.generateKey()).matches("[0-9a-f]{16}");
+    }
+
+    @Test
+    void base64StringKeyGeneratorProducesUrlSafeKeysWithoutPadding() {
+        Base64StringKeyGenerator generator = new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding(), 32);
+
+        String key = generator.generateKey();
+
+        assertThat(key).hasSize(43).matches("[A-Za-z0-9_-]+");
+    }
+
+    @Test
+    void codecAndEncodingUtilitiesRoundTripTextAndByteRanges() {
+        String text = "Spring Security crypto \u2615";
+        byte[] utf8 = Utf8.encode(text);
+
+        assertThat(Utf8.decode(utf8)).isEqualTo(text);
+        assertThat(Hex.encode(new byte[] {0x00, 0x0f, (byte) 0xff }))
+                .containsExactly('0', '0', '0', 'f', 'f', 'f');
+        assertThat(Hex.decode("000fff")).containsExactly(0x00, 0x0f, (byte) 0xff);
+        assertThat(EncodingUtils.concatenate(new byte[] {1, 2 }, new byte[] {3 }, new byte[] {4, 5 }))
+                .containsExactly(1, 2, 3, 4, 5);
+        assertThat(EncodingUtils.subArray(new byte[] {10, 20, 30, 40, 50 }, 1, 4)).containsExactly(20, 30, 40);
+        assertThatThrownBy(() -> Hex.decode("abc")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void textEncryptorsEncryptDecryptAndUseAuthenticatedMode() {
+        TextEncryptor standardText = Encryptors.text("text-password", SALT);
+        TextEncryptor authenticatedText = Encryptors.delux("text-password", SALT);
+        String message = "token=abc123&scope=read write";
+
+        String standardCiphertext = standardText.encrypt(message);
+        String authenticatedCiphertext = authenticatedText.encrypt(message);
+
+        assertThat(standardCiphertext).isNotEqualTo(message).matches("[0-9a-f]+");
+        assertThat(authenticatedCiphertext).isNotEqualTo(message).matches("[0-9a-f]+");
+        assertThat(standardText.decrypt(standardCiphertext)).isEqualTo(message);
+        assertThat(authenticatedText.decrypt(authenticatedCiphertext)).isEqualTo(message);
+        assertThatThrownBy(() -> authenticatedText.decrypt(standardCiphertext)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void queryableTextEncryptorProducesStableCiphertextForLookupValues() {
+        TextEncryptor firstEncryptor = Encryptors.queryableText("lookup-password", SALT);
+        TextEncryptor secondEncryptor = Encryptors.queryableText("lookup-password", SALT);
+        String lookupValue = "customer-12345";
+
+        String firstCiphertext = firstEncryptor.encrypt(lookupValue);
+        String repeatedCiphertext = firstEncryptor.encrypt(lookupValue);
+        String secondEncryptorCiphertext = secondEncryptor.encrypt(lookupValue);
+        String differentCiphertext = firstEncryptor.encrypt("customer-67890");
+
+        assertThat(firstCiphertext).isNotEqualTo(lookupValue).matches("[0-9a-f]+");
+        assertThat(repeatedCiphertext).isEqualTo(firstCiphertext);
+        assertThat(secondEncryptorCiphertext).isEqualTo(firstCiphertext);
+        assertThat(differentCiphertext).isNotEqualTo(firstCiphertext);
+        assertThat(secondEncryptor.decrypt(firstCiphertext)).isEqualTo(lookupValue);
+    }
+
+    @Test
+    void bytesEncryptorsRoundTripBinaryPayloadsWithCbcAndGcm() {
+        BytesEncryptor standard = Encryptors.standard("bytes-password", SALT);
+        BytesEncryptor stronger = Encryptors.stronger("bytes-password", SALT);
+        byte[] payload = new byte[] {0, 1, 2, 3, 4, 5, 127, (byte) 128, (byte) 255 };
+
+        byte[] standardCiphertext = standard.encrypt(payload);
+        byte[] strongerCiphertext = stronger.encrypt(payload);
+
+        assertThat(Arrays.equals(standardCiphertext, payload)).isFalse();
+        assertThat(Arrays.equals(strongerCiphertext, payload)).isFalse();
+        assertThat(standardCiphertext).hasSizeGreaterThan(payload.length);
+        assertThat(strongerCiphertext).hasSizeGreaterThan(payload.length);
+        assertThat(standard.decrypt(standardCiphertext)).containsExactly(payload);
+        assertThat(stronger.decrypt(strongerCiphertext)).containsExactly(payload);
+        assertThatThrownBy(() -> stronger.decrypt(standardCiphertext)).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -71,8 +71,8 @@ public class Spring_security_cryptoTest {
 
     @Test
     void pbkdf2PasswordEncoderSupportsHexAndBase64EncodedHashes() {
-        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
-        hexEncoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
 
         String hexEncoded = hexEncoder.encode(PASSWORD);
 
@@ -80,8 +80,8 @@ public class Spring_security_cryptoTest {
         assertThat(hexEncoder.matches(PASSWORD, hexEncoded)).isTrue();
         assertThat(hexEncoder.matches(WRONG_PASSWORD, hexEncoded)).isFalse();
 
-        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
-        base64Encoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
+        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
         base64Encoder.setEncodeHashAsBase64(true);
 
         String base64Encoded = base64Encoder.encode(PASSWORD);
@@ -93,8 +93,8 @@ public class Spring_security_cryptoTest {
 
     @Test
     void delegatingPasswordEncoderUsesCurrentIdAndVerifiesExplicitLegacyId() {
-        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 64, 1_000);
-        pbkdf2.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
         Map<String, PasswordEncoder> encoders = new HashMap<>();
         encoders.put("bcrypt", new BCryptPasswordEncoder(4));
         encoders.put("pbkdf2", pbkdf2);
@@ -177,21 +177,19 @@ public class Spring_security_cryptoTest {
     }
 
     @Test
-    void queryableTextEncryptorProducesStableCiphertextForLookupValues() {
-        TextEncryptor firstEncryptor = Encryptors.queryableText("lookup-password", SALT);
-        TextEncryptor secondEncryptor = Encryptors.queryableText("lookup-password", SALT);
+    void noOpTextEncryptorRoundTripsPlainTextValues() {
+        TextEncryptor encryptor = Encryptors.noOpText();
         String lookupValue = "customer-12345";
+        String differentLookupValue = "customer-67890";
 
-        String firstCiphertext = firstEncryptor.encrypt(lookupValue);
-        String repeatedCiphertext = firstEncryptor.encrypt(lookupValue);
-        String secondEncryptorCiphertext = secondEncryptor.encrypt(lookupValue);
-        String differentCiphertext = firstEncryptor.encrypt("customer-67890");
+        String ciphertext = encryptor.encrypt(lookupValue);
+        String repeatedCiphertext = encryptor.encrypt(lookupValue);
+        String differentCiphertext = encryptor.encrypt(differentLookupValue);
 
-        assertThat(firstCiphertext).isNotEqualTo(lookupValue).matches("[0-9a-f]+");
-        assertThat(repeatedCiphertext).isEqualTo(firstCiphertext);
-        assertThat(secondEncryptorCiphertext).isEqualTo(firstCiphertext);
-        assertThat(differentCiphertext).isNotEqualTo(firstCiphertext);
-        assertThat(secondEncryptor.decrypt(firstCiphertext)).isEqualTo(lookupValue);
+        assertThat(ciphertext).isEqualTo(lookupValue);
+        assertThat(repeatedCiphertext).isEqualTo(ciphertext);
+        assertThat(differentCiphertext).isEqualTo(differentLookupValue);
+        assertThat(encryptor.decrypt(ciphertext)).isEqualTo(lookupValue);
     }
 
     @Test

--- a/tests/src/org.springframework.security/spring-security-crypto/6.0.0/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-crypto/6.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.security.crypto.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3365

This PR provides test fixes and new metadata for org.springframework.security:spring-security-crypto:6.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 55681
- Cached input tokens: 342016
- Output tokens: 4367
- Entries found: 38
- Iterations: 1
- Library coverage percentage: 36.79
- Previous library version metadata entries: 38
- Previous library version coverage percentage: 36.76

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework.security:spring-security-crypto:5.7.3: 0/0 covered calls (100.00%)
- org.springframework.security:spring-security-crypto:6.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework.security:spring-security-crypto:5.7.3: 7429/15606 (47.60%)
- org.springframework.security:spring-security-crypto:6.0.0: 7386/15469 (47.75%)

**Line:**
- org.springframework.security:spring-security-crypto:5.7.3: 450/1224 (36.76%)
- org.springframework.security:spring-security-crypto:6.0.0: 454/1234 (36.79%)

**Method:**
- org.springframework.security:spring-security-crypto:5.7.3: 103/239 (43.10%)
- org.springframework.security:spring-security-crypto:6.0.0: 104/240 (43.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java 2/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
index 2f99039bfa..e7f687c182 100644
--- 1/tests/src/org.springframework.security/spring-security-crypto/5.7.3/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
+++ 2/tests/src/org.springframework.security/spring-security-crypto/6.0.0/src/test/java/org_springframework_security/spring_security_crypto/Spring_security_cryptoTest.java
@@ -71,8 +71,8 @@ public class Spring_security_cryptoTest {
 
     @Test
     void pbkdf2PasswordEncoderSupportsHexAndBase64EncodedHashes() {
-        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
-        hexEncoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Pbkdf2PasswordEncoder hexEncoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
 
         String hexEncoded = hexEncoder.encode(PASSWORD);
 
@@ -80,8 +80,8 @@ public class Spring_security_cryptoTest {
         assertThat(hexEncoder.matches(PASSWORD, hexEncoded)).isTrue();
         assertThat(hexEncoder.matches(WRONG_PASSWORD, hexEncoded)).isFalse();
 
-        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 64, 1_000);
-        base64Encoder.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
+        Pbkdf2PasswordEncoder base64Encoder = new Pbkdf2PasswordEncoder("application-wide-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512);
         base64Encoder.setEncodeHashAsBase64(true);
 
         String base64Encoded = base64Encoder.encode(PASSWORD);
@@ -93,8 +93,8 @@ public class Spring_security_cryptoTest {
 
     @Test
     void delegatingPasswordEncoderUsesCurrentIdAndVerifiesExplicitLegacyId() {
-        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 64, 1_000);
-        pbkdf2.setAlgorithm(SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+        Pbkdf2PasswordEncoder pbkdf2 = new Pbkdf2PasswordEncoder("delegating-secret", 8, 1_000,
+                SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
         Map<String, PasswordEncoder> encoders = new HashMap<>();
         encoders.put("bcrypt", new BCryptPasswordEncoder(4));
         encoders.put("pbkdf2", pbkdf2);
@@ -177,21 +177,19 @@ public class Spring_security_cryptoTest {
     }
 
     @Test
-    void queryableTextEncryptorProducesStableCiphertextForLookupValues() {
-        TextEncryptor firstEncryptor = Encryptors.queryableText("lookup-password", SALT);
-        TextEncryptor secondEncryptor = Encryptors.queryableText("lookup-password", SALT);
+    void noOpTextEncryptorRoundTripsPlainTextValues() {
+        TextEncryptor encryptor = Encryptors.noOpText();
         String lookupValue = "customer-12345";
+        String differentLookupValue = "customer-67890";
 
-        String firstCiphertext = firstEncryptor.encrypt(lookupValue);
-        String repeatedCiphertext = firstEncryptor.encrypt(lookupValue);
-        String secondEncryptorCiphertext = secondEncryptor.encrypt(lookupValue);
-        String differentCiphertext = firstEncryptor.encrypt("customer-67890");
+        String ciphertext = encryptor.encrypt(lookupValue);
+        String repeatedCiphertext = encryptor.encrypt(lookupValue);
+        String differentCiphertext = encryptor.encrypt(differentLookupValue);
 
-        assertThat(firstCiphertext).isNotEqualTo(lookupValue).matches("[0-9a-f]+");
-        assertThat(repeatedCiphertext).isEqualTo(firstCiphertext);
-        assertThat(secondEncryptorCiphertext).isEqualTo(firstCiphertext);
-        assertThat(differentCiphertext).isNotEqualTo(firstCiphertext);
-        assertThat(secondEncryptor.decrypt(firstCiphertext)).isEqualTo(lookupValue);
+        assertThat(ciphertext).isEqualTo(lookupValue);
+        assertThat(repeatedCiphertext).isEqualTo(ciphertext);
+        assertThat(differentCiphertext).isEqualTo(differentLookupValue);
+        assertThat(encryptor.decrypt(ciphertext)).isEqualTo(lookupValue);
     }
 
     @Test

```
