### PR TITLE
[GenAI] Test fix for org.flywaydb:flyway-sqlserver:11.8.1 using gpt-5.5

### DIFF
--- a/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
@@ -1,0 +1,146 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.KerberosModel",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getLogin",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setLogin",
+          "parameterTypes" : [
+            "org.flywaydb.database.sqlserver.LoginModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.LoginModel",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getFile",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setFile",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getClean",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getKerberos",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setClean",
+          "parameterTypes" : [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        },
+        {
+          "name" : "setKerberos",
+          "parameterTypes" : [
+            "org.flywaydb.database.sqlserver.KerberosModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      },
+      "type" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerApplicationLockTemplate"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConnection"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerSchema"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -2,11 +2,17 @@
   {
     "latest" : true,
     "metadata-version" : "11.8.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/11.8.1/flyway-sqlserver-11.8.1-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/blob/flyway-11.8.1/documentation/Reference/Database%20Driver%20Reference/SQL%20Server%20Database.md",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server and Azure Synapse database-specific support to Flyway. It provides the SQL Server database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
     "tested-versions" : [
       "11.8.1"
     ],
     "allowed-packages" : [
-      "org.flywaydb"
+      "org.flywaydb.clean",
+      "org.flywaydb.database.sqlserver"
     ]
   },
   {

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "11.8.1",
+    "tested-versions" : [
+      "11.8.1"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
+    ]
+  },
+  {
     "metadata-version" : "10.19.0",
     "test-version" : "10.10.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/10.19.0/flyway-sqlserver-10.19.0-sources.jar",

--- a/stats/org.flywaydb/flyway-sqlserver/11.8.1/execution-metrics.json
+++ b/stats/org.flywaydb/flyway-sqlserver/11.8.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-04-29": {
+    "timestamp": "2026-04-29T21:37:00.454541Z",
+    "library": "org.flywaydb:flyway-sqlserver:11.8.1",
+    "starting_commit": "1461a1a7cdbd3062e7d4df621f238dca7dd3e166",
+    "ending_commit": "cdb22283efbd52da76fb33b578074a7571cc11a0",
+    "previous_library": "org.flywaydb:flyway-sqlserver:10.10.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.8.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1154,
+          "missed": 3167,
+          "ratio": 0.267068,
+          "total": 4321
+        },
+        "line": {
+          "covered": 197,
+          "missed": 514,
+          "ratio": 0.277075,
+          "total": 711
+        },
+        "method": {
+          "covered": 79,
+          "missed": 148,
+          "ratio": 0.348018,
+          "total": 227
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "10.10.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1128,
+          "missed": 3125,
+          "ratio": 0.265225,
+          "total": 4253
+        },
+        "line": {
+          "covered": 192,
+          "missed": 503,
+          "ratio": 0.276259,
+          "total": 695
+        },
+        "method": {
+          "covered": 76,
+          "missed": 147,
+          "ratio": 0.340807,
+          "total": 223
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 69239,
+      "cached_input_tokens_used": 796672,
+      "output_tokens_used": 5788,
+      "iterations": 1,
+      "cost_usd": 0.5719,
+      "tested_library_loc": 197,
+      "metadata_entries": 25,
+      "previous_library_metadata_entries": 12,
+      "code_coverage_percent": 27.71,
+      "previous_library_coverage_percent": 27.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java",
+      "metadata_file": "metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.flywaydb/flyway-sqlserver/11.8.1/stats.json
+++ b/stats/org.flywaydb/flyway-sqlserver/11.8.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "11.8.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1154,
+        "missed" : 3167,
+        "ratio" : 0.267068,
+        "total" : 4321
+      },
+      "line" : {
+        "covered" : 197,
+        "missed" : 514,
+        "ratio" : 0.277075,
+        "total" : 711
+      },
+      "method" : {
+        "covered" : 79,
+        "missed" : 148,
+        "ratio" : 0.348018,
+        "total" : 227
+      }
+    }
+  } ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/.gitignore
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/.gitignore
@@ -1,0 +1,6 @@
+gradlew.bat
+gradlew
+gradle/
+build/
+mssql-stderr.txt
+mssql-stdout.txt

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.assertj:assertj-core:3.22.0"
+    testImplementation "org.awaitility:awaitility:4.2.0"
+    testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
+}
+
+graalvmNative {
+    binaries {
+        all {
+            buildArgs.add("-H:+AddAllCharsets")
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.22.0"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
     testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
 }
 

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/gradle.properties
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 11.8.1
+metadata.dir = org.flywaydb/flyway-sqlserver/11.8.1/

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/required-docker-images.txt
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/required-docker-images.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/settings.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.flywaydb.flyway-sqlserver_tests'

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package flyway.sqlserver;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.resource.LoadableResource;
+import org.flywaydb.core.internal.resource.classpath.ClassPathResource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This is needed as GraalVM doesn't support enumerating resources. It uses a hardcoded list of migrations.
+ */
+class FixedResourceProvider implements ResourceProvider {
+    private static final Set<String> MIGRATIONS;
+
+    static {
+        Set<String> migrations = new HashSet<>();
+        migrations.add("db/migration/V1__create_table.sql");
+        migrations.add("db/migration/V2__alter_table.sql");
+        MIGRATIONS = Collections.unmodifiableSet(migrations);
+    }
+
+    @Override
+    public LoadableResource getResource(String name) {
+        if (!MIGRATIONS.contains(name)) {
+            return null;
+        }
+        return new ClassPathResource(null, name, getClass().getClassLoader(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Collection<LoadableResource> getResources(String prefix, String[] suffixes) {
+        return MIGRATIONS.stream()
+                .map(file -> new ClassPathResource(null, file, getClass().getClassLoader(), StandardCharsets.UTF_8))
+                .collect(Collectors.toList());
+    }
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FlywaySqlServerTests.java
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FlywaySqlServerTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package flyway.sqlserver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import javax.sql.DataSource;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import org.awaitility.Awaitility;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlywaySqlServerTests {
+
+    private static final String USERNAME = "sa";
+
+    private static final String PASSWORD = "Secret12";
+
+    private static final String JDBC_URL = "jdbc:sqlserver://localhost:1433;encrypt=false";
+
+    private static Process process;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting MSSQL ...");
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "-p", "1433:1433", "-e", "ACCEPT_EULA=Y",
+                "-e", "MSSQL_SA_PASSWORD=" + PASSWORD,
+                "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+                .redirectOutput(new File("mssql-stdout.txt"))
+                .redirectError(new File("mssql-stderr.txt"))
+                .start();
+
+        // Wait until connection can be established
+        Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            getDataSource().getConnection().close();
+            return true;
+        });
+        System.out.println("MSSQL started");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (process != null && process.isAlive()) {
+            System.out.println("Shutting down MSSQL");
+            process.destroy();
+        }
+    }
+
+    @Test
+    void migrate() {
+        DataSource dataSource = getDataSource();
+
+        Configuration configuration = new FluentConfiguration()
+                .dataSource(dataSource)
+                .encoding(StandardCharsets.UTF_8)
+                .resourceProvider(new FixedResourceProvider());
+
+        Flyway flyway = new Flyway(configuration);
+        MigrateResult migration = flyway.migrate();
+
+        assertThat(migration.success).isTrue();
+        assertThat(migration.migrationsExecuted).isEqualTo(2);
+    }
+
+    private static DataSource getDataSource() {
+        SQLServerDataSource dataSource = new SQLServerDataSource();
+        dataSource.setURL(JDBC_URL);
+        dataSource.setUser(USERNAME);
+        dataSource.setPassword(PASSWORD);
+        return dataSource;
+    }
+
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerApplicationLockTemplate"
+      },
+      "glob" : "db/migration/V1__create_table.sql"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerApplicationLockTemplate"
+      },
+      "glob" : "db/migration/V2__alter_table.sql"
+    }
+  ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/test/resource-config.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/test/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qdb/migration/V1__create_table.sql\\E"
+      },
+      {
+        "pattern": "\\Qdb/migration/V2__alter_table.sql\\E"
+      }
+    ]
+  }
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V1__create_table.sql
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V1__create_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE test
+(
+    id    INT PRIMARY KEY,
+    title VARCHAR NOT NULL
+);

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V2__alter_table.sql
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V2__alter_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE test
+    ADD name INT NOT NULL DEFAULT 1;

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.**"
+    }
+  ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.flywaydb.**"
+      "includeClasses" : "org.flywaydb.clean.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.database.sqlserver.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #1657

