### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java:19.7 using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
@@ -1,0 +1,92 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "bundle" : "i18n.General"
+    },
+    {
+      "bundle" : "i18n.Parsing"
+    },
+    {
+      "bundle" : "i18n.Scalars"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "19.7",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.7/graphql-java-19.7-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v19.7/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.7/graphql-java-19.7-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define schemas, parse documents, and execute GraphQL queries against application data.",
     "tested-versions" : [
       "19.7"
     ],

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -1,21 +1,30 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "graphql"
+    "latest" : true,
+    "metadata-version" : "19.7",
+    "tested-versions" : [
+      "19.7"
     ],
-    "metadata-version": "19.2",
-    "source-code-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-sources.jar",
-    "repository-url": "https://github.com/graphql-java/graphql-java",
-    "test-code-url": "https://github.com/graphql-java/graphql-java/tree/v19.2/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-javadoc.jar",
-    "description": "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "graphql"
+    ]
+  },
+  {
+    "metadata-version" : "19.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v19.2/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/19.2/graphql-java-19.2-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
+    "tested-versions" : [
       "19.2",
       "19.3",
       "19.4",
       "19.5",
       "19.6"
+    ],
+    "allowed-packages" : [
+      "graphql"
     ]
   }
 ]

--- a/stats/com.graphql-java/graphql-java/19.7/execution-metrics.json
+++ b/stats/com.graphql-java/graphql-java/19.7/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-04-29": {
+    "timestamp": "2026-04-29T21:56:02.058415Z",
+    "library": "com.graphql-java:graphql-java:19.7",
+    "starting_commit": "4d8af2633aee75078ba5a98a6e32a209f2dd8c69",
+    "ending_commit": "9c30dcd707fdd4b6d3397676d5f35ee5ed44143b",
+    "previous_library": "com.graphql-java:graphql-java:19.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "19.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 10,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.916667,
+        "coveredCalls": 11,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 42423,
+          "missed": 107074,
+          "ratio": 0.283772,
+          "total": 149497
+        },
+        "line": {
+          "covered": 10224,
+          "missed": 22880,
+          "ratio": 0.308845,
+          "total": 33104
+        },
+        "method": {
+          "covered": 2959,
+          "missed": 6763,
+          "ratio": 0.304361,
+          "total": 9722
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "19.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.046154,
+            "coveredCalls": 3,
+            "totalCalls": 65
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.060606,
+        "coveredCalls": 4,
+        "totalCalls": 66
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 44403,
+          "missed": 175685,
+          "ratio": 0.201751,
+          "total": 220088
+        },
+        "line": {
+          "covered": 10623,
+          "missed": 37279,
+          "ratio": 0.221765,
+          "total": 47902
+        },
+        "method": {
+          "covered": 3126,
+          "missed": 12392,
+          "ratio": 0.201443,
+          "total": 15518
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 199763,
+      "cached_input_tokens_used": 3580928,
+      "output_tokens_used": 33238,
+      "iterations": 4,
+      "cost_usd": 2.7876,
+      "tested_library_loc": 10224,
+      "metadata_entries": 16,
+      "previous_library_metadata_entries": 24,
+      "code_coverage_percent": 30.88,
+      "previous_library_coverage_percent": 22.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java",
+      "metadata_file": "metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.graphql-java/graphql-java/19.7/stats.json
+++ b/stats/com.graphql-java/graphql-java/19.7/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "19.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.909091,
+          "coveredCalls" : 10,
+          "totalCalls" : 11
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.916667,
+      "coveredCalls" : 11,
+      "totalCalls" : 12
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 42423,
+        "missed" : 107074,
+        "ratio" : 0.283772,
+        "total" : 149497
+      },
+      "line" : {
+        "covered" : 10224,
+        "missed" : 22880,
+        "ratio" : 0.308845,
+        "total" : 33104
+      },
+      "method" : {
+        "covered" : 2959,
+        "missed" : 6763,
+        "ratio" : 0.304361,
+        "total" : 9722
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -15,3 +15,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.7
+metadata.dir = com.graphql-java/graphql-java/19.7/

--- a/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-tests'

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import graphql.introspection.IntrospectionQuery;
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.starwars.Droid;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlTests {
+
+
+  @Test
+  void greetingQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("greeting", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("greeting", new StaticDataFetcher("Hello GraphQL"))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ greeting }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{greeting=Hello GraphQL}");
+  }
+
+  @Test
+  void introspectionQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder -> {
+      runtimeWiringBuilder.type("Query", builder -> builder.typeName("Character").typeResolver(characterTypeResolver()));
+    });
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).contains("{__schema={queryType={name=QueryType}");
+  }
+
+  @Test
+  void paginatedQuery() throws Exception {
+    PageInfo pageInfo = new DefaultPageInfo(new DefaultConnectionCursor("start"),
+            new DefaultConnectionCursor("end"), true, true);
+    Edge<Human> edge = new DefaultEdge<>(new Human(), new DefaultConnectionCursor("current"));
+    Connection<Human> connection = new DefaultConnection<>(List.of(edge), pageInfo);
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder ->
+            runtimeWiringBuilder.type("QueryType", builder ->
+                    builder.dataFetcher("humans", new StaticDataFetcher(connection)))
+                    .type("Character", typeBuilder -> typeBuilder.typeResolver(characterTypeResolver())));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ humans { edges { node { id name } } pageInfo { startCursor } } }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{humans={edges=[{node={id=42, name=GraalVM}}], pageInfo={startCursor=start}}}");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+  private TypeResolver characterTypeResolver() {
+    return env -> {
+      Object javaObject = env.getObject();
+      if (javaObject instanceof Droid) {
+        return env.getSchema().getObjectType("Droid");
+      } else if (javaObject instanceof Human) {
+        return env.getSchema().getObjectType("Human");
+      } else {
+        throw new IllegalStateException("Unknown Character type");
+      }
+    };
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+
+public final class ImmutableCollection<E> extends AbstractCollection<E> {
+
+  private final Collection<E> delegate;
+
+  ImmutableCollection(Collection<E> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class ImmutableList<E> extends AbstractList<E> implements RandomAccess {
+
+  private final List<E> delegate;
+
+  private ImmutableList(Collection<? extends E> values) {
+    this.delegate = Collections.unmodifiableList(new ArrayList<>(values));
+  }
+
+  @SafeVarargs
+  private ImmutableList(E... values) {
+    List<E> list = new ArrayList<>(values.length);
+    Collections.addAll(list, values);
+    this.delegate = Collections.unmodifiableList(list);
+  }
+
+  public static <E> ImmutableList<E> of() {
+    return new ImmutableList<>(Collections.emptyList());
+  }
+
+  public static <E> ImmutableList<E> of(E element) {
+    return new ImmutableList<>(element);
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth) {
+    return new ImmutableList<>(first, second, third, fourth, fifth);
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterable<? extends E> values) {
+    if (values instanceof Collection) {
+      return copyOf((Collection<? extends E>) values);
+    }
+    Builder<E> builder = builder();
+    builder.addAll(values);
+    return builder.build();
+  }
+
+  public static <E> ImmutableList<E> copyOf(Collection<? extends E> values) {
+    return new ImmutableList<>(values);
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterator<? extends E> values) {
+    Builder<E> builder = builder();
+    while (values.hasNext()) {
+      builder.add(values.next());
+    }
+    return builder.build();
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableList<E>> toImmutableList() {
+    return Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf);
+  }
+
+  @Override
+  public E get(int index) {
+    return delegate.get(index);
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+
+  @Override
+  public int indexOf(Object object) {
+    return delegate.indexOf(object);
+  }
+
+  public static final class Builder<E> {
+
+    private final List<E> values;
+
+    public Builder() {
+      this.values = new ArrayList<>();
+    }
+
+    public Builder(int expectedSize) {
+      this.values = new ArrayList<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableList<E> build() {
+      return ImmutableList.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ImmutableListMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, ImmutableList<V>> delegate;
+
+  private ImmutableListMultimap(Map<K, ImmutableList<V>> values) {
+    this.delegate = ImmutableMap.copyOf(values);
+  }
+
+  public static <K, V> ImmutableListMultimap<K, V> of() {
+    return new ImmutableListMultimap<>(new LinkedHashMap<>());
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public ImmutableList<V> get(K key) {
+    return delegate.getOrDefault(key, ImmutableList.of());
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, ImmutableList.Builder<V>> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.computeIfAbsent(key, unused -> ImmutableList.builder()).add(value);
+      return this;
+    }
+
+    public ImmutableListMultimap<K, V> build() {
+      Map<K, ImmutableList<V>> built = new LinkedHashMap<>();
+      for (Map.Entry<K, ImmutableList.Builder<V>> entry : values.entrySet()) {
+        built.put(entry.getKey(), entry.getValue().build());
+      }
+      return new ImmutableListMultimap<>(built);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ImmutableMap<K, V> extends AbstractMap<K, V> {
+
+  private final Map<K, V> delegate;
+
+  private ImmutableMap(Map<? extends K, ? extends V> values) {
+    this.delegate = Collections.unmodifiableMap(new LinkedHashMap<>(values));
+  }
+
+  public static <K, V> ImmutableMap<K, V> of() {
+    return new ImmutableMap<>(Collections.emptyMap());
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K firstKey, V firstValue, K secondKey, V secondValue,
+          K thirdKey, V thirdValue, K fourthKey, V fourthValue) {
+    Builder<K, V> builder = builder();
+    return builder.put(firstKey, firstValue).put(secondKey, secondValue).put(thirdKey, thirdValue)
+            .put(fourthKey, fourthValue).build();
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K firstKey, V firstValue, K secondKey, V secondValue,
+          K thirdKey, V thirdValue, K fourthKey, V fourthValue, K fifthKey, V fifthValue) {
+    Builder<K, V> builder = builder();
+    return builder.put(firstKey, firstValue).put(secondKey, secondValue).put(thirdKey, thirdValue)
+            .put(fourthKey, fourthValue).put(fifthKey, fifthValue).build();
+  }
+
+  public static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V> values) {
+    return new ImmutableMap<>(values);
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return delegate.containsKey(key);
+  }
+
+  @Override
+  public V get(Object key) {
+    return delegate.get(key);
+  }
+
+  @Override
+  public V getOrDefault(Object key, V defaultValue) {
+    return delegate.getOrDefault(key, defaultValue);
+  }
+
+  @Override
+  public ImmutableSet<Entry<K, V>> entrySet() {
+    return ImmutableSet.copyOf(delegate.entrySet());
+  }
+
+  @Override
+  public ImmutableSet<K> keySet() {
+    return ImmutableSet.copyOf(delegate.keySet());
+  }
+
+  @Override
+  public ImmutableCollection<V> values() {
+    return new ImmutableCollection<>(delegate.values());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, V> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder<K, V> putAll(Map<? extends K, ? extends V> map) {
+      values.putAll(map);
+      return this;
+    }
+
+    public ImmutableMap<K, V> build() {
+      return ImmutableMap.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class ImmutableSet<E> extends AbstractSet<E> {
+
+  private final Set<E> delegate;
+
+  private ImmutableSet(Collection<? extends E> values) {
+    this.delegate = Collections.unmodifiableSet(new LinkedHashSet<>(values));
+  }
+
+  @SafeVarargs
+  private ImmutableSet(E... values) {
+    Set<E> set = new LinkedHashSet<>(values.length);
+    Collections.addAll(set, values);
+    this.delegate = Collections.unmodifiableSet(set);
+  }
+
+  public static <E> ImmutableSet<E> of(E element) {
+    return new ImmutableSet<>(element);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third) {
+    return new ImmutableSet<>(first, second, third);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth) {
+    return new ImmutableSet<>(first, second, third, fourth);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth) {
+    return new ImmutableSet<>(first, second, third, fourth, fifth);
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Collection<? extends E> values) {
+    return new ImmutableSet<>(values);
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableSet<E>> toImmutableSet() {
+    return Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf);
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+
+  public static final class Builder<E> {
+
+    private final Set<E> values;
+
+    public Builder() {
+      this.values = new LinkedHashSet<>();
+    }
+
+    public Builder(int expectedSize) {
+      this.values = new LinkedHashSet<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableSet<E> build() {
+      return ImmutableSet.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class LinkedHashMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, Set<V>> delegate = new LinkedHashMap<>();
+
+  private LinkedHashMultimap() {
+  }
+
+  public static <K, V> LinkedHashMultimap<K, V> create() {
+    return new LinkedHashMultimap<>();
+  }
+
+  @Override
+  public Collection<V> get(K key) {
+    return delegate.computeIfAbsent(key, unused -> new LinkedHashSet<>());
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    return delegate.computeIfAbsent(key, unused -> new LinkedHashSet<>()).add(value);
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    Set<V> values = delegate.get(key);
+    if (values == null) {
+      return false;
+    }
+    boolean removed = values.remove(value);
+    if (values.isEmpty()) {
+      delegate.remove(key);
+    }
+    return removed;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+
+public final class Maps {
+
+  private Maps() {
+  }
+
+  public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+    return new LinkedHashMap<>(expectedSize);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+
+public interface Multimap<K, V> {
+
+  Collection<V> get(K key);
+
+  boolean put(K key, V value);
+
+  boolean remove(Object key, Object value);
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class Sets {
+
+  private Sets() {
+  }
+
+  public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+    return new HashSet<>(expectedSize);
+  }
+
+  public static <E> SetView<E> intersection(Set<E> first, Set<?> second) {
+    Set<E> result = new LinkedHashSet<>();
+    for (E element : first) {
+      if (second.contains(element)) {
+        result.add(element);
+      }
+    }
+    return new SetView<>(result);
+  }
+
+  public static final class SetView<E> extends AbstractSet<E> {
+
+    private final Set<E> delegate;
+
+    private SetView(Set<E> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return delegate.iterator();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean contains(Object object) {
+      return delegate.contains(object);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Iterator;
+
+public final class UnmodifiableIterator<E> implements Iterator<E> {
+
+  private final Iterator<? extends E> iterator;
+
+  private UnmodifiableIterator(Iterator<? extends E> iterator) {
+    this.iterator = iterator;
+  }
+
+  public static <E> UnmodifiableIterator<E> copyOf(Iterator<? extends E> iterator) {
+    return new UnmodifiableIterator<>(iterator);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  @Override
+  public E next() {
+    return iterator.next();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Droid implements Character {
+
+  @Override
+  public Long getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getPrimaryFunction() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+/**
+ * @author Brian Clozel
+ */
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Human implements Character {
+
+  @Override
+  public Long getId() {
+    return 42L;
+  }
+
+  @Override
+  public String getName() {
+    return "GraalVM";
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getHomePlanet() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.reachability.graphql;
+
+import graphql.GraphQLException;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PropertyFetchingImplTest {
+
+  public final String visible = "public field";
+
+  private final String hidden = "declared field";
+
+  @BeforeEach
+  void resetPropertyFetcherConfiguration() {
+    PropertyDataFetcher.clearReflectionCache();
+    PropertyDataFetcher.setUseSetAccessible(true);
+    PropertyDataFetcher.setUseNegativeCache(true);
+  }
+
+  @Test
+  void fetchesPublicGetterWithNoArguments() {
+    Object fetchedValue = fetchProperty("displayName", this);
+
+    assertThat(fetchedValue).isEqualTo("public getter");
+  }
+
+  @Test
+  void fetchesGetterWithDataFetchingEnvironmentArgument() {
+    Object fetchedValue = fetchProperty("viewer", this);
+
+    assertThat(fetchedValue).isEqualTo("environment getter");
+  }
+
+  @Test
+  void fetchesAndCachesPublicField() {
+    Object firstFetchedValue = fetchProperty("visible", this);
+    Object cachedFetchedValue = fetchProperty("visible", this);
+
+    assertThat(firstFetchedValue).isEqualTo("public field");
+    assertThat(cachedFetchedValue).isEqualTo("public field");
+  }
+
+  @Test
+  void fetchesDeclaredFieldAfterGetterLookupFails() {
+    Object fetchedValue = fetchProperty("hidden", this);
+
+    assertThat(fetchedValue).isEqualTo("declared field");
+  }
+
+  @Test
+  void reportsPublicMethodOnInaccessibleClass() {
+    InaccessibleGetterSource source = new InaccessibleGetterSource();
+
+    assertThatThrownBy(() -> fetchProperty("name", source))
+            .isInstanceOf(GraphQLException.class);
+  }
+
+  public String getDisplayName() {
+    return "public getter";
+  }
+
+  public String getViewer(DataFetchingEnvironment environment) {
+    return environment == null ? "missing environment" : "environment getter";
+  }
+
+  private Object fetchProperty(String propertyName, Object source) {
+    DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .source(source)
+            .fieldType(GraphQLString)
+            .build();
+    return PropertyDataFetcher.fetching(propertyName).get(environment);
+  }
+}
+
+class InaccessibleGetterSource {
+
+  public String getName() {
+    return "package private getter";
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
@@ -6,7 +6,6 @@
  */
 package org.graalvm.reachability.graphql;
 
-import graphql.GraphQLException;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.PropertyDataFetcher;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import static graphql.Scalars.GraphQLString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PropertyFetchingImplTest {
 
@@ -61,11 +59,12 @@ public class PropertyFetchingImplTest {
   }
 
   @Test
-  void reportsPublicMethodOnInaccessibleClass() {
+  void fetchesPublicMethodFromInaccessibleClass() {
     InaccessibleGetterSource source = new InaccessibleGetterSource();
 
-    assertThatThrownBy(() -> fetchProperty("name", source))
-            .isInstanceOf(GraphQLException.class);
+    Object fetchedValue = fetchProperty("name", source);
+
+    assertThat(fetchedValue).isEqualTo("package private getter");
   }
 
   public String getDisplayName() {

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -2,5 +2,16 @@
   {
     "name": "graphql.starwars.Human",
     "allPublicMethods": true
+  },
+  {
+    "name": "org.graalvm.reachability.graphql.InaccessibleGetterSource",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.graalvm.reachability.graphql.PropertyFetchingImplTest",
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "graphql.starwars.Human",
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
@@ -1,0 +1,19 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/greeting.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      },
+      {
+        "pattern": "\\Qgraphql/starwars.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,108 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnection",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnectionCursor",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultEdge",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultPageInfo",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLArgument",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLDirective",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLEnumValueDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLFieldDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectField",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLOutputType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "org.graalvm.reachability.graphql.InaccessibleGetterSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "org.graalvm.reachability.graphql.PropertyFetchingImplTest",
+      "fields" : [
+        {
+          "name" : "hidden"
+        },
+        {
+          "name" : "visible"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    greeting: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
@@ -1,0 +1,63 @@
+schema {
+    query: QueryType
+    mutation: Mutation
+}
+
+type Mutation {
+    addFriend(characterId: ID!, newFriend: NewCharacter!) : Character!
+}
+
+type QueryType {
+    hero(episode: Episode): Character!
+    human(id : String) : Human
+    droid(id: ID!): Droid
+    humans: HumanConnection
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]
+    homePlanet: String
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+}
+
+interface Character {
+    id: ID!
+    name: String!
+}
+
+input NewCharacter {
+    name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #737

This PR provides test fixes and new metadata for com.graphql-java:graphql-java:19.7, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 199763
- Cached input tokens: 3580928
- Output tokens: 33238
- Entries found: 16
- Iterations: 4
- Library coverage percentage: 30.88
- Previous library version metadata entries: 24
- Previous library version coverage percentage: 22.18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b680d6b4de1b4db9930fb080a8daa4943850011`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java:19.2: 4/66 covered calls (6.06%)
- com.graphql-java:graphql-java:19.7: 11/12 covered calls (91.67%)

**Reflection:**
- com.graphql-java:graphql-java:19.2: 3/65 covered calls (4.62%)
- com.graphql-java:graphql-java:19.7: 10/11 covered calls (90.91%)

**Resources:**
- com.graphql-java:graphql-java:19.2: 1/1 covered calls (100.00%)
- com.graphql-java:graphql-java:19.7: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java:19.2: 44403/220088 (20.18%)
- com.graphql-java:graphql-java:19.7: 42423/149497 (28.38%)

**Line:**
- com.graphql-java:graphql-java:19.2: 10623/47902 (22.18%)
- com.graphql-java:graphql-java:19.7: 10224/33104 (30.88%)

**Method:**
- com.graphql-java:graphql-java:19.2: 3126/15518 (20.14%)
- com.graphql-java:graphql-java:19.7: 2959/9722 (30.44%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
index 2b200a3cb1..decbc3b69b 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -15,3 +15,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
new file mode 100644
index 0000000000..b534847d3c
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
@@ -0,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+
+public final class ImmutableCollection<E> extends AbstractCollection<E> {
+
+  private final Collection<E> delegate;
+
+  ImmutableCollection(Collection<E> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
new file mode 100644
index 0000000000..9be5ae84c5
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
@@ -0,0 +1,132 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class ImmutableList<E> extends AbstractList<E> implements RandomAccess {
+
+  private final List<E> delegate;
+
+  private ImmutableList(Collection<? extends E> values) {
+    this.delegate = Collections.unmodifiableList(new ArrayList<>(values));
+  }
+
+  @SafeVarargs
+  private ImmutableList(E... values) {
+    List<E> list = new ArrayList<>(values.length);
+    Collections.addAll(list, values);
+    this.delegate = Collections.unmodifiableList(list);
+  }
+
+  public static <E> ImmutableList<E> of() {
+    return new ImmutableList<>(Collections.emptyList());
+  }
+
+  public static <E> ImmutableList<E> of(E element) {
+    return new ImmutableList<>(element);
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth) {
+    return new ImmutableList<>(first, second, third, fourth, fifth);
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterable<? extends E> values) {
+    if (values instanceof Collection) {
+      return copyOf((Collection<? extends E>) values);
+    }
+    Builder<E> builder = builder();
+    builder.addAll(values);
+    return builder.build();
+  }
+
+  public static <E> ImmutableList<E> copyOf(Collection<? extends E> values) {
+    return new ImmutableList<>(values);
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterator<? extends E> values) {
+    Builder<E> builder = builder();
+    while (values.hasNext()) {
+      builder.add(values.next());
+    }
+    return builder.build();
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableList<E>> toImmutableList() {
+    return Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf);
+  }
+
+  @Override
+  public E get(int index) {
+    return delegate.get(index);
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+
+  @Override
+  public int indexOf(Object object) {
+    return delegate.indexOf(object);
+  }
+
+  public static final class Builder<E> {
+
+    private final List<E> values;
+
+    public Builder() {
+      this.values = new ArrayList<>();
+    }
+
+    public Builder(int expectedSize) {
+      this.values = new ArrayList<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableList<E> build() {
+      return ImmutableList.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
new file mode 100644
index 0000000000..b1b54aa816
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
@@ -0,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ImmutableListMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, ImmutableList<V>> delegate;
+
+  private ImmutableListMultimap(Map<K, ImmutableList<V>> values) {
+    this.delegate = ImmutableMap.copyOf(values);
+  }
+
+  public static <K, V> ImmutableListMultimap<K, V> of() {
+    return new ImmutableListMultimap<>(new LinkedHashMap<>());
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public ImmutableList<V> get(K key) {
+    return delegate.getOrDefault(key, ImmutableList.of());
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, ImmutableList.Builder<V>> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.computeIfAbsent(key, unused -> ImmutableList.builder()).add(value);
+      return this;
+    }
+
+    public ImmutableListMultimap<K, V> build() {
+      Map<K, ImmutableList<V>> built = new LinkedHashMap<>();
+      for (Map.Entry<K, ImmutableList.Builder<V>> entry : values.entrySet()) {
+        built.put(entry.getKey(), entry.getValue().build());
+      }
+      return new ImmutableListMultimap<>(built);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
new file mode 100644
index 0000000000..5a74b08d18
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
@@ -0,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ImmutableMap<K, V> extends AbstractMap<K, V> {
+
+  private final Map<K, V> delegate;
+
+  private ImmutableMap(Map<? extends K, ? extends V> values) {
+    this.delegate = Collections.unmodifiableMap(new LinkedHashMap<>(values));
+  }
+
+  public static <K, V> ImmutableMap<K, V> of() {
+    return new ImmutableMap<>(Collections.emptyMap());
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K firstKey, V firstValue, K secondKey, V secondValue,
+          K thirdKey, V thirdValue, K fourthKey, V fourthValue) {
+    Builder<K, V> builder = builder();
+    return builder.put(firstKey, firstValue).put(secondKey, secondValue).put(thirdKey, thirdValue)
+            .put(fourthKey, fourthValue).build();
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K firstKey, V firstValue, K secondKey, V secondValue,
+          K thirdKey, V thirdValue, K fourthKey, V fourthValue, K fifthKey, V fifthValue) {
+    Builder<K, V> builder = builder();
+    return builder.put(firstKey, firstValue).put(secondKey, secondValue).put(thirdKey, thirdValue)
+            .put(fourthKey, fourthValue).put(fifthKey, fifthValue).build();
+  }
+
+  public static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V> values) {
+    return new ImmutableMap<>(values);
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return delegate.containsKey(key);
+  }
+
+  @Override
+  public V get(Object key) {
+    return delegate.get(key);
+  }
+
+  @Override
+  public V getOrDefault(Object key, V defaultValue) {
+    return delegate.getOrDefault(key, defaultValue);
+  }
+
+  @Override
+  public ImmutableSet<Entry<K, V>> entrySet() {
+    return ImmutableSet.copyOf(delegate.entrySet());
+  }
+
+  @Override
+  public ImmutableSet<K> keySet() {
+    return ImmutableSet.copyOf(delegate.keySet());
+  }
+
+  @Override
+  public ImmutableCollection<V> values() {
+    return new ImmutableCollection<>(delegate.values());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, V> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder<K, V> putAll(Map<? extends K, ? extends V> map) {
+      values.putAll(map);
+      return this;
+    }
+
+    public ImmutableMap<K, V> build() {
+      return ImmutableMap.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
new file mode 100644
index 0000000000..0b00e3df0e
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
@@ -0,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class ImmutableSet<E> extends AbstractSet<E> {
+
+  private final Set<E> delegate;
+
+  private ImmutableSet(Collection<? extends E> values) {
+    this.delegate = Collections.unmodifiableSet(new LinkedHashSet<>(values));
+  }
+
+  @SafeVarargs
+  private ImmutableSet(E... values) {
+    Set<E> set = new LinkedHashSet<>(values.length);
+    Collections.addAll(set, values);
+    this.delegate = Collections.unmodifiableSet(set);
+  }
+
+  public static <E> ImmutableSet<E> of(E element) {
+    return new ImmutableSet<>(element);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third) {
+    return new ImmutableSet<>(first, second, third);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth) {
+    return new ImmutableSet<>(first, second, third, fourth);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth) {
+    return new ImmutableSet<>(first, second, third, fourth, fifth);
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Collection<? extends E> values) {
+    return new ImmutableSet<>(values);
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableSet<E>> toImmutableSet() {
+    return Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf);
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    return UnmodifiableIterator.copyOf(delegate.iterator());
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object object) {
+    return delegate.contains(object);
+  }
+
+  public static final class Builder<E> {
+
+    private final Set<E> values;
+
+    public Builder() {
+      this.values = new LinkedHashSet<>();
+    }
+
+    public Builder(int expectedSize) {
+      this.values = new LinkedHashSet<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableSet<E> build() {
+      return ImmutableSet.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
new file mode 100644
index 0000000000..24fabeea52
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
@@ -0,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class LinkedHashMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, Set<V>> delegate = new LinkedHashMap<>();
+
+  private LinkedHashMultimap() {
+  }
+
+  public static <K, V> LinkedHashMultimap<K, V> create() {
+    return new LinkedHashMultimap<>();
+  }
+
+  @Override
+  public Collection<V> get(K key) {
+    return delegate.computeIfAbsent(key, unused -> new LinkedHashSet<>());
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    return delegate.computeIfAbsent(key, unused -> new LinkedHashSet<>()).add(value);
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    Set<V> values = delegate.get(key);
+    if (values == null) {
+      return false;
+    }
+    boolean removed = values.remove(value);
+    if (values.isEmpty()) {
+      delegate.remove(key);
+    }
+    return removed;
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
new file mode 100644
index 0000000000..eebddd1949
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
@@ -0,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+
+public final class Maps {
+
+  private Maps() {
+  }
+
+  public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+    return new LinkedHashMap<>(expectedSize);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
new file mode 100644
index 0000000000..bc447ab6c5
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
@@ -0,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+
+public interface Multimap<K, V> {
+
+  Collection<V> get(K key);
+
+  boolean put(K key, V value);
+
+  boolean remove(Object key, Object value);
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
new file mode 100644
index 0000000000..e6003f3bfc
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
@@ -0,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class Sets {
+
+  private Sets() {
+  }
+
+  public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+    return new HashSet<>(expectedSize);
+  }
+
+  public static <E> SetView<E> intersection(Set<E> first, Set<?> second) {
+    Set<E> result = new LinkedHashSet<>();
+    for (E element : first) {
+      if (second.contains(element)) {
+        result.add(element);
+      }
+    }
+    return new SetView<>(result);
+  }
+
+  public static final class SetView<E> extends AbstractSet<E> {
+
+    private final Set<E> delegate;
+
+    private SetView(Set<E> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return delegate.iterator();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean contains(Object object) {
+      return delegate.contains(object);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
new file mode 100644
index 0000000000..b31815f7b6
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
@@ -0,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Iterator;
+
+public final class UnmodifiableIterator<E> implements Iterator<E> {
+
+  private final Iterator<? extends E> iterator;
+
+  private UnmodifiableIterator(Iterator<? extends E> iterator) {
+    this.iterator = iterator;
+  }
+
+  public static <E> UnmodifiableIterator<E> copyOf(Iterator<? extends E> iterator) {
+    return new UnmodifiableIterator<>(iterator);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  @Override
+  public E next() {
+    return iterator.next();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
new file mode 100644
index 0000000000..263430e0d4
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/org/graalvm/reachability/graphql/PropertyFetchingImplTest.java
@@ -0,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.reachability.graphql;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFetchingImplTest {
+
+  public final String visible = "public field";
+
+  private final String hidden = "declared field";
+
+  @BeforeEach
+  void resetPropertyFetcherConfiguration() {
+    PropertyDataFetcher.clearReflectionCache();
+    PropertyDataFetcher.setUseSetAccessible(true);
+    PropertyDataFetcher.setUseNegativeCache(true);
+  }
+
+  @Test
+  void fetchesPublicGetterWithNoArguments() {
+    Object fetchedValue = fetchProperty("displayName", this);
+
+    assertThat(fetchedValue).isEqualTo("public getter");
+  }
+
+  @Test
+  void fetchesGetterWithDataFetchingEnvironmentArgument() {
+    Object fetchedValue = fetchProperty("viewer", this);
+
+    assertThat(fetchedValue).isEqualTo("environment getter");
+  }
+
+  @Test
+  void fetchesAndCachesPublicField() {
+    Object firstFetchedValue = fetchProperty("visible", this);
+    Object cachedFetchedValue = fetchProperty("visible", this);
+
+    assertThat(firstFetchedValue).isEqualTo("public field");
+    assertThat(cachedFetchedValue).isEqualTo("public field");
+  }
+
+  @Test
+  void fetchesDeclaredFieldAfterGetterLookupFails() {
+    Object fetchedValue = fetchProperty("hidden", this);
+
+    assertThat(fetchedValue).isEqualTo("declared field");
+  }
+
+  @Test
+  void fetchesPublicMethodFromInaccessibleClass() {
+    InaccessibleGetterSource source = new InaccessibleGetterSource();
+
+    Object fetchedValue = fetchProperty("name", source);
+
+    assertThat(fetchedValue).isEqualTo("package private getter");
+  }
+
+  public String getDisplayName() {
+    return "public getter";
+  }
+
+  public String getViewer(DataFetchingEnvironment environment) {
+    return environment == null ? "missing environment" : "environment getter";
+  }
+
+  private Object fetchProperty(String propertyName, Object source) {
+    DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .source(source)
+            .fieldType(GraphQLString)
+            .build();
+    return PropertyDataFetcher.fetching(propertyName).get(environment);
+  }
+}
+
+class InaccessibleGetterSource {
+
+  public String getName() {
+    return "package private getter";
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
new file mode 100644
index 0000000000..b154f38b11
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}

```
