### PR TITLE
[GenAI] Add support for org.apache.geronimo.specs:geronimo-osgi-locator:1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json
+++ b/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "glob" : "META-INF/services/org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$GreetingService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "glob" : "META-INF/services/org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$MissingService"
+    }
+  ]
+}

--- a/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/index.json
+++ b/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator/1.0/geronimo-osgi-locator-1.0-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/geronimo/specs/tags/geronimo-osgi-support-1.0",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator-itests/1.0/geronimo-osgi-locator-itests-1.0-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator/1.0/geronimo-osgi-locator-1.0-javadoc.jar",
+    "description" : "Geronimo OSGi Locator provides helper classes intended to be embedded as a private package in other Geronimo specification bundles rather than used as a standalone library. It locates provider classes and service implementations through the Geronimo OSGi registry, with classpath-based fallback lookup outside an OSGi framework.",
+    "tested-versions" : [
+      "1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.geronimo.osgi.locator"
+    ]
+  }
+]

--- a/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/execution-metrics.json
+++ b/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-04-29": {
+    "timestamp": "2026-04-29T18:00:45.830547Z",
+    "library": "org.apache.geronimo.specs:geronimo-osgi-locator:1.0",
+    "starting_commit": "488b6e4dbdbf8f3c4cec94a922dd1fdcc329f2f9",
+    "ending_commit": "c9cc736d13c4d22204aa4e7c1f86fd86c7a75442",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 390,
+          "missed": 107,
+          "ratio": 0.784708,
+          "total": 497
+        },
+        "line": {
+          "covered": 113,
+          "missed": 40,
+          "ratio": 0.738562,
+          "total": 153
+        },
+        "method": {
+          "covered": 18,
+          "missed": 6,
+          "ratio": 0.75,
+          "total": 24
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 341019,
+      "cached_input_tokens_used": 2290688,
+      "output_tokens_used": 24871,
+      "iterations": 5,
+      "cost_usd": 1.8914,
+      "generated_loc": 222,
+      "tested_library_loc": 113,
+      "metadata_entries": 2,
+      "code_coverage_percent": 73.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java",
+      "metadata_file": "metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/stats.json
+++ b/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 390,
+        "missed" : 107,
+        "ratio" : 0.784708,
+        "total" : 497
+      },
+      "line" : {
+        "covered" : 113,
+        "missed" : 40,
+        "ratio" : 0.738562,
+        "total" : 153
+      },
+      "method" : {
+        "covered" : 18,
+        "missed" : 6,
+        "ratio" : 0.75,
+        "total" : 24
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/.gitignore
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/build.gradle
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.geronimo.specs:geronimo-osgi-locator:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/gradle.properties
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.geronimo.specs:geronimo-osgi-locator:1.0
+library.version = 1.0
+metadata.dir = org.apache.geronimo.specs/geronimo-osgi-locator/1.0/

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/settings.gradle
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.geronimo.specs.geronimo-osgi-locator_tests'

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_geronimo_specs.geronimo_osgi_locator;
+
+import org.junit.jupiter.api.Test;
+
+class Geronimo_osgi_locatorTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -165,6 +165,35 @@ public class Geronimo_osgi_locatorTest {
         }
     }
 
