### PR TITLE
[GenAI] Test fix for org.fusesource.jansi:jansi:2.0 using gpt-5.5

### DIFF
--- a/metadata/org.fusesource.jansi/jansi/2.0/reachability-metadata.json
+++ b/metadata/org.fusesource.jansi/jansi/2.0/reachability-metadata.json
@@ -1,0 +1,38 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.jansi.internal.JansiLoader"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.jansi.AnsiMain"
+      },
+      "glob": "META-INF/maven/org.fusesource.jansi/jansi/pom.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.jansi.internal.JansiLoader"
+      },
+      "glob": "META-INF/maven/org.fusesource.jansi/jansi/pom.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.jansi.internal.JansiLoader"
+      },
+      "glob": "org/fusesource/jansi/internal/native/Linux/x86_64/libjansi.so"
+    }
+  ]
+}

--- a/metadata/org.fusesource.jansi/jansi/index.json
+++ b/metadata/org.fusesource.jansi/jansi/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0",
+    "tested-versions" : [
+      "2.0"
+    ],
+    "allowed-packages" : [
+      "org.fusesource.hawtjni.runtime",
+      "org.fusesource.jansi"
+    ]
+  },
+  {
     "metadata-version" : "1.16",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/1.16/jansi-1.16-sources.jar",
     "repository-url" : "https://github.com/fusesource/jansi",

--- a/metadata/org.fusesource.jansi/jansi/index.json
+++ b/metadata/org.fusesource.jansi/jansi/index.json
@@ -2,11 +2,15 @@
   {
     "latest" : true,
     "metadata-version" : "2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/2.0/jansi-2.0-sources.jar",
+    "repository-url" : "https://github.com/fusesource/jansi",
+    "test-code-url" : "https://github.com/fusesource/jansi/tree/jansi-2.0/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/2.0/jansi-2.0-javadoc.jar",
+    "description" : "Jansi is a Java library for generating and interpreting ANSI escape sequences in console output. It wraps output streams and native terminal support so Java applications can emit styled text and interact with terminal capabilities across platforms.",
     "tested-versions" : [
       "2.0"
     ],
     "allowed-packages" : [
-      "org.fusesource.hawtjni.runtime",
       "org.fusesource.jansi"
     ]
   },

--- a/stats/org.fusesource.jansi/jansi/2.0/execution-metrics.json
+++ b/stats/org.fusesource.jansi/jansi/2.0/execution-metrics.json
@@ -1,0 +1,104 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T21:06:39.762642Z",
+    "library": "org.fusesource.jansi:jansi:2.0",
+    "starting_commit": "cf37370b54468766f96662380e3c4784a1052747",
+    "ending_commit": "4ab3e6076642c17f7b2dbc0b920900600d40548f",
+    "previous_library": "org.fusesource.jansi:jansi:1.16",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 595,
+          "missed": 5479,
+          "ratio": 0.097959,
+          "total": 6074
+        },
+        "line": {
+          "covered": 145,
+          "missed": 1197,
+          "ratio": 0.108048,
+          "total": 1342
+        },
+        "method": {
+          "covered": 23,
+          "missed": 291,
+          "ratio": 0.073248,
+          "total": 314
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.16",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 638,
+          "missed": 6343,
+          "ratio": 0.091391,
+          "total": 6981
+        },
+        "line": {
+          "covered": 116,
+          "missed": 1365,
+          "ratio": 0.078325,
+          "total": 1481
+        },
+        "method": {
+          "covered": 15,
+          "missed": 352,
+          "ratio": 0.040872,
+          "total": 367
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 77346,
+      "cached_input_tokens_used": 665088,
+      "output_tokens_used": 8007,
+      "iterations": 2,
+      "cost_usd": 0.5727,
+      "tested_library_loc": 145,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 11,
+      "code_coverage_percent": 10.8,
+      "previous_library_coverage_percent": 7.83
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java",
+      "metadata_file": "metadata/org.fusesource.jansi/jansi/2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.fusesource.jansi/jansi/2.0/stats.json
+++ b/stats/org.fusesource.jansi/jansi/2.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 595,
+        "missed" : 5479,
+        "ratio" : 0.097959,
+        "total" : 6074
+      },
+      "line" : {
+        "covered" : 145,
+        "missed" : 1197,
+        "ratio" : 0.108048,
+        "total" : 1342
+      },
+      "method" : {
+        "covered" : 23,
+        "missed" : 291,
+        "ratio" : 0.073248,
+        "total" : 314
+      }
+    }
+  } ]
+}

