### PR TITLE
[GenAI] Test fix for org.jboss.narayana.jta:jta:7.3.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.narayana.jta/jta/7.3.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.narayana.jta/jta/7.3.1.Final/reachability-metadata.json
@@ -1,0 +1,165 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "byte[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.xa.XidImple"
+      },
+      "type" : "byte[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.arjPropertyManager"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.CoreEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.common.arjPropertyManager"
+      },
+      "type" : "com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.arjuna.logging.tsLogger"
+      },
+      "type" : "com.arjuna.ats.arjuna.logging.arjunaI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.arjuna.ats.jta.common.JTAEnvironmentBean",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.logging.jtaLogger"
+      },
+      "type" : "com.arjuna.ats.jta.logging.jtaI18NLogger_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "type" : "javax.xml.stream.XMLInputFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "ConfigurationInfo.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "META-INF/services/javax.xml.stream.XMLInputFactory"
+    }
+  ]
+}

--- a/metadata/org.jboss.narayana.jta/jta/index.json
+++ b/metadata/org.jboss.narayana.jta/jta/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "7.3.1.Final",
+    "tested-versions" : [
+      "7.3.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.narayana.jta",
+      "com.arjuna.ats.arjuna.common",
+      "com.arjuna.ats.internal.arjuna.utils",
+      "com.arjuna.ats.arjuna.logging",
+      "com.arjuna.ats.jta.common",
+      "com.arjuna.ats.jta.logging",
+      "com.arjuna.common.logging"
+    ]
+  },
+  {
     "metadata-version" : "5.12.4.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final-sources.jar",
     "repository-url" : "https://github.com/jbosstm/narayana",

--- a/metadata/org.jboss.narayana.jta/jta/index.json
+++ b/metadata/org.jboss.narayana.jta/jta/index.json
@@ -2,17 +2,19 @@
   {
     "latest" : true,
     "metadata-version" : "7.3.1.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/7.3.1.Final/jta-7.3.1.Final-sources.jar",
+    "repository-url" : "https://github.com/jbosstm/narayana",
+    "test-code-url" : "https://github.com/jbosstm/narayana/tree/7.3.1.Final/ArjunaJTA/jta/tests",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/narayana/jta/narayana-jta/7.3.1.Final/narayana-jta-7.3.1.Final-javadoc.jar",
+    "description" : "Narayana JTA provides a Java Transaction API implementation built on the Narayana transaction manager. It coordinates transactional work and recovery across local resources, application servers, and XA-capable systems.",
     "tested-versions" : [
       "7.3.1.Final"
     ],
     "allowed-packages" : [
-      "org.jboss.narayana.jta",
       "com.arjuna.ats.arjuna.common",
-      "com.arjuna.ats.internal.arjuna.utils",
       "com.arjuna.ats.arjuna.logging",
-      "com.arjuna.ats.jta.common",
-      "com.arjuna.ats.jta.logging",
-      "com.arjuna.common.logging"
+      "com.arjuna.ats.internal.jta",
+      "com.arjuna.ats.jta"
     ]
   },
   {

--- a/stats/org.jboss.narayana.jta/jta/7.3.1.Final/execution-metrics.json
+++ b/stats/org.jboss.narayana.jta/jta/7.3.1.Final/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-04-29": {
+    "timestamp": "2026-04-29T21:35:50.265990Z",
+    "library": "org.jboss.narayana.jta:jta:7.3.1.Final",
+    "starting_commit": "f1b84c2079e5f876b0c3790c184e1e8855927918",
+    "ending_commit": "0e5c699aa709788fe8914e77497f2cd49a5ff94b",
+    "previous_library": "org.jboss.narayana.jta:jta:5.12.4.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "7.3.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 725,
+          "missed": 17316,
+          "ratio": 0.040186,
+          "total": 18041
+        },
+        "line": {
+          "covered": 223,
+          "missed": 4962,
+          "ratio": 0.043009,
+          "total": 5185
+        },
+        "method": {
+          "covered": 37,
+          "missed": 930,
+          "ratio": 0.038263,
+          "total": 967
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.12.4.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 759,
+          "missed": 18148,
+          "ratio": 0.040144,
+          "total": 18907
+        },
+        "line": {
+          "covered": 222,
+          "missed": 4903,
+          "ratio": 0.043317,
+          "total": 5125
+        },
+        "method": {
+          "covered": 38,
+          "missed": 919,
+          "ratio": 0.039707,
+          "total": 957
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 142524,
+      "cached_input_tokens_used": 1750016,
+      "output_tokens_used": 9363,
+      "iterations": 1,
+      "cost_usd": 1.1559,
+      "tested_library_loc": 223,
+      "metadata_entries": 35,
+      "previous_library_metadata_entries": 24,
+      "code_coverage_percent": 4.3,
+      "previous_library_coverage_percent": 4.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/JNDIManagerTest.java",
+      "metadata_file": "metadata/org.jboss.narayana.jta/jta/7.3.1.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.narayana.jta/jta/7.3.1.Final/stats.json
+++ b/stats/org.jboss.narayana.jta/jta/7.3.1.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "7.3.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 725,
+        "missed" : 17316,
+        "ratio" : 0.040186,
+        "total" : 18041
+      },
+      "line" : {
+        "covered" : 223,
+        "missed" : 4962,
+        "ratio" : 0.043009,
+        "total" : 5185
+      },
+      "method" : {
+        "covered" : 37,
+        "missed" : 930,
+        "ratio" : 0.038263,
+        "total" : 967
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/.gitignore
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/build.gradle
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.narayana.jta:jta:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.jboss.logging:jboss-logging:3.2.1.Final'
+    testImplementation 'org.jboss:jboss-transaction-spi:7.6.1.Final'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.narayana.jta:jta:7.3.1.Final
+library.version = 7.3.1.Final
+metadata.dir = org.jboss.narayana.jta/jta/7.3.1.Final/

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/settings.gradle
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.narayana.jta.jta_tests'

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/JNDIManagerTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/JNDIManagerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.arjuna.ats.jta.utils.JNDIManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JNDIManagerTest {
+    @Test
+    void bindTransactionSynchronizationRegistryImplementationUsesConfiguredClass() throws Exception {
+        JTAEnvironmentBean environmentBean = jtaPropertyManager.getJTAEnvironmentBean();
+        String originalClassName = environmentBean.getTransactionSynchronizationRegistryClassName();
+        String originalJndiName = environmentBean.getTransactionSynchronizationRegistryJNDIContext();
+
+        try {
+            TestTransactionSynchronizationRegistry.CONSTRUCTOR_CALLS.set(0);
+            environmentBean.setTransactionSynchronizationRegistryClassName(
+                TestTransactionSynchronizationRegistry.class.getName()
+            );
+            environmentBean.setTransactionSynchronizationRegistryJNDIContext(
+                "java:/test/TransactionSynchronizationRegistry"
+            );
+
+            RecordingInitialContext initialContext = new RecordingInitialContext();
+
+            JNDIManager.bindJTATransactionSynchronizationRegistryImplementation(initialContext);
+
+            assertThat(TestTransactionSynchronizationRegistry.CONSTRUCTOR_CALLS).hasValue(1);
+            assertThat(initialContext.boundName).isEqualTo("java:/test/TransactionSynchronizationRegistry");
+            assertThat(initialContext.boundValue).isInstanceOf(TestTransactionSynchronizationRegistry.class);
+        } finally {
+            environmentBean.setTransactionSynchronizationRegistryClassName(originalClassName);
+            environmentBean.setTransactionSynchronizationRegistryJNDIContext(originalJndiName);
+        }
+    }
+
+    public static final class TestTransactionSynchronizationRegistry implements TransactionSynchronizationRegistry {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        private final Map<Object, Object> resources = new HashMap<>();
+        private boolean rollbackOnly;
+
+        public TestTransactionSynchronizationRegistry() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public Object getTransactionKey() {
+            return this;
+        }
+
+        @Override
+        public void putResource(Object key, Object value) {
+            resources.put(key, value);
+        }
+
+        @Override
+        public Object getResource(Object key) {
+            return resources.get(key);
+        }
+
+        @Override
+        public void registerInterposedSynchronization(Synchronization synchronization) {
+        }
+
+        @Override
+        public int getTransactionStatus() {
+            return Status.STATUS_NO_TRANSACTION;
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            rollbackOnly = true;
+        }
+
+        @Override
+        public boolean getRollbackOnly() {
+            return rollbackOnly;
+        }
+    }
+
+    private static final class RecordingInitialContext extends InitialContext {
+        private String boundName;
+        private Object boundValue;
+
+        private RecordingInitialContext() throws NamingException {
+            super(true);
+        }
+
+        @Override
+        public void rebind(String name, Object obj) {
+            boundName = name;
+            boundValue = obj;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import com.arjuna.ats.arjuna.coordinator.TwoPhaseOutcome;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XAOnePhaseResourceTest {
+    @Test
+    void packAndUnpackSerializableXaResource() throws Exception {
+        SerializableXaResource.COMMIT_CALLS.set(0);
+
+        XAOnePhaseResource resource = new XAOnePhaseResource(
+            new SerializableXaResource("pack-unpack"),
+            new SerializableXid(41, new byte[]{1, 2, 3}, new byte[]{4, 5, 6}),
+            null
+        );
+        OutputObjectState outputState = new OutputObjectState();
+
+        resource.pack(outputState);
+
+        XAOnePhaseResource restoredResource = new XAOnePhaseResource();
+        restoredResource.unpack(new InputObjectState(outputState));
+
+        assertThat(restoredResource.toString()).contains("pack-unpack");
+        assertThat(restoredResource.commit()).isEqualTo(TwoPhaseOutcome.FINISH_OK);
+        assertThat(SerializableXaResource.COMMIT_CALLS).hasValue(1);
+    }
+
+    private static final class SerializableXaResource implements XAResource, Serializable {
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger COMMIT_CALLS = new AtomicInteger();
+
+        private final String name;
+
+        private SerializableXaResource(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void commit(Xid xid, boolean onePhase) {
+            COMMIT_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public void end(Xid xid, int flags) {
+        }
+
+        @Override
+        public void forget(Xid xid) {
+        }
+
+        @Override
+        public int getTransactionTimeout() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSameRM(XAResource xaResource) {
+            return xaResource == this;
+        }
+
+        @Override
+        public int prepare(Xid xid) {
+            return XA_OK;
+        }
+
+        @Override
+        public Xid[] recover(int flag) {
+            return new Xid[0];
+        }
+
+        @Override
+        public void rollback(Xid xid) {
+        }
+
+        @Override
+        public boolean setTransactionTimeout(int seconds) {
+            return true;
+        }
+
+        @Override
+        public void start(Xid xid, int flags) {
+        }
+
+        @Override
+        public String toString() {
+            return "SerializableXaResource[" + name + "]";
+        }
+    }
+
+    private static final class SerializableXid implements Xid, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final int formatId;
+        private final byte[] globalTransactionId;
+        private final byte[] branchQualifier;
+
+        private SerializableXid(int formatId, byte[] globalTransactionId, byte[] branchQualifier) {
+            this.formatId = formatId;
+            this.globalTransactionId = globalTransactionId;
+            this.branchQualifier = branchQualifier;
+        }
+
+        @Override
+        public int getFormatId() {
+            return formatId;
+        }
+
+        @Override
+        public byte[] getGlobalTransactionId() {
+            return globalTransactionId;
+        }
+
+        @Override
+        public byte[] getBranchQualifier() {
+            return branchQualifier;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
@@ -12,9 +12,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.coordinator.TwoPhaseOutcome;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.arjuna.utils.UuidProcessId;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ public class XAOnePhaseResourceTest {
     @Test
     void packAndUnpackSerializableXaResource() throws Exception {
         SerializableXaResource.COMMIT_CALLS.set(0);
+        arjPropertyManager.getCoreEnvironmentBean().setProcessImplementation(new UuidProcessId());
 
         XAOnePhaseResource resource = new XAOnePhaseResource(
             new SerializableXaResource("pack-unpack"),

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_narayana_jta.jta;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import com.arjuna.ats.arjuna.ObjectType;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XAResourceRecordTest {
+    @Test
+    void saveAndRestoreStateWithSerializableXaResource() throws Exception {
+        SerializableXaResource.COMMIT_CALLS.set(0);
+
+        XAResourceRecord resourceRecord = new XAResourceRecord(
+            null,
+            new SerializableXaResource("xa-resource-record"),
+            new SerializableXid(73, new byte[]{1, 3, 5}, new byte[]{2, 4, 6}),
+            null
+        );
+        resourceRecord.setProductName("Test Product");
+        resourceRecord.setProductVersion("2026.04");
+        resourceRecord.setJndiName("java:/test/XAResourceRecord");
+
+        OutputObjectState outputState = new OutputObjectState();
+
+        assertThat(resourceRecord.save_state(outputState, ObjectType.ANDPERSISTENT)).isTrue();
+
+        XAResourceRecord restoredRecord = new XAResourceRecord();
+
+        assertThat(restoredRecord.restore_state(new InputObjectState(outputState), ObjectType.ANDPERSISTENT)).isTrue();
+        assertThat(restoredRecord.getProductName()).isEqualTo("Test Product");
+        assertThat(restoredRecord.getProductVersion()).isEqualTo("2026.04");
+        assertThat(restoredRecord.getJndiName()).isEqualTo("java:/test/XAResourceRecord");
+        assertThat(restoredRecord.getXid().getFormatId()).isEqualTo(73);
+        assertThat(restoredRecord.getXid().getGlobalTransactionId()).containsExactly((byte) 1, (byte) 3, (byte) 5);
+        assertThat(restoredRecord.getXid().getBranchQualifier()).containsExactly((byte) 2, (byte) 4, (byte) 6);
+        assertThat(restoredRecord.toString()).contains("xa-resource-record");
+
+        XAResource restoredResource = (XAResource) restoredRecord.value();
+
+        assertThat(restoredResource).isInstanceOf(SerializableXaResource.class);
+
+        restoredResource.commit(restoredRecord.getXid(), true);
+
+        assertThat(SerializableXaResource.COMMIT_CALLS).hasValue(1);
+    }
+
+    private static final class SerializableXaResource implements XAResource, Serializable {
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger COMMIT_CALLS = new AtomicInteger();
+
+        private final String name;
+
+        private SerializableXaResource(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void commit(Xid xid, boolean onePhase) {
+            COMMIT_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public void end(Xid xid, int flags) {
+        }
+
+        @Override
+        public void forget(Xid xid) {
+        }
+
+        @Override
+        public int getTransactionTimeout() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSameRM(XAResource xaResource) {
+            return xaResource == this;
+        }
+
+        @Override
+        public int prepare(Xid xid) {
+            return XA_OK;
+        }
+
+        @Override
+        public Xid[] recover(int flag) {
+            return new Xid[0];
+        }
+
+        @Override
+        public void rollback(Xid xid) {
+        }
+
+        @Override
+        public boolean setTransactionTimeout(int seconds) {
+            return true;
+        }
+
+        @Override
+        public void start(Xid xid, int flags) {
+        }
+
+        @Override
+        public String toString() {
+            return "SerializableXaResource[" + name + "]";
+        }
+    }
+
+    private static final class SerializableXid implements Xid, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final int formatId;
+        private final byte[] globalTransactionId;
+        private final byte[] branchQualifier;
+
+        private SerializableXid(int formatId, byte[] globalTransactionId, byte[] branchQualifier) {
+            this.formatId = formatId;
+            this.globalTransactionId = globalTransactionId;
+            this.branchQualifier = branchQualifier;
+        }
+
+        @Override
+        public int getFormatId() {
+            return formatId;
+        }
+
+        @Override
+        public byte[] getGlobalTransactionId() {
+            return globalTransactionId;
+        }
+
+        @Override
+        public byte[] getBranchQualifier() {
+            return branchQualifier;
+        }
+    }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
@@ -13,8 +13,10 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import com.arjuna.ats.arjuna.ObjectType;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.arjuna.utils.UuidProcessId;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ public class XAResourceRecordTest {
     @Test
     void saveAndRestoreStateWithSerializableXaResource() throws Exception {
         SerializableXaResource.COMMIT_CALLS.set(0);
+        arjPropertyManager.getCoreEnvironmentBean().setProcessImplementation(new UuidProcessId());
 
         XAResourceRecord resourceRecord = new XAResourceRecord(
             null,

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/resource-config.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qjbossts-properties.xml\\E"
+      }
+    ]
+  }
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/serialization-config.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/org.jboss.narayana.jta.jta.tests/serialization-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "java.lang.String"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXaResource"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXid"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXaResource"
+  },
+  {
+    "name": "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXid"
+  }
+]

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.utils.JNDIManager"
+      },
+      "type" : "org_jboss_narayana_jta.jta.JNDIManagerTest$TestTransactionSynchronizationRegistry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAOnePhaseResourceTest$SerializableXid",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXaResource",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord"
+      },
+      "type" : "org_jboss_narayana_jta.jta.XAResourceRecordTest$SerializableXid",
+      "serializable" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.arjuna.ats.jta.common.jtaPropertyManager"
+      },
+      "glob" : "jbossts-properties.xml"
+    }
+  ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/jbossts-properties.xml
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/resources/jbossts-properties.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+</properties>

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.narayana.jta.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.jboss.narayana.jta.**"
+      "includeClasses" : "com.arjuna.ats.internal.jta.**"
+    },
+    {
+      "includeClasses" : "com.arjuna.ats.jta.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #1844

This PR provides test fixes and new metadata for org.jboss.narayana.jta:jta:7.3.1.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 142524
- Cached input tokens: 1750016
- Output tokens: 9363
- Entries found: 35
- Iterations: 1
- Library coverage percentage: 4.3
- Previous library version metadata entries: 24
- Previous library version coverage percentage: 4.33

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.narayana.jta:jta:5.12.4.Final: 8/8 covered calls (100.00%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 9/9 covered calls (100.00%)

**Reflection:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 8/8 covered calls (100.00%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 9/9 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 759/18907 (4.01%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 725/18041 (4.02%)

**Line:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 222/5125 (4.33%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 223/5185 (4.30%)

**Method:**
- org.jboss.narayana.jta:jta:5.12.4.Final: 38/957 (3.97%)
- org.jboss.narayana.jta:jta:7.3.1.Final: 37/967 (3.83%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
index 31b566a4ae..ab42a87310 100644
--- 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
+++ 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAOnePhaseResourceTest.java
@@ -12,9 +12,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.coordinator.TwoPhaseOutcome;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.arjuna.utils.UuidProcessId;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAOnePhaseResource;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ public class XAOnePhaseResourceTest {
     @Test
     void packAndUnpackSerializableXaResource() throws Exception {
         SerializableXaResource.COMMIT_CALLS.set(0);
+        arjPropertyManager.getCoreEnvironmentBean().setProcessImplementation(new UuidProcessId());
 
         XAOnePhaseResource resource = new XAOnePhaseResource(
             new SerializableXaResource("pack-unpack"),
diff --git 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
index 2c30bc1d49..53dd25c840 100644
--- 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
+++ 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/src/test/java/org_jboss_narayana_jta/jta/XAResourceRecordTest.java
@@ -13,8 +13,10 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import com.arjuna.ats.arjuna.ObjectType;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.arjuna.utils.UuidProcessId;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ public class XAResourceRecordTest {
     @Test
     void saveAndRestoreStateWithSerializableXaResource() throws Exception {
         SerializableXaResource.COMMIT_CALLS.set(0);
+        arjPropertyManager.getCoreEnvironmentBean().setProcessImplementation(new UuidProcessId());
 
         XAResourceRecord resourceRecord = new XAResourceRecord(
             null,
diff --git 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/user-code-filter.json 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
index 92f42bd7a7..eed3c8b598 100644
--- 1/tests/src/org.jboss.narayana.jta/jta/5.12.4.Final/user-code-filter.json
+++ 2/tests/src/org.jboss.narayana.jta/jta/7.3.1.Final/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.jboss.narayana.jta.**"
+      "includeClasses" : "com.arjuna.ats.internal.jta.**"
+    },
+    {
+      "includeClasses" : "com.arjuna.ats.jta.**"
     }
   ]
 }

```
