### PR TITLE
[GenAI] Test fix for org.jsoup:jsoup:1.15.1 using gpt-5.5

### DIFF
--- a/metadata/org.jsoup/jsoup/1.15.1/reachability-metadata.json
+++ b/metadata/org.jsoup/jsoup/1.15.1/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jsoup.internal.StringUtil"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/org.jsoup/jsoup/index.json
+++ b/metadata/org.jsoup/jsoup/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.15.1",
+    "tested-versions" : [
+      "1.15.1"
+    ],
+    "allowed-packages" : [
+      "org.jsoup"
+    ]
+  },
+  {
     "metadata-version" : "1.13.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1-sources.jar",
     "repository-url" : "https://github.com/jhy/jsoup",

--- a/metadata/org.jsoup/jsoup/index.json
+++ b/metadata/org.jsoup/jsoup/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.15.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.15.1/jsoup-1.15.1-sources.jar",
+    "repository-url" : "https://github.com/jhy/jsoup",
+    "test-code-url" : "https://github.com/jhy/jsoup/tree/jsoup-1.15.1/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.15.1/jsoup-1.15.1-javadoc.jar",
+    "description" : "jsoup is a Java library for parsing, cleaning, extracting, and manipulating real-world HTML. It provides a DOM API with CSS selector and jQuery-like methods while following the WHATWG HTML5 parsing model.",
     "tested-versions" : [
       "1.15.1"
     ],

--- a/stats/org.jsoup/jsoup/1.15.1/execution-metrics.json
+++ b/stats/org.jsoup/jsoup/1.15.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T20:53:44.157686Z",
+    "library": "org.jsoup:jsoup:1.15.1",
+    "starting_commit": "4f742a3749e346dfda4399b1d81422e547070217",
+    "ending_commit": "935005731721359ec73396739130773094b2ca13",
+    "previous_library": "org.jsoup:jsoup:1.13.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.15.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16928,
+          "missed": 19926,
+          "ratio": 0.459326,
+          "total": 36854
+        },
+        "line": {
+          "covered": 3317,
+          "missed": 4848,
+          "ratio": 0.406246,
+          "total": 8165
+        },
+        "method": {
+          "covered": 787,
+          "missed": 811,
+          "ratio": 0.492491,
+          "total": 1598
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.13.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16588,
+          "missed": 17751,
+          "ratio": 0.483066,
+          "total": 34339
+        },
+        "line": {
+          "covered": 3140,
+          "missed": 4294,
+          "ratio": 0.422384,
+          "total": 7434
+        },
+        "method": {
+          "covered": 754,
+          "missed": 724,
+          "ratio": 0.510149,
+          "total": 1478
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 19097,
+      "cached_input_tokens_used": 109056,
+      "output_tokens_used": 1021,
+      "iterations": 1,
+      "cost_usd": 0.0851,
+      "tested_library_loc": 3317,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 40.62,
+      "previous_library_coverage_percent": 42.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java",
+      "metadata_file": "metadata/org.jsoup/jsoup/1.15.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jsoup/jsoup/1.15.1/stats.json
+++ b/stats/org.jsoup/jsoup/1.15.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.15.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 16928,
+        "missed" : 19926,
+        "ratio" : 0.459326,
+        "total" : 36854
+      },
+      "line" : {
+        "covered" : 3317,
+        "missed" : 4848,
+        "ratio" : 0.406246,
+        "total" : 8165
+      },
+      "method" : {
+        "covered" : 787,
+        "missed" : 811,
+        "ratio" : 0.492491,
+        "total" : 1598
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jsoup/jsoup/1.15.1/.gitignore
+++ b/tests/src/org.jsoup/jsoup/1.15.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jsoup/jsoup/1.15.1/build.gradle
+++ b/tests/src/org.jsoup/jsoup/1.15.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jsoup:jsoup:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jsoup/jsoup/1.15.1/gradle.properties
+++ b/tests/src/org.jsoup/jsoup/1.15.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jsoup:jsoup:1.15.1
+library.version = 1.15.1
+metadata.dir = org.jsoup/jsoup/1.15.1/

--- a/tests/src/org.jsoup/jsoup/1.15.1/settings.gradle
+++ b/tests/src/org.jsoup/jsoup/1.15.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jsoup.jsoup_tests'

--- a/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
+++ b/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jsoup.jsoup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Entities;
+import org.jsoup.nodes.FormElement;
+import org.jsoup.nodes.Node;
+import org.jsoup.parser.Parser;
+import org.jsoup.safety.Whitelist;
+import org.jsoup.select.Elements;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import org.junit.jupiter.api.Test;
+
+public class JsoupTest {
+    @Test
+    public void parsesHtmlDocumentAndExposesDomNavigation() {
+        String html = """
+                <!doctype html>
+                <html>
+                <head>
+                    <title>Example article</title>
+                    <meta charset="utf-8">
+                </head>
+                <body>
+                    <nav><a href="../about">About</a></nav>
+                    <article id="story" class="post featured" data-id="42">
+                        <h1>Readable HTML</h1>
+                        <p class="lead">Jsoup parses <em>real-world</em> markup.</p>
+                        <p>Second paragraph with <a href="/docs/start.html?x=1#top">docs</a>.</p>
+                    </article>
+                </body>
+                </html>
+                """;
+
+        Document document = Jsoup.parse(html, "file:/news/index.html");
+        Element article = requireFirst(document, "article.post.featured[data-id=42]");
+        Element lead = requireFirst(article, "p.lead");
+        Element docsLink = requireFirst(article, "p + p a[href]");
+
+        assertThat(document.title()).isEqualTo("Example article");
+        assertThat(document.charset().name()).isEqualTo("UTF-8");
+        assertThat(article.id()).isEqualTo("story");
+        assertThat(article.classNames()).containsExactlyInAnyOrder("post", "featured");
+        assertThat(article.dataset()).containsEntry("id", "42");
+        assertThat(lead.ownText()).isEqualTo("Jsoup parses markup.");
+        assertThat(lead.text()).isEqualTo("Jsoup parses real-world markup.");
+        assertThat(docsLink.absUrl("href")).isEqualTo("file:/docs/start.html?x=1#top");
+        assertThat(requireFirst(document, "nav a").absUrl("href")).isEqualTo("file:/about");
+    }
+
+    @Test
+    public void selectsElementsWithCombinatorsPseudoSelectorsAndAttributeQueries() {
+        Document document = Jsoup.parse("""
+                <main>
+                    <section class="catalog" data-region="eu-west">
+                        <h2>Books</h2>
+                        <ul>
+                            <li data-sku="book-001" class="item selected"><span class="name">Native Java</span> <b>19.99</b></li>
+                            <li data-sku="book-002" class="item"><span class="name">HTML Parsing</span> <b>24.50</b></li>
+                            <li data-sku="mag-101" class="item"><span class="name">Monthly Digest</span> <b>4.99</b></li>
+                        </ul>
+                    </section>
+                    <section class="catalog" data-region="us-east">
+                        <h2>Music</h2>
+                        <p class="empty">No products yet</p>
+                    </section>
+                </main>
+                """);
+
+        Elements catalogSections = document.select("section.catalog:has(li.item)");
+        Elements bookItems = document.select("section[data-region^=eu] li[data-sku^=book-]");
+        Elements matchedByTextItems = document.select("li.item:matches(HTML Parsing|Monthly Digest)");
+        Elements followingItems = document.select("li.selected ~ li");
+
+        assertThat(catalogSections).hasSize(1);
+        assertThat(bookItems.eachText()).containsExactly("Native Java 19.99", "HTML Parsing 24.50");
+        assertThat(document.select("li.item:nth-of-type(2) .name").text()).isEqualTo("HTML Parsing");
+        assertThat(document.select("p:containsOwn(No products yet)")).hasSize(1);
+        assertThat(document.select("li[data-sku$=101]").text()).isEqualTo("Monthly Digest 4.99");
+        assertThat(followingItems).hasSize(2);
+        assertThat(document.select("section.catalog:not([data-region=eu-west]) h2").text()).isEqualTo("Music");
+        assertThat(matchedByTextItems.eachText()).containsExactly("HTML Parsing 24.50", "Monthly Digest 4.99");
+    }
+
+    @Test
+    public void mutatesElementsAttributesAndGeneratedMarkup() {
+        Document document = Jsoup.parseBodyFragment("<div id='root'><p class='intro'>Hello</p></div>");
+        document.outputSettings().prettyPrint(false);
+        Element root = requireFirst(document, "#root");
+        Element intro = requireFirst(root, "p.intro");
+
+        root.prependElement("header").text("Title");
+        Element list = root.appendElement("ol").attr("data-kind", "steps");
+        list.appendElement("li").text("Parse");
+        list.appendElement("li").text("Select");
+        list.appendElement("li").text("Manipulate");
+        intro.addClass("lead").attr("data-source", "fixture").text("Hello jsoup");
+        intro.before("<aside>Before paragraph</aside>");
+        intro.after("<aside>After paragraph</aside>");
+        intro.toggleClass("intro");
+
+        assertThat(root.children().eachText())
+                .containsExactly("Title", "Before paragraph", "Hello jsoup", "After paragraph", "Parse Select Manipulate");
+        assertThat(intro.hasClass("intro")).isFalse();
+        assertThat(intro.hasClass("lead")).isTrue();
+        assertThat(intro.dataset()).containsEntry("source", "fixture");
+        assertThat(list.children().eachText()).containsExactly("Parse", "Select", "Manipulate");
+        assertThat(document.body().html()).contains("<p class=\"lead\" data-source=\"fixture\">Hello jsoup</p>");
+    }
+
+    @Test
+    public void sanitizesUntrustedHtmlWithCustomWhitelist() {
+        String dirtyHtml = """
+                <section data-safe="yes" data-secret="no">
+                    <h1>Welcome</h1>
+                    <script>alert('x')</script>
+                    <p onclick="steal()">Read <a href="https://example.test/read" rel="nofollow">more</a></p>
+                    <a href="javascript:alert(1)">bad link</a>
+                    <img src="https://example.test/logo.png" onerror="steal()" alt="logo">
+                </section>
+                """;
+        Whitelist whitelist = Whitelist.relaxed()
+                .addTags("section")
+                .addAttributes("section", "data-safe")
+                .addProtocols("a", "href", "https")
+                .addProtocols("img", "src", "https");
+
+        String sanitized = Jsoup.clean(dirtyHtml, whitelist);
+        Document cleaned = Jsoup.parseBodyFragment(sanitized);
+        Element section = requireFirst(cleaned, "section[data-safe=yes]");
+        Element safeLink = requireFirst(cleaned, "a[href='https://example.test/read']");
+        Element image = requireFirst(cleaned, "img[src='https://example.test/logo.png']");
+
+        assertThat(cleaned.select("script")).isEmpty();
+        assertThat(cleaned.select("[onclick], [onerror], [data-secret]")).isEmpty();
+        assertThat(cleaned.select("a[href^=javascript]")).isEmpty();
+        assertThat(section.text()).contains("Welcome", "Read more", "bad link");
+        assertThat(safeLink.text()).isEqualTo("more");
+        assertThat(image.attr("alt")).isEqualTo("logo");
+    }
+
+    @Test
+    public void parsesXmlWhilePreservingCaseNamespacesAndTextNodes() {
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <feed xmlns:media="https://example.test/media">
+                    <entry id="a1">
+                        <Title>First &amp; Foremost</Title>
+                        <media:thumbnail url="https://example.test/thumb.png" width="64" />
+                    </entry>
+                    <entry id="a2"><Title>Second</Title></entry>
+                </feed>
+                """;
+
+        Document document = Jsoup.parse(xml, "", Parser.xmlParser());
+        document.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+        Element firstEntry = requireFirst(document, "entry[id=a1]");
+        Element thumbnail = document.getElementsByTag("media:thumbnail").first();
+        List<String> rootChildNodeNames = document.childNodes().stream()
+                .map(Node::nodeName)
+                .collect(Collectors.toList());
+
+        assertThat(document.select("Title").eachText()).containsExactly("First & Foremost", "Second");
+        assertThat(firstEntry.children().first().tagName()).isEqualTo("Title");
+        assertThat(thumbnail).isNotNull();
+        assertThat(thumbnail.attr("url")).isEqualTo("https://example.test/thumb.png");
+        assertThat(thumbnail.attr("width")).isEqualTo("64");
+        assertThat(rootChildNodeNames).contains("#declaration", "feed");
+    }
+
+    @Test
+    public void extractsSubmittedFormDataFromControls() {
+        Document document = Jsoup.parse("""
+                <form id="search" action="/submit" method="post">
+                    <input type="text" name="q" value="graalvm">
+                    <input type="password" name="ignored" value="secret" disabled>
+                    <input type="checkbox" name="feature" value="metadata" checked>
+                    <input type="checkbox" name="feature" value="agent">
+                    <input type="radio" name="mode" value="fast">
+                    <input type="radio" name="mode" value="safe" checked>
+                    <select name="format">
+                        <option value="html">HTML</option>
+                        <option value="xml" selected>XML</option>
+                    </select>
+                    <textarea name="notes">Use public APIs</textarea>
+                    <button type="button" value="go">Go</button>
+                </form>
+                """, "https://example.test/app/index.html");
+        FormElement form = (FormElement) requireFirst(document, "form#search");
+        requireFirst(form, "input[name=q]").val("native image");
+        requireFirst(form, "option[value=xml]").removeAttr("selected");
+        requireFirst(form, "option[value=html]").attr("selected", "selected");
+
+        List<Connection.KeyVal> formData = form.formData();
+        Map<String, List<String>> valuesByKey = formData.stream()
+                .collect(Collectors.groupingBy(
+                        Connection.KeyVal::key,
+                        LinkedHashMap::new,
+                        Collectors.mapping(Connection.KeyVal::value, Collectors.toList())));
+
+        assertThat(form.attr("action")).isEqualTo("/submit");
+        assertThat(form.attr("method")).isEqualTo("post");
+        assertThat(valuesByKey).containsEntry("q", List.of("native image"));
+        assertThat(valuesByKey).containsEntry("feature", List.of("metadata"));
+        assertThat(valuesByKey).containsEntry("mode", List.of("safe"));
+        assertThat(valuesByKey).containsEntry("format", List.of("html"));
+        assertThat(valuesByKey).containsEntry("notes", List.of("Use public APIs"));
+        assertThat(valuesByKey).doesNotContainKey("ignored");
+        assertThat(valuesByKey).doesNotContainKey("submit");
+    }
+
+    @Test
+    public void controlsOutputEscapingCharsetAndSyntax() {
+        Document document = Jsoup.parseBodyFragment("<p title='snowman \u2603 & copy \u00a9'>5 < 7 & \u03c0</p><br>");
+        Document.OutputSettings outputSettings = new Document.OutputSettings()
+                .charset("US-ASCII")
+                .escapeMode(Entities.EscapeMode.xhtml)
+                .syntax(Document.OutputSettings.Syntax.xml)
+                .prettyPrint(false);
+        document.outputSettings(outputSettings);
+
+        String escapedText = Entities.escape("\u00a9 \u03c0 \u2603 & <", document.outputSettings());
+        Document.OutputSettings clonedSettings = document.outputSettings().clone()
+                .charset("UTF-8")
+                .escapeMode(Entities.EscapeMode.extended);
+
+        assertThat(document.body().html())
+                .isEqualTo("<p title=\"snowman &#x2603; &amp; copy &#xa9;\">5 &lt; 7 &amp; &#x3c0;</p><br />");
+        assertThat(escapedText).isEqualTo("&#xa9; &#x3c0; &#x2603; &amp; &lt;");
+        assertThat(document.outputSettings().charset().name()).isEqualTo("US-ASCII");
+        assertThat(document.outputSettings().escapeMode()).isEqualTo(Entities.EscapeMode.xhtml);
+        assertThat(document.outputSettings().syntax()).isEqualTo(Document.OutputSettings.Syntax.xml);
+        assertThat(clonedSettings.charset().name()).isEqualTo("UTF-8");
+        assertThat(clonedSettings.escapeMode()).isEqualTo(Entities.EscapeMode.extended);
+    }
+
+    @Test
+    public void iteratesAttributesAndKeepsTextAndHtmlEscapingDistinct() {
+        Document document = Jsoup.parseBodyFragment("<a id='download' href='/file?a=1&amp;b=2' title='A &amp; B'>A &amp; B</a>");
+        Element link = requireFirst(document, "a#download");
+        Map<String, String> attributes = new LinkedHashMap<>();
+        for (Attribute attribute : link.attributes()) {
+            attributes.put(attribute.getKey(), attribute.getValue());
+        }
+
+        assertThat(attributes).containsEntry("href", "/file?a=1&b=2");
+        assertThat(attributes).containsEntry("title", "A & B");
+        assertThat(link.text()).isEqualTo("A & B");
+        assertThat(link.html()).isEqualTo("A &amp; B");
+        assertThat(link.outerHtml()).contains("href=\"/file?a=1&amp;b=2\"");
+    }
+
+    @Test
+    public void traversesNodeTreeWithDepthAwareVisitorCallbacks() {
+        Document document = Jsoup.parseBodyFragment("<article><h1>Title</h1><p>Lead <em>details</em></p><!-- editorial note --></article>");
+        Element article = requireFirst(document, "article");
+        List<String> events = new ArrayList<>();
+
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                events.add("enter:" + depth + ":" + node.nodeName());
+            }
+
+            @Override
+            public void tail(Node node, int depth) {
+                if (node instanceof Element) {
+                    events.add("exit:" + depth + ":" + node.nodeName());
+                }
+            }
+        }, article);
+
+        assertThat(events).containsExactly(
+                "enter:0:article",
+                "enter:1:h1",
+                "enter:2:#text",
+                "exit:1:h1",
+                "enter:1:p",
+                "enter:2:#text",
+                "enter:2:em",
+                "enter:3:#text",
+                "exit:2:em",
+                "exit:1:p",
+                "enter:1:#comment",
+                "exit:0:article");
+    }
+
+    private static Element requireFirst(Element root, String cssQuery) {
+        Element element = root.selectFirst(cssQuery);
+        assertThat(element).as("Expected selector <%s> under <%s> to match", cssQuery, root.nodeName()).isNotNull();
+        return element;
+    }
+}

--- a/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
+++ b/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
@@ -23,7 +23,7 @@ import org.jsoup.nodes.Entities;
 import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
 import org.jsoup.parser.Parser;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
@@ -137,13 +137,13 @@ public class JsoupTest {
                     <img src="https://example.test/logo.png" onerror="steal()" alt="logo">
                 </section>
                 """;
-        Whitelist whitelist = Whitelist.relaxed()
+        Safelist safelist = Safelist.relaxed()
                 .addTags("section")
                 .addAttributes("section", "data-safe")
                 .addProtocols("a", "href", "https")
                 .addProtocols("img", "src", "https");
 
-        String sanitized = Jsoup.clean(dirtyHtml, whitelist);
+        String sanitized = Jsoup.clean(dirtyHtml, safelist);
         Document cleaned = Jsoup.parseBodyFragment(sanitized);
         Element section = requireFirst(cleaned, "section[data-safe=yes]");
         Element safeLink = requireFirst(cleaned, "a[href='https://example.test/read']");

--- a/tests/src/org.jsoup/jsoup/1.15.1/user-code-filter.json
+++ b/tests/src/org.jsoup/jsoup/1.15.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jsoup.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3358

This PR provides test fixes and new metadata for org.jsoup:jsoup:1.15.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 19097
- Cached input tokens: 109056
- Output tokens: 1021
- Entries found: 1
- Iterations: 1
- Library coverage percentage: 40.62
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 42.24

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jsoup:jsoup:1.13.1: 0/0 covered calls (100.00%)
- org.jsoup:jsoup:1.15.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jsoup:jsoup:1.13.1: 16588/34339 (48.31%)
- org.jsoup:jsoup:1.15.1: 16928/36854 (45.93%)

**Line:**
- org.jsoup:jsoup:1.13.1: 3140/7434 (42.24%)
- org.jsoup:jsoup:1.15.1: 3317/8165 (40.62%)

**Method:**
- org.jsoup:jsoup:1.13.1: 754/1478 (51.01%)
- org.jsoup:jsoup:1.15.1: 787/1598 (49.25%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jsoup/jsoup/1.13.1/src/test/java/org_jsoup/jsoup/JsoupTest.java 2/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
index d4b6b92d91..66aba880bb 100644
--- 1/tests/src/org.jsoup/jsoup/1.13.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
+++ 2/tests/src/org.jsoup/jsoup/1.15.1/src/test/java/org_jsoup/jsoup/JsoupTest.java
@@ -23,7 +23,7 @@ import org.jsoup.nodes.Entities;
 import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
 import org.jsoup.parser.Parser;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
@@ -137,13 +137,13 @@ public class JsoupTest {
                     <img src="https://example.test/logo.png" onerror="steal()" alt="logo">
                 </section>
                 """;
-        Whitelist whitelist = Whitelist.relaxed()
+        Safelist safelist = Safelist.relaxed()
                 .addTags("section")
                 .addAttributes("section", "data-safe")
                 .addProtocols("a", "href", "https")
                 .addProtocols("img", "src", "https");
 
-        String sanitized = Jsoup.clean(dirtyHtml, whitelist);
+        String sanitized = Jsoup.clean(dirtyHtml, safelist);
         Document cleaned = Jsoup.parseBodyFragment(sanitized);
         Element section = requireFirst(cleaned, "section[data-safe=yes]");
         Element safeLink = requireFirst(cleaned, "a[href='https://example.test/read']");

```