+    @Test
+    void jrePropertyFileLookupSupportsStandardPropertiesSyntax() throws Exception {
+        String originalJavaHome = System.getProperty("java.home");
+        System.setProperty("java.home", tempDir.toString());
+        try {
+            Path configurationDirectory = Files.createDirectories(tempDir.resolve("conf"));
+            Files.writeString(configurationDirectory.resolve("advanced-providers.properties"),
+                    "# comments are ignored\n"
+                            + "provider = " + AlphaProvider.class.getName() + "\n"
+                            + "escaped\\ key: " + BetaProvider.class.getName() + "\n"
+                            + "continued = " + GammaProvider.class.getName() + "\\\n"
+                            + "  $Nested\n",
+                    StandardCharsets.UTF_8);
+
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/advanced-providers.properties", "provider"))
+                    .isEqualTo(AlphaProvider.class.getName());
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/advanced-providers.properties", "escaped key"))
+                    .isEqualTo(BetaProvider.class.getName());
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/advanced-providers.properties", "continued"))
+                    .isEqualTo(GammaProvider.class.getName() + "$Nested");
+        } finally {
+            if (originalJavaHome == null) {
+                System.clearProperty("java.home");
+            } else {
+                System.setProperty("java.home", originalJavaHome);
+            }
+        }
+    }
+
     private static void writeServiceDefinition(Path root, Class<?> serviceType, String contents) throws Exception {
         Path servicesDirectory = Files.createDirectories(root.resolve("META-INF").resolve("services"));
         Files.writeString(servicesDirectory.resolve(serviceType.getName()), contents, StandardCharsets.UTF_8);

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -6,11 +6,197 @@
  */
 package org_apache_geronimo_specs.geronimo_osgi_locator;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Geronimo_osgi_locatorTest {
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.geronimo.osgi.locator.ProviderLocator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Geronimo_osgi_locatorTest {
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearLocatorState() {
+        ProviderLocator.destroy();
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void loadClassUsesExplicitLoaderBeforeContextClassFallback() throws Exception {
+        ClassLoader currentLoader = Geronimo_osgi_locatorTest.class.getClassLoader();
+
+        assertThat(ProviderLocator.loadClass(AlphaProvider.class.getName(), null, currentLoader))
+                .isEqualTo(AlphaProvider.class);
+        assertThat(ProviderLocator.loadClass(BetaProvider.class.getName(), Geronimo_osgi_locatorTest.class,
+                new RejectingClassLoader()))
+                .isEqualTo(BetaProvider.class);
+    }
+
+    @Test
+    void loadClassUsesThreadContextClassLoader() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader originalLoader = thread.getContextClassLoader();
+        thread.setContextClassLoader(Geronimo_osgi_locatorTest.class.getClassLoader());
+        try {
+            assertThat(ProviderLocator.loadClass(GreetingService.class.getName())).isEqualTo(GreetingService.class);
+        } finally {
+            thread.setContextClassLoader(originalLoader);
+        }
+    }
+
+    @Test
+    void serviceLookupReadsFirstNonCommentProviderFromMetaInfServices() throws Exception {
+        Path classPathRoot = Files.createDirectory(tempDir.resolve("single-provider"));
+        writeServiceDefinition(classPathRoot, GreetingService.class,
+                "# leading comment\n"
+                        + "\n"
+                        + "  " + AlphaProvider.class.getName() + "  # inline comment\n"
+                        + BetaProvider.class.getName() + "\n");
+
+        try (URLClassLoader loader = newServiceLoader(classPathRoot)) {
+            Class<?> serviceClass = ProviderLocator.getServiceClass(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+            Object service = ProviderLocator.getService(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+
+            assertThat(serviceClass).isEqualTo(AlphaProvider.class);
+            assertThat(service).isInstanceOf(AlphaProvider.class);
+            assertThat(((GreetingService) service).name()).isEqualTo("alpha");
+        }
+    }
+
+    @Test
+    void serviceLookupsReturnAllDistinctProvidersInDefinitionOrder() throws Exception {
+        Path firstRoot = Files.createDirectory(tempDir.resolve("first-root"));
+        Path secondRoot = Files.createDirectory(tempDir.resolve("second-root"));
+        writeServiceDefinition(firstRoot, GreetingService.class,
+                AlphaProvider.class.getName() + "\n"
+                        + BetaProvider.class.getName() + "\n"
+                        + AlphaProvider.class.getName() + " # duplicate is ignored by class lookup\n");
+        writeServiceDefinition(secondRoot, GreetingService.class,
+                "# another service resource\n"
+                        + BetaProvider.class.getName() + "\n"
+                        + GammaProvider.class.getName() + "\n");
+
+        try (URLClassLoader loader = newServiceLoader(firstRoot, secondRoot)) {
+            List<Class<?>> serviceClasses = ProviderLocator.getServiceClasses(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+            List<Object> services = ProviderLocator.getServices(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+
+            assertThat(serviceClasses).containsExactly(AlphaProvider.class, BetaProvider.class, GammaProvider.class);
+            assertThat(serviceNames(services)).containsExactly("alpha", "beta", "gamma");
+        }
+    }
+
+    @Test
+    void missingServiceDefinitionsReturnNullAndEmptyLists() throws Exception {
+        Path emptyRoot = Files.createDirectory(tempDir.resolve("empty-root"));
+
+        try (URLClassLoader loader = newServiceLoader(emptyRoot)) {
+            assertThat(ProviderLocator.getServiceClass(MissingService.class.getName(), Geronimo_osgi_locatorTest.class,
+                    loader)).isNull();
+            assertThat(ProviderLocator.getService(MissingService.class.getName(), Geronimo_osgi_locatorTest.class,
+                    loader)).isNull();
+            assertThat(ProviderLocator.getServiceClasses(MissingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader)).isEmpty();
+            assertThat(ProviderLocator.getServices(MissingService.class.getName(), Geronimo_osgi_locatorTest.class,
+                    loader)).isEmpty();
+        }
+    }
+
+    @Test
+    void locatorReturnsEmptyResultsWhenNoOsgiRegistryIsAvailable() {
+        assertThat(ProviderLocator.locate(AlphaProvider.class.getName())).isNull();
+        assertThat(ProviderLocator.locateAll(AlphaProvider.class.getName())).isEmpty();
+    }
+
+    @Test
+    void jrePropertyFileLookupReadsPropertiesFromCurrentJavaHome() throws Exception {
+        String originalJavaHome = System.getProperty("java.home");
+        System.setProperty("java.home", tempDir.toString());
+        try {
+            Path configurationDirectory = Files.createDirectories(tempDir.resolve("conf"));
+            Files.writeString(configurationDirectory.resolve("providers.properties"),
+                    "provider=" + AlphaProvider.class.getName() + "\n"
+                            + "description=Geronimo locator test\n",
+                    StandardCharsets.UTF_8);
+
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/providers.properties", "provider"))
+                    .isEqualTo(AlphaProvider.class.getName());
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/providers.properties", "unknown")).isNull();
+            assertThat(ProviderLocator.lookupByJREPropertyFile("conf/missing.properties", "provider")).isNull();
+        } finally {
+            System.setProperty("java.home", originalJavaHome);
+        }
+    }
+
+    private static void writeServiceDefinition(Path root, Class<?> serviceType, String contents) throws Exception {
+        Path servicesDirectory = Files.createDirectories(root.resolve("META-INF").resolve("services"));
+        Files.writeString(servicesDirectory.resolve(serviceType.getName()), contents, StandardCharsets.UTF_8);
+    }
+
+    private static URLClassLoader newServiceLoader(Path... roots) throws Exception {
+        URL[] urls = new URL[roots.length];
+        for (int index = 0; index < roots.length; index++) {
+            urls[index] = roots[index].toUri().toURL();
+        }
+        return new URLClassLoader(urls, Geronimo_osgi_locatorTest.class.getClassLoader());
+    }
+
+    private static List<String> serviceNames(List<Object> services) {
+        List<String> names = new ArrayList<>();
+        for (Object service : services) {
+            names.add(((GreetingService) service).name());
+        }
+        return names;
+    }
+
+    public interface GreetingService {
+        String name();
+    }
+
+    public interface MissingService {
+    }
+
+    public static class AlphaProvider implements GreetingService {
+        @Override
+        public String name() {
+            return "alpha";
+        }
+    }
+
+    public static class BetaProvider implements GreetingService {
+        @Override
+        public String name() {
+            return "beta";
+        }
+    }
+
+    public static class GammaProvider implements GreetingService {
+        @Override
+        public String name() {
+            return "gamma";
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
     }
 }

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -75,6 +75,27 @@ public class Geronimo_osgi_locatorTest {
     }
 
     @Test
+    void singleServiceLookupSkipsEmptyDefinitionsBeforeUsingNextProvider() throws Exception {
+        Path emptyRoot = Files.createDirectory(tempDir.resolve("empty-definition-root"));
+        Path providerRoot = Files.createDirectory(tempDir.resolve("provider-definition-root"));
+        writeServiceDefinition(emptyRoot, GreetingService.class,
+                "# no provider in this resource\n"
+                        + "\n");
+        writeServiceDefinition(providerRoot, GreetingService.class, BetaProvider.class.getName() + "\n");
+
+        try (URLClassLoader loader = newServiceLoader(emptyRoot, providerRoot)) {
+            Class<?> serviceClass = ProviderLocator.getServiceClass(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+            Object service = ProviderLocator.getService(GreetingService.class.getName(),
+                    Geronimo_osgi_locatorTest.class, loader);
+
+            assertThat(serviceClass).isEqualTo(BetaProvider.class);
+            assertThat(service).isInstanceOf(BetaProvider.class);
+            assertThat(((GreetingService) service).name()).isEqualTo("beta");
+        }
+    }
+
+    @Test
     void serviceLookupsReturnAllDistinctProvidersInDefinitionOrder() throws Exception {
         Path firstRoot = Files.createDirectory(tempDir.resolve("first-root"));
         Path secondRoot = Files.createDirectory(tempDir.resolve("second-root"));
@@ -136,7 +157,11 @@ public class Geronimo_osgi_locatorTest {
             assertThat(ProviderLocator.lookupByJREPropertyFile("conf/providers.properties", "unknown")).isNull();
             assertThat(ProviderLocator.lookupByJREPropertyFile("conf/missing.properties", "provider")).isNull();
         } finally {
-            System.setProperty("java.home", originalJavaHome);
+            if (originalJavaHome == null) {
+                System.clearProperty("java.home");
+            } else {
+                System.setProperty("java.home", originalJavaHome);
+            }
         }
     }
 

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$AlphaProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$BetaProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$GammaProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$GreetingService"
+    }
+  ]
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.geronimo.osgi.locator.**"
+      "includeClasses" : "org.apache.geronimo.osgi.locator.**"
     }
   ]
 }

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.geronimo.osgi.locator.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3132

This PR introduces tests and metadata for org.apache.geronimo.specs:geronimo-osgi-locator:1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 341019
- Cached input tokens: 2290688
- Output tokens: 24871
- Entries: 2
- Iterations: 5
- Library coverage percentage: 73.86
- Generated lines of code: 222
- Tested library lines of code: 113

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 6/6 covered calls (100.00%)
- Reflection: 4/4 covered calls (100.00%)
- Resources: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 390/497 (78.47%)
- Line: 113/153 (73.86%)
- Method: 18/24 (75.00%)
