### PR TITLE
[GenAI] Test fix for org.apache.httpcomponents:httpcore:4.4.11 using gpt-5.5

### DIFF
--- a/metadata/org.apache.httpcomponents/httpcore/4.4.11/reachability-metadata.json
+++ b/metadata/org.apache.httpcomponents/httpcore/4.4.11/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.ExceptionUtils"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "initCause",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.VersionInfo"
+      },
+      "glob": "org/apache/http/version.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.11",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11-sources.jar",
+    "repository-url" : "https://github.com/apache/httpcomponents-core",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11-javadoc.jar",
+    "description" : "Apache HttpCore provides low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
     "tested-versions" : [
       "4.4.11"
     ],

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.4.11",
+    "tested-versions" : [
+      "4.4.11"
+    ],
+    "allowed-packages" : [
+      "org.apache.http"
+    ]
+  },
+  {
     "metadata-version" : "4.4.10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/stats/org.apache.httpcomponents/httpcore/4.4.11/execution-metrics.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.11/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-04-29": {
+    "timestamp": "2026-04-29T21:12:07.832331Z",
+    "library": "org.apache.httpcomponents:httpcore:4.4.11",
+    "starting_commit": "a7213cef4f51c5a48dcae1b30b80e95f4e1ccb77",
+    "ending_commit": "bc09582c1971701b8b0860098853457c8a81c002",
+    "previous_library": "org.apache.httpcomponents:httpcore:4.4.10",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24447,
+          "ratio": 0.013159,
+          "total": 24773
+        },
+        "line": {
+          "covered": 85,
+          "missed": 6051,
+          "ratio": 0.013853,
+          "total": 6136
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1404,
+          "ratio": 0.015428,
+          "total": 1426
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.4.10",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24415,
+          "ratio": 0.013177,
+          "total": 24741
+        },
+        "line": {
+          "covered": 86,
+          "missed": 6074,
+          "ratio": 0.013961,
+          "total": 6160
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1400,
+          "ratio": 0.015471,
+          "total": 1422
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 40409,
+      "cached_input_tokens_used": 269824,
+      "output_tokens_used": 2330,
+      "iterations": 1,
+      "cost_usd": 0.2048,
+      "tested_library_loc": 85,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 1.39,
+      "previous_library_coverage_percent": 1.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java",
+      "metadata_file": "metadata/org.apache.httpcomponents/httpcore/4.4.11/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.httpcomponents/httpcore/4.4.11/stats.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.11/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.11",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 326,
+        "missed" : 24447,
+        "ratio" : 0.013159,
+        "total" : 24773
+      },
+      "line" : {
+        "covered" : 85,
+        "missed" : 6051,
+        "ratio" : 0.013853,
+        "total" : 6136
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 1404,
+        "ratio" : 0.015428,
+        "total" : 1426
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/.gitignore
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/build.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.httpcomponents:httpcore:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.httpcomponents:httpcore:4.4.11
+library.version = 4.4.11
+metadata.dir = org.apache.httpcomponents/httpcore/4.4.11/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/settings.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.httpcomponents.httpcore_tests'

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class ExceptionUtilsTest {
+
+    @Test
+    void initCauseAssignsTheProvidedCause() {
+        IllegalArgumentException throwable = new IllegalArgumentException("outer");
+        IllegalStateException cause = new IllegalStateException("inner");
+
+        ExceptionUtils.initCause(throwable, cause);
+
+        assertThat(throwable).hasCause(cause);
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.entity.SerializableEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializableEntityTest {
+
+    @Test
+    void bufferizedEntitySerializesContentWhenCreated() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta"));
+
+        SerializableEntity entity = new SerializableEntity(payload, true);
+        byte[] expectedBytes = serialize(payload);
+
+        assertThat(entity.isRepeatable()).isTrue();
+        assertThat(entity.isStreaming()).isFalse();
+        assertThat(entity.getContentLength()).isEqualTo(expectedBytes.length);
+        assertThat(readAllBytes(entity.getContent())).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    void streamingEntityWritesSerializedObjectToOutputStream() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("gamma", "delta"));
+
+        SerializableEntity entity = new SerializableEntity(payload);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        assertThat(entity.isStreaming()).isTrue();
+
+        entity.writeTo(out);
+
+        assertThat(out.toByteArray()).isEqualTo(serialize(payload));
+    }
+
+    private static byte[] readAllBytes(InputStream content) throws IOException {
+        try (InputStream inputStream = content) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionInfoTest {
+
+    @Test
+    void loadVersionInfoReadsPackagedVersionProperties() {
+        ClassLoader classLoader = VersionInfo.class.getClassLoader();
+        VersionInfo versionInfo = VersionInfo.loadVersionInfo("org.apache.http", classLoader);
+
+        assertThat(versionInfo).isNotNull();
+        assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
+        assertThat(versionInfo.getModule()).isEqualTo("httpcore");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.10");
+        assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
+        assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
+    }
+
+    @Test
+    void getUserAgentUsesThePackagedRelease() {
+        String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
+
+        assertThat(userAgent)
+                .isEqualTo("httpcore-test/4.4.10 (Java/" + System.getProperty("java.version") + ")");
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -21,7 +21,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.10");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.11");
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +31,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.10 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/4.4.11 (Java/" + System.getProperty("java.version") + ")");
     }
 }

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.11/user-code-filter.json
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.11/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3346

This PR provides test fixes and new metadata for org.apache.httpcomponents:httpcore:4.4.11, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 40409
- Cached input tokens: 269824
- Output tokens: 2330
- Entries found: 7
- Iterations: 1
- Library coverage percentage: 1.39
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 1.4

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.httpcomponents:httpcore:4.4.10: 4/4 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.11: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.httpcomponents:httpcore:4.4.10: 3/3 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.11: 3/3 covered calls (100.00%)

**Resources:**
- org.apache.httpcomponents:httpcore:4.4.10: 1/1 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.11: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.httpcomponents:httpcore:4.4.10: 326/24741 (1.32%)
- org.apache.httpcomponents:httpcore:4.4.11: 326/24773 (1.32%)

**Line:**
- org.apache.httpcomponents:httpcore:4.4.10: 86/6160 (1.40%)
- org.apache.httpcomponents:httpcore:4.4.11: 85/6136 (1.39%)

**Method:**
- org.apache.httpcomponents:httpcore:4.4.10: 22/1422 (1.55%)
- org.apache.httpcomponents:httpcore:4.4.11: 22/1426 (1.54%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java 2/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
index 15259ad46a..5a5ce49b83 100644
--- 1/tests/src/org.apache.httpcomponents/httpcore/4.4.10/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ 2/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -21,7 +21,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.10");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.11");
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +31,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.10 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/4.4.11 (Java/" + System.getProperty("java.version") + ")");
     }
 }

```
