### PR TITLE
[GenAI] Test fix for org.iq80.snappy:snappy:0.5 using gpt-5.5

### DIFF
--- a/metadata/org.iq80.snappy/snappy/0.5/reachability-metadata.json
+++ b/metadata/org.iq80.snappy/snappy/0.5/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.iq80.snappy.UnsafeUtil"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.iq80.snappy/snappy/index.json
+++ b/metadata/org.iq80.snappy/snappy/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.5",
+    "tested-versions" : [
+      "0.5"
+    ],
+    "allowed-packages" : [
+      "org.iq80.snappy"
+    ]
+  },
+  {
     "metadata-version" : "0.4",
     "source-code-url" : "https://repo1.maven.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4-sources.jar",
     "repository-url" : "https://github.com/dain/snappy",

--- a/metadata/org.iq80.snappy/snappy/index.json
+++ b/metadata/org.iq80.snappy/snappy/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.5",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/iq80/snappy/snappy/0.5/snappy-0.5-sources.jar",
+    "repository-url" : "https://github.com/dain/snappy",
+    "test-code-url" : "https://github.com/dain/snappy/tree/snappy-0.5/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/iq80/snappy/snappy/0.5/snappy-0.5-javadoc.jar",
+    "description" : "Snappy is a pure Java port of Google's Snappy compression library. It provides APIs and stream classes for compressing and decompressing data in Snappy block and framed formats.",
     "tested-versions" : [
       "0.5"
     ],

--- a/stats/org.iq80.snappy/snappy/0.5/execution-metrics.json
+++ b/stats/org.iq80.snappy/snappy/0.5/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T20:57:46.726737Z",
+    "library": "org.iq80.snappy:snappy:0.5",
+    "starting_commit": "22e8e8bb4851710a7f2e91afd9ec84cf7036e32d",
+    "ending_commit": "5cf45159334e346d31a7028fa097b36cfd3400ad",
+    "previous_library": "org.iq80.snappy:snappy:0.4",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11470,
+          "missed": 1889,
+          "ratio": 0.858597,
+          "total": 13359
+        },
+        "line": {
+          "covered": 422,
+          "missed": 342,
+          "ratio": 0.552356,
+          "total": 764
+        },
+        "method": {
+          "covered": 65,
+          "missed": 62,
+          "ratio": 0.511811,
+          "total": 127
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.6,
+            "coveredCalls": 3,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.6,
+        "coveredCalls": 3,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11862,
+          "missed": 1996,
+          "ratio": 0.855968,
+          "total": 13858
+        },
+        "line": {
+          "covered": 538,
+          "missed": 327,
+          "ratio": 0.621965,
+          "total": 865
+        },
+        "method": {
+          "covered": 103,
+          "missed": 59,
+          "ratio": 0.635802,
+          "total": 162
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 45969,
+      "cached_input_tokens_used": 117248,
+      "output_tokens_used": 1548,
+      "iterations": 1,
+      "cost_usd": 0.105,
+      "tested_library_loc": 422,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 55.24,
+      "previous_library_coverage_percent": 62.2
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java",
+      "metadata_file": "metadata/org.iq80.snappy/snappy/0.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.iq80.snappy/snappy/0.5/stats.json
+++ b/stats/org.iq80.snappy/snappy/0.5/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "0.5",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11470,
+        "missed" : 1889,
+        "ratio" : 0.858597,
+        "total" : 13359
+      },
+      "line" : {
+        "covered" : 422,
+        "missed" : 342,
+        "ratio" : 0.552356,
+        "total" : 764
+      },
+      "method" : {
+        "covered" : 65,
+        "missed" : 62,
+        "ratio" : 0.511811,
+        "total" : 127
+      }
+    }
+  } ]
+}

--- a/tests/src/org.iq80.snappy/snappy/0.5/.gitignore
+++ b/tests/src/org.iq80.snappy/snappy/0.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.iq80.snappy/snappy/0.5/build.gradle
+++ b/tests/src/org.iq80.snappy/snappy/0.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.iq80.snappy:snappy:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.iq80.snappy/snappy/0.5/gradle.properties
+++ b/tests/src/org.iq80.snappy/snappy/0.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.iq80.snappy:snappy:0.5
+library.version = 0.5
+metadata.dir = org.iq80.snappy/snappy/0.5/

--- a/tests/src/org.iq80.snappy/snappy/0.5/settings.gradle
+++ b/tests/src/org.iq80.snappy/snappy/0.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.iq80.snappy.snappy_tests'

