### PR TITLE
[Automation] Generated metadata for org.immutables:value:2.8.9-ea-0

### DIFF
--- a/metadata/org.immutables/value/2.8.9-ea-0/reachability-metadata.json
+++ b/metadata/org.immutables/value/2.8.9-ea-0/reachability-metadata.json
@@ -1,0 +1,368 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ArrayListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ArrayListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$HashMultiset"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$HashMultiset",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ImmutableListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$SerializationProxy",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Platform"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ObjectArrays"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.io.$Closer$SuppressingSuppressor"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
+        {
+          "name" : "addSuppressed",
+          "parameterTypes" : [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.util.AbstractMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.ArrayDeque",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.Collections$ReverseComparator",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.HashSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.LinkedHashSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.TreeSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$generator$.$AnnotationMirrors$GetTypeAnnotations"
+      },
+      "type" : "javax.lang.model.type.TypeMirror",
+      "methods" : [
+        {
+          "name" : "getAnnotationMirrors",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableMultimap",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization$FieldSetter"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableMultimap",
+      "fields" : [
+        {
+          "name" : "map"
+        },
+        {
+          "name" : "size"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "emptySet"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.processor.ProxyProcessor"
+      },
+      "type" : "org.immutables.value.internal.$processor$.$Processor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.base.$Throwables"
+      },
+      "type" : "sun.misc.SharedSecrets"
+    }
+  ],
+  "serialization" : [
+    {
+      "type" : "java.util.CollSer"
+    },
+    {
+      "type" : "java.util.Collections$UnmodifiableMap"
+    },
+    {
+      "type" : "java.util.ImmutableCollections$List12"
+    },
+    {
+      "type" : "java.util.ImmutableCollections$MapN"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractListMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractMapBasedMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractMapBasedMultiset"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractSetMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractSortedSetMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$SerializationProxy"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence$Equals"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence$Identity"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$generator$.$ExtensionLoader$1"
+      },
+      "glob" : "META-INF/annotations/org.immutables.value.immutable"
+    }
+  ]
+}

--- a/metadata/org.immutables/value/index.json
+++ b/metadata/org.immutables/value/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.8.9-ea-0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-sources.jar",
+    "repository-url" : "https://github.com/immutables/immutables",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-javadoc.jar",
+    "description" : "Immutables Value provides compile-time annotations and an annotation processor that generate consistent immutable value objects from abstract classes, interfaces, or annotations. It helps Java projects define type-safe, fluent value types with less handwritten boilerplate.",
+    "test-version" : "2.8.6",
+    "tested-versions" : [
+      "2.8.9-ea-0"
+    ],
+    "allowed-packages" : [
+      "org.immutables"
+    ]
+  },
+  {
     "metadata-version" : "2.8.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.6/value-2.8.6-sources.jar",
     "repository-url" : "https://github.com/immutables/immutables",

--- a/stats/org.immutables/value/2.8.9-ea-0/stats.json
+++ b/stats/org.immutables/value/2.8.9-ea-0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.8.9-ea-0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 50,
+          "totalCalls" : 50
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 51,
+      "totalCalls" : 51
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6598,
+        "missed" : 300955,
+        "ratio" : 0.021453,
+        "total" : 307553
+      },
+      "line" : {
+        "covered" : 1593,
+        "missed" : 60881,
+        "ratio" : 0.025499,
+        "total" : 62474
+      },
+      "method" : {
+        "covered" : 653,
+        "missed" : 9795,
+        "ratio" : 0.0625,
+        "total" : 10448
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3353

This PR provides new metadata needed for the org.immutables:value:2.8.9-ea-0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.immutables:value:2.8.6`): 78
- Metadata entries (new `org.immutables:value:2.8.9-ea-0`): 80
- Library coverage (previous): 2.61%
- Library coverage (new): 2.55%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.immutables:value:2.8.6: 51/51 covered calls (100.00%)
- org.immutables:value:2.8.9-ea-0: 51/51 covered calls (100.00%)

**Reflection:**
- org.immutables:value:2.8.6: 50/50 covered calls (100.00%)
- org.immutables:value:2.8.9-ea-0: 50/50 covered calls (100.00%)

**Resources:**
- org.immutables:value:2.8.6: 1/1 covered calls (100.00%)
- org.immutables:value:2.8.9-ea-0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.immutables:value:2.8.6: 6540/295763 (2.21%)
- org.immutables:value:2.8.9-ea-0: 6598/307553 (2.15%)

**Line:**
- org.immutables:value:2.8.6: 1578/60535 (2.61%)
- org.immutables:value:2.8.9-ea-0: 1593/62474 (2.55%)

**Method:**
- org.immutables:value:2.8.6: 646/10250 (6.30%)
- org.immutables:value:2.8.9-ea-0: 653/10448 (6.25%)
