### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-metrics:1.59.0 using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/reachability-metadata.json
@@ -1,0 +1,81 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.SdkMeter"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.SdkMeterProvider"
+      },
+      "type": "io.opentelemetry.api.incubator.metrics.ExtendedDefaultMeterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProvider",
+      "methods": [
+        {
+          "name": "resetForTest",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.common.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "addMeterConfiguratorCondition",
+          "parameterTypes": [
+            "java.util.function.Predicate",
+            "io.opentelemetry.sdk.metrics.internal.MeterConfig"
+          ]
+        },
+        {
+          "name": "setMeterConfigurator",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.common.internal.ScopeConfigurator"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil"
+      },
+      "type": "io.opentelemetry.sdk.metrics.ViewBuilder",
+      "methods": [
+        {
+          "name": "addAttributesProcessor",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.DoubleAdder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.metrics.internal.concurrent.AdderUtil"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.59.0",
+    "tested-versions" : [
+      "1.59.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry"
+    ]
+  },
+  {
     "metadata-version" : "1.56.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.56.0/opentelemetry-sdk-metrics-1.56.0-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "1.59.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.59.0/opentelemetry-sdk-metrics-1.59.0-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.59.0/sdk/metrics/src/test/java",
+    "documentation-url" : "https://javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/index.html",
+    "description" : "This module provides the OpenTelemetry Java SDK implementation for metrics, including the meter provider, metric readers, views, and aggregation pipeline. Applications and instrumentation use it to configure metric collection and produce metric data that can be exported through OpenTelemetry.",
     "tested-versions" : [
       "1.59.0"
     ],
     "allowed-packages" : [
-      "io.opentelemetry"
+      "io.opentelemetry.sdk.metrics"
     ]
   },
   {

--- a/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T22:22:22.687637Z",
+    "library": "io.opentelemetry:opentelemetry-sdk-metrics:1.59.0",
+    "starting_commit": "502c2cded09e60683d46dc7a9bed8c48d7807b71",
+    "ending_commit": "6c49c18bd8959e4998902269d69e7da5bfe7f877",
+    "previous_library": "io.opentelemetry:opentelemetry-sdk-metrics:1.56.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.59.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3250,
+          "missed": 15444,
+          "ratio": 0.173853,
+          "total": 18694
+        },
+        "line": {
+          "covered": 869,
+          "missed": 3391,
+          "ratio": 0.203991,
+          "total": 4260
+        },
+        "method": {
+          "covered": 283,
+          "missed": 924,
+          "ratio": 0.234466,
+          "total": 1207
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.56.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3250,
+          "missed": 15437,
+          "ratio": 0.173918,
+          "total": 18687
+        },
+        "line": {
+          "covered": 869,
+          "missed": 3391,
+          "ratio": 0.203991,
+          "total": 4260
+        },
+        "method": {
+          "covered": 283,
+          "missed": 925,
+          "ratio": 0.234272,
+          "total": 1208
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 27502,
+      "cached_input_tokens_used": 131072,
+      "output_tokens_used": 1467,
+      "iterations": 1,
+      "cost_usd": 0.1095,
+      "tested_library_loc": 869,
+      "metadata_entries": 12,
+      "previous_library_metadata_entries": 13,
+      "code_coverage_percent": 20.4,
+      "previous_library_coverage_percent": 20.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.59.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3250,
+        "missed" : 15444,
+        "ratio" : 0.173853,
+        "total" : 18694
+      },
+      "line" : {
+        "covered" : 869,
+        "missed" : 3391,
+        "ratio" : 0.203991,
+        "total" : 4260
+      },
+      "method" : {
+        "covered" : 283,
+        "missed" : 924,
+        "ratio" : 0.234466,
+        "total" : 1207
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-metrics:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--allow-incomplete-classpath')
+        }
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version=1.59.0
+metadata.dir=io.opentelemetry/opentelemetry-sdk-trace/1.59.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'opentelemetry-sdk-metrics-test'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/OpenTelemetrySdkMetricsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.sdk.metrics.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import org.junit.jupiter.api.Test;
+
+
+public class OpenTelemetrySdkMetricsTest {
+
+    @Test
+    public void sdkMetricsTest() {
+        SdkMeterProviderBuilder sdkMeterProvider =
+                SdkMeterProvider.builder().setExemplarFilter(ExemplarFilter.alwaysOff());
+
+        try (SdkMeterProvider provider = sdkMeterProvider.build()) {
+            provider.meterBuilder("test");
+        }
+
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.internal.MeterConfig;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SdkMeterProviderUtilTest {
+
+    @Test
+    public void setMeterConfiguratorOnBuilderDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.setMeterConfigurator(
+                builder, disableMeterNamed("builder-disabled-meter"));
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter =
+                    createCounter(provider, "builder-enabled-meter", "builder.enabled.counter");
+            LongCounter disabledCounter =
+                    createCounter(provider, "builder-disabled-meter", "builder.disabled.counter");
+
+            enabledCounter.add(2);
+            disabledCounter.add(4);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("builder.enabled.counter")
+                    .doesNotContain("builder.disabled.counter");
+            assertThat(sumValue(metrics, "builder.enabled.counter")).isEqualTo(2);
+        }
+    }
+
+    @Test
+    public void addMeterConfiguratorConditionDisablesMatchingMeter() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder().registerMetricReader(reader);
+
+        SdkMeterProviderUtil.addMeterConfiguratorCondition(
+                builder,
+                scopeInfo -> scopeInfo.getName().startsWith("conditional-disabled"),
+                MeterConfig.disabled());
+
+        try (SdkMeterProvider provider = builder.build()) {
+            LongCounter enabledCounter = createCounter(
+                    provider, "conditional-enabled-meter", "conditional.enabled.counter");
+            LongCounter disabledCounter = createCounter(
+                    provider, "conditional-disabled-meter", "conditional.disabled.counter");
+
+            enabledCounter.add(3);
+            disabledCounter.add(6);
+
+            Collection<MetricData> metrics = reader.collectAllMetrics();
+            assertThat(metrics).extracting(MetricData::getName)
+                    .contains("conditional.enabled.counter")
+                    .doesNotContain("conditional.disabled.counter");
+            assertThat(sumValue(metrics, "conditional.enabled.counter")).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void setMeterConfiguratorOnProviderAndResetForTestDisableExistingMeters() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+
+        try (SdkMeterProvider provider =
+                SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+            LongCounter counter = createCounter(provider, "runtime-meter", "runtime.counter");
+            counter.add(5);
+
+            assertThat(sumValue(reader.collectAllMetrics(), "runtime.counter")).isEqualTo(5);
+
+            SdkMeterProviderUtil.setMeterConfigurator(provider, disableMeterNamed("runtime-meter"));
+            counter.add(8);
+
+            assertThat(reader.collectAllMetrics()).extracting(MetricData::getName)
+                    .doesNotContain("runtime.counter");
+
+            SdkMeterProviderUtil.resetForTest(provider);
+
+            assertThat(reader.collectAllMetrics()).isEmpty();
+        }
+    }
+
+    @Test
+    public void appendFilteredBaggageAttributesAddsMatchingBaggageAfterAttributeFiltering() {
+        CapturingMetricReader reader = new CapturingMetricReader();
+        ViewBuilder viewBuilder = View.builder().setAttributeFilter(Set.of("existing"));
+        SdkMeterProviderUtil.appendFilteredBaggageAttributes(
+                viewBuilder, key -> key.equals("tenant"));
+
+        try (SdkMeterProvider provider = SdkMeterProvider.builder()
+                .registerMetricReader(reader)
+                .registerView(
+                        InstrumentSelector.builder()
+                                .setName("baggage.counter")
+                                .setType(InstrumentType.COUNTER)
+                                .build(),
+                        viewBuilder.build())
+                .build()) {
+            LongCounter counter = createCounter(provider, "baggage-meter", "baggage.counter");
+            Context context = Baggage.builder()
+                    .put("tenant", "alpha")
+                    .put("ignored", "beta")
+                    .build()
+                    .storeInContext(Context.root());
+
+            counter.add(7, Attributes.of(AttributeKey.stringKey("existing"), "kept"), context);
+
+            LongPointData point = getOnlyPoint(reader.collectAllMetrics(), "baggage.counter");
+            assertThat(point.getValue()).isEqualTo(7);
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("existing")))
+                    .isEqualTo("kept");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("tenant")))
+                    .isEqualTo("alpha");
+            assertThat(point.getAttributes().get(AttributeKey.stringKey("ignored"))).isNull();
+        }
+    }
+
+    private static ScopeConfigurator<MeterConfig> disableMeterNamed(String meterName) {
+        return scopeInfo -> scopeInfo.getName().equals(meterName)
+                ? MeterConfig.disabled()
+                : MeterConfig.enabled();
+    }
+
+    private static LongCounter createCounter(
+            SdkMeterProvider provider, String meterName, String counterName) {
+        return provider.meterBuilder(meterName).build().counterBuilder(counterName).build();
+    }
+
+    private static long sumValue(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        return metric.getLongSumData().getPoints().stream()
+                .mapToLong(LongPointData::getValue)
+                .sum();
+    }
+
+    private static LongPointData getOnlyPoint(Collection<MetricData> metrics, String metricName) {
+        MetricData metric = metrics.stream()
+                .filter(candidate -> candidate.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric: " + metricName));
+        assertThat(metric.getLongSumData().getPoints()).hasSize(1);
+        return metric.getLongSumData().getPoints().iterator().next();
+    }
+
+    private static final class CapturingMetricReader implements MetricReader {
+
+        private CollectionRegistration registration = CollectionRegistration.noop();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            this.registration = registration;
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        Collection<MetricData> collectAllMetrics() {
+            return registration.collectAllMetrics();
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.**"
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "io.opentelemetry.**"
+      "includeClasses" : "io.opentelemetry.sdk.metrics.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3341

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-metrics:1.59.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 27502
- Cached input tokens: 131072
- Output tokens: 1467
- Entries found: 12
- Iterations: 1
- Library coverage percentage: 20.4
- Previous library version metadata entries: 13
- Previous library version coverage percentage: 20.4

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f67043299acd8f354ed9b5dd51b0b218fe009c74`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 5/5 covered calls (100.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 5/5 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 5/5 covered calls (100.00%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 3250/18687 (17.39%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 3250/18694 (17.39%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 869/4260 (20.40%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 869/4260 (20.40%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-metrics:1.56.0: 283/1208 (23.43%)
- io.opentelemetry:opentelemetry-sdk-metrics:1.59.0: 283/1207 (23.45%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
index b5c6a0ee8a..68fdeb7568 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/src/test/java/opentelemetry/SdkMeterProviderUtilTest.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
index 9178454061..8d10356eed 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.56.0/user-code-filter.json
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-metrics/1.59.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "io.opentelemetry.**"
+      "includeClasses" : "io.opentelemetry.sdk.metrics.**"
     }
   ]
 }

```
