### PR TITLE
Review library bulk update PRs by default

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -38,8 +38,8 @@ FORGE_REVIEW_LABEL=library-new-request ./do-work.sh --review-limit 2
 
 The same limits can be controlled with environment variables such as
 `FORGE_WORK_LIMIT`, `FORGE_JAVAC_WORK_LIMIT`, `FORGE_JAVA_RUN_WORK_LIMIT`,
-`FORGE_NI_RUN_WORK_LIMIT`, `FORGE_REVIEW_LIMIT`, and
-`DO_WORK_SLEEP_SECONDS`.
+`FORGE_NI_RUN_WORK_LIMIT`, `FORGE_REVIEW_LIMIT`,
+`FORGE_BULK_UPDATE_REVIEW_LIMIT`, and `DO_WORK_SLEEP_SECONDS`.
 
 ## Setup
 

--- a/forge/do-work.sh
+++ b/forge/do-work.sh
@@ -63,8 +63,8 @@ Options:
   --review-limit N
       Process up to N review tasks per PR label per run; 0 disables review queues.
       Defaults to FORGE_REVIEW_LIMIT, then 1. Without FORGE_REVIEW_LABEL, reviews
-      library-new-request, fixes-javac-fail, fixes-java-run-fail, and
-      fixes-native-image-run-fail PRs each cycle.
+      library-new-request, fixes-javac-fail, fixes-java-run-fail,
+      fixes-native-image-run-fail, and library-bulk-update PRs each cycle.
   --in-metadata-repo
       Deprecated compatibility no-op; in-repo mode is always used.
 
@@ -88,7 +88,7 @@ Environment:
       Deprecated compatibility switch. Defaults to 1 because Forge now always
       runs inside the reachability metadata repo.
   FORGE_LIBRARY_REVIEW_LIMIT, FORGE_JAVAC_REVIEW_LIMIT, FORGE_JAVA_RUN_REVIEW_LIMIT,
-  FORGE_NI_RUN_REVIEW_LIMIT
+  FORGE_NI_RUN_REVIEW_LIMIT, FORGE_BULK_UPDATE_REVIEW_LIMIT
       Override FORGE_REVIEW_LIMIT for one default review queue.
 
 Examples:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -118,6 +118,7 @@ LABEL_NI_RUN_FAIL = "fails-native-image-run"
 LABEL_PR_JAVAC_FIX = "fixes-javac-fail"
 LABEL_PR_JAVA_RUN_FIX = "fixes-java-run-fail"
 LABEL_PR_NI_RUN_FIX = "fixes-native-image-run-fail"
+LABEL_PR_LIBRARY_BULK_UPDATE = "library-bulk-update"
 LABEL_PRIORITY = "priority"
 LABEL_HUMAN_INTERVENTION = "human-intervention"
 
@@ -2432,6 +2433,11 @@ def get_review_queue_configs_from_environment() -> list[ReviewQueueConfig]:
         ReviewQueueConfig(
             label=LABEL_PR_NI_RUN_FIX,
             limit=get_env_non_negative_int("FORGE_NI_RUN_REVIEW_LIMIT", review_limit),
+            model=review_model,
+        ),
+        ReviewQueueConfig(
+            label=LABEL_PR_LIBRARY_BULK_UPDATE,
+            limit=get_env_non_negative_int("FORGE_BULK_UPDATE_REVIEW_LIMIT", review_limit),
             model=review_model,
         ),
     ]

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -515,6 +515,46 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             ],
         )
 
+    def test_default_review_queue_configs_include_bulk_update_reviews(self) -> None:
+        env = {
+            "FORGE_REVIEW_LIMIT": "2",
+            "FORGE_LIBRARY_REVIEW_LIMIT": "0",
+            "FORGE_BULK_UPDATE_REVIEW_LIMIT": "4",
+            "FORGE_REVIEW_MODEL": "review-model",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            configs = forge_metadata.get_review_queue_configs_from_environment()
+
+        self.assertEqual(
+            [(config.label, config.limit, config.model) for config in configs],
+            [
+                (forge_metadata.LABEL_LIBRARY_NEW, 0, "review-model"),
+                (forge_metadata.LABEL_PR_JAVAC_FIX, 2, "review-model"),
+                (forge_metadata.LABEL_PR_JAVA_RUN_FIX, 2, "review-model"),
+                (forge_metadata.LABEL_PR_NI_RUN_FIX, 2, "review-model"),
+                (forge_metadata.LABEL_PR_LIBRARY_BULK_UPDATE, 4, "review-model"),
+            ],
+        )
+
+    def test_review_label_environment_overrides_default_review_queues(self) -> None:
+        env = {
+            "FORGE_REVIEW_LABEL": forge_metadata.LABEL_PR_LIBRARY_BULK_UPDATE,
+            "FORGE_REVIEW_LIMIT": "3",
+            "FORGE_BULK_UPDATE_REVIEW_LIMIT": "0",
+            "FORGE_REVIEW_MODEL": "review-model",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            configs = forge_metadata.get_review_queue_configs_from_environment()
+
+        self.assertEqual(
+            [(config.label, config.limit, config.model) for config in configs],
+            [
+                (forge_metadata.LABEL_PR_LIBRARY_BULK_UPDATE, 3, "review-model"),
+            ],
+        )
+
     def test_process_work_queues_skips_zero_limit_queues(self) -> None:
         env = {
             "FORGE_JAVAC_WORK_LIMIT": "0",


### PR DESCRIPTION
Fixes #3410.

### Summary
- Adds `library-bulk-update` to Forge default review queues.
- Adds `FORGE_BULK_UPDATE_REVIEW_LIMIT` for per-queue review throttling.
- Documents the new queue and limit override.
- Covers default and explicit label queue selection in Forge unit tests.

### Testing
- `python3 -m unittest tests.test_forge_metadata` from `forge/`