### PR TITLE
[GenAI] Add support for io.smallrye.common:smallrye-common-function:2.2.0 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye.common/smallrye-common-function/2.2.0/reachability-metadata.json
+++ b/metadata/io.smallrye.common/smallrye-common-function/2.2.0/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.function.FunctionsLogging"
+      },
+      "type": "io.smallrye.common.function.FunctionsLogging_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.smallrye.common/smallrye-common-function/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-function/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-function/2.2.0/smallrye-common-function-2.2.0-sources.jar",
+    "repository-url" : "https://github.com/smallrye/smallrye-common",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://javadoc.io/doc/io.smallrye.common/smallrye-common-function/2.2.0/",
+    "description" : "SmallRye Common Function provides Java functional interfaces and utility methods for composing and adapting functions, consumers, suppliers, predicates, and runnables. It includes exception-aware variants of common functional types so callers can work with checked exceptions in functional-style APIs.",
+    "tested-versions" : [
+      "2.2.0"
+    ],
+    "allowed-packages" : [
+      "io.smallrye.common.function"
+    ]
+  }
+]

--- a/stats/io.smallrye.common/smallrye-common-function/2.2.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-function/2.2.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-29": {
+    "timestamp": "2026-04-29T19:50:35.710212Z",
+    "library": "io.smallrye.common:smallrye-common-function:2.2.0",
+    "starting_commit": "a8c1c80b211e2913b7e30cb497590c88a7d59e18",
+    "ending_commit": "6b033c132233a3adec5891fb8cd00710f663a4d4",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1299,
+          "missed": 112,
+          "ratio": 0.920624,
+          "total": 1411
+        },
+        "line": {
+          "covered": 294,
+          "missed": 12,
+          "ratio": 0.960784,
+          "total": 306
+        },
+        "method": {
+          "covered": 229,
+          "missed": 6,
+          "ratio": 0.974468,
+          "total": 235
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 266799,
+      "cached_input_tokens_used": 1461760,
+      "output_tokens_used": 22640,
+      "iterations": 4,
+      "cost_usd": 1.4101,
+      "generated_loc": 480,
+      "tested_library_loc": 294,
+      "metadata_entries": 2,
+      "code_coverage_percent": 96.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java",
+      "metadata_file": "metadata/io.smallrye.common/smallrye-common-function/2.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye.common/smallrye-common-function/2.2.0/stats.json
+++ b/stats/io.smallrye.common/smallrye-common-function/2.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1299,
+        "missed" : 112,
+        "ratio" : 0.920624,
+        "total" : 1411
+      },
+      "line" : {
+        "covered" : 294,
+        "missed" : 12,
+        "ratio" : 0.960784,
+        "total" : 306
+      },
+      "method" : {
+        "covered" : 229,
+        "missed" : 6,
+        "ratio" : 0.974468,
+        "total" : 235
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/.gitignore
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/build.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye.common:smallrye-common-function:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/gradle.properties
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye.common:smallrye-common-function:2.2.0
+library.version = 2.2.0
+metadata.dir = io.smallrye.common/smallrye-common-function/2.2.0/

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/settings.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.common.smallrye-common-function_tests'

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
@@ -250,6 +250,28 @@ public class Smallrye_common_functionTest {
     }
 
     @Test
+    void objectLongConsumersComposeWhilePreservingLongValues() throws TestException {
+        List<String> events = new ArrayList<>();
+        long firstLargeValue = 4_294_967_296L;
+        long secondLargeValue = firstLargeValue + 1L;
+        ExceptionObjLongConsumer<String, TestException> record = (label, value) -> events.add(
+                label + ":record:" + value);
+        ExceptionObjLongConsumer<String, TestException> verifyLargeValue = (label, value) -> {
+            assertThat(value).isGreaterThan(Integer.MAX_VALUE);
+            events.add(label + ":verified:" + (value - 1L));
+        };
+
+        record.andThen(verifyLargeValue).accept("first", firstLargeValue);
+        verifyLargeValue.compose(record).accept("second", secondLargeValue);
+
+        assertThat(events).containsExactly(
+                "first:record:4294967296",
+                "first:verified:4294967295",
+                "second:record:4294967297",
+                "second:verified:4294967296");
+    }
+
+    @Test
     void unaryAndBinaryOperatorsKeepOperatorTypes() throws TestException {
         ExceptionUnaryOperator<String, TestException> upper = String::toUpperCase;
         ExceptionUnaryOperator<String, TestException> bracket = value -> "[" + value + "]";

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye_common.smallrye_common_function;
+
+import org.junit.jupiter.api.Test;
+
+class Smallrye_common_functionTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
@@ -6,11 +6,487 @@
  */
 package io_smallrye_common.smallrye_common_function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.DoubleFunction;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
+import java.util.function.ObjDoubleConsumer;
+import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleBiFunction;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongBiFunction;
+import java.util.function.ToLongFunction;
+
+import io.smallrye.common.function.ExceptionBiConsumer;
+import io.smallrye.common.function.ExceptionBiFunction;
+import io.smallrye.common.function.ExceptionBiPredicate;
+import io.smallrye.common.function.ExceptionBinaryOperator;
+import io.smallrye.common.function.ExceptionConsumer;
+import io.smallrye.common.function.ExceptionFunction;
+import io.smallrye.common.function.ExceptionIntFunction;
+import io.smallrye.common.function.ExceptionLongFunction;
+import io.smallrye.common.function.ExceptionObjIntConsumer;
+import io.smallrye.common.function.ExceptionObjLongConsumer;
+import io.smallrye.common.function.ExceptionPredicate;
+import io.smallrye.common.function.ExceptionRunnable;
+import io.smallrye.common.function.ExceptionSupplier;
+import io.smallrye.common.function.ExceptionToIntBiFunction;
+import io.smallrye.common.function.ExceptionToIntFunction;
+import io.smallrye.common.function.ExceptionToLongBiFunction;
+import io.smallrye.common.function.ExceptionToLongFunction;
+import io.smallrye.common.function.ExceptionUnaryOperator;
+import io.smallrye.common.function.Functions;
 import org.junit.jupiter.api.Test;
 
-class Smallrye_common_functionTest {
+public class Smallrye_common_functionTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void functionsComposeWithFunctionsConsumersPredicatesAndSuppliers() throws TestException {
+        ExceptionFunction<String, String, TestException> trim = value -> value.trim();
+        ExceptionFunction<String, Integer, TestException> length = String::length;
+        ExceptionBiFunction<String, String, String, TestException> describe = (original, trimmed) -> original
+                + "->" + trimmed;
+        List<String> consumed = new ArrayList<>();
+
+        assertThat(trim.andThen(length).apply("  alpha  ")).isEqualTo(5);
+        assertThat(length.compose(trim).apply("  beta ")).isEqualTo(4);
+        assertThat(trim.andThen(describe).apply("  gamma ")).isEqualTo("  gamma ->gamma");
+
+        trim.andThen((ExceptionConsumer<String, TestException>) consumed::add).accept(" delta ");
+        ExceptionBiConsumer<String, String, TestException> recordOriginalAndResult = (original, result) -> consumed.add(
+                original + result);
+        trim.andThen(recordOriginalAndResult).accept(" epsilon ");
+
+        assertThat(consumed).containsExactly("delta", " epsilon epsilon");
+        assertThat(trim.andThen((ExceptionPredicate<String, TestException>) "zeta"::equals).test(" zeta ")).isTrue();
+        ExceptionBiPredicate<String, String, TestException> originalContainsResult = (original, result) -> original
+                .contains(result);
+        assertThat(trim.andThen(originalContainsResult).test(" eta ")).isTrue();
+        assertThat(trim.compose((ExceptionSupplier<String, TestException>) () -> " theta ").get()).isEqualTo("theta");
+    }
+
+    @Test
+    void biFunctionsComposeArgumentsAndContinueWithFunctionsOrConsumers() throws TestException {
+        ExceptionBiFunction<String, String, String, TestException> join = (left, right) -> left + ":" + right;
+        ExceptionFunction<String, Integer, TestException> length = String::length;
+        ExceptionConsumer<String, TestException> rejectEmptyJoin = value -> {
+            if (value.equals(":")) {
+                throw new TestException("blank");
+            }
+        };
+        AtomicInteger observedLength = new AtomicInteger();
+
+        assertThat(join.andThen(length).apply("red", "blue")).isEqualTo(8);
+        join.andThen(rejectEmptyJoin).accept("red", "blue");
+        assertThat(join.compose(() -> "left", () -> "right").get()).isEqualTo("left:right");
+
+        join.andThen((ExceptionConsumer<String, TestException>) value -> observedLength.set(value.length()))
+                .accept("a", "bc");
+        assertThat(observedLength).hasValue(4);
+        assertThatThrownBy(() -> join.andThen(rejectEmptyJoin).accept("", ""))
+                .isInstanceOf(TestException.class)
+                .hasMessage("blank");
+    }
+
+    @Test
+    void predicatesApplyBooleanCombinatorsWithShortCircuitingAndXor() throws TestException {
+        AtomicInteger calls = new AtomicInteger();
+        ExceptionPredicate<String, TestException> startsWithA = value -> {
+            calls.incrementAndGet();
+            return value.startsWith("a");
+        };
+        ExceptionPredicate<String, TestException> endsWithZ = value -> {
+            calls.incrementAndGet();
+            return value.endsWith("z");
+        };
+
+        assertThat(startsWithA.and(endsWithZ).test("az")).isTrue();
+        assertThat(calls).hasValue(2);
+        assertThat(startsWithA.and(endsWithZ).test("bz")).isFalse();
+        assertThat(calls).hasValue(3);
+        assertThat(startsWithA.or(endsWithZ).test("alpha")).isTrue();
+        assertThat(calls).hasValue(4);
+        assertThat(startsWithA.xor(endsWithZ).test("alpha")).isTrue();
+        assertThat(calls).hasValue(6);
+        assertThat(startsWithA.not().test("beta")).isTrue();
+        assertThat(startsWithA.with(endsWithZ).test("alpha", "jazz")).isTrue();
+    }
+
+    @Test
+    void biPredicatesApplyBooleanCombinatorsToBothArguments() throws TestException {
+        ExceptionBiPredicate<String, Integer, TestException> lengthAtLeast = (text, minimum) -> text.length()
+                >= minimum;
+        ExceptionBiPredicate<String, Integer, TestException> containsDigit = (text, ignored) -> text.chars()
+                .anyMatch(Character::isDigit);
+
+        assertThat(lengthAtLeast.and(containsDigit).test("a1b2", 4)).isTrue();
+        assertThat(lengthAtLeast.and(containsDigit).test("abc", 4)).isFalse();
+        assertThat(lengthAtLeast.or(containsDigit).test("a1", 5)).isTrue();
+        assertThat(lengthAtLeast.xor(containsDigit).test("abcde", 3)).isTrue();
+        assertThat(lengthAtLeast.xor(containsDigit).test("a1b2", 3)).isFalse();
+        assertThat(lengthAtLeast.not().test("abc", 5)).isTrue();
+    }
+
+    @Test
+    void consumersAndRunnablesComposeInDocumentedOrder() throws TestException {
+        List<String> events = new ArrayList<>();
+        ExceptionRunnable<TestException> firstRun = () -> events.add("run:first");
+        ExceptionRunnable<TestException> secondRun = () -> events.add("run:second");
+        ExceptionConsumer<String, TestException> firstConsumer = value -> events.add("first:" + value);
+        ExceptionConsumer<String, TestException> secondConsumer = value -> events.add("second:" + value);
+        ExceptionBiConsumer<String, Integer, TestException> firstBiConsumer = (text, number) -> events.add(
+                text + number);
+        ExceptionBiConsumer<String, Integer, TestException> secondBiConsumer = (text, number) -> events.add(
+                text.toUpperCase() + number);
+
+        firstRun.andThen(secondRun).run();
+        firstRun.compose(secondRun).run();
+        firstConsumer.andThen(secondConsumer).accept("value");
+        firstConsumer.compose(secondConsumer).accept("again");
+        firstConsumer.compose(() -> "supplied").run();
+        firstBiConsumer.andThen(secondBiConsumer).accept("n", 7);
+        firstBiConsumer.compose(() -> "s", () -> 9).run();
+
+        assertThat(events).containsExactly(
+                "run:first", "run:second", "run:second", "run:first",
+                "first:value", "second:value", "first:again", "second:again",
+                "first:supplied", "n7", "N7", "s9");
+    }
+
+    @Test
+    void suppliersContinueAsRunnablesOrMappedSuppliers() throws TestException {
+        List<String> consumed = new ArrayList<>();
+        ExceptionSupplier<String, TestException> supplier = () -> "payload";
+        ExceptionConsumer<String, TestException> consumer = consumed::add;
+        ExceptionFunction<String, Integer, TestException> length = String::length;
+
+        supplier.andThen(consumer).run();
+
+        assertThat(supplier.andThen(length).get()).isEqualTo(7);
+        assertThat(consumed).containsExactly("payload");
+    }
+
+    @Test
+    void primitiveFunctionsComposeThroughIntAndLongSpecializations() throws TestException {
+        ExceptionToIntFunction<String, TestException> toInt = String::length;
+        ExceptionToLongFunction<String, TestException> toLong = value -> value.length() * 10L;
+        ExceptionIntFunction<String, TestException> describeInt = value -> "int:" + value;
+        ExceptionLongFunction<String, TestException> describeLong = value -> "long:" + value;
+        ExceptionToIntBiFunction<String, String, TestException> sumLengths = (left, right) -> left.length()
+                + right.length();
+        ExceptionToLongBiFunction<String, String, TestException> multiplyLengths = (left, right) -> (long) left.length()
+                * right.length();
+
+        assertThat(toInt.andThen(describeInt).apply("abcd")).isEqualTo("int:4");
+        assertThat(toInt.andThen(describeLong).apply("abc")).isEqualTo("long:3");
+        ExceptionFunction<Integer, String, TestException> repeat = value -> "x".repeat(value);
+        assertThat(toInt.compose(repeat).apply(5)).isEqualTo(5);
+        assertThat(toLong.andThen(describeLong).apply("abc")).isEqualTo("long:30");
+        assertThat(toLong.compose(repeat).apply(4)).isEqualTo(40L);
+        assertThat(describeInt.compose(toInt).apply("hello")).isEqualTo("int:5");
+        assertThat(describeLong.compose(toLong).apply("hi")).isEqualTo("long:20");
+        assertThat(sumLengths.andThen(describeInt).apply("ab", "cde")).isEqualTo("int:5");
+        assertThat(sumLengths.andThen(describeLong).apply("ab", "c")).isEqualTo("long:3");
+        assertThat(multiplyLengths.andThen(describeLong).apply("ab", "cde")).isEqualTo("long:6");
+    }
+
+    @Test
+    void objectPrimitiveConsumersComposeWithMatchingAndWidenedLongConsumers() throws TestException {
+        StringBuilder first = new StringBuilder();
+        StringBuilder second = new StringBuilder();
+        StringBuilder third = new StringBuilder();
+        ExceptionObjIntConsumer<StringBuilder, TestException> appendInt = (builder, value) -> builder.append("i")
+                .append(value);
+        ExceptionObjIntConsumer<StringBuilder, TestException> appendAgain = (builder, value) -> builder.append("a")
+                .append(value);
+        ExceptionObjLongConsumer<StringBuilder, TestException> appendLong = (builder, value) -> builder.append("l")
+                .append(value);
+
+        appendInt.andThen(appendAgain).accept(first, 3);
+        appendInt.compose(appendAgain).accept(second, 4);
+        appendInt.andThen(appendLong).compose(appendLong).accept(third, 5);
+
+        assertThat(first).hasToString("i3a3");
+        assertThat(second).hasToString("a4i4");
+        assertThat(third).hasToString("l5i5l5");
+    }
+
+    @Test
+    void unaryAndBinaryOperatorsKeepOperatorTypes() throws TestException {
+        ExceptionUnaryOperator<String, TestException> upper = String::toUpperCase;
+        ExceptionUnaryOperator<String, TestException> bracket = value -> "[" + value + "]";
+        ExceptionFunction<String, String, TestException> reverse = value -> new StringBuilder(value).reverse()
+                .toString();
+        ExceptionBinaryOperator<String, TestException> join = (left, right) -> left + right;
+
+        assertThat(ExceptionUnaryOperator.<String, TestException>identity().apply("same")).isEqualTo("same");
+        assertThat(ExceptionUnaryOperator.of(reverse).apply("abc")).isEqualTo("cba");
+        assertThat(ExceptionUnaryOperator.of(upper)).isSameAs(upper);
+        assertThat(upper.andThen(bracket).apply("smallrye")).isEqualTo("[SMALLRYE]");
+        assertThat(bracket.compose(upper).apply("smallrye")).isEqualTo("[SMALLRYE]");
+        assertThat(join.andThen(bracket).apply("small", "rye")).isEqualTo("[smallrye]");
+        assertThatThrownBy(() -> ExceptionUnaryOperator.of(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void functionAdaptersInvokeStandardAndExceptionFunctionalInterfaces() throws TestException {
+        AtomicInteger counter = new AtomicInteger();
+        List<String> values = new ArrayList<>();
+
+        Functions.runnableConsumer().accept(() -> counter.incrementAndGet());
+        Functions.<TestException>exceptionRunnableConsumer().accept(() -> counter.addAndGet(2));
+        Functions.runnableExceptionConsumer().accept(() -> counter.addAndGet(3));
+        Functions.<String>consumerBiConsumer().accept(values::add, "consumer");
+        Functions.<String, TestException>exceptionConsumerBiConsumer().accept(values::add, "exception-consumer");
+        Functions.<String>consumerExceptionBiConsumer().accept(values::add, "runtime-consumer");
+
+        assertThat(Functions.<String>supplierFunction().apply(() -> "supplied")).isEqualTo("supplied");
+        assertThat(Functions.<String, TestException>exceptionSupplierFunction().apply(() -> "exception-supplied"))
+                .isEqualTo("exception-supplied");
+        assertThat(Functions.<String>supplierExceptionFunction().apply(() -> "runtime-supplied"))
+                .isEqualTo("runtime-supplied");
+        assertThat(Functions.<String>supplierFunctionBiFunction().apply(Supplier::get, () -> "bi-supplied"))
+                .isEqualTo("bi-supplied");
+        assertThat(Functions.<String, TestException>exceptionSupplierFunctionBiFunction()
+                .apply(ExceptionSupplier::get, () -> "exception-bi-supplied"))
+                .isEqualTo("exception-bi-supplied");
+        assertThat(Functions.<String, Integer>functionBiFunction().apply(String::length, "four"))
+                .isEqualTo(4);
+        assertThat(Functions.<String, Integer, TestException>exceptionFunctionBiFunction()
+                .apply(String::length, "five5"))
+                .isEqualTo(5);
+        assertThat(Functions.<String, Integer>functionExceptionBiFunction().apply(String::length, "sixsix"))
+                .isEqualTo(6);
+        assertThat(counter).hasValue(6);
+        assertThat(values).containsExactly("consumer", "exception-consumer", "runtime-consumer");
+    }
+
+    @Test
+    void constantCapturingDiscardingAndClosingHelpersHaveExpectedSideEffects() throws TestException {
+        AtomicInteger counter = new AtomicInteger();
+        StringBuilder builder = new StringBuilder();
+        RecordingCloseable closeable = new RecordingCloseable();
+
+        assertThat(Functions.constantSupplier("constant").get()).isEqualTo("constant");
+        assertThat(Functions.constantSupplier(null).get()).isNull();
+        assertThat(Functions.<String, TestException>constantExceptionSupplier("exception-constant").get())
+                .isEqualTo("exception-constant");
+
+        Functions.capturingRunnable((String value) -> builder.append(value), "one").run();
+        Functions.capturingRunnable((String left, String right) -> builder.append(left).append(right), "t", "wo").run();
+        Functions.exceptionCapturingRunnable((String value) -> builder.append(value), "three").run();
+        Functions.exceptionCapturingRunnable((String left, String right) -> builder.append(left).append(right),
+                "fo", "ur").run();
+        Functions.<String>discardingConsumer().accept("ignored");
+        Functions.<String, TestException>discardingExceptionConsumer().accept("ignored");
+        Functions.<String, Integer>discardingBiConsumer().accept("ignored", 1);
+        Functions.<String, Integer, TestException>discardingExceptionBiConsumer().accept("ignored", 2);
+        Functions.<RecordingCloseable>closingConsumer().accept(closeable);
+
+        assertThat(builder).hasToString("onetwothreefour");
+        assertThat(counter).hasValue(0);
+        assertThat(closeable.closed()).isTrue();
+        assertThatCode(() -> Functions.exceptionLoggingConsumer().accept(new TestException("logged")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void quietAndRuntimeExceptionHelpersBridgeCheckedExceptionsToJdkConsumers() {
+        List<Exception> handled = new ArrayList<>();
+        Consumer<String> quietConsumer = Functions.quiet(value -> {
+            throw new TestException("consumer:" + value);
+        }, handled::add);
+        ExceptionBiConsumer<String, Integer, TestException> throwingBiConsumer = (value, number) -> {
+            throw new TestException("bi:" + value + number);
+        };
+        ExceptionObjIntConsumer<String, TestException> throwingObjIntConsumer = (value, number) -> {
+            throw new TestException("int:" + value + number);
+        };
+        ExceptionObjLongConsumer<String, TestException> throwingObjLongConsumer = (value, number) -> {
+            throw new TestException("long:" + value + number);
+        };
+        BiConsumer<String, Integer> quietBiConsumer = Functions.quiet(throwingBiConsumer, handled::add);
+        ObjIntConsumer<String> quietObjIntConsumer = Functions.quiet(throwingObjIntConsumer, handled::add);
+        ObjLongConsumer<String> quietObjLongConsumer = Functions.quiet(throwingObjLongConsumer, handled::add);
+
+        quietConsumer.accept("a");
+        quietBiConsumer.accept("b", 2);
+        quietObjIntConsumer.accept("c", 3);
+        quietObjLongConsumer.accept("d", 4L);
+
+        assertThat(handled).extracting(Throwable::getMessage)
+                .containsExactly("consumer:a", "bi:b2", "int:c3", "long:d4");
+        assertThatThrownBy(() -> Functions.runtimeExceptionThrowingConsumer(
+                (TestException exception) -> new IllegalStateException("wrapped", exception))
+                .accept(new TestException("checked")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("wrapped")
+                .hasCauseInstanceOf(TestException.class);
+    }
+
+    @Test
+    void castsKeepFunctionalBehaviorAcrossJdkAndExceptionFunctionalTypes() throws Exception {
+        List<String> seen = new ArrayList<>();
+        Consumer<Object> objectConsumer = value -> seen.add("consumer:" + value);
+        Predicate<Object> objectPredicate = value -> value.toString().startsWith("s");
+        Supplier<String> stringSupplier = () -> "supplier";
+        Function<Object, String> objectFunction = Object::toString;
+        DoubleFunction<String> doubleFunction = value -> "double:" + value;
+        IntFunction<String> intFunction = value -> "int:" + value;
+        LongFunction<String> longFunction = value -> "long:" + value;
+        ToDoubleFunction<Object> toDoubleFunction = value -> value.toString().length() + 0.5d;
+        ToIntFunction<Object> toIntFunction = value -> value.toString().length();
+        ToLongFunction<Object> toLongFunction = value -> value.toString().length() * 10L;
+        BiConsumer<Object, Number> biConsumer = (value, number) -> seen.add(value + ":" + number);
+        ObjDoubleConsumer<Object> objDoubleConsumer = (value, number) -> seen.add(value + ":" + number);
+        ObjIntConsumer<Object> objIntConsumer = (value, number) -> seen.add(value + ":" + number);
+        ObjLongConsumer<Object> objLongConsumer = (value, number) -> seen.add(value + ":" + number);
+        BiPredicate<Object, Number> biPredicate = (value, number) -> value.toString().length() == number.intValue();
+        BiFunction<Object, Number, String> biFunction = (value, number) -> value + ":" + number;
+        ToDoubleBiFunction<Object, Number> toDoubleBiFunction = (value, number) -> value.toString().length()
+                + number.doubleValue();
+        ToIntBiFunction<Object, Number> toIntBiFunction = (value, number) -> value.toString().length()
+                + number.intValue();
+        ToLongBiFunction<Object, Number> toLongBiFunction = (value, number) -> value.toString().length()
+                + number.longValue();
+
+        Consumer<String> castConsumer = Functions.cast(objectConsumer);
+        Predicate<String> castPredicate = Functions.cast(objectPredicate);
+        Supplier<Object> castSupplier = Functions.cast(stringSupplier);
+        Function<String, Object> castFunction = Functions.cast(objectFunction);
+        DoubleFunction<Object> castDoubleFunction = Functions.cast(doubleFunction);
+        IntFunction<Object> castIntFunction = Functions.cast(intFunction);
+        LongFunction<Object> castLongFunction = Functions.cast(longFunction);
+        ToDoubleFunction<String> castToDoubleFunction = Functions.cast(toDoubleFunction);
+        ToIntFunction<String> castToIntFunction = Functions.cast(toIntFunction);
+        ToLongFunction<String> castToLongFunction = Functions.cast(toLongFunction);
+        BiConsumer<String, Integer> castBiConsumer = Functions.cast(biConsumer);
+        ObjDoubleConsumer<String> castObjDoubleConsumer = Functions.cast(objDoubleConsumer);
+        ObjIntConsumer<String> castObjIntConsumer = Functions.cast(objIntConsumer);
+        ObjLongConsumer<String> castObjLongConsumer = Functions.cast(objLongConsumer);
+        BiPredicate<String, Integer> castBiPredicate = Functions.cast(biPredicate);
+        BiFunction<String, Integer, Object> castBiFunction = Functions.cast(biFunction);
+        ToDoubleBiFunction<String, Integer> castToDoubleBiFunction = Functions.cast(toDoubleBiFunction);
+        ToIntBiFunction<String, Integer> castToIntBiFunction = Functions.cast(toIntBiFunction);
+        ToLongBiFunction<String, Integer> castToLongBiFunction = Functions.cast(toLongBiFunction);
+
+        castConsumer.accept("seen");
+        castBiConsumer.accept("bi", 1);
+        castObjDoubleConsumer.accept("double", 2.5d);
+        castObjIntConsumer.accept("int", 3);
+        castObjLongConsumer.accept("long", 4L);
+
+        assertThat(castPredicate.test("smallrye")).isTrue();
+        assertThat(castSupplier.get()).isEqualTo("supplier");
+        assertThat(castFunction.apply("value")).isEqualTo("value");
+        assertThat(castDoubleFunction.apply(1.5d)).isEqualTo("double:1.5");
+        assertThat(castIntFunction.apply(7)).isEqualTo("int:7");
+        assertThat(castLongFunction.apply(8L)).isEqualTo("long:8");
+        assertThat(castToDoubleFunction.applyAsDouble("abcd")).isEqualTo(4.5d);
+        assertThat(castToIntFunction.applyAsInt("abc")).isEqualTo(3);
+        assertThat(castToLongFunction.applyAsLong("abc")).isEqualTo(30L);
+        assertThat(castBiPredicate.test("abc", 3)).isTrue();
+        assertThat(castBiFunction.apply("answer", 42)).isEqualTo("answer:42");
+        assertThat(castToDoubleBiFunction.applyAsDouble("abc", 2)).isEqualTo(5.0d);
+        assertThat(castToIntBiFunction.applyAsInt("abc", 2)).isEqualTo(5);
+        assertThat(castToLongBiFunction.applyAsLong("abc", 2)).isEqualTo(5L);
+        assertThat(seen).containsExactly("consumer:seen", "bi:1", "double:2.5", "int:3", "long:4");
+
+        assertExceptionCasts();
+    }
+
+    private static void assertExceptionCasts() throws Exception {
+        List<String> seen = new ArrayList<>();
+        ExceptionConsumer<Object, TestException> consumer = value -> seen.add("consumer:" + value);
+        ExceptionPredicate<Object, TestException> predicate = value -> value.toString().contains("yes");
+        ExceptionSupplier<String, TestException> supplier = () -> "exception-supplier";
+        ExceptionFunction<Object, String, TestException> function = Object::toString;
+        ExceptionIntFunction<String, TestException> intFunction = value -> "int:" + value;
+        ExceptionLongFunction<String, TestException> longFunction = value -> "long:" + value;
+        ExceptionToIntFunction<Object, TestException> toIntFunction = value -> value.toString().length();
+        ExceptionToLongFunction<Object, TestException> toLongFunction = value -> value.toString().length() * 2L;
+        ExceptionBiConsumer<Object, Number, TestException> biConsumer = (value, number) -> seen.add(
+                value + ":" + number);
+        ExceptionObjIntConsumer<Object, TestException> objIntConsumer = (value, number) -> seen.add(
+                value + ":" + number);
+        ExceptionObjLongConsumer<Object, TestException> objLongConsumer = (value, number) -> seen.add(
+                value + ":" + number);
+        ExceptionBiPredicate<Object, Number, TestException> biPredicate = (value, number) -> value.toString().length()
+                == number.intValue();
+        ExceptionBiFunction<Object, Number, String, TestException> biFunction = (value, number) -> value + ":" + number;
+        ExceptionToIntBiFunction<Object, Number, TestException> toIntBiFunction = (value, number) -> value.toString()
+                .length() + number.intValue();
+        ExceptionToLongBiFunction<Object, Number, TestException> toLongBiFunction = (value, number) -> value.toString()
+                .length() + number.longValue();
+
+        ExceptionConsumer<String, Exception> castConsumer = Functions.cast(consumer);
+        ExceptionPredicate<String, Exception> castPredicate = Functions.cast(predicate);
+        ExceptionSupplier<Object, Exception> castSupplier = Functions.cast(supplier);
+        ExceptionFunction<String, Object, Exception> castFunction = Functions.cast(function);
+        ExceptionIntFunction<Object, Exception> castIntFunction = Functions.cast(intFunction);
+        ExceptionLongFunction<Object, Exception> castLongFunction = Functions.cast(longFunction);
+        ExceptionToIntFunction<String, Exception> castToIntFunction = Functions.cast(toIntFunction);
+        ExceptionToLongFunction<String, Exception> castToLongFunction = Functions.cast(toLongFunction);
+        ExceptionBiConsumer<String, Integer, Exception> castBiConsumer = Functions.cast(biConsumer);
+        ExceptionObjIntConsumer<String, Exception> castObjIntConsumer = Functions.cast(objIntConsumer);
+        ExceptionObjLongConsumer<String, Exception> castObjLongConsumer = Functions.cast(objLongConsumer);
+        ExceptionBiPredicate<String, Integer, Exception> castBiPredicate = Functions.cast(biPredicate);
+        ExceptionBiFunction<String, Integer, Object, Exception> castBiFunction = Functions.cast(biFunction);
+        ExceptionToIntBiFunction<String, Integer, Exception> castToIntBiFunction = Functions.cast(toIntBiFunction);
+        ExceptionToLongBiFunction<String, Integer, Exception> castToLongBiFunction = Functions.cast(toLongBiFunction);
+
+        castConsumer.accept("seen");
+        castBiConsumer.accept("bi", 1);
+        castObjIntConsumer.accept("int", 2);
+        castObjLongConsumer.accept("long", 3L);
+
+        assertThat(castPredicate.test("yes")).isTrue();
+        assertThat(castSupplier.get()).isEqualTo("exception-supplier");
+        assertThat(castFunction.apply("value")).isEqualTo("value");
+        assertThat(castIntFunction.apply(4)).isEqualTo("int:4");
+        assertThat(castLongFunction.apply(5L)).isEqualTo("long:5");
+        assertThat(castToIntFunction.apply("abc")).isEqualTo(3);
+        assertThat(castToLongFunction.apply("abc")).isEqualTo(6L);
+        assertThat(castBiPredicate.test("abc", 3)).isTrue();
+        assertThat(castBiFunction.apply("answer", 42)).isEqualTo("answer:42");
+        assertThat(castToIntBiFunction.apply("abc", 2)).isEqualTo(5);
+        assertThat(castToLongBiFunction.apply("abc", 2)).isEqualTo(5L);
+        assertThat(seen).containsExactly("consumer:seen", "bi:1", "int:2", "long:3");
+    }
+
+    private static final class RecordingCloseable implements AutoCloseable {
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        private boolean closed() {
+            return closed.get();
+        }
+    }
+
+    private static final class TestException extends Exception {
+        private TestException(String message) {
+            super(message);
+        }
     }
 }

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/src/test/java/io_smallrye_common/smallrye_common_function/Smallrye_common_functionTest.java
@@ -207,6 +207,28 @@ public class Smallrye_common_functionTest {
     }
 
     @Test
+    void primitiveResultFunctionsChainToGeneralFunctions() throws TestException {
+        List<String> calls = new ArrayList<>();
+        ExceptionIntFunction<String, TestException> classifyInt = value -> {
+            calls.add("int:" + value);
+            return value % 2 == 0 ? "even" : "odd";
+        };
+        ExceptionLongFunction<String, TestException> classifyLong = value -> {
+            calls.add("long:" + value);
+            return value > 100L ? "large" : "small";
+        };
+        ExceptionFunction<String, String, TestException> decorate = value -> {
+            calls.add("decorate:" + value);
+            return "[" + value + "]";
+        };
+
+        assertThat(classifyInt.andThen(decorate).apply(8)).isEqualTo("[even]");
+        assertThat(classifyLong.andThen(decorate).apply(42L)).isEqualTo("[small]");
+
+        assertThat(calls).containsExactly("int:8", "decorate:even", "long:42", "decorate:small");
+    }
+
+    @Test
     void objectPrimitiveConsumersComposeWithMatchingAndWidenedLongConsumers() throws TestException {
         StringBuilder first = new StringBuilder();
         StringBuilder second = new StringBuilder();

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.smallrye.common.function.**"
+    }
+  ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-function/2.2.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.smallrye.common.function.**"
+      "includeClasses" : "io.smallrye.common.function.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3303

This PR introduces tests and metadata for io.smallrye.common:smallrye-common-function:2.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 266799
- Cached input tokens: 1461760
- Output tokens: 22640
- Entries: 2
- Iterations: 4
- Library coverage percentage: 96.08
- Generated lines of code: 480
- Tested library lines of code: 294

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `f29b7496e1f99de3797016780c6cc9282cde7df7`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1299/1411 (92.06%)
- Line: 294/306 (96.08%)
- Method: 229/235 (97.45%)
