### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-core:12.3.0

### DIFF
--- a/metadata/org.flywaydb/flyway-core/12.3.0/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-core/12.3.0/reachability-metadata.json
@@ -1,0 +1,534 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcConnectionFactory"
+      },
+      "type" : "com.ibm.icu.text.Collator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "type" : "org.apache.logging.log4j.util.EnvironmentPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "type" : "org.apache.logging.log4j.util.SystemPropertiesPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBaselineMigrationPrefix",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setBaselineMigrationPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.NullFlywayTelemetryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.PlaceholderPropertyResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.jdbc.ErrorOverrideInitializerStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type" : "org.flywaydb.core.internal.logging.log4j2.Log4j2LogCreator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type" : "org.flywaydb.core.internal.logging.slf4j.Slf4jLogCreator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.CheckCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DeployCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffTextCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.GenerateCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.ModelCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.OfflinePermitConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.OfflinePermitConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.UndoCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isCheckDriftOnMigrate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isPublishResult",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCheckDriftOnMigrate",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setPublishResult",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.scanner.classpath.ClasspathLocationHandlerImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.scanner.filesystem.FilesystemLocationHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcConnectionFactory"
+      },
+      "type" : "org.h2.mvstore.MVStore$TxCounter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcConnectionFactory"
+      },
+      "type" : "org.h2.mvstore.Page"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "type" : "org.osgi.framework.FrameworkUtil"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "type" : "org.slf4j.simple.SimpleServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.ser.Serializers[]"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "META-INF/log4j-provider.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FlywayDbWebsiteLinks"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcConnectionFactory"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.spi.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.util.PropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "glob" : "META-INF/services/org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.apachecommons.ApacheCommonsLogCreator"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
+      },
+      "glob" : "db/callback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.classpath.ClasspathLocationHandlerImpl"
+      },
+      "glob" : "db/migration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "log4j2.StatusLogger.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "log4j2.component.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "log4j2.simplelog.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "log4j2.system.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.license.VersionPrinter"
+      },
+      "glob" : "org/flywaydb/core/internal/version.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.LicenseGuard"
+      },
+      "glob" : "simplelogger.properties"
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.3.0",
+    "test-version" : "11.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/12.3.0/flyway-core-12.3.0-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-12.3.0/documentation",
+    "description" : "Flyway Core is a database migration library that manages and applies versioned schema changes across supported databases. It tracks migration history and helps keep database schemas consistent with application releases.",
+    "tested-versions" : [
+      "12.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache",
+      "org.flywaydb",
+      "org.slf4j"
+    ]
+  },
+  {
     "metadata-version" : "11.14.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/11.14.1/flyway-core-11.14.1-sources.jar",
     "repository-url" : "https://github.com/flyway/flyway",

--- a/stats/org.flywaydb/flyway-core/12.3.0/stats.json
+++ b/stats/org.flywaydb/flyway-core/12.3.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "12.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.108108,
+          "coveredCalls" : 4,
+          "totalCalls" : 37
+        },
+        "resources" : {
+          "coverageRatio" : 0.666667,
+          "coveredCalls" : 4,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 0.186047,
+      "coveredCalls" : 8,
+      "totalCalls" : 43
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 17760,
+        "missed" : 30364,
+        "ratio" : 0.369047,
+        "total" : 48124
+      },
+      "line" : {
+        "covered" : 3895,
+        "missed" : 6750,
+        "ratio" : 0.365899,
+        "total" : 10645
+      },
+      "method" : {
+        "covered" : 942,
+        "missed" : 1601,
+        "ratio" : 0.370429,
+        "total" : 2543
+      }
+    }
+  } ]
+}

--- a/tests/src/org.flywaydb/flyway-core/11.14.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-core/11.14.1/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 graalvmNative {
     binaries {
         test {
+            buildArgs.add('--enable-url-protocols=https')
             buildArgs.add('--no-fallback')
         }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#1608

This PR provides new metadata needed for the org.flywaydb:flyway-core:12.3.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.flywaydb:flyway-core:11.14.1`): 50
- Metadata entries (new `org.flywaydb:flyway-core:12.3.0`): 89
- Library coverage (previous): 36.79%
- Library coverage (new): 36.59%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f67043299acd8f354ed9b5dd51b0b218fe009c74`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-core:11.14.1: 8/43 covered calls (18.60%)
- org.flywaydb:flyway-core:12.3.0: 8/43 covered calls (18.60%)

**Reflection:**
- org.flywaydb:flyway-core:11.14.1: 4/37 covered calls (10.81%)
- org.flywaydb:flyway-core:12.3.0: 4/37 covered calls (10.81%)

**Resources:**
- org.flywaydb:flyway-core:11.14.1: 4/6 covered calls (66.67%)
- org.flywaydb:flyway-core:12.3.0: 4/6 covered calls (66.67%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-core:11.14.1: 17315/46754 (37.03%)
- org.flywaydb:flyway-core:12.3.0: 17760/48124 (36.90%)

**Line:**
- org.flywaydb:flyway-core:11.14.1: 3801/10333 (36.79%)
- org.flywaydb:flyway-core:12.3.0: 3895/10645 (36.59%)

**Method:**
- org.flywaydb:flyway-core:11.14.1: 950/2471 (38.45%)
- org.flywaydb:flyway-core:12.3.0: 942/2543 (37.04%)