This PR provides test fixes and new metadata for org.flywaydb:flyway-sqlserver:11.8.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 69239
- Cached input tokens: 796672
- Output tokens: 5788
- Entries found: 25
- Iterations: 1
- Library coverage percentage: 27.71
- Previous library version metadata entries: 12
- Previous library version coverage percentage: 27.63

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-sqlserver:10.10.0: 0/0 covered calls (100.00%)
- org.flywaydb:flyway-sqlserver:11.8.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-sqlserver:10.10.0: 1128/4253 (26.52%)
- org.flywaydb:flyway-sqlserver:11.8.1: 1154/4321 (26.71%)

**Line:**
- org.flywaydb:flyway-sqlserver:10.10.0: 192/695 (27.63%)
- org.flywaydb:flyway-sqlserver:11.8.1: 197/711 (27.71%)

**Method:**
- org.flywaydb:flyway-sqlserver:10.10.0: 76/223 (34.08%)
- org.flywaydb:flyway-sqlserver:11.8.1: 79/227 (34.80%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle 2/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
index d412c25335..f6633e6d0e 100644
--- 1/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle
+++ 2/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.22.0"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
     testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
 }
 
diff --git 1/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json 2/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
index 46bbe981bf..b98844dadb 100644
--- 1/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json
+++ 2/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -4,7 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.flywaydb.**"
+      "includeClasses" : "org.flywaydb.clean.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.database.sqlserver.**"
     }
   ]
 }

```
