### PR TITLE
Make Forge automation branches deterministic

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -30,6 +30,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
     SUCCESS_WITH_INTERVENTION_STATUS,
 )
 from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
+from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts import metrics_writer
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics, validate_benchmark_run_metrics
@@ -218,10 +219,11 @@ def create_feature_branch_for_library(group, artifact, library_version):
     """
     Reset the feature branch for the given coordinates to the current detached HEAD.
     Branch name is in the following format:
-    ai/add-lib-support-<group>-<artifact>-<version>
+    ai/<login>/add-lib-support-<group>-<artifact>-<version>
     """
 
-    new_branch = f"ai/add-lib-support-{group}-{artifact}-{library_version}"
+    new_branch = build_ai_branch_name(f"add-lib-support-{group}-{artifact}-{library_version}")
+    delete_remote_branch_if_exists(new_branch)
     subprocess.run(
         ["git", "switch", "-C", new_branch],
         check=True,

--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
+from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
 from utility_scripts.source_context import populate_artifact_urls
@@ -79,6 +80,7 @@ def run_gradle_test(
 
 def create_or_switch_branch(reachability_metadata_path: str, branch: str) -> None:
     """Reset the workflow branch to the current detached HEAD."""
+    delete_remote_branch_if_exists(branch, cwd=reachability_metadata_path)
     subprocess.run(
         ["git", "switch", "-C", branch],
         cwd=reachability_metadata_path,
@@ -100,7 +102,10 @@ def main(argv=None) -> int:
     new_version = args.new_version
 
     group, artifact, _ = current_coordinates.split(":")
-    branch = f"auto/fix-{group}-{artifact}-{new_version}"
+    branch = build_ai_branch_name(
+        f"fix-native-image-run-{group}-{artifact}-{new_version}",
+        cwd=reachability_metadata_path,
+    )
     print(f"[pipeline] Creating branch: {branch}")
     create_or_switch_branch(reachability_metadata_path, branch)
 

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -19,7 +19,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
     SUCCESS_WITH_INTERVENTION_STATUS,
 )
 from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
-from git_scripts.common_git import build_ai_branch_name, ensure_gh_authenticated
+from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
@@ -232,6 +232,7 @@ def create_project_prep_checkpoint(config: JavaFailWorkflowConfig, group, artifa
     new_branch = build_ai_branch_name(
         f"{config.branch_prefix}-{group}-{artifact}-{updated_library_version}",
     )
+    delete_remote_branch_if_exists(new_branch)
     subprocess.run(
         ["git", "switch", "-C", new_branch],
         check=True,

--- a/forge/benchmarks/benchmark_runner.py
+++ b/forge/benchmarks/benchmark_runner.py
@@ -30,6 +30,7 @@ BENCHMARK_WORKTREE_DIRNAME = "forge_benchmark_worktrees"
 
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
 from utility_scripts.metrics_writer import count_metadata_entries
+from git_scripts.common_git import build_ai_branch_name
 
 
 def parse_args(argv):
@@ -414,7 +415,7 @@ def main(argv: Optional[List[str]] = None):
 
         for coords in libraries:
             group, artifact, library_version = split_coords(coords)
-            new_branch = f"ai/add-lib-support-{group}-{artifact}-{library_version}"
+            new_branch = build_ai_branch_name(f"add-lib-support-{group}-{artifact}-{library_version}")
             subprocess.run([
                 "git",
                 "branch",

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -284,6 +284,37 @@ def build_ai_branch_name(branch_suffix: str, cwd=None) -> str:
     return f"ai/{authenticated_login}/{branch_suffix}"
 
 
+def git_remote_branch_exists(branch: str, remote: str = "origin", cwd: str | None = None) -> bool:
+    """Return True when the remote has a branch with this name."""
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--heads", remote, branch],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    print(
+        f"ERROR: Failed to check whether `{remote}/{branch}` exists:\n{result.stderr.strip()}",
+        file=sys.stderr,
+    )
+    result.check_returncode()
+    return False
+
+
+def delete_remote_branch_if_exists(branch: str, remote: str = "origin", cwd: str | None = None) -> bool:
+    """Delete a remote branch when it exists, returning True if deletion ran."""
+    if not git_remote_branch_exists(branch, remote=remote, cwd=cwd):
+        return False
+    print(f"[git-branch] Deleting existing remote branch {remote}/{branch}.")
+    subprocess.run(["git", "push", remote, "--delete", branch], cwd=cwd, check=True)
+    return True
+
+
 def _project_item_status_fields() -> str:
     """Return the reusable GraphQL selection for project item status lookup."""
     return """

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -19,6 +19,7 @@ from git_scripts.common_git import (
     format_stats_diff,
     format_forge_revision_section,
     build_ai_branch_name,
+    delete_remote_branch_if_exists,
 )
 from git_scripts.make_pr_javac_fix import generate_diff_text
 from utility_scripts.library_stats import stats_artifact_dir
@@ -241,9 +242,10 @@ def push_current_branch_to_origin(
         f"fix-java-run-{group}-{artifact}-{new_version}",
         cwd=repo_path,
     )
+    delete_remote_branch_if_exists(branch, cwd=repo_path)
     subprocess.run(
-        ["git", "switch", branch],
-        check=False,
+        ["git", "switch", "-C", branch],
+        check=True,
         cwd=repo_path,
     )
     stage_and_commit(

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -23,6 +23,7 @@ from git_scripts.common_git import (
     format_stats_diff,
     format_forge_revision_section,
     build_ai_branch_name,
+    delete_remote_branch_if_exists,
     get_configured_reviewers,
 )
 from utility_scripts.library_stats import stats_artifact_dir
@@ -329,9 +330,10 @@ def push_current_branch_to_origin(
         f"fix-javac-{group}-{artifact}-{new_version}",
         cwd=repo_path,
     )
+    delete_remote_branch_if_exists(branch, cwd=repo_path)
     subprocess.run(
-        ["git", "switch", branch],
-        check=False,
+        ["git", "switch", "-C", branch],
+        check=True,
         cwd=repo_path,
     )
     stage_and_commit(

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -21,6 +21,7 @@ from git_scripts.common_git import (
     format_stats_section,
     format_forge_revision_section,
     build_ai_branch_name,
+    delete_remote_branch_if_exists,
     get_configured_reviewers,
 )
 from utility_scripts.metrics_writer import (
@@ -286,6 +287,7 @@ def push_current_branch_to_origin(coordinates, repo_path, metrics_repo_path=None
         f"add-lib-support-{group}-{artifact}-{library_version}",
         cwd=repo_path,
     )
+    delete_remote_branch_if_exists(new_branch, cwd=repo_path)
     subprocess.run(["git", "switch", "-C", new_branch], check=True, cwd=repo_path)
 
     stage_and_commit(
@@ -300,15 +302,6 @@ def push_current_branch_to_origin(coordinates, repo_path, metrics_repo_path=None
 
     base_ref = _fetch_pr_base(repo_path)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    remote_branch = subprocess.run(
-        ["git", "ls-remote", "--exit-code", "--heads", "origin", new_branch],
-        cwd=repo_path,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    if remote_branch.returncode == 0:
-        subprocess.run(["git", "push", "origin", "--delete", new_branch], check=True, cwd=repo_path)
-
     subprocess.run(
         ["git", "push", "origin", new_branch],
         check=True,

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -16,6 +16,8 @@ from git_scripts.common_git import (
     find_issue_for_coordinates as find_issue_common,
     format_stats_diff,
     format_forge_revision_section,
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
     get_configured_reviewers,
 )
 from utility_scripts.metrics_writer import (
@@ -195,9 +197,13 @@ def push_current_branch_to_origin(
     group, artifact, old_version = parse_coordinate_parts(old_coordinates)
     new_coordinates = f"{group}:{artifact}:{new_version}"
 
-    branch = f"auto/fix-{group}-{artifact}-{new_version}"
+    branch = build_ai_branch_name(
+        f"fix-native-image-run-{group}-{artifact}-{new_version}",
+        cwd=repo_path,
+    )
+    delete_remote_branch_if_exists(branch, cwd=repo_path)
     subprocess.run(
-        ["git", "switch", branch],
+        ["git", "switch", "-C", branch],
         cwd=repo_path,
         check=True,
     )

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -23,6 +23,29 @@ class ForgeRevisionSectionTests(unittest.TestCase):
         self.assertIn("- Forge commit hash: `abc123`", section)
 
 
+class RemoteBranchDeletionTests(unittest.TestCase):
+    def test_delete_remote_branch_if_exists_skips_missing_remote_branch(self) -> None:
+        with patch.object(common_git, "git_remote_branch_exists", return_value=False), \
+                patch.object(common_git.subprocess, "run") as run:
+            deleted = common_git.delete_remote_branch_if_exists("ai/user/fix-lib")
+
+        self.assertFalse(deleted)
+        run.assert_not_called()
+
+    def test_delete_remote_branch_if_exists_deletes_existing_remote_branch(self) -> None:
+        with patch.object(common_git, "git_remote_branch_exists", return_value=True), \
+                patch.object(common_git.subprocess, "run") as run, \
+                patch("sys.stdout", new_callable=io.StringIO):
+            deleted = common_git.delete_remote_branch_if_exists("ai/user/fix-lib", cwd="/repo")
+
+        self.assertTrue(deleted)
+        run.assert_called_once_with(
+            ["git", "push", "origin", "--delete", "ai/user/fix-lib"],
+            cwd="/repo",
+            check=True,
+        )
+
+
 class GitHubRateLimitTests(unittest.TestCase):
     def test_common_gh_raises_typed_rate_limit_error_from_stderr(self) -> None:
         completed_process = subprocess.CompletedProcess(


### PR DESCRIPTION
## What does this PR do?

Fixes: #3408

This PR keeps Forge automation branch names deterministic per job type, GitHub login, library group, artifact, and version. Before starting or publishing generated work, Forge now deletes the matching remote branch if it already exists, avoiding non-fast-forward push failures during finalization.

Summary:
- Add shared helpers for detecting and deleting remote branches.
- Reset deterministic remote branches for new-library, javac, java-run, and native-image-run workflows.
- Align Native Image run branch names with the `ai/<login>/<job-type>-<group>-<artifact>-<version>` format.
- Update benchmark cleanup and add unit coverage for remote branch deletion.

Testing:
- `python3 -m py_compile git_scripts/common_git.py git_scripts/make_pr_javac_fix.py git_scripts/make_pr_java_run_fix.py git_scripts/make_pr_new_library_support.py git_scripts/make_pr_ni_run_fix.py ai_workflows/java_fail_workflow.py ai_workflows/add_new_library_support.py ai_workflows/fix_ni_run.py benchmarks/benchmark_runner.py`
- `python3 -m unittest tests.test_common_git`
- `python3 -m unittest discover tests`
- `git diff --check`