### PR TITLE
[GenAI] Test fix for io.netty:netty-resolver:5.0.0.Alpha2 using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-resolver/5.0.0.Alpha2/reachability-metadata.json
+++ b/metadata/io.netty/netty-resolver/5.0.0.Alpha2/reachability-metadata.json
@@ -1,0 +1,110 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "android.app.Application"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "java.nio.Buffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "java.time.Clock"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.SimpleNameResolver"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-resolver/index.json
+++ b/metadata/io.netty/netty-resolver/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.0.0.Alpha2",
+    "tested-versions" : [
+      "5.0.0.Alpha2"
+    ],
+    "allowed-packages" : [
+      "io.netty.resolver"
+    ]
+  },
+  {
     "metadata-version" : "4.1.79.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/4.1.79.Final/netty-resolver-4.1.79.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-resolver/index.json
+++ b/metadata/io.netty/netty-resolver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "5.0.0.Alpha2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/5.0.0.Alpha2/netty-resolver-5.0.0.Alpha2-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/5.0.0.Alpha2/netty-resolver-5.0.0.Alpha2-javadoc.jar",
+    "description" : "Netty Resolver provides asynchronous name resolution abstractions used by Netty networking components. It supplies resolver groups and default or no-op InetSocketAddress resolvers that integrate with Netty's Future and EventExecutor APIs.",
     "tested-versions" : [
       "5.0.0.Alpha2"
     ],

--- a/stats/io.netty/netty-resolver/5.0.0.Alpha2/execution-metrics.json
+++ b/stats/io.netty/netty-resolver/5.0.0.Alpha2/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T20:03:41.877957Z",
+    "library": "io.netty:netty-resolver:5.0.0.Alpha2",
+    "starting_commit": "bae9f430efab1f659a469fc0ddedcaf4f3f2c278",
+    "ending_commit": "0623da5df235ef66b8d7300cdd9795f50f797e4e",
+    "previous_library": "io.netty:netty-resolver:4.1.79.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.0.Alpha2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 252,
+          "missed": 138,
+          "ratio": 0.646154,
+          "total": 390
+        },
+        "line": {
+          "covered": 66,
+          "missed": 36,
+          "ratio": 0.647059,
+          "total": 102
+        },
+        "method": {
+          "covered": 22,
+          "missed": 5,
+          "ratio": 0.814815,
+          "total": 27
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.1.79.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1045,
+          "missed": 790,
+          "ratio": 0.569482,
+          "total": 1835
+        },
+        "line": {
+          "covered": 230,
+          "missed": 172,
+          "ratio": 0.572139,
+          "total": 402
+        },
+        "method": {
+          "covered": 64,
+          "missed": 37,
+          "ratio": 0.633663,
+          "total": 101
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 104081,
+      "cached_input_tokens_used": 778240,
+      "output_tokens_used": 6270,
+      "iterations": 1,
+      "cost_usd": 0.5772,
+      "tested_library_loc": 66,
+      "metadata_entries": 24,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 64.71,
+      "previous_library_coverage_percent": 57.21
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java",
+      "metadata_file": "metadata/io.netty/netty-resolver/5.0.0.Alpha2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-resolver/5.0.0.Alpha2/stats.json
+++ b/stats/io.netty/netty-resolver/5.0.0.Alpha2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.0.Alpha2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 252,
+        "missed" : 138,
+        "ratio" : 0.646154,
+        "total" : 390
+      },
+      "line" : {
+        "covered" : 66,
+        "missed" : 36,
+        "ratio" : 0.647059,
+        "total" : 102
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 5,
+        "ratio" : 0.814815,
+        "total" : 27
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/.gitignore
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/build.gradle
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-resolver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/gradle.properties
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-resolver:5.0.0.Alpha2
+library.version = 5.0.0.Alpha2
+metadata.dir = io.netty/netty-resolver/5.0.0.Alpha2/

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/settings.gradle
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-resolver_tests'

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_resolver;
+
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.CompositeNameResolver;
+import io.netty.resolver.DefaultNameResolver;
+import io.netty.resolver.HostsFileEntries;
+import io.netty.resolver.HostsFileEntriesProvider;
+import io.netty.resolver.HostsFileParser;
+import io.netty.resolver.InetSocketAddressResolver;
+import io.netty.resolver.RoundRobinInetAddressResolver;
+import io.netty.resolver.SimpleNameResolver;
+import io.netty.util.concurrent.DefaultEventExecutor;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Netty_resolverTest {
+
+    private static final EventExecutor EXECUTOR = ImmediateEventExecutor.INSTANCE;
+
+    @Test
+    void hostsFileParsersNormalizeAliasesAndPreserveProviderAddressLists() throws Exception {
+        String hostsFile = """
+                # loopback aliases
+                127.0.0.1 LOCALHOST loopback
+                10.0.0.10 Example.Test alias
+                10.0.0.11 example.test
+                ::1 LOCALHOST ip6-localhost
+                2001:db8::1 Example.Test
+                not-an-ip ignored.example
+                """;
+
+        HostsFileEntriesProvider provider = HostsFileEntriesProvider.parser().parse(new StringReader(hostsFile));
+
+        assertThat(provider.ipv4Entries()).containsKeys("localhost", "loopback", "example.test", "alias");
+        assertThat(provider.ipv6Entries()).containsKeys("localhost", "ip6-localhost", "example.test");
+        assertThat(provider.ipv4Entries()).doesNotContainKey("LOCALHOST");
+        assertThat(provider.ipv4Entries().get("example.test"))
+                .containsExactly(ip("10.0.0.10"), ip("10.0.0.11"));
+        assertThat(provider.ipv6Entries().get("example.test"))
+                .containsExactly(ip("2001:db8::1"));
+
+        HostsFileEntries entries = HostsFileParser.parse(new StringReader(hostsFile));
+
+        assertThat(entries.inet4Entries().get("localhost")).isEqualTo(ip("127.0.0.1"));
+        assertThat(entries.inet6Entries().get("localhost")).isEqualTo(ip("::1"));
+        assertThat(entries.inet4Entries().get("example.test")).isEqualTo(ip("10.0.0.10"));
+        assertThat(entries.inet6Entries().get("example.test")).isEqualTo(ip("2001:db8::1"));
+        assertThat(entries.inet4Entries()).doesNotContainKey("ignored.example");
+    }
+
+    @Test
+    void defaultNameResolverResolvesIpv4AndIpv6Literals() throws Exception {
+        DefaultNameResolver resolver = new DefaultNameResolver(EXECUTOR);
+
+        try {
+            InetAddress resolvedIpv4 = resolver.resolve("198.51.100.70").syncUninterruptibly().getNow();
+            List<InetAddress> resolvedAllIpv4 = resolver.resolveAll("198.51.100.70").syncUninterruptibly().getNow();
+            InetAddress resolvedIpv6 = resolver.resolve("2001:db8::70").syncUninterruptibly().getNow();
+            List<InetAddress> resolvedAllIpv6 = resolver.resolveAll("2001:db8::70").syncUninterruptibly().getNow();
+
+            assertThat(resolvedIpv4).isEqualTo(ip("198.51.100.70"));
+            assertThat(resolvedAllIpv4).containsExactly(ip("198.51.100.70"));
+            assertThat(resolvedIpv6).isEqualTo(ip("2001:db8::70"));
+            assertThat(resolvedAllIpv6).containsExactly(ip("2001:db8::70"));
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    void compositeNameResolverFallsBackToLaterResolvers() throws Exception {
+        RecordingNameResolver firstResolver = new RecordingNameResolver(EXECUTOR, Map.of());
+        RecordingNameResolver secondResolver = new RecordingNameResolver(
+                EXECUTOR,
+                Map.of("example.test", List.of(ip("203.0.113.10"), ip("203.0.113.11")))
+        );
+        CompositeNameResolver<InetAddress> resolver = new CompositeNameResolver<>(EXECUTOR, firstResolver, secondResolver);
+
+        try {
+            InetAddress resolved = resolver.resolve("example.test").syncUninterruptibly().getNow();
+            List<InetAddress> resolvedAll = resolver.resolveAll("example.test").syncUninterruptibly().getNow();
+
+            assertThat(resolved).isEqualTo(ip("203.0.113.10"));
+            assertThat(resolvedAll).containsExactly(ip("203.0.113.10"), ip("203.0.113.11"));
+            assertThat(firstResolver.resolveHosts).containsExactly("example.test");
+            assertThat(firstResolver.resolveAllHosts).containsExactly("example.test");
+            assertThat(secondResolver.resolveHosts).containsExactly("example.test");
+            assertThat(secondResolver.resolveAllHosts).containsExactly("example.test");
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    void inetSocketAddressResolverResolvesSingleAndAllAddressesWithOriginalPort() throws Exception {
+        RecordingNameResolver nameResolver = new RecordingNameResolver(
+                EXECUTOR,
+                Map.of("example.test", List.of(ip("198.51.100.20"), ip("198.51.100.21")))
+        );
+        InetSocketAddressResolver resolver = new InetSocketAddressResolver(EXECUTOR, nameResolver);
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("example.test", 8443);
+
+        try {
+            assertThat(resolver.isSupported(unresolved)).isTrue();
+            assertThat(resolver.isResolved(unresolved)).isFalse();
+
+            InetSocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
+            List<InetSocketAddress> resolvedAll = resolver.resolveAll(unresolved).syncUninterruptibly().getNow();
+
+            assertThat(resolved.isUnresolved()).isFalse();
+            assertThat(resolved.getAddress()).isEqualTo(ip("198.51.100.20"));
+            assertThat(resolved.getPort()).isEqualTo(8443);
+            assertThat(resolvedAll)
+                    .extracting(InetSocketAddress::getAddress)
+                    .containsExactly(ip("198.51.100.20"), ip("198.51.100.21"));
+            assertThat(resolvedAll)
+                    .extracting(InetSocketAddress::getPort)
+                    .containsOnly(8443);
+            assertThat(nameResolver.resolveHosts).containsExactly("example.test");
+            assertThat(nameResolver.resolveAllHosts).containsExactly("example.test");
+        } finally {
+            resolver.close();
+        }
+
+        assertThat(nameResolver.closed).isTrue();
+    }
+
+    @Test
+    void addressResolverGroupCachesResolversPerExecutorAndClosesCreatedResolvers() throws Exception {
+        RecordingAddressResolverGroup group = new RecordingAddressResolverGroup(
+                Map.of("example.test", List.of(ip("192.0.2.44")))
+        );
+        DefaultEventExecutor otherExecutor = new DefaultEventExecutor();
+
+        try {
+            AddressResolver<InetSocketAddress> firstResolver = group.getResolver(EXECUTOR);
+            AddressResolver<InetSocketAddress> cachedResolver = group.getResolver(EXECUTOR);
+            AddressResolver<InetSocketAddress> otherResolver = group.getResolver(otherExecutor);
+
+            assertThat(firstResolver).isSameAs(cachedResolver);
+            assertThat(otherResolver).isNotSameAs(firstResolver);
+            assertThat(group.createdNameResolvers).hasSize(2);
+
+            InetSocketAddress resolved = firstResolver
+                    .resolve(InetSocketAddress.createUnresolved("example.test", 8080))
+                    .syncUninterruptibly()
+                    .getNow();
+
+            assertThat(resolved.getAddress()).isEqualTo(ip("192.0.2.44"));
+            assertThat(resolved.getPort()).isEqualTo(8080);
+
+            group.close();
+
+            assertThat(group.createdNameResolvers)
+                    .allSatisfy(nameResolver -> assertThat(nameResolver.closed).isTrue());
+        } finally {
+            otherExecutor.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void roundRobinInetAddressResolverUsesResolveAllResultsForSingleAndBulkLookups() throws Exception {
+        List<InetAddress> addresses = List.of(ip("203.0.113.30"), ip("203.0.113.31"), ip("203.0.113.32"));
+        RecordingNameResolver nameResolver = new RecordingNameResolver(
+                EXECUTOR,
+                Map.of("roundrobin.test", addresses)
+        );
+        RoundRobinInetAddressResolver resolver = new RoundRobinInetAddressResolver(EXECUTOR, nameResolver);
+
+        try {
+            InetAddress resolved = resolver.resolve("roundrobin.test").syncUninterruptibly().getNow();
+            List<InetAddress> resolvedAll = resolver.resolveAll("roundrobin.test").syncUninterruptibly().getNow();
+
+            assertThat(resolved).isIn(addresses);
+            assertThat(resolvedAll).containsExactlyInAnyOrderElementsOf(addresses);
+            assertThat(nameResolver.resolveHosts).isEmpty();
+            assertThat(nameResolver.resolveAllHosts).containsExactly("roundrobin.test", "roundrobin.test");
+        } finally {
+            resolver.close();
+        }
+
+        assertThat(nameResolver.closed).isTrue();
+    }
+
+    private static InetAddress ip(String literal) throws UnknownHostException {
+        return InetAddress.getByName(literal);
+    }
+
+    private static final class RecordingNameResolver extends SimpleNameResolver<InetAddress> {
+        private final Map<String, List<InetAddress>> addressesByHost;
+        private final List<String> resolveHosts = new ArrayList<>();
+        private final List<String> resolveAllHosts = new ArrayList<>();
+        private boolean closed;
+
+        private RecordingNameResolver(EventExecutor executor, Map<String, List<InetAddress>> addressesByHost) {
+            super(executor);
+            this.addressesByHost = addressesByHost;
+        }
+
+        @Override
+        protected void doResolve(String inetHost, Promise<InetAddress> promise) throws Exception {
+            resolveHosts.add(inetHost);
+            List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
+            if (addresses == null || addresses.isEmpty()) {
+                promise.setFailure(new UnknownHostException(inetHost));
+                return;
+            }
+            promise.setSuccess(addresses.get(0));
+        }
+
+        @Override
+        protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
+            resolveAllHosts.add(inetHost);
+            List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
+            if (addresses == null || addresses.isEmpty()) {
+                promise.setFailure(new UnknownHostException(inetHost));
+                return;
+            }
+            promise.setSuccess(List.copyOf(addresses));
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        private static String normalize(String host) {
+            return host.toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    private static final class RecordingAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+        private final Map<String, List<InetAddress>> addressesByHost;
+        private final List<RecordingNameResolver> createdNameResolvers = new ArrayList<>();
+
+        private RecordingAddressResolverGroup(Map<String, List<InetAddress>> addressesByHost) {
+            this.addressesByHost = addressesByHost;
+        }
+
+        @Override
+        protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
+            RecordingNameResolver nameResolver = new RecordingNameResolver(executor, addressesByHost);
+            createdNameResolvers.add(nameResolver);
+            return new InetSocketAddressResolver(executor, nameResolver);
+        }
+    }
+}

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
@@ -6,163 +6,123 @@
  */
 package io_netty.netty_resolver;
 
-import java.io.StringReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import io.netty.resolver.AddressResolver;
-import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.CompositeNameResolver;
 import io.netty.resolver.DefaultNameResolver;
-import io.netty.resolver.HostsFileEntries;
-import io.netty.resolver.HostsFileEntriesProvider;
-import io.netty.resolver.HostsFileParser;
-import io.netty.resolver.InetSocketAddressResolver;
-import io.netty.resolver.RoundRobinInetAddressResolver;
+import io.netty.resolver.NameResolver;
+import io.netty.resolver.NameResolverGroup;
+import io.netty.resolver.NoopNameResolver;
+import io.netty.resolver.NoopNameResolverGroup;
 import io.netty.resolver.SimpleNameResolver;
-import io.netty.util.concurrent.DefaultEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Netty_resolverTest {
 
     private static final EventExecutor EXECUTOR = ImmediateEventExecutor.INSTANCE;
 
     @Test
-    void hostsFileParsersNormalizeAliasesAndPreserveProviderAddressLists() throws Exception {
-        String hostsFile = """
-                # loopback aliases
-                127.0.0.1 LOCALHOST loopback
-                10.0.0.10 Example.Test alias
-                10.0.0.11 example.test
-                ::1 LOCALHOST ip6-localhost
-                2001:db8::1 Example.Test
-                not-an-ip ignored.example
-                """;
-
-        HostsFileEntriesProvider provider = HostsFileEntriesProvider.parser().parse(new StringReader(hostsFile));
-
-        assertThat(provider.ipv4Entries()).containsKeys("localhost", "loopback", "example.test", "alias");
-        assertThat(provider.ipv6Entries()).containsKeys("localhost", "ip6-localhost", "example.test");
-        assertThat(provider.ipv4Entries()).doesNotContainKey("LOCALHOST");
-        assertThat(provider.ipv4Entries().get("example.test"))
-                .containsExactly(ip("10.0.0.10"), ip("10.0.0.11"));
-        assertThat(provider.ipv6Entries().get("example.test"))
-                .containsExactly(ip("2001:db8::1"));
-
-        HostsFileEntries entries = HostsFileParser.parse(new StringReader(hostsFile));
-
-        assertThat(entries.inet4Entries().get("localhost")).isEqualTo(ip("127.0.0.1"));
-        assertThat(entries.inet6Entries().get("localhost")).isEqualTo(ip("::1"));
-        assertThat(entries.inet4Entries().get("example.test")).isEqualTo(ip("10.0.0.10"));
-        assertThat(entries.inet6Entries().get("example.test")).isEqualTo(ip("2001:db8::1"));
-        assertThat(entries.inet4Entries()).doesNotContainKey("ignored.example");
-    }
-
-    @Test
-    void defaultNameResolverResolvesIpv4AndIpv6Literals() throws Exception {
+    void defaultNameResolverResolvesIpv4AndIpv6SocketAddresses() throws Exception {
         DefaultNameResolver resolver = new DefaultNameResolver(EXECUTOR);
 
         try {
-            InetAddress resolvedIpv4 = resolver.resolve("198.51.100.70").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAllIpv4 = resolver.resolveAll("198.51.100.70").syncUninterruptibly().getNow();
-            InetAddress resolvedIpv6 = resolver.resolve("2001:db8::70").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAllIpv6 = resolver.resolveAll("2001:db8::70").syncUninterruptibly().getNow();
+            InetSocketAddress unresolvedIpv4 = InetSocketAddress.createUnresolved("198.51.100.70", 8080);
+            InetSocketAddress resolvedIpv4 = resolver.resolve(unresolvedIpv4).syncUninterruptibly().getNow();
+            InetSocketAddress resolvedByHostAndPort = resolver.resolve("198.51.100.71", 8443)
+                    .syncUninterruptibly()
+                    .getNow();
+            InetSocketAddress unresolvedIpv6 = InetSocketAddress.createUnresolved("2001:db8::70", 9090);
+            InetSocketAddress resolvedIpv6 = resolver.resolve(unresolvedIpv6).syncUninterruptibly().getNow();
 
-            assertThat(resolvedIpv4).isEqualTo(ip("198.51.100.70"));
-            assertThat(resolvedAllIpv4).containsExactly(ip("198.51.100.70"));
-            assertThat(resolvedIpv6).isEqualTo(ip("2001:db8::70"));
-            assertThat(resolvedAllIpv6).containsExactly(ip("2001:db8::70"));
+            assertThat(resolvedIpv4.isUnresolved()).isFalse();
+            assertThat(resolvedIpv4.getAddress()).isEqualTo(ip("198.51.100.70"));
+            assertThat(resolvedIpv4.getPort()).isEqualTo(8080);
+            assertThat(resolvedByHostAndPort.getAddress()).isEqualTo(ip("198.51.100.71"));
+            assertThat(resolvedByHostAndPort.getPort()).isEqualTo(8443);
+            assertThat(resolvedIpv6.isUnresolved()).isFalse();
+            assertThat(resolvedIpv6.getAddress()).isEqualTo(ip("2001:db8::70"));
+            assertThat(resolvedIpv6.getPort()).isEqualTo(9090);
         } finally {
             resolver.close();
         }
     }
 
     @Test
-    void compositeNameResolverFallsBackToLaterResolvers() throws Exception {
-        RecordingNameResolver firstResolver = new RecordingNameResolver(EXECUTOR, Map.of());
-        RecordingNameResolver secondResolver = new RecordingNameResolver(
+    void simpleNameResolverReportsSupportAndReturnsAlreadyResolvedAddresses() throws Exception {
+        RecordingNameResolver resolver = new RecordingNameResolver(
                 EXECUTOR,
-                Map.of("example.test", List.of(ip("203.0.113.10"), ip("203.0.113.11")))
+                Map.of("example.test", List.of(ip("203.0.113.10")))
         );
-        CompositeNameResolver<InetAddress> resolver = new CompositeNameResolver<>(EXECUTOR, firstResolver, secondResolver);
+        InetSocketAddress resolvedAddress = new InetSocketAddress(ip("203.0.113.20"), 443);
+        SocketAddress unsupportedAddress = new SocketAddress() { };
 
         try {
-            InetAddress resolved = resolver.resolve("example.test").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAll = resolver.resolveAll("example.test").syncUninterruptibly().getNow();
+            InetSocketAddress result = resolver.resolve(resolvedAddress).syncUninterruptibly().getNow();
 
-            assertThat(resolved).isEqualTo(ip("203.0.113.10"));
-            assertThat(resolvedAll).containsExactly(ip("203.0.113.10"), ip("203.0.113.11"));
-            assertThat(firstResolver.resolveHosts).containsExactly("example.test");
-            assertThat(firstResolver.resolveAllHosts).containsExactly("example.test");
-            assertThat(secondResolver.resolveHosts).containsExactly("example.test");
-            assertThat(secondResolver.resolveAllHosts).containsExactly("example.test");
+            assertThat(resolver.isSupported(resolvedAddress)).isTrue();
+            assertThat(resolver.isSupported(unsupportedAddress)).isFalse();
+            assertThat(resolver.isResolved(resolvedAddress)).isTrue();
+            assertThat(result).isSameAs(resolvedAddress);
+            assertThat(resolver.resolveHosts).isEmpty();
+            assertThatThrownBy(() -> resolver.isResolved(unsupportedAddress))
+                    .isInstanceOf(UnsupportedAddressTypeException.class);
         } finally {
             resolver.close();
         }
+
+        assertThat(resolver.closed).isTrue();
     }
 
     @Test
-    void inetSocketAddressResolverResolvesSingleAndAllAddressesWithOriginalPort() throws Exception {
-        RecordingNameResolver nameResolver = new RecordingNameResolver(
+    void simpleNameResolverResolvesUnresolvedAddressesAndPropagatesFailures() throws Exception {
+        RecordingNameResolver resolver = new RecordingNameResolver(
                 EXECUTOR,
-                Map.of("example.test", List.of(ip("198.51.100.20"), ip("198.51.100.21")))
+                Map.of("example.test", List.of(ip("203.0.113.30")))
         );
-        InetSocketAddressResolver resolver = new InetSocketAddressResolver(EXECUTOR, nameResolver);
-        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("example.test", 8443);
 
         try {
-            assertThat(resolver.isSupported(unresolved)).isTrue();
-            assertThat(resolver.isResolved(unresolved)).isFalse();
-
+            InetSocketAddress unresolved = InetSocketAddress.createUnresolved("Example.Test", 8443);
             InetSocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
-            List<InetSocketAddress> resolvedAll = resolver.resolveAll(unresolved).syncUninterruptibly().getNow();
+            Throwable failure = resolver.resolve("missing.test", 9443).awaitUninterruptibly().cause();
 
             assertThat(resolved.isUnresolved()).isFalse();
-            assertThat(resolved.getAddress()).isEqualTo(ip("198.51.100.20"));
+            assertThat(resolved.getAddress()).isEqualTo(ip("203.0.113.30"));
             assertThat(resolved.getPort()).isEqualTo(8443);
-            assertThat(resolvedAll)
-                    .extracting(InetSocketAddress::getAddress)
-                    .containsExactly(ip("198.51.100.20"), ip("198.51.100.21"));
-            assertThat(resolvedAll)
-                    .extracting(InetSocketAddress::getPort)
-                    .containsOnly(8443);
-            assertThat(nameResolver.resolveHosts).containsExactly("example.test");
-            assertThat(nameResolver.resolveAllHosts).containsExactly("example.test");
+            assertThat(resolver.resolveHosts).containsExactly("Example.Test", "missing.test");
+            assertThat(failure).isInstanceOf(UnknownHostException.class)
+                    .hasMessage("missing.test");
         } finally {
             resolver.close();
         }
-
-        assertThat(nameResolver.closed).isTrue();
     }
 
     @Test
-    void addressResolverGroupCachesResolversPerExecutorAndClosesCreatedResolvers() throws Exception {
-        RecordingAddressResolverGroup group = new RecordingAddressResolverGroup(
+    void nameResolverGroupCachesResolverAndClosesCreatedResolver() throws Exception {
+        RecordingNameResolverGroup group = new RecordingNameResolverGroup(
                 Map.of("example.test", List.of(ip("192.0.2.44")))
         );
-        DefaultEventExecutor otherExecutor = new DefaultEventExecutor();
-
         try {
-            AddressResolver<InetSocketAddress> firstResolver = group.getResolver(EXECUTOR);
-            AddressResolver<InetSocketAddress> cachedResolver = group.getResolver(EXECUTOR);
-            AddressResolver<InetSocketAddress> otherResolver = group.getResolver(otherExecutor);
+            NameResolver<InetSocketAddress> firstResolver = group.getResolver(EXECUTOR);
+            NameResolver<InetSocketAddress> cachedResolver = group.getResolver(EXECUTOR);
 
             assertThat(firstResolver).isSameAs(cachedResolver);
-            assertThat(otherResolver).isNotSameAs(firstResolver);
-            assertThat(group.createdNameResolvers).hasSize(2);
+            assertThat(group.createdNameResolvers).hasSize(1);
 
             InetSocketAddress resolved = firstResolver
-                    .resolve(InetSocketAddress.createUnresolved("example.test", 8080))
+                    .resolve("example.test", 8080)
                     .syncUninterruptibly()
                     .getNow();
 
@@ -174,69 +134,73 @@ public class Netty_resolverTest {
             assertThat(group.createdNameResolvers)
                     .allSatisfy(nameResolver -> assertThat(nameResolver.closed).isTrue());
         } finally {
-            otherExecutor.shutdownGracefully().syncUninterruptibly();
+            group.close();
         }
     }
 
     @Test
-    void roundRobinInetAddressResolverUsesResolveAllResultsForSingleAndBulkLookups() throws Exception {
-        List<InetAddress> addresses = List.of(ip("203.0.113.30"), ip("203.0.113.31"), ip("203.0.113.32"));
-        RecordingNameResolver nameResolver = new RecordingNameResolver(
-                EXECUTOR,
-                Map.of("roundrobin.test", addresses)
-        );
-        RoundRobinInetAddressResolver resolver = new RoundRobinInetAddressResolver(EXECUTOR, nameResolver);
+    void noopNameResolverTreatsSocketAddressesAsAlreadyResolved() {
+        NoopNameResolver resolver = new NoopNameResolver(EXECUTOR);
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("unresolved.example", 8080);
 
         try {
-            InetAddress resolved = resolver.resolve("roundrobin.test").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAll = resolver.resolveAll("roundrobin.test").syncUninterruptibly().getNow();
+            SocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
 
-            assertThat(resolved).isIn(addresses);
-            assertThat(resolvedAll).containsExactlyInAnyOrderElementsOf(addresses);
-            assertThat(nameResolver.resolveHosts).isEmpty();
-            assertThat(nameResolver.resolveAllHosts).containsExactly("roundrobin.test", "roundrobin.test");
+            assertThat(resolver.isSupported(unresolved)).isTrue();
+            assertThat(resolver.isResolved(unresolved)).isTrue();
+            assertThat(resolved).isSameAs(unresolved);
         } finally {
             resolver.close();
         }
+    }
 
-        assertThat(nameResolver.closed).isTrue();
+    @Test
+    void noopNameResolverGroupReusesResolverForExecutor() {
+        try {
+            NameResolver<SocketAddress> resolver = NoopNameResolverGroup.INSTANCE.getResolver(EXECUTOR);
+            NameResolver<SocketAddress> cachedResolver = NoopNameResolverGroup.INSTANCE.getResolver(EXECUTOR);
+            InetSocketAddress unresolved = InetSocketAddress.createUnresolved("pipeline-resolved.example", 443);
+            SocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
+
+            assertThat(resolver).isSameAs(cachedResolver);
+            assertThat(resolved).isSameAs(unresolved);
+        } finally {
+            NoopNameResolverGroup.INSTANCE.close();
+        }
     }
 
     private static InetAddress ip(String literal) throws UnknownHostException {
         return InetAddress.getByName(literal);
     }
 
-    private static final class RecordingNameResolver extends SimpleNameResolver<InetAddress> {
+    private static final class RecordingNameResolver extends SimpleNameResolver<InetSocketAddress> {
         private final Map<String, List<InetAddress>> addressesByHost;
         private final List<String> resolveHosts = new ArrayList<>();
-        private final List<String> resolveAllHosts = new ArrayList<>();
         private boolean closed;
 
         private RecordingNameResolver(EventExecutor executor, Map<String, List<InetAddress>> addressesByHost) {
-            super(executor);
+            super(executor, InetSocketAddress.class);
             this.addressesByHost = addressesByHost;
         }
 
         @Override
-        protected void doResolve(String inetHost, Promise<InetAddress> promise) throws Exception {
+        protected boolean doIsResolved(InetSocketAddress address) {
+            return !address.isUnresolved();
+        }
+
+        @Override
+        protected void doResolve(
+                InetSocketAddress unresolvedAddress,
+                Promise<InetSocketAddress> promise
+        ) throws Exception {
+            String inetHost = unresolvedAddress.getHostString();
             resolveHosts.add(inetHost);
             List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
             if (addresses == null || addresses.isEmpty()) {
                 promise.setFailure(new UnknownHostException(inetHost));
                 return;
             }
-            promise.setSuccess(addresses.get(0));
-        }
-
-        @Override
-        protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
-            resolveAllHosts.add(inetHost);
-            List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
-            if (addresses == null || addresses.isEmpty()) {
-                promise.setFailure(new UnknownHostException(inetHost));
-                return;
-            }
-            promise.setSuccess(List.copyOf(addresses));
+            promise.setSuccess(new InetSocketAddress(addresses.get(0), unresolvedAddress.getPort()));
         }
 
         @Override
@@ -249,19 +213,19 @@ public class Netty_resolverTest {
         }
     }
 
-    private static final class RecordingAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+    private static final class RecordingNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
         private final Map<String, List<InetAddress>> addressesByHost;
         private final List<RecordingNameResolver> createdNameResolvers = new ArrayList<>();
 
-        private RecordingAddressResolverGroup(Map<String, List<InetAddress>> addressesByHost) {
+        private RecordingNameResolverGroup(Map<String, List<InetAddress>> addressesByHost) {
             this.addressesByHost = addressesByHost;
         }
 
         @Override
-        protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
+        protected NameResolver<InetSocketAddress> newResolver(EventExecutor executor) {
             RecordingNameResolver nameResolver = new RecordingNameResolver(executor, addressesByHost);
             createdNameResolvers.add(nameResolver);
-            return new InetSocketAddressResolver(executor, nameResolver);
+            return nameResolver;
         }
     }
 }

--- a/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/user-code-filter.json
+++ b/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.netty.resolver.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3391

This PR provides test fixes and new metadata for io.netty:netty-resolver:5.0.0.Alpha2, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 104081
- Cached input tokens: 778240
- Output tokens: 6270
- Entries found: 24
- Iterations: 1
- Library coverage percentage: 64.71
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 57.21

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7d7780548430ab6fa24a9003afd20df256db2146`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-resolver:4.1.79.Final: 0/0 covered calls (100.00%)
- io.netty:netty-resolver:5.0.0.Alpha2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-resolver:4.1.79.Final: 1045/1835 (56.95%)
- io.netty:netty-resolver:5.0.0.Alpha2: 252/390 (64.62%)

**Line:**
- io.netty:netty-resolver:4.1.79.Final: 230/402 (57.21%)
- io.netty:netty-resolver:5.0.0.Alpha2: 66/102 (64.71%)

**Method:**
- io.netty:netty-resolver:4.1.79.Final: 64/101 (63.37%)
- io.netty:netty-resolver:5.0.0.Alpha2: 22/27 (81.48%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.netty/netty-resolver/4.1.79.Final/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java 2/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
index 8f283f46cb..f5291d6758 100644
--- 1/tests/src/io.netty/netty-resolver/4.1.79.Final/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
+++ 2/tests/src/io.netty/netty-resolver/5.0.0.Alpha2/src/test/java/io_netty/netty_resolver/Netty_resolverTest.java
@@ -6,163 +6,123 @@
  */
 package io_netty.netty_resolver;
 
-import java.io.StringReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import io.netty.resolver.AddressResolver;
-import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.CompositeNameResolver;
 import io.netty.resolver.DefaultNameResolver;
-import io.netty.resolver.HostsFileEntries;
-import io.netty.resolver.HostsFileEntriesProvider;
-import io.netty.resolver.HostsFileParser;
-import io.netty.resolver.InetSocketAddressResolver;
-import io.netty.resolver.RoundRobinInetAddressResolver;
+import io.netty.resolver.NameResolver;
+import io.netty.resolver.NameResolverGroup;
+import io.netty.resolver.NoopNameResolver;
+import io.netty.resolver.NoopNameResolverGroup;
 import io.netty.resolver.SimpleNameResolver;
-import io.netty.util.concurrent.DefaultEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Netty_resolverTest {
 
     private static final EventExecutor EXECUTOR = ImmediateEventExecutor.INSTANCE;
 
     @Test
-    void hostsFileParsersNormalizeAliasesAndPreserveProviderAddressLists() throws Exception {
-        String hostsFile = """
-                # loopback aliases
-                127.0.0.1 LOCALHOST loopback
-                10.0.0.10 Example.Test alias
-                10.0.0.11 example.test
-                ::1 LOCALHOST ip6-localhost
-                2001:db8::1 Example.Test
-                not-an-ip ignored.example
-                """;
-
-        HostsFileEntriesProvider provider = HostsFileEntriesProvider.parser().parse(new StringReader(hostsFile));
-
-        assertThat(provider.ipv4Entries()).containsKeys("localhost", "loopback", "example.test", "alias");
-        assertThat(provider.ipv6Entries()).containsKeys("localhost", "ip6-localhost", "example.test");
-        assertThat(provider.ipv4Entries()).doesNotContainKey("LOCALHOST");
-        assertThat(provider.ipv4Entries().get("example.test"))
-                .containsExactly(ip("10.0.0.10"), ip("10.0.0.11"));
-        assertThat(provider.ipv6Entries().get("example.test"))
-                .containsExactly(ip("2001:db8::1"));
-
-        HostsFileEntries entries = HostsFileParser.parse(new StringReader(hostsFile));
-
-        assertThat(entries.inet4Entries().get("localhost")).isEqualTo(ip("127.0.0.1"));
-        assertThat(entries.inet6Entries().get("localhost")).isEqualTo(ip("::1"));
-        assertThat(entries.inet4Entries().get("example.test")).isEqualTo(ip("10.0.0.10"));
-        assertThat(entries.inet6Entries().get("example.test")).isEqualTo(ip("2001:db8::1"));
-        assertThat(entries.inet4Entries()).doesNotContainKey("ignored.example");
-    }
-
-    @Test
-    void defaultNameResolverResolvesIpv4AndIpv6Literals() throws Exception {
+    void defaultNameResolverResolvesIpv4AndIpv6SocketAddresses() throws Exception {
         DefaultNameResolver resolver = new DefaultNameResolver(EXECUTOR);
 
         try {
-            InetAddress resolvedIpv4 = resolver.resolve("198.51.100.70").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAllIpv4 = resolver.resolveAll("198.51.100.70").syncUninterruptibly().getNow();
-            InetAddress resolvedIpv6 = resolver.resolve("2001:db8::70").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAllIpv6 = resolver.resolveAll("2001:db8::70").syncUninterruptibly().getNow();
-
-            assertThat(resolvedIpv4).isEqualTo(ip("198.51.100.70"));
-            assertThat(resolvedAllIpv4).containsExactly(ip("198.51.100.70"));
-            assertThat(resolvedIpv6).isEqualTo(ip("2001:db8::70"));
-            assertThat(resolvedAllIpv6).containsExactly(ip("2001:db8::70"));
+            InetSocketAddress unresolvedIpv4 = InetSocketAddress.createUnresolved("198.51.100.70", 8080);
+            InetSocketAddress resolvedIpv4 = resolver.resolve(unresolvedIpv4).syncUninterruptibly().getNow();
+            InetSocketAddress resolvedByHostAndPort = resolver.resolve("198.51.100.71", 8443)
+                    .syncUninterruptibly()
+                    .getNow();
+            InetSocketAddress unresolvedIpv6 = InetSocketAddress.createUnresolved("2001:db8::70", 9090);
+            InetSocketAddress resolvedIpv6 = resolver.resolve(unresolvedIpv6).syncUninterruptibly().getNow();
+
+            assertThat(resolvedIpv4.isUnresolved()).isFalse();
+            assertThat(resolvedIpv4.getAddress()).isEqualTo(ip("198.51.100.70"));
+            assertThat(resolvedIpv4.getPort()).isEqualTo(8080);
+            assertThat(resolvedByHostAndPort.getAddress()).isEqualTo(ip("198.51.100.71"));
+            assertThat(resolvedByHostAndPort.getPort()).isEqualTo(8443);
+            assertThat(resolvedIpv6.isUnresolved()).isFalse();
+            assertThat(resolvedIpv6.getAddress()).isEqualTo(ip("2001:db8::70"));
+            assertThat(resolvedIpv6.getPort()).isEqualTo(9090);
         } finally {
             resolver.close();
         }
     }
 
     @Test
-    void compositeNameResolverFallsBackToLaterResolvers() throws Exception {
-        RecordingNameResolver firstResolver = new RecordingNameResolver(EXECUTOR, Map.of());
-        RecordingNameResolver secondResolver = new RecordingNameResolver(
+    void simpleNameResolverReportsSupportAndReturnsAlreadyResolvedAddresses() throws Exception {
+        RecordingNameResolver resolver = new RecordingNameResolver(
                 EXECUTOR,
-                Map.of("example.test", List.of(ip("203.0.113.10"), ip("203.0.113.11")))
+                Map.of("example.test", List.of(ip("203.0.113.10")))
         );
-        CompositeNameResolver<InetAddress> resolver = new CompositeNameResolver<>(EXECUTOR, firstResolver, secondResolver);
+        InetSocketAddress resolvedAddress = new InetSocketAddress(ip("203.0.113.20"), 443);
+        SocketAddress unsupportedAddress = new SocketAddress() { };
 
         try {
-            InetAddress resolved = resolver.resolve("example.test").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAll = resolver.resolveAll("example.test").syncUninterruptibly().getNow();
-
-            assertThat(resolved).isEqualTo(ip("203.0.113.10"));
-            assertThat(resolvedAll).containsExactly(ip("203.0.113.10"), ip("203.0.113.11"));
-            assertThat(firstResolver.resolveHosts).containsExactly("example.test");
-            assertThat(firstResolver.resolveAllHosts).containsExactly("example.test");
-            assertThat(secondResolver.resolveHosts).containsExactly("example.test");
-            assertThat(secondResolver.resolveAllHosts).containsExactly("example.test");
+            InetSocketAddress result = resolver.resolve(resolvedAddress).syncUninterruptibly().getNow();
+
+            assertThat(resolver.isSupported(resolvedAddress)).isTrue();
+            assertThat(resolver.isSupported(unsupportedAddress)).isFalse();
+            assertThat(resolver.isResolved(resolvedAddress)).isTrue();
+            assertThat(result).isSameAs(resolvedAddress);
+            assertThat(resolver.resolveHosts).isEmpty();
+            assertThatThrownBy(() -> resolver.isResolved(unsupportedAddress))
+                    .isInstanceOf(UnsupportedAddressTypeException.class);
         } finally {
             resolver.close();
         }
+
+        assertThat(resolver.closed).isTrue();
     }
 
     @Test
-    void inetSocketAddressResolverResolvesSingleAndAllAddressesWithOriginalPort() throws Exception {
-        RecordingNameResolver nameResolver = new RecordingNameResolver(
+    void simpleNameResolverResolvesUnresolvedAddressesAndPropagatesFailures() throws Exception {
+        RecordingNameResolver resolver = new RecordingNameResolver(
                 EXECUTOR,
-                Map.of("example.test", List.of(ip("198.51.100.20"), ip("198.51.100.21")))
+                Map.of("example.test", List.of(ip("203.0.113.30")))
         );
-        InetSocketAddressResolver resolver = new InetSocketAddressResolver(EXECUTOR, nameResolver);
-        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("example.test", 8443);
 
         try {
-            assertThat(resolver.isSupported(unresolved)).isTrue();
-            assertThat(resolver.isResolved(unresolved)).isFalse();
-
+            InetSocketAddress unresolved = InetSocketAddress.createUnresolved("Example.Test", 8443);
             InetSocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
-            List<InetSocketAddress> resolvedAll = resolver.resolveAll(unresolved).syncUninterruptibly().getNow();
+            Throwable failure = resolver.resolve("missing.test", 9443).awaitUninterruptibly().cause();
 
             assertThat(resolved.isUnresolved()).isFalse();
-            assertThat(resolved.getAddress()).isEqualTo(ip("198.51.100.20"));
+            assertThat(resolved.getAddress()).isEqualTo(ip("203.0.113.30"));
             assertThat(resolved.getPort()).isEqualTo(8443);
-            assertThat(resolvedAll)
-                    .extracting(InetSocketAddress::getAddress)
-                    .containsExactly(ip("198.51.100.20"), ip("198.51.100.21"));
-            assertThat(resolvedAll)
-                    .extracting(InetSocketAddress::getPort)
-                    .containsOnly(8443);
-            assertThat(nameResolver.resolveHosts).containsExactly("example.test");
-            assertThat(nameResolver.resolveAllHosts).containsExactly("example.test");
+            assertThat(resolver.resolveHosts).containsExactly("Example.Test", "missing.test");
+            assertThat(failure).isInstanceOf(UnknownHostException.class)
+                    .hasMessage("missing.test");
         } finally {
             resolver.close();
         }
-
-        assertThat(nameResolver.closed).isTrue();
     }
 
     @Test
-    void addressResolverGroupCachesResolversPerExecutorAndClosesCreatedResolvers() throws Exception {
-        RecordingAddressResolverGroup group = new RecordingAddressResolverGroup(
+    void nameResolverGroupCachesResolverAndClosesCreatedResolver() throws Exception {
+        RecordingNameResolverGroup group = new RecordingNameResolverGroup(
                 Map.of("example.test", List.of(ip("192.0.2.44")))
         );
-        DefaultEventExecutor otherExecutor = new DefaultEventExecutor();
-
         try {
-            AddressResolver<InetSocketAddress> firstResolver = group.getResolver(EXECUTOR);
-            AddressResolver<InetSocketAddress> cachedResolver = group.getResolver(EXECUTOR);
-            AddressResolver<InetSocketAddress> otherResolver = group.getResolver(otherExecutor);
+            NameResolver<InetSocketAddress> firstResolver = group.getResolver(EXECUTOR);
+            NameResolver<InetSocketAddress> cachedResolver = group.getResolver(EXECUTOR);
 
             assertThat(firstResolver).isSameAs(cachedResolver);
-            assertThat(otherResolver).isNotSameAs(firstResolver);
-            assertThat(group.createdNameResolvers).hasSize(2);
+            assertThat(group.createdNameResolvers).hasSize(1);
 
             InetSocketAddress resolved = firstResolver
-                    .resolve(InetSocketAddress.createUnresolved("example.test", 8080))
+                    .resolve("example.test", 8080)
                     .syncUninterruptibly()
                     .getNow();
 
@@ -174,69 +134,73 @@ public class Netty_resolverTest {
             assertThat(group.createdNameResolvers)
                     .allSatisfy(nameResolver -> assertThat(nameResolver.closed).isTrue());
         } finally {
-            otherExecutor.shutdownGracefully().syncUninterruptibly();
+            group.close();
         }
     }
 
     @Test
-    void roundRobinInetAddressResolverUsesResolveAllResultsForSingleAndBulkLookups() throws Exception {
-        List<InetAddress> addresses = List.of(ip("203.0.113.30"), ip("203.0.113.31"), ip("203.0.113.32"));
-        RecordingNameResolver nameResolver = new RecordingNameResolver(
-                EXECUTOR,
-                Map.of("roundrobin.test", addresses)
-        );
-        RoundRobinInetAddressResolver resolver = new RoundRobinInetAddressResolver(EXECUTOR, nameResolver);
+    void noopNameResolverTreatsSocketAddressesAsAlreadyResolved() {
+        NoopNameResolver resolver = new NoopNameResolver(EXECUTOR);
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("unresolved.example", 8080);
 
         try {
-            InetAddress resolved = resolver.resolve("roundrobin.test").syncUninterruptibly().getNow();
-            List<InetAddress> resolvedAll = resolver.resolveAll("roundrobin.test").syncUninterruptibly().getNow();
+            SocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
 
-            assertThat(resolved).isIn(addresses);
-            assertThat(resolvedAll).containsExactlyInAnyOrderElementsOf(addresses);
-            assertThat(nameResolver.resolveHosts).isEmpty();
-            assertThat(nameResolver.resolveAllHosts).containsExactly("roundrobin.test", "roundrobin.test");
+            assertThat(resolver.isSupported(unresolved)).isTrue();
+            assertThat(resolver.isResolved(unresolved)).isTrue();
+            assertThat(resolved).isSameAs(unresolved);
         } finally {
             resolver.close();
         }
+    }
+
+    @Test
+    void noopNameResolverGroupReusesResolverForExecutor() {
+        try {
+            NameResolver<SocketAddress> resolver = NoopNameResolverGroup.INSTANCE.getResolver(EXECUTOR);
+            NameResolver<SocketAddress> cachedResolver = NoopNameResolverGroup.INSTANCE.getResolver(EXECUTOR);
+            InetSocketAddress unresolved = InetSocketAddress.createUnresolved("pipeline-resolved.example", 443);
+            SocketAddress resolved = resolver.resolve(unresolved).syncUninterruptibly().getNow();
 
-        assertThat(nameResolver.closed).isTrue();
+            assertThat(resolver).isSameAs(cachedResolver);
+            assertThat(resolved).isSameAs(unresolved);
+        } finally {
+            NoopNameResolverGroup.INSTANCE.close();
+        }
     }
 
     private static InetAddress ip(String literal) throws UnknownHostException {
         return InetAddress.getByName(literal);
     }
 
-    private static final class RecordingNameResolver extends SimpleNameResolver<InetAddress> {
+    private static final class RecordingNameResolver extends SimpleNameResolver<InetSocketAddress> {
         private final Map<String, List<InetAddress>> addressesByHost;
         private final List<String> resolveHosts = new ArrayList<>();
-        private final List<String> resolveAllHosts = new ArrayList<>();
         private boolean closed;
 
         private RecordingNameResolver(EventExecutor executor, Map<String, List<InetAddress>> addressesByHost) {
-            super(executor);
+            super(executor, InetSocketAddress.class);
             this.addressesByHost = addressesByHost;
         }
 
         @Override
-        protected void doResolve(String inetHost, Promise<InetAddress> promise) throws Exception {
-            resolveHosts.add(inetHost);
-            List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
-            if (addresses == null || addresses.isEmpty()) {
-                promise.setFailure(new UnknownHostException(inetHost));
-                return;
-            }
-            promise.setSuccess(addresses.get(0));
+        protected boolean doIsResolved(InetSocketAddress address) {
+            return !address.isUnresolved();
         }
 
         @Override
-        protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
-            resolveAllHosts.add(inetHost);
+        protected void doResolve(
+                InetSocketAddress unresolvedAddress,
+                Promise<InetSocketAddress> promise
+        ) throws Exception {
+            String inetHost = unresolvedAddress.getHostString();
+            resolveHosts.add(inetHost);
             List<InetAddress> addresses = addressesByHost.get(normalize(inetHost));
             if (addresses == null || addresses.isEmpty()) {
                 promise.setFailure(new UnknownHostException(inetHost));
                 return;
             }
-            promise.setSuccess(List.copyOf(addresses));
+            promise.setSuccess(new InetSocketAddress(addresses.get(0), unresolvedAddress.getPort()));
         }
 
         @Override
@@ -249,19 +213,19 @@ public class Netty_resolverTest {
         }
     }
 
-    private static final class RecordingAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+    private static final class RecordingNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
         private final Map<String, List<InetAddress>> addressesByHost;
         private final List<RecordingNameResolver> createdNameResolvers = new ArrayList<>();
 
-        private RecordingAddressResolverGroup(Map<String, List<InetAddress>> addressesByHost) {
+        private RecordingNameResolverGroup(Map<String, List<InetAddress>> addressesByHost) {
             this.addressesByHost = addressesByHost;
         }
 
         @Override
-        protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
+        protected NameResolver<InetSocketAddress> newResolver(EventExecutor executor) {
             RecordingNameResolver nameResolver = new RecordingNameResolver(executor, addressesByHost);
             createdNameResolvers.add(nameResolver);
-            return new InetSocketAddressResolver(executor, nameResolver);
+            return nameResolver;
         }
     }
 }

```