--- a/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
+++ b/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_iq80_snappy.snappy;
+
+import org.iq80.snappy.Snappy;
+import org.iq80.snappy.SnappyInputStream;
+import org.iq80.snappy.SnappyOutputStream;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SnappyInternalUtilsTest {
+    @Test
+    void compressesAndDecompressesBlockPayload() throws Exception {
+        byte[] payload = createCompressiblePayload();
+
+        byte[] compressed = Snappy.compress(payload);
+        byte[] decompressed = Snappy.uncompress(compressed, 0, compressed.length);
+
+        assertThat(compressed).isNotEmpty();
+        assertThat(Snappy.getUncompressedLength(compressed, 0)).isEqualTo(payload.length);
+        assertThat(decompressed).isEqualTo(payload);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void writesAndReadsSnappyStreamPayload() throws Exception {
+        byte[] payload = createCompressiblePayload();
+        ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
+
+        try (SnappyOutputStream snappyOutput = new SnappyOutputStream(compressedOutput)) {
+            snappyOutput.write(payload, 0, 256);
+            snappyOutput.write(payload, 256, payload.length - 256);
+        }
+
+        byte[] compressed = compressedOutput.toByteArray();
+        byte[] decompressed = readSnappyStream(compressed);
+
+        assertThat(compressed).isNotEmpty();
+        assertThat(decompressed).isEqualTo(payload);
+    }
+
+    private static byte[] readSnappyStream(byte[] compressed) throws IOException {
+        try (SnappyInputStream snappyInput = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+            return snappyInput.readAllBytes();
+        }
+    }
+
+    private static byte[] createCompressiblePayload() {
+        byte[] phrase = "snappy dynamic access coverage payload ".getBytes(StandardCharsets.UTF_8);
+        byte[] payload = new byte[phrase.length * 128];
+
+        for (int offset = 0; offset < payload.length; offset += phrase.length) {
+            System.arraycopy(phrase, 0, payload, offset, phrase.length);
+        }
+        Arrays.fill(payload, 64, 128, (byte) 'x');
+        return payload;
+    }
+}

--- a/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
+++ b/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
@@ -7,8 +7,8 @@
 package org_iq80_snappy.snappy;
 
 import org.iq80.snappy.Snappy;
-import org.iq80.snappy.SnappyInputStream;
-import org.iq80.snappy.SnappyOutputStream;
+import org.iq80.snappy.SnappyFramedInputStream;
+import org.iq80.snappy.SnappyFramedOutputStream;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -32,13 +32,12 @@ public class SnappyInternalUtilsTest {
         assertThat(decompressed).isEqualTo(payload);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void writesAndReadsSnappyStreamPayload() throws Exception {
         byte[] payload = createCompressiblePayload();
         ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
 
-        try (SnappyOutputStream snappyOutput = new SnappyOutputStream(compressedOutput)) {
+        try (SnappyFramedOutputStream snappyOutput = new SnappyFramedOutputStream(compressedOutput)) {
             snappyOutput.write(payload, 0, 256);
             snappyOutput.write(payload, 256, payload.length - 256);
         }
@@ -51,7 +50,7 @@ public class SnappyInternalUtilsTest {
     }
 
     private static byte[] readSnappyStream(byte[] compressed) throws IOException {
-        try (SnappyInputStream snappyInput = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+        try (SnappyFramedInputStream snappyInput = new SnappyFramedInputStream(new ByteArrayInputStream(compressed))) {
             return snappyInput.readAllBytes();
         }
     }

--- a/tests/src/org.iq80.snappy/snappy/0.5/user-code-filter.json
+++ b/tests/src/org.iq80.snappy/snappy/0.5/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.iq80.snappy.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3354

This PR provides test fixes and new metadata for org.iq80.snappy:snappy:0.5, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 45969
- Cached input tokens: 117248
- Output tokens: 1548
- Entries found: 2
- Iterations: 1
- Library coverage percentage: 55.24
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 62.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.iq80.snappy:snappy:0.4: 3/5 covered calls (60.00%)
- org.iq80.snappy:snappy:0.5: 1/1 covered calls (100.00%)

**Reflection:**
- org.iq80.snappy:snappy:0.4: 3/5 covered calls (60.00%)
- org.iq80.snappy:snappy:0.5: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.iq80.snappy:snappy:0.4: 11862/13858 (85.60%)
- org.iq80.snappy:snappy:0.5: 11470/13359 (85.86%)

**Line:**
- org.iq80.snappy:snappy:0.4: 538/865 (62.20%)
- org.iq80.snappy:snappy:0.5: 422/764 (55.24%)

**Method:**
- org.iq80.snappy:snappy:0.4: 103/162 (63.58%)
- org.iq80.snappy:snappy:0.5: 65/127 (51.18%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.iq80.snappy/snappy/0.4/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java 2/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
index 024b16a779..53cfa7c270 100644
--- 1/tests/src/org.iq80.snappy/snappy/0.4/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
+++ 2/tests/src/org.iq80.snappy/snappy/0.5/src/test/java/org_iq80_snappy/snappy/SnappyInternalUtilsTest.java
@@ -7,8 +7,8 @@
 package org_iq80_snappy.snappy;
 
 import org.iq80.snappy.Snappy;
-import org.iq80.snappy.SnappyInputStream;
-import org.iq80.snappy.SnappyOutputStream;
+import org.iq80.snappy.SnappyFramedInputStream;
+import org.iq80.snappy.SnappyFramedOutputStream;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -32,13 +32,12 @@ public class SnappyInternalUtilsTest {
         assertThat(decompressed).isEqualTo(payload);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void writesAndReadsSnappyStreamPayload() throws Exception {
         byte[] payload = createCompressiblePayload();
         ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
 
-        try (SnappyOutputStream snappyOutput = new SnappyOutputStream(compressedOutput)) {
+        try (SnappyFramedOutputStream snappyOutput = new SnappyFramedOutputStream(compressedOutput)) {
             snappyOutput.write(payload, 0, 256);
             snappyOutput.write(payload, 256, payload.length - 256);
         }
@@ -51,7 +50,7 @@ public class SnappyInternalUtilsTest {
     }
 
     private static byte[] readSnappyStream(byte[] compressed) throws IOException {
-        try (SnappyInputStream snappyInput = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+        try (SnappyFramedInputStream snappyInput = new SnappyFramedInputStream(new ByteArrayInputStream(compressed))) {
             return snappyInput.readAllBytes();
         }
     }

```