--- a/tests/src/org.fusesource.jansi/jansi/2.0/.gitignore
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.fusesource.jansi/jansi/2.0/build.gradle
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.fusesource.jansi:jansi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.fusesource.jansi/jansi/2.0/gradle.properties
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.fusesource.jansi:jansi:2.0
+library.version = 2.0
+metadata.dir = org.fusesource.jansi/jansi/2.0/

--- a/tests/src/org.fusesource.jansi/jansi/2.0/settings.gradle
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.fusesource.jansi.jansi_tests'

--- a/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/AnsiMainTest.java
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/AnsiMainTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_jansi.jansi;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import org.fusesource.jansi.AnsiMain;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnsiMainTest {
+
+    @Test
+    void readsBundledPomPropertiesVersion() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(AnsiMain.class, MethodHandles.lookup());
+        MethodHandle getPomPropertiesVersion = lookup.findStatic(
+                AnsiMain.class,
+                "getPomPropertiesVersion",
+                MethodType.methodType(String.class, String.class));
+
+        String version = (String) getPomPropertiesVersion.invokeExact("org.fusesource.jansi/jansi");
+
+        assertThat(version).isNotBlank();
+    }
+}

--- a/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_jansi.jansi;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LibraryTest {
+
+    private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
+    private static final String EXTRACTED_LIBRARY_NAME = "graalvmjansiextractnative";
+    private static final String TEST_LIBRARY_VERSION = "integration-test";
+
+    @Test
+    void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
+        Library library = new Library(MISSING_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+
+        assertThatThrownBy(library::load)
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining("Could not load library. Reasons:");
+
+        assertThat(classLoader.requestedResources).containsExactlyElementsOf(expectedResourceLookups(library));
+    }
+
+    @Test
+    void loadMakesExtractedNativeLibraryExecutableBeforeLoading(@TempDir final Path tempDirectory) throws IOException {
+        Path extractionDirectory = tempDirectory.resolve("extracted");
+        Files.createDirectories(extractionDirectory);
+        Path userHomeFile = tempDirectory.resolve("user-home-file");
+        Files.write(userHomeFile, new byte[0]);
+
+        Library directoryProbe = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, null);
+        String versionedLibraryName = EXTRACTED_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION;
+        String resourceName = resourcePath(directoryProbe.getSpecificSearchDirs()[0], versionedLibraryName);
+        Path resourceFile = tempDirectory.resolve(mapLibraryName(versionedLibraryName));
+        Files.write(resourceFile, "not a native library".getBytes(StandardCharsets.UTF_8));
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
+                LibraryTest.class.getClassLoader(),
+                resourceName,
+                resourceFile.toUri().toURL());
+        Library library = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+
+        String previousTempDirectory = setSystemProperty("java.io.tmpdir", extractionDirectory.toString());
+        String previousUserHome = setSystemProperty("user.home", userHomeFile.toString());
+        try {
+            assertThatThrownBy(library::load)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessageContaining("Could not load library. Reasons:");
+        } finally {
+            restoreSystemProperty("java.io.tmpdir", previousTempDirectory);
+            restoreSystemProperty("user.home", previousUserHome);
+        }
+
+        assertThat(classLoader.requestedResources).contains(resourceName);
+        List<Path> extractedLibraries = extractedLibraries(extractionDirectory, versionedLibraryName);
+        assertThat(extractedLibraries).hasSize(1);
+        if (!Library.getPlatform().startsWith("windows")) {
+            assertThat(Files.isExecutable(extractedLibraries.get(0))).isTrue();
+        }
+    }
+
+    private static List<String> expectedResourceLookups(final Library library) {
+        List<String> paths = new ArrayList<String>();
+        for (String directory : library.getSpecificSearchDirs()) {
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION));
+            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME));
+        }
+        return paths;
+    }
+
+    private static String resourcePath(final String directory, final String libraryName) {
+        return "META-INF/native/" + directory + "/" + mapLibraryName(libraryName);
+    }
+
+    private static String mapLibraryName(final String libraryName) {
+        String mappedName = System.mapLibraryName(libraryName);
+        if (mappedName.endsWith(".dylib")) {
+            return mappedName.substring(0, mappedName.length() - ".dylib".length()) + ".jnilib";
+        }
+        return mappedName;
+    }
+
+    private static List<Path> extractedLibraries(final Path directory, final String libraryName) throws IOException {
+        String mappedName = mapLibraryName(libraryName);
+        int extensionStart = mappedName.lastIndexOf('.');
+        String prefix = mappedName.substring(0, extensionStart) + "-";
+        String suffix = mappedName.substring(extensionStart);
+        try (Stream<Path> files = Files.list(directory)) {
+            return files.filter(path -> extractedLibraryNameMatches(path, prefix, suffix)).collect(Collectors.toList());
+        }
+    }
+
+    private static boolean extractedLibraryNameMatches(final Path path, final String prefix, final String suffix) {
+        String fileName = path.getFileName().toString();
+        return fileName.startsWith(prefix) && fileName.endsWith(suffix);
+    }
+
+    private static String setSystemProperty(final String key, final String value) {
+        String previousValue = System.getProperty(key);
+        System.setProperty(key, value);
+        return previousValue;
+    }
+
+    private static void restoreSystemProperty(final String key, final String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previousValue);
+        }
+    }
+
+    public static final class TrackingResourceClassLoader extends ClassLoader {
+
+        private final List<String> requestedResources = new ArrayList<String>();
+        private final String resourceName;
+        private final URL resource;
+
+        public TrackingResourceClassLoader(final ClassLoader parent) {
+            this(parent, null, null);
+        }
+
+        public TrackingResourceClassLoader(final ClassLoader parent, final String resourceName, final URL resource) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.resource = resource;
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResources.add(name);
+            if (name.equals(resourceName)) {
+                return resource;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -7,88 +7,57 @@
 package org_fusesource_jansi.jansi;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.fusesource.hawtjni.runtime.Library;
+import org.fusesource.jansi.internal.JansiLoader;
+import org.fusesource.jansi.internal.OSInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LibraryTest {
 
-    private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
-    private static final String EXTRACTED_LIBRARY_NAME = "graalvmjansiextractnative";
-    private static final String TEST_LIBRARY_VERSION = "integration-test";
-
     @Test
-    void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
-        Library library = new Library(MISSING_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
-
-        assertThatThrownBy(library::load)
-                .isInstanceOf(UnsatisfiedLinkError.class)
-                .hasMessageContaining("Could not load library. Reasons:");
-
-        assertThat(classLoader.requestedResources).containsExactlyElementsOf(expectedResourceLookups(library));
-    }
-
-    @Test
-    void loadMakesExtractedNativeLibraryExecutableBeforeLoading(@TempDir final Path tempDirectory) throws IOException {
-        Path extractionDirectory = tempDirectory.resolve("extracted");
+    void initializeExtractsAndLoadsBundledNativeLibrary(@TempDir final Path tempDirectory) throws IOException {
+        Path extractionDirectory = tempDirectory.resolve("jansi-extraction");
         Files.createDirectories(extractionDirectory);
-        Path userHomeFile = tempDirectory.resolve("user-home-file");
-        Files.write(userHomeFile, new byte[0]);
+        String mappedLibraryName = mapLibraryName("jansi");
+        String nativeResourcePath = "/org/fusesource/jansi/internal/native/"
+                + OSInfo.getNativeLibFolderPathForCurrentOS() + "/" + mappedLibraryName;
+        URL nativeResource = JansiLoader.class.getResource(nativeResourcePath);
 
-        Library directoryProbe = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, null);
-        String versionedLibraryName = EXTRACTED_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION;
-        String resourceName = resourcePath(directoryProbe.getSpecificSearchDirs()[0], versionedLibraryName);
-        Path resourceFile = tempDirectory.resolve(mapLibraryName(versionedLibraryName));
-        Files.write(resourceFile, "not a native library".getBytes(StandardCharsets.UTF_8));
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
-                LibraryTest.class.getClassLoader(),
-                resourceName,
-                resourceFile.toUri().toURL());
-        Library library = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+        assertThat(nativeResource).isNotNull();
 
-        String previousTempDirectory = setSystemProperty("java.io.tmpdir", extractionDirectory.toString());
-        String previousUserHome = setSystemProperty("user.home", userHomeFile.toString());
+        String previousTempDirectory = setSystemProperty("jansi.tmpdir", extractionDirectory.toString());
+        String previousLibraryPath = clearSystemProperty("library.jansi.path");
+        String previousLibraryName = clearSystemProperty("library.jansi.name");
         try {
-            assertThatThrownBy(library::load)
-                    .isInstanceOf(UnsatisfiedLinkError.class)
-                    .hasMessageContaining("Could not load library. Reasons:");
+            assertThat(JansiLoader.initialize()).isTrue();
         } finally {
-            restoreSystemProperty("java.io.tmpdir", previousTempDirectory);
-            restoreSystemProperty("user.home", previousUserHome);
+            restoreSystemProperty("jansi.tmpdir", previousTempDirectory);
+            restoreSystemProperty("library.jansi.path", previousLibraryPath);
+            restoreSystemProperty("library.jansi.name", previousLibraryName);
         }
 
-        assertThat(classLoader.requestedResources).contains(resourceName);
-        List<Path> extractedLibraries = extractedLibraries(extractionDirectory, versionedLibraryName);
-        assertThat(extractedLibraries).hasSize(1);
-        if (!Library.getPlatform().startsWith("windows")) {
-            assertThat(Files.isExecutable(extractedLibraries.get(0))).isTrue();
+        assertThat(JansiLoader.getNativeLibrarySourceUrl()).contains(nativeResourcePath.substring(1));
+        Path extractedLibrary = Path.of(JansiLoader.getNativeLibraryPath());
+        assertThat(extractedLibrary).exists().isRegularFile();
+        assertThat(extractedLibrary.getParent()).isEqualTo(extractionDirectory);
+        assertThat(extractedLibrary.getFileName().toString()).startsWith("jansi-").endsWith(mappedLibraryName);
+        assertThat(Files.readAllBytes(extractedLibrary)).isEqualTo(resourceBytes(nativeResource));
+        if (!OSInfo.getOSName().equals("Windows")) {
+            assertThat(Files.isExecutable(extractedLibrary)).isTrue();
         }
     }
 
-    private static List<String> expectedResourceLookups(final Library library) {
-        List<String> paths = new ArrayList<String>();
-        for (String directory : library.getSpecificSearchDirs()) {
-            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION));
-            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME));
+    private static byte[] resourceBytes(final URL resource) throws IOException {
+        try (InputStream inputStream = resource.openStream()) {
+            return inputStream.readAllBytes();
         }
-        return paths;
-    }
-
-    private static String resourcePath(final String directory, final String libraryName) {
-        return "META-INF/native/" + directory + "/" + mapLibraryName(libraryName);
     }
 
     private static String mapLibraryName(final String libraryName) {
@@ -99,24 +68,15 @@ public class LibraryTest {
         return mappedName;
     }
 
-    private static List<Path> extractedLibraries(final Path directory, final String libraryName) throws IOException {
-        String mappedName = mapLibraryName(libraryName);
-        int extensionStart = mappedName.lastIndexOf('.');
-        String prefix = mappedName.substring(0, extensionStart) + "-";
-        String suffix = mappedName.substring(extensionStart);
-        try (Stream<Path> files = Files.list(directory)) {
-            return files.filter(path -> extractedLibraryNameMatches(path, prefix, suffix)).collect(Collectors.toList());
-        }
-    }
-
-    private static boolean extractedLibraryNameMatches(final Path path, final String prefix, final String suffix) {
-        String fileName = path.getFileName().toString();
-        return fileName.startsWith(prefix) && fileName.endsWith(suffix);
-    }
-
     private static String setSystemProperty(final String key, final String value) {
         String previousValue = System.getProperty(key);
         System.setProperty(key, value);
+        return previousValue;
+    }
+
+    private static String clearSystemProperty(final String key) {
+        String previousValue = System.getProperty(key);
+        System.clearProperty(key);
         return previousValue;
     }
 
@@ -125,32 +85,6 @@ public class LibraryTest {
             System.clearProperty(key);
         } else {
             System.setProperty(key, previousValue);
-        }
-    }
-
-    public static final class TrackingResourceClassLoader extends ClassLoader {
-
-        private final List<String> requestedResources = new ArrayList<String>();
-        private final String resourceName;
-        private final URL resource;
-
-        public TrackingResourceClassLoader(final ClassLoader parent) {
-            this(parent, null, null);
-        }
-
-        public TrackingResourceClassLoader(final ClassLoader parent, final String resourceName, final URL resource) {
-            super(parent);
-            this.resourceName = resourceName;
-            this.resource = resource;
-        }
-
-        @Override
-        public URL getResource(final String name) {
-            requestedResources.add(name);
-            if (name.equals(resourceName)) {
-                return resource;
-            }
-            return null;
         }
     }
 }

--- a/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.fusesource.hawtjni.runtime.**"
+    },
+    {
+      "includeClasses" : "org.fusesource.jansi.**"
+    }
+  ]
+}

--- a/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
+++ b/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
@@ -4,9 +4,6 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.fusesource.hawtjni.runtime.**"
-    },
-    {
       "includeClasses" : "org.fusesource.jansi.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #3351

This PR provides test fixes and new metadata for org.fusesource.jansi:jansi:2.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 77346
- Cached input tokens: 665088
- Output tokens: 8007
- Entries found: 5
- Iterations: 2
- Library coverage percentage: 10.8
- Previous library version metadata entries: 11
- Previous library version coverage percentage: 7.83

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.fusesource.jansi:jansi:1.16: 11/11 covered calls (100.00%)
- org.fusesource.jansi:jansi:2.0: 5/5 covered calls (100.00%)

**Reflection:**
- org.fusesource.jansi:jansi:1.16: 10/10 covered calls (100.00%)
- org.fusesource.jansi:jansi:2.0: N/A

**Resources:**
- org.fusesource.jansi:jansi:1.16: 1/1 covered calls (100.00%)
- org.fusesource.jansi:jansi:2.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.fusesource.jansi:jansi:1.16: 638/6981 (9.14%)
- org.fusesource.jansi:jansi:2.0: 595/6074 (9.80%)

**Line:**
- org.fusesource.jansi:jansi:1.16: 116/1481 (7.83%)
- org.fusesource.jansi:jansi:2.0: 145/1342 (10.80%)

**Method:**
- org.fusesource.jansi:jansi:1.16: 15/367 (4.09%)
- org.fusesource.jansi:jansi:2.0: 23/314 (7.32%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/AnsiMainTest.java 2/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/AnsiMainTest.java
new file mode 100644
index 0000000000..f2230048e6
--- /dev/null
+++ 2/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/AnsiMainTest.java
@@ -0,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_jansi.jansi;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import org.fusesource.jansi.AnsiMain;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnsiMainTest {
+
+    @Test
+    void readsBundledPomPropertiesVersion() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(AnsiMain.class, MethodHandles.lookup());
+        MethodHandle getPomPropertiesVersion = lookup.findStatic(
+                AnsiMain.class,
+                "getPomPropertiesVersion",
+                MethodType.methodType(String.class, String.class));
+
+        String version = (String) getPomPropertiesVersion.invokeExact("org.fusesource.jansi/jansi");
+
+        assertThat(version).isNotBlank();
+    }
+}
diff --git 1/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java 2/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
index b3ebe3dfee..3b6db75633 100644
--- 1/tests/src/org.fusesource.jansi/jansi/1.16/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
+++ 2/tests/src/org.fusesource.jansi/jansi/2.0/src/test/java/org_fusesource_jansi/jansi/LibraryTest.java
@@ -7,88 +7,57 @@
 package org_fusesource_jansi.jansi;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.fusesource.hawtjni.runtime.Library;
+import org.fusesource.jansi.internal.JansiLoader;
+import org.fusesource.jansi.internal.OSInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LibraryTest {
 
-    private static final String MISSING_LIBRARY_NAME = "graalvmjansimissingnative";
-    private static final String EXTRACTED_LIBRARY_NAME = "graalvmjansiextractnative";
-    private static final String TEST_LIBRARY_VERSION = "integration-test";
-
     @Test
-    void loadChecksBundledNativeLibraryResourcesWhenNativeLibraryLookupFails() {
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(LibraryTest.class.getClassLoader());
-        Library library = new Library(MISSING_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
-
-        assertThatThrownBy(library::load)
-                .isInstanceOf(UnsatisfiedLinkError.class)
-                .hasMessageContaining("Could not load library. Reasons:");
-
-        assertThat(classLoader.requestedResources).containsExactlyElementsOf(expectedResourceLookups(library));
-    }
-
-    @Test
-    void loadMakesExtractedNativeLibraryExecutableBeforeLoading(@TempDir final Path tempDirectory) throws IOException {
-        Path extractionDirectory = tempDirectory.resolve("extracted");
+    void initializeExtractsAndLoadsBundledNativeLibrary(@TempDir final Path tempDirectory) throws IOException {
+        Path extractionDirectory = tempDirectory.resolve("jansi-extraction");
         Files.createDirectories(extractionDirectory);
-        Path userHomeFile = tempDirectory.resolve("user-home-file");
-        Files.write(userHomeFile, new byte[0]);
+        String mappedLibraryName = mapLibraryName("jansi");
+        String nativeResourcePath = "/org/fusesource/jansi/internal/native/"
+                + OSInfo.getNativeLibFolderPathForCurrentOS() + "/" + mappedLibraryName;
+        URL nativeResource = JansiLoader.class.getResource(nativeResourcePath);
 
-        Library directoryProbe = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, null);
-        String versionedLibraryName = EXTRACTED_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION;
-        String resourceName = resourcePath(directoryProbe.getSpecificSearchDirs()[0], versionedLibraryName);
-        Path resourceFile = tempDirectory.resolve(mapLibraryName(versionedLibraryName));
-        Files.write(resourceFile, "not a native library".getBytes(StandardCharsets.UTF_8));
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
-                LibraryTest.class.getClassLoader(),
-                resourceName,
-                resourceFile.toUri().toURL());
-        Library library = new Library(EXTRACTED_LIBRARY_NAME, TEST_LIBRARY_VERSION, classLoader);
+        assertThat(nativeResource).isNotNull();
 
-        String previousTempDirectory = setSystemProperty("java.io.tmpdir", extractionDirectory.toString());
-        String previousUserHome = setSystemProperty("user.home", userHomeFile.toString());
+        String previousTempDirectory = setSystemProperty("jansi.tmpdir", extractionDirectory.toString());
+        String previousLibraryPath = clearSystemProperty("library.jansi.path");
+        String previousLibraryName = clearSystemProperty("library.jansi.name");
         try {
-            assertThatThrownBy(library::load)
-                    .isInstanceOf(UnsatisfiedLinkError.class)
-                    .hasMessageContaining("Could not load library. Reasons:");
+            assertThat(JansiLoader.initialize()).isTrue();
         } finally {
-            restoreSystemProperty("java.io.tmpdir", previousTempDirectory);
-            restoreSystemProperty("user.home", previousUserHome);
+            restoreSystemProperty("jansi.tmpdir", previousTempDirectory);
+            restoreSystemProperty("library.jansi.path", previousLibraryPath);
+            restoreSystemProperty("library.jansi.name", previousLibraryName);
         }
 
-        assertThat(classLoader.requestedResources).contains(resourceName);
-        List<Path> extractedLibraries = extractedLibraries(extractionDirectory, versionedLibraryName);
-        assertThat(extractedLibraries).hasSize(1);
-        if (!Library.getPlatform().startsWith("windows")) {
-            assertThat(Files.isExecutable(extractedLibraries.get(0))).isTrue();
+        assertThat(JansiLoader.getNativeLibrarySourceUrl()).contains(nativeResourcePath.substring(1));
+        Path extractedLibrary = Path.of(JansiLoader.getNativeLibraryPath());
+        assertThat(extractedLibrary).exists().isRegularFile();
+        assertThat(extractedLibrary.getParent()).isEqualTo(extractionDirectory);
+        assertThat(extractedLibrary.getFileName().toString()).startsWith("jansi-").endsWith(mappedLibraryName);
+        assertThat(Files.readAllBytes(extractedLibrary)).isEqualTo(resourceBytes(nativeResource));
+        if (!OSInfo.getOSName().equals("Windows")) {
+            assertThat(Files.isExecutable(extractedLibrary)).isTrue();
         }
     }
 
-    private static List<String> expectedResourceLookups(final Library library) {
-        List<String> paths = new ArrayList<String>();
-        for (String directory : library.getSpecificSearchDirs()) {
-            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME + "-" + TEST_LIBRARY_VERSION));
-            paths.add(resourcePath(directory, MISSING_LIBRARY_NAME));
+    private static byte[] resourceBytes(final URL resource) throws IOException {
+        try (InputStream inputStream = resource.openStream()) {
+            return inputStream.readAllBytes();
         }
-        return paths;
-    }
-
-    private static String resourcePath(final String directory, final String libraryName) {
-        return "META-INF/native/" + directory + "/" + mapLibraryName(libraryName);
     }
 
     private static String mapLibraryName(final String libraryName) {
@@ -99,27 +68,18 @@ public class LibraryTest {
         return mappedName;
     }
 
-    private static List<Path> extractedLibraries(final Path directory, final String libraryName) throws IOException {
-        String mappedName = mapLibraryName(libraryName);
-        int extensionStart = mappedName.lastIndexOf('.');
-        String prefix = mappedName.substring(0, extensionStart) + "-";
-        String suffix = mappedName.substring(extensionStart);
-        try (Stream<Path> files = Files.list(directory)) {
-            return files.filter(path -> extractedLibraryNameMatches(path, prefix, suffix)).collect(Collectors.toList());
-        }
-    }
-
-    private static boolean extractedLibraryNameMatches(final Path path, final String prefix, final String suffix) {
-        String fileName = path.getFileName().toString();
-        return fileName.startsWith(prefix) && fileName.endsWith(suffix);
-    }
-
     private static String setSystemProperty(final String key, final String value) {
         String previousValue = System.getProperty(key);
         System.setProperty(key, value);
         return previousValue;
     }
 
+    private static String clearSystemProperty(final String key) {
+        String previousValue = System.getProperty(key);
+        System.clearProperty(key);
+        return previousValue;
+    }
+
     private static void restoreSystemProperty(final String key, final String previousValue) {
         if (previousValue == null) {
             System.clearProperty(key);
@@ -127,30 +87,4 @@ public class LibraryTest {
             System.setProperty(key, previousValue);
         }
     }
-
-    public static final class TrackingResourceClassLoader extends ClassLoader {
-
-        private final List<String> requestedResources = new ArrayList<String>();
-        private final String resourceName;
-        private final URL resource;
-
-        public TrackingResourceClassLoader(final ClassLoader parent) {
-            this(parent, null, null);
-        }
-
-        public TrackingResourceClassLoader(final ClassLoader parent, final String resourceName, final URL resource) {
-            super(parent);
-            this.resourceName = resourceName;
-            this.resource = resource;
-        }
-
-        @Override
-        public URL getResource(final String name) {
-            requestedResources.add(name);
-            if (name.equals(resourceName)) {
-                return resource;
-            }
-            return null;
-        }
-    }
 }
diff --git 1/tests/src/org.fusesource.jansi/jansi/1.16/user-code-filter.json 2/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
index 163d1cea93..416c1e5da3 100644
--- 1/tests/src/org.fusesource.jansi/jansi/1.16/user-code-filter.json
+++ 2/tests/src/org.fusesource.jansi/jansi/2.0/user-code-filter.json
@@ -3,9 +3,6 @@
     {
       "excludeClasses" : "**"
     },
-    {
-      "includeClasses" : "org.fusesource.hawtjni.runtime.**"
-    },
     {
       "includeClasses" : "org.fusesource.jansi.**"
     }

```
