### PR TITLE
[GenAI] Test fix for dom4j:dom4j:20040902.021138 using gpt-5.5

### DIFF
--- a/metadata/dom4j/dom4j/20040902.021138/reachability-metadata.json
+++ b/metadata/dom4j/dom4j/20040902.021138/reachability-metadata.json
@@ -1,0 +1,119 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.bean.BeanDocumentFactory"
+      },
+      "type" : "org.dom4j.bean.BeanDocumentFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.bean.BeanMetaData"
+      },
+      "type" : "org.dom4j.rule.Rule",
+      "methods" : [
+        {
+          "name" : "getMode",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setMode",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "getPriority",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setPriority",
+          "parameterTypes" : [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.tree.ConcurrentReaderHashMap"
+      },
+      "type" : "org.dom4j.tree.ConcurrentReaderHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.tree.ConcurrentReaderHashMap"
+      },
+      "type" : "org.dom4j.tree.ConcurrentReaderHashMap$BarrierLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.DocumentFactory"
+      },
+      "type" : "org.dom4j.DocumentFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.QName"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ],
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.QName"
+      },
+      "type" : "org.dom4j.Namespace",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.QName"
+      },
+      "type" : "org.dom4j.QName",
+      "fields" : [
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "qualifiedName"
+        },
+        {
+          "name" : "hashCode"
+        },
+        {
+          "name" : "documentFactory"
+        }
+      ],
+      "serializable" : true
+    }
+  ]
+}

--- a/metadata/dom4j/dom4j/index.json
+++ b/metadata/dom4j/dom4j/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "20040902.021138",
+    "tested-versions" : [
+      "20040902.021138"
+    ],
+    "allowed-packages" : [
+      "org.dom4j"
+    ]
+  },
+  {
     "metadata-version" : "1.6.1",
     "source-code-url" : "https://repo1.maven.org/maven2/dom4j/dom4j/1.6.1/dom4j-1.6.1-sources.jar",
     "repository-url" : "https://github.com/dom4j/dom4j",

--- a/metadata/dom4j/dom4j/index.json
+++ b/metadata/dom4j/dom4j/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "20040902.021138",
+    "source-code-url" : "https://github.com/dom4j/dom4j/tree/449d34d2494bb726b05fdae2bd0577ee53fe73aa/src/java",
+    "repository-url" : "https://github.com/dom4j/dom4j",
+    "test-code-url" : "https://github.com/dom4j/dom4j/tree/449d34d2494bb726b05fdae2bd0577ee53fe73aa/src/test",
+    "documentation-url" : "https://github.com/dom4j/dom4j/tree/449d34d2494bb726b05fdae2bd0577ee53fe73aa/xdocs",
+    "description" : "dom4j is an open source Java framework for processing XML with XPath support and integration with DOM, SAX, and JAXP. It provides a flexible object model and APIs for reading, writing, navigating, and manipulating XML documents in Java applications.",
     "tested-versions" : [
       "20040902.021138"
     ],

--- a/stats/dom4j/dom4j/20040902.021138/execution-metrics.json
+++ b/stats/dom4j/dom4j/20040902.021138/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T22:56:26.245183Z",
+    "library": "dom4j:dom4j:20040902.021138",
+    "starting_commit": "d1cad2659c395de443e6e3785e3ac4f8935c7082",
+    "ending_commit": "829740b9708d648af5ce0d7dbf5c44c826498125",
+    "previous_library": "dom4j:dom4j:1.6.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "20040902.021138",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.862069,
+            "coveredCalls": 25,
+            "totalCalls": 29
+          }
+        },
+        "coverageRatio": 0.862069,
+        "coveredCalls": 25,
+        "totalCalls": 29
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3810,
+          "missed": 49602,
+          "ratio": 0.071332,
+          "total": 53412
+        },
+        "line": {
+          "covered": 1072,
+          "missed": 12659,
+          "ratio": 0.078072,
+          "total": 13731
+        },
+        "method": {
+          "covered": 326,
+          "missed": 2839,
+          "ratio": 0.103002,
+          "total": 3165
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.6.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.952381,
+            "coveredCalls": 40,
+            "totalCalls": 42
+          }
+        },
+        "coverageRatio": 0.952381,
+        "coveredCalls": 40,
+        "totalCalls": 42
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3482,
+          "missed": 31131,
+          "ratio": 0.100598,
+          "total": 34613
+        },
+        "line": {
+          "covered": 988,
+          "missed": 8269,
+          "ratio": 0.10673,
+          "total": 9257
+        },
+        "method": {
+          "covered": 287,
+          "missed": 2246,
+          "ratio": 0.113304,
+          "total": 2533
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 734201,
+      "cached_input_tokens_used": 10529280,
+      "output_tokens_used": 56847,
+      "iterations": 11,
+      "cost_usd": 6.97,
+      "tested_library_loc": 1072,
+      "metadata_entries": 26,
+      "previous_library_metadata_entries": 60,
+      "code_coverage_percent": 7.81,
+      "previous_library_coverage_percent": 10.67
+    },
+    "artifacts": {
+      "test_file": "tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/XMLTableColumnDefinitionTest.java",
+      "metadata_file": "metadata/dom4j/dom4j/20040902.021138/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/dom4j/dom4j/20040902.021138/stats.json
+++ b/stats/dom4j/dom4j/20040902.021138/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "20040902.021138",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.862069,
+          "coveredCalls" : 25,
+          "totalCalls" : 29
+        }
+      },
+      "coverageRatio" : 0.862069,
+      "coveredCalls" : 25,
+      "totalCalls" : 29
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3810,
+        "missed" : 49602,
+        "ratio" : 0.071332,
+        "total" : 53412
+      },
+      "line" : {
+        "covered" : 1072,
+        "missed" : 12659,
+        "ratio" : 0.078072,
+        "total" : 13731
+      },
+      "method" : {
+        "covered" : 326,
+        "missed" : 2839,
+        "ratio" : 0.103002,
+        "total" : 3165
+      }
+    }
+  } ]
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/.gitignore
+++ b/tests/src/dom4j/dom4j/20040902.021138/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/dom4j/dom4j/20040902.021138/build.gradle
+++ b/tests/src/dom4j/dom4j/20040902.021138/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "dom4j:dom4j:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/build.gradle
+++ b/tests/src/dom4j/dom4j/20040902.021138/build.gradle
@@ -8,10 +8,26 @@ plugins {
     id "org.graalvm.internal.tck"
 }
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://repo.maven.apache.org/maven2")
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeModule("dom4j", "dom4j")
+        }
+    }
+}
+
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "dom4j:dom4j:$libraryVersion"
+    testImplementation "dom4j:dom4j:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/dom4j/dom4j/20040902.021138/gradle.properties
+++ b/tests/src/dom4j/dom4j/20040902.021138/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = dom4j:dom4j:20040902.021138
+library.version = 20040902.021138
+metadata.dir = dom4j/dom4j/20040902.021138/

--- a/tests/src/dom4j/dom4j/20040902.021138/settings.gradle
+++ b/tests/src/dom4j/dom4j/20040902.021138/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'dom4j.dom4j_tests'

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.dom4j.bean.BeanDocumentFactory;
+import org.dom4j.bean.BeanElement;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class BeanDocumentFactoryTest {
+    @Test
+    void createsBeanBackedElementFromClassAttribute() throws Exception {
+        BeanDocumentFactory factory = new BeanDocumentFactory();
+        clearCompilerGeneratedClassCache();
+        AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute("", "class", "class", "CDATA", factory.getClass().getName());
+
+        Element element = factory.createElement(QName.get("configuredBean"), attributes);
+        Object data = ((BeanElement) element).getData();
+
+        assertThat(element).isInstanceOf(BeanElement.class);
+        assertThat(element.getName()).isEqualTo("configuredBean");
+        assertThat(data).isNotSameAs(factory);
+        assertThat(data.getClass()).isEqualTo(factory.getClass());
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = BeanDocumentFactory.class.getDeclaredField("class$org$dom4j$bean$BeanDocumentFactory");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
@@ -8,8 +8,6 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
-
 import org.dom4j.Element;
 import org.dom4j.QName;
 import org.dom4j.bean.BeanDocumentFactory;
@@ -19,24 +17,17 @@ import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanDocumentFactoryTest {
     @Test
-    void createsBeanBackedElementFromClassAttribute() throws Exception {
+    void createsBeanBackedElementFromClassAttribute() {
         BeanDocumentFactory factory = new BeanDocumentFactory();
-        clearCompilerGeneratedClassCache();
         AttributesImpl attributes = new AttributesImpl();
-        attributes.addAttribute("", "class", "class", "CDATA", factory.getClass().getName());
+        attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
 
         Element element = factory.createElement(QName.get("configuredBean"), attributes);
         Object data = ((BeanElement) element).getData();
 
         assertThat(element).isInstanceOf(BeanElement.class);
         assertThat(element.getName()).isEqualTo("configuredBean");
+        assertThat(data).isInstanceOf(BeanDocumentFactory.class);
         assertThat(data).isNotSameAs(factory);
-        assertThat(data.getClass()).isEqualTo(factory.getClass());
-    }
-
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        Field field = BeanDocumentFactory.class.getDeclaredField("class$org$dom4j$bean$BeanDocumentFactory");
-        field.setAccessible(true);
-        field.set(null, null);
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
@@ -8,6 +8,10 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
 import org.dom4j.Element;
 import org.dom4j.QName;
 import org.dom4j.bean.BeanDocumentFactory;
@@ -16,6 +20,16 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanDocumentFactoryTest {
+    @Test
+    void compilerGeneratedClassLookupResolvesBeanDocumentFactoryType() throws Throwable {
+        MethodHandle classLookup = MethodHandles.privateLookupIn(BeanDocumentFactory.class, MethodHandles.lookup())
+                .findStatic(BeanDocumentFactory.class, "class$", MethodType.methodType(Class.class, String.class));
+
+        Class<?> resolvedClass = (Class<?>) classLookup.invoke(BeanDocumentFactory.class.getName());
+
+        assertThat(resolvedClass).isEqualTo(BeanDocumentFactory.class);
+    }
+
     @Test
     void createsBeanBackedElementFromClassAttribute() {
         BeanDocumentFactory factory = new BeanDocumentFactory();

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+
+import org.dom4j.QName;
+import org.dom4j.bean.BeanDocumentFactory;
+import org.dom4j.bean.BeanElement;
+import org.dom4j.tree.NamespaceStack;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class BeanElementTest {
+    @Test
+    void compilerGeneratedClassLookupResolvesBeanElementType() throws Throwable {
+        MethodHandle classLookup = MethodHandles.privateLookupIn(BeanElement.class, MethodHandles.lookup())
+                .findStatic(BeanElement.class, "class$", MethodType.methodType(Class.class, String.class));
+
+        Class<?> resolvedClass = (Class<?>) classLookup.invoke(BeanElement.class.getName());
+
+        assertThat(resolvedClass).isEqualTo(BeanElement.class);
+    }
+
+    @Test
+    void saxClassAttributeInitializesBackingBean() throws Exception {
+        clearCompilerGeneratedClassCache();
+        BeanElement element = new BeanElement(QName.get("configuredBean"));
+        AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
+
+        element.setAttributes(attributes, new NamespaceStack(), false);
+
+        assertThat(element.getData()).isInstanceOf(BeanDocumentFactory.class);
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = BeanElement.class.getDeclaredField("class$org$dom4j$bean$BeanElement");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
@@ -8,22 +8,27 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dom4j.QName;
+import org.dom4j.Element;
 import org.dom4j.bean.BeanDocumentFactory;
 import org.dom4j.bean.BeanElement;
-import org.dom4j.tree.NamespaceStack;
+import org.dom4j.io.SAXContentHandler;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanElementTest {
     @Test
-    void saxClassAttributeInitializesBackingBean() throws Exception {
-        BeanElement element = new BeanElement(QName.get("configuredBean"));
+    void saxContentHandlerInitializesBackingBeanFromClassAttribute() throws Exception {
+        SAXContentHandler handler = new SAXContentHandler(BeanDocumentFactory.getInstance());
         AttributesImpl attributes = new AttributesImpl();
         attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
 
-        element.setAttributes(attributes, new NamespaceStack(), false);
+        handler.startDocument();
+        handler.startElement("", "configuredBean", "configuredBean", attributes);
+        handler.endElement("", "configuredBean", "configuredBean");
+        handler.endDocument();
 
-        assertThat(element.getData()).isInstanceOf(BeanDocumentFactory.class);
+        Element rootElement = handler.getDocument().getRootElement();
+        assertThat(rootElement).isInstanceOf(BeanElement.class);
+        assertThat(((BeanElement) rootElement).getData()).isInstanceOf(BeanDocumentFactory.class);
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
@@ -8,11 +8,6 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Field;
-
 import org.dom4j.QName;
 import org.dom4j.bean.BeanDocumentFactory;
 import org.dom4j.bean.BeanElement;
@@ -22,18 +17,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanElementTest {
     @Test
-    void compilerGeneratedClassLookupResolvesBeanElementType() throws Throwable {
-        MethodHandle classLookup = MethodHandles.privateLookupIn(BeanElement.class, MethodHandles.lookup())
-                .findStatic(BeanElement.class, "class$", MethodType.methodType(Class.class, String.class));
-
-        Class<?> resolvedClass = (Class<?>) classLookup.invoke(BeanElement.class.getName());
-
-        assertThat(resolvedClass).isEqualTo(BeanElement.class);
-    }
-
-    @Test
     void saxClassAttributeInitializesBackingBean() throws Exception {
-        clearCompilerGeneratedClassCache();
         BeanElement element = new BeanElement(QName.get("configuredBean"));
         AttributesImpl attributes = new AttributesImpl();
         attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
@@ -41,11 +25,5 @@ public class BeanElementTest {
         element.setAttributes(attributes, new NamespaceStack(), false);
 
         assertThat(element.getData()).isInstanceOf(BeanDocumentFactory.class);
-    }
-
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        Field field = BeanElement.class.getDeclaredField("class$org$dom4j$bean$BeanElement");
-        field.setAccessible(true);
-        field.set(null, null);
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanMetaDataTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanMetaDataTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.QName;
+import org.dom4j.bean.BeanMetaData;
+import org.dom4j.rule.Rule;
+import org.junit.jupiter.api.Test;
+
+public class BeanMetaDataTest {
+    @Test
+    void readsAndWritesBeanPropertiesThroughMetadata() {
+        BeanMetaData metaData = BeanMetaData.get(Rule.class);
+        Rule rule = new Rule();
+        int modeIndex = metaData.getIndex("mode");
+
+        metaData.setData(modeIndex, rule, "edit");
+        Object mode = metaData.getData(modeIndex, rule);
+
+        assertThat(modeIndex).isNotNegative();
+        assertThat(mode).isEqualTo("edit");
+        assertThat(rule.getMode()).isEqualTo("edit");
+    }
+
+    @Test
+    void resolvesPropertyIndexByQNameBeforeAccessingBeanData() {
+        BeanMetaData metaData = new BeanMetaData(Rule.class);
+        Rule rule = new Rule();
+        int priorityIndex = metaData.getIndex(QName.get("priority"));
+
+        metaData.setData(priorityIndex, rule, Double.valueOf(4.5));
+        Object priority = metaData.getData(priorityIndex, rule);
+
+        assertThat(priorityIndex).isNotNegative();
+        assertThat(priority).isEqualTo(Double.valueOf(4.5));
+        assertThat(rule.getPriority()).isEqualTo(4.5);
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+import org.dom4j.tree.NamespaceCache;
+import org.junit.jupiter.api.Test;
+
+public class ConcurrentReaderHashMapTest {
+    @Test
+    void serializesUriCacheEntries() throws Exception {
+        ExposedNamespaceCache namespaceCache = new ExposedNamespaceCache();
+        Map uriCache = namespaceCache.getExposedURICache("urn:dom4j-cache-test");
+        uriCache.clear();
+        uriCache.put("first-prefix", "first-uri");
+        uriCache.put("second-prefix", "second-uri");
+
+        Map restored = roundTrip(uriCache);
+
+        assertThat(restored).isNotSameAs(uriCache);
+        assertThat(restored).containsEntry("first-prefix", "first-uri");
+        assertThat(restored).containsEntry("second-prefix", "second-uri");
+        assertThat(restored).hasSize(2);
+    }
+
+    private static Map roundTrip(Map cache) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(cache);
+        }
+
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (Map) in.readObject();
+        }
+    }
+
+    private static class ExposedNamespaceCache extends NamespaceCache {
+        Map getExposedURICache(String uri) {
+            return getURICache(uri);
+        }
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Map;
@@ -19,14 +20,14 @@ import org.junit.jupiter.api.Test;
 
 public class ConcurrentReaderHashMapTest {
     @Test
-    void serializesUriCacheEntries() throws Exception {
+    void serializesUriCacheEntries() throws IOException, ClassNotFoundException {
         ExposedNamespaceCache namespaceCache = new ExposedNamespaceCache();
-        Map uriCache = namespaceCache.getExposedURICache("urn:dom4j-cache-test");
+        Map<String, String> uriCache = namespaceCache.getExposedURICache("urn:dom4j-serialization-test");
         uriCache.clear();
         uriCache.put("first-prefix", "first-uri");
         uriCache.put("second-prefix", "second-uri");
 
-        Map restored = roundTrip(uriCache);
+        Map<String, String> restored = roundTrip(uriCache);
 
         assertThat(restored).isNotSameAs(uriCache);
         assertThat(restored).containsEntry("first-prefix", "first-uri");
@@ -34,20 +35,38 @@ public class ConcurrentReaderHashMapTest {
         assertThat(restored).hasSize(2);
     }
 
-    private static Map roundTrip(Map cache) throws Exception {
+    @Test
+    void uriCacheTracksMutableEntries() {
+        ExposedNamespaceCache namespaceCache = new ExposedNamespaceCache();
+        Map<String, String> uriCache = namespaceCache.getExposedURICache("urn:dom4j-cache-test");
+        uriCache.clear();
+
+        uriCache.put("first-prefix", "first-uri");
+        uriCache.put("second-prefix", "second-uri");
+        Object removed = uriCache.remove("first-prefix");
+
+        assertThat(removed).isEqualTo("first-uri");
+        assertThat(uriCache).containsEntry("second-prefix", "second-uri");
+        assertThat(uriCache).doesNotContainKey("first-prefix");
+        assertThat(uriCache).hasSize(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> roundTrip(Map<String, String> cache) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
             out.writeObject(cache);
         }
 
         try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-            return (Map) in.readObject();
+            return (Map<String, String>) in.readObject();
         }
     }
 
     private static class ExposedNamespaceCache extends NamespaceCache {
-        Map getExposedURICache(String uri) {
-            return getURICache(uri);
+        @SuppressWarnings("unchecked")
+        Map<String, String> getExposedURICache(String uri) {
+            return (Map<String, String>) getURICache(uri);
         }
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.dom.DOMDocument;
+import org.dom4j.io.DOMWriter;
+import org.junit.jupiter.api.Test;
+
+public class DOMWriterTest {
+    @Test
+    void resolvesAndInstantiatesDomDocuments() throws Exception {
+        DOMWriter defaultWriter = new DOMWriter();
+
+        Class<?> defaultDocumentClass = defaultWriter.getDomDocumentClass();
+
+        assertThat(org.w3c.dom.Document.class.isAssignableFrom(defaultDocumentClass))
+                .isTrue();
+
+        DOMWriter namedWriter = new DOMWriter();
+        namedWriter.setDomDocumentClassName(DOMDocument.class.getName());
+        assertThat(namedWriter.getDomDocumentClass()).isEqualTo(DOMDocument.class);
+
+        org.w3c.dom.Document configuredDocument = new DOMWriter(RecordingDomDocument.class)
+                .write(sampleDocument());
+        assertDomDocument(configuredDocument, RecordingDomDocument.class);
+
+        org.w3c.dom.Document fallbackDocument = new FallbackDOMWriter().write(sampleDocument());
+        assertDomDocument(fallbackDocument, RecordingDomDocument.class);
+    }
+
+    private static Document sampleDocument() {
+        Element root = DocumentHelper.createElement("root");
+        root.addAttribute("id", "sample");
+        root.addElement("child").addText("value");
+
+        return DocumentHelper.createDocument(root);
+    }
+
+    private static void assertDomDocument(org.w3c.dom.Document document,
+            Class<? extends org.w3c.dom.Document> expectedClass) {
+        assertThat(document).isInstanceOf(expectedClass);
+        assertThat(document.getDocumentElement().getNodeName()).isEqualTo("root");
+        assertThat(document.getDocumentElement().getAttribute("id"))
+                .isEqualTo("sample");
+        assertThat(document.getDocumentElement().getFirstChild().getNodeName())
+                .isEqualTo("child");
+    }
+
+    public static final class RecordingDomDocument extends DOMDocument {
+        public RecordingDomDocument() {
+            super();
+        }
+    }
+
+    private static final class FallbackDOMWriter extends DOMWriter {
+        @Override
+        public Class getDomDocumentClass() {
+            return RecordingDomDocument.class;
+        }
+
+        @Override
+        protected org.w3c.dom.Document createDomDocumentViaJAXP() throws DocumentException {
+            return null;
+        }
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
@@ -14,22 +14,37 @@ import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.dom.DOMDocument;
 import org.dom4j.io.DOMWriter;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(OrderAnnotation.class)
 public class DOMWriterTest {
     @Test
-    void resolvesAndInstantiatesDomDocuments() throws Exception {
+    @Order(1)
+    void resolvesDefaultDomDocumentClassThroughPublicAccessor() throws Exception {
         DOMWriter defaultWriter = new DOMWriter();
 
         Class<?> defaultDocumentClass = defaultWriter.getDomDocumentClass();
 
+        assertThat(defaultDocumentClass).isNotNull();
         assertThat(org.w3c.dom.Document.class.isAssignableFrom(defaultDocumentClass))
                 .isTrue();
+    }
 
+    @Test
+    @Order(2)
+    void resolvesNamedDomDocumentClass() throws Exception {
         DOMWriter namedWriter = new DOMWriter();
         namedWriter.setDomDocumentClassName(DOMDocument.class.getName());
-        assertThat(namedWriter.getDomDocumentClass()).isEqualTo(DOMDocument.class);
 
+        assertThat(namedWriter.getDomDocumentClass()).isEqualTo(DOMDocument.class);
+    }
+
+    @Test
+    @Order(3)
+    void instantiatesConfiguredAndFallbackDomDocuments() throws Exception {
         org.w3c.dom.Document configuredDocument = new DOMWriter(RecordingDomDocument.class)
                 .write(sampleDocument());
         assertDomDocument(configuredDocument, RecordingDomDocument.class);

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
@@ -8,6 +8,8 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
+
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
@@ -24,6 +26,7 @@ public class DOMWriterTest {
     @Test
     @Order(1)
     void resolvesDefaultDomDocumentClassThroughPublicAccessor() throws Exception {
+        clearCompilerGeneratedClassCache();
         DOMWriter defaultWriter = new DOMWriter();
 
         Class<?> defaultDocumentClass = defaultWriter.getDomDocumentClass();
@@ -69,6 +72,12 @@ public class DOMWriterTest {
                 .isEqualTo("sample");
         assertThat(document.getDocumentElement().getFirstChild().getNodeName())
                 .isEqualTo("child");
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = DOMWriter.class.getDeclaredField("class$org$dom4j$io$DOMWriter");
+        field.setAccessible(true);
+        field.set(null, null);
     }
 
     public static final class RecordingDomDocument extends DOMDocument {

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
@@ -9,20 +9,16 @@ package dom4j.dom4j;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.FutureTask;
 
 import org.dom4j.DocumentFactory;
 import org.junit.jupiter.api.Test;
 
 public class DocumentFactoryTest {
     @Test
-    void getInstanceCreatesDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
+    void createsDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
         clearCompilerGeneratedClassCache();
 
-        FutureTask<DocumentFactory> task = new FutureTask<>(DocumentFactory::getInstance);
-        Thread thread = new Thread(task);
-        thread.start();
-        DocumentFactory factory = task.get();
+        DocumentFactory factory = ExposedDocumentFactory.createDefaultFactory();
 
         assertThat(factory).isInstanceOf(DocumentFactory.class);
         assertThat(factory.createElement("root").getName()).isEqualTo("root");
@@ -32,5 +28,14 @@ public class DocumentFactoryTest {
         Field field = DocumentFactory.class.getDeclaredField("class$org$dom4j$DocumentFactory");
         field.setAccessible(true);
         field.set(null, null);
+    }
+}
+
+final class ExposedDocumentFactory extends DocumentFactory {
+    private ExposedDocumentFactory() {
+    }
+
+    static DocumentFactory createDefaultFactory() {
+        return createSingleton(DocumentFactory.class.getName());
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
@@ -9,16 +9,20 @@ package dom4j.dom4j;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.FutureTask;
 
 import org.dom4j.DocumentFactory;
 import org.junit.jupiter.api.Test;
 
 public class DocumentFactoryTest {
     @Test
-    void createsDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
+    void getInstanceCreatesDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
         clearCompilerGeneratedClassCache();
 
-        DocumentFactory factory = ExposedDocumentFactory.createDefaultFactory();
+        FutureTask<DocumentFactory> task = new FutureTask<>(DocumentFactory::getInstance);
+        Thread thread = new Thread(task);
+        thread.start();
+        DocumentFactory factory = task.get();
 
         assertThat(factory).isInstanceOf(DocumentFactory.class);
         assertThat(factory.createElement("root").getName()).isEqualTo("root");
@@ -28,14 +32,5 @@ public class DocumentFactoryTest {
         Field field = DocumentFactory.class.getDeclaredField("class$org$dom4j$DocumentFactory");
         field.setAccessible(true);
         field.set(null, null);
-    }
-}
-
-final class ExposedDocumentFactory extends DocumentFactory {
-    private ExposedDocumentFactory() {
-    }
-
-    static DocumentFactory createDefaultFactory() {
-        return createSingleton(DocumentFactory.class.getName());
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.FutureTask;
+
+import org.dom4j.DocumentFactory;
+import org.junit.jupiter.api.Test;
+
+public class DocumentFactoryTest {
+    @Test
+    void getInstanceCreatesDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
+        clearCompilerGeneratedClassCache();
+
+        FutureTask<DocumentFactory> task = new FutureTask<>(DocumentFactory::getInstance);
+        Thread thread = new Thread(task);
+        thread.start();
+        DocumentFactory factory = task.get();
+
+        assertThat(factory).isInstanceOf(DocumentFactory.class);
+        assertThat(factory.createElement("root").getName()).isEqualTo("root");
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = DocumentFactory.class.getDeclaredField("class$org$dom4j$DocumentFactory");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.dtd.AttributeDecl;
+import org.dom4j.dtd.ElementDecl;
+import org.dom4j.util.PerThreadSingleton;
+import org.junit.jupiter.api.Test;
+
+public class PerThreadSingletonTest {
+    @Test
+    void createsAndCachesInstanceLoadedByContextClassLoader() {
+        PerThreadSingleton singleton = new PerThreadSingleton();
+        singleton.setSingletonClassName(ElementDecl.class.getName());
+
+        Object first = singleton.instance();
+        Object second = singleton.instance();
+
+        assertThat(first).isInstanceOf(ElementDecl.class);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
+        String className = AttributeDecl.class.getName();
+        Thread thread = Thread.currentThread();
+        ClassLoader originalClassLoader = thread.getContextClassLoader();
+        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
+
+        try {
+            PerThreadSingleton singleton = new PerThreadSingleton();
+            singleton.setSingletonClassName(className);
+
+            Object instance = singleton.instance();
+
+            assertThat(instance).isInstanceOf(AttributeDecl.class);
+        } finally {
+            thread.setContextClassLoader(originalClassLoader);
+        }
+    }
+}
+
+final class RejectingContextClassLoader extends ClassLoader {
+    private final String rejectedClassName;
+
+    RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
+        super(parent);
+        this.rejectedClassName = rejectedClassName;
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (rejectedClassName.equals(name)) {
+            throw new ClassNotFoundException(name);
+        }
+        return super.loadClass(name);
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
@@ -8,57 +8,25 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dom4j.dtd.AttributeDecl;
-import org.dom4j.dtd.ElementDecl;
-import org.dom4j.util.PerThreadSingleton;
+import org.dom4j.DocumentFactory;
+import org.dom4j.Element;
+import org.dom4j.util.IndexedDocumentFactory;
+import org.dom4j.util.IndexedElement;
 import org.junit.jupiter.api.Test;
 
 public class PerThreadSingletonTest {
     @Test
-    void createsAndCachesInstanceLoadedByContextClassLoader() {
-        PerThreadSingleton singleton = new PerThreadSingleton();
-        singleton.setSingletonClassName(ElementDecl.class.getName());
+    void indexedDocumentFactorySingletonCreatesIndexedElements() {
+        DocumentFactory firstFactory = IndexedDocumentFactory.getInstance();
+        DocumentFactory secondFactory = IndexedDocumentFactory.getInstance();
 
-        Object first = singleton.instance();
-        Object second = singleton.instance();
+        Element root = firstFactory.createElement("root");
+        root.addAttribute("id", "sample");
+        root.addElement("child").addAttribute("name", "first");
 
-        assertThat(first).isInstanceOf(ElementDecl.class);
-        assertThat(second).isSameAs(first);
-    }
-
-    @Test
-    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
-        String className = AttributeDecl.class.getName();
-        Thread thread = Thread.currentThread();
-        ClassLoader originalClassLoader = thread.getContextClassLoader();
-        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
-
-        try {
-            PerThreadSingleton singleton = new PerThreadSingleton();
-            singleton.setSingletonClassName(className);
-
-            Object instance = singleton.instance();
-
-            assertThat(instance).isInstanceOf(AttributeDecl.class);
-        } finally {
-            thread.setContextClassLoader(originalClassLoader);
-        }
-    }
-}
-
-final class RejectingContextClassLoader extends ClassLoader {
-    private final String rejectedClassName;
-
-    RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
-        super(parent);
-        this.rejectedClassName = rejectedClassName;
-    }
-
-    @Override
-    public Class<?> loadClass(String name) throws ClassNotFoundException {
-        if (rejectedClassName.equals(name)) {
-            throw new ClassNotFoundException(name);
-        }
-        return super.loadClass(name);
+        assertThat(secondFactory).isSameAs(firstFactory);
+        assertThat(root).isInstanceOf(IndexedElement.class);
+        assertThat(root.attribute(0).getValue()).isEqualTo("sample");
+        assertThat(root.element("child").attribute(0).getValue()).isEqualTo("first");
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/QNameTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/QNameTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.dom4j.Namespace;
+import org.dom4j.QName;
+import org.junit.jupiter.api.Test;
+
+public class QNameTest {
+    @Test
+    void cachedNamePreservesNamespaceDetails() {
+        QName qName = QName.get("element", "sample", "urn:sample");
+
+        assertThat(qName.getName()).isEqualTo("element");
+        assertThat(qName.getNamespacePrefix()).isEqualTo("sample");
+        assertThat(qName.getNamespaceURI()).isEqualTo("urn:sample");
+        assertThat(qName.getQualifiedName()).isEqualTo("sample:element");
+    }
+
+    @Test
+    void serializedNameRestoresTransientNamespace() throws Exception {
+        QName original = new QName("entry", Namespace.get("feed", "urn:feed"));
+        original.setDocumentFactory(null);
+
+        QName restored = roundTrip(original);
+
+        assertThat(restored).isNotSameAs(original);
+        assertThat(restored.getName()).isEqualTo("entry");
+        assertThat(restored.getNamespacePrefix()).isEqualTo("feed");
+        assertThat(restored.getNamespaceURI()).isEqualTo("urn:feed");
+        assertThat(restored.getQualifiedName()).isEqualTo("feed:entry");
+        assertThat(restored).isEqualTo(original);
+    }
+
+    private static QName roundTrip(QName qName) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(qName);
+        }
+
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (QName) in.readObject();
+        }
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SAXContentHandlerTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SAXContentHandlerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.Document;
+import org.dom4j.io.SAXContentHandler;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.ext.Locator2Impl;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class SAXContentHandlerTest {
+    @Test
+    void createsDocumentWithEncodingFromSaxLocator() throws Exception {
+        Locator2Impl locator = new Locator2Impl();
+        locator.setEncoding("UTF-8");
+        SAXContentHandler handler = new SAXContentHandler();
+        handler.setDocumentLocator(locator);
+
+        String text = "content";
+        handler.startDocument();
+        handler.startElement("", "root", "root", new AttributesImpl());
+        handler.characters(text.toCharArray(), 0, text.length());
+        handler.endElement("", "root", "root");
+        handler.endDocument();
+
+        Document document = handler.getDocument();
+        assertThat(document.getXMLEncoding()).isEqualTo("UTF-8");
+        assertThat(document.getRootElement().getName()).isEqualTo("root");
+        assertThat(document.getRootElement().getText()).isEqualTo("content");
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.dtd.AttributeDecl;
+import org.dom4j.dtd.ElementDecl;
+import org.dom4j.util.SimpleSingleton;
+import org.junit.jupiter.api.Test;
+
+public class SimpleSingletonTest {
+    @Test
+    void createsAndReusesSingletonInstanceLoadedByContextClassLoader() {
+        SimpleSingleton singleton = new SimpleSingleton();
+        singleton.setSingletonClassName(ElementDecl.class.getName());
+
+        Object first = singleton.instance();
+        Object second = singleton.instance();
+
+        assertThat(first).isInstanceOf(ElementDecl.class);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
+        String className = AttributeDecl.class.getName();
+        Thread thread = Thread.currentThread();
+        ClassLoader originalClassLoader = thread.getContextClassLoader();
+        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
+
+        try {
+            SimpleSingleton singleton = new SimpleSingleton();
+            singleton.setSingletonClassName(className);
+
+            Object instance = singleton.instance();
+
+            assertThat(instance).isInstanceOf(AttributeDecl.class);
+        } finally {
+            thread.setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class RejectingContextClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
@@ -8,57 +8,43 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dom4j.dtd.AttributeDecl;
-import org.dom4j.dtd.ElementDecl;
-import org.dom4j.util.SimpleSingleton;
+import org.dom4j.Attribute;
+import org.dom4j.DocumentFactory;
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.dom4j.util.NonLazyDocumentFactory;
+import org.dom4j.util.NonLazyElement;
+import org.dom4j.util.UserDataAttribute;
+import org.dom4j.util.UserDataDocumentFactory;
+import org.dom4j.util.UserDataElement;
 import org.junit.jupiter.api.Test;
 
 public class SimpleSingletonTest {
     @Test
-    void createsAndReusesSingletonInstanceLoadedByContextClassLoader() {
-        SimpleSingleton singleton = new SimpleSingleton();
-        singleton.setSingletonClassName(ElementDecl.class.getName());
+    void nonLazyDocumentFactorySingletonCreatesNonLazyElements() {
+        DocumentFactory firstFactory = NonLazyDocumentFactory.getInstance();
+        DocumentFactory secondFactory = NonLazyDocumentFactory.getInstance();
 
-        Object first = singleton.instance();
-        Object second = singleton.instance();
+        Element root = firstFactory.createElement("root");
+        root.addElement("child").addText("value");
 
-        assertThat(first).isInstanceOf(ElementDecl.class);
-        assertThat(second).isSameAs(first);
+        assertThat(secondFactory).isSameAs(firstFactory);
+        assertThat(root).isInstanceOf(NonLazyElement.class);
+        assertThat(root.element("child").getText()).isEqualTo("value");
     }
 
     @Test
-    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
-        String className = AttributeDecl.class.getName();
-        Thread thread = Thread.currentThread();
-        ClassLoader originalClassLoader = thread.getContextClassLoader();
-        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
+    void userDataDocumentFactoryCreatesUserDataNodes() {
+        DocumentFactory factory = UserDataDocumentFactory.getInstance();
+        Element element = factory.createElement("entry");
+        Attribute attribute = factory.createAttribute(element, QName.get("id"), "42");
 
-        try {
-            SimpleSingleton singleton = new SimpleSingleton();
-            singleton.setSingletonClassName(className);
+        ((UserDataElement) element).setData("element-data");
+        ((UserDataAttribute) attribute).setData("attribute-data");
 
-            Object instance = singleton.instance();
-
-            assertThat(instance).isInstanceOf(AttributeDecl.class);
-        } finally {
-            thread.setContextClassLoader(originalClassLoader);
-        }
-    }
-
-    private static final class RejectingContextClassLoader extends ClassLoader {
-        private final String rejectedClassName;
-
-        private RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
-            super(parent);
-            this.rejectedClassName = rejectedClassName;
-        }
-
-        @Override
-        public Class<?> loadClass(String name) throws ClassNotFoundException {
-            if (rejectedClassName.equals(name)) {
-                throw new ClassNotFoundException(name);
-            }
-            return super.loadClass(name);
-        }
+        assertThat(element).isInstanceOf(UserDataElement.class);
+        assertThat(attribute).isInstanceOf(UserDataAttribute.class);
+        assertThat(((UserDataElement) element).getData()).isEqualTo("element-data");
+        assertThat(((UserDataAttribute) attribute).getData()).isEqualTo("attribute-data");
     }
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/XMLTableColumnDefinitionTest.java
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/XMLTableColumnDefinitionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dom4j.Node;
+import org.dom4j.swing.XMLTableColumnDefinition;
+import org.junit.jupiter.api.Test;
+
+public class XMLTableColumnDefinitionTest {
+    @Test
+    void resolvesColumnClassesForSupportedValueTypes() {
+        assertThat(columnClassFor(XMLTableColumnDefinition.STRING_TYPE))
+                .isEqualTo(String.class);
+        assertThat(columnClassFor(XMLTableColumnDefinition.NUMBER_TYPE))
+                .isEqualTo(Number.class);
+        assertThat(columnClassFor(XMLTableColumnDefinition.NODE_TYPE))
+                .isEqualTo(Node.class);
+        assertThat(columnClassFor(XMLTableColumnDefinition.OBJECT_TYPE))
+                .isEqualTo(Object.class);
+    }
+
+    private static Class<?> columnClassFor(int type) {
+        XMLTableColumnDefinition column = new XMLTableColumnDefinition();
+        column.setType(type);
+
+        return column.getColumnClass();
+    }
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/dom4j-dom4j-test-metadata/reflect-config.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/dom4j-dom4j-test-metadata/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "org.dom4j.DocumentFactory",
+    "fields": [
+      {
+        "name": "class$org$dom4j$DocumentFactory",
+        "allowWrite": true
+      }
+    ]
+  }
+]

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/dom4j-dom4j-test-metadata/reflect-config.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/dom4j-dom4j-test-metadata/reflect-config.json
@@ -7,5 +7,14 @@
         "allowWrite": true
       }
     ]
+  },
+  {
+    "name": "org.dom4j.io.DOMWriter",
+    "fields": [
+      {
+        "name": "class$org$dom4j$io$DOMWriter",
+        "allowWrite": true
+      }
+    ]
   }
 ]

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.io.DOMWriter"
+      },
+      "type" : "dom4j.dom4j.DOMWriterTest$RecordingDomDocument",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -11,6 +11,18 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.dom4j.io.SAXContentHandler"
+      },
+      "type" : "org.xml.sax.ext.Locator2Impl",
+      "methods" : [
+        {
+          "name" : "getEncoding",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -11,18 +11,6 @@
           "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.dom4j.io.SAXContentHandler"
-      },
-      "type" : "org.xml.sax.ext.Locator2Impl",
-      "methods" : [
-        {
-          "name" : "getEncoding",
-          "parameterTypes" : [ ]
-        }
-      ]
     }
   ]
 }

--- a/tests/src/dom4j/dom4j/20040902.021138/user-code-filter.json
+++ b/tests/src/dom4j/dom4j/20040902.021138/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.dom4j.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3340

This PR provides test fixes and new metadata for dom4j:dom4j:20040902.021138, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 734201
- Cached input tokens: 10529280
- Output tokens: 56847
- Entries found: 26
- Iterations: 11
- Library coverage percentage: 7.81
- Previous library version metadata entries: 60
- Previous library version coverage percentage: 10.67

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f7aed5669e06d878a351fd788197be293f9c902a`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- dom4j:dom4j:1.6.1: 40/42 covered calls (95.24%)
- dom4j:dom4j:20040902.021138: 25/29 covered calls (86.21%)

**Reflection:**
- dom4j:dom4j:1.6.1: 40/42 covered calls (95.24%)
- dom4j:dom4j:20040902.021138: 25/29 covered calls (86.21%)

#### Library coverage

**Instruction:**
- dom4j:dom4j:1.6.1: 3482/34613 (10.06%)
- dom4j:dom4j:20040902.021138: 3810/53412 (7.13%)

**Line:**
- dom4j:dom4j:1.6.1: 988/9257 (10.67%)
- dom4j:dom4j:20040902.021138: 1072/13731 (7.81%)

**Method:**
- dom4j:dom4j:1.6.1: 287/2533 (11.33%)
- dom4j:dom4j:20040902.021138: 326/3165 (10.30%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/dom4j/dom4j/1.6.1/build.gradle 2/tests/src/dom4j/dom4j/20040902.021138/build.gradle
index c5292239fb..ecfd245c17 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/build.gradle
+++ 2/tests/src/dom4j/dom4j/20040902.021138/build.gradle
@@ -8,10 +8,26 @@ plugins {
     id "org.graalvm.internal.tck"
 }
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://repo.maven.apache.org/maven2")
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeModule("dom4j", "dom4j")
+        }
+    }
+}
+
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "dom4j:dom4j:$libraryVersion"
+    testImplementation "dom4j:dom4j:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
index 913ca4b2f0..f510bb4181 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanDocumentFactoryTest.java
@@ -8,7 +8,9 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 import org.dom4j.Element;
 import org.dom4j.QName;
@@ -19,24 +21,27 @@ import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanDocumentFactoryTest {
     @Test
-    void createsBeanBackedElementFromClassAttribute() throws Exception {
+    void compilerGeneratedClassLookupResolvesBeanDocumentFactoryType() throws Throwable {
+        MethodHandle classLookup = MethodHandles.privateLookupIn(BeanDocumentFactory.class, MethodHandles.lookup())
+                .findStatic(BeanDocumentFactory.class, "class$", MethodType.methodType(Class.class, String.class));
+
+        Class<?> resolvedClass = (Class<?>) classLookup.invoke(BeanDocumentFactory.class.getName());
+
+        assertThat(resolvedClass).isEqualTo(BeanDocumentFactory.class);
+    }
+
+    @Test
+    void createsBeanBackedElementFromClassAttribute() {
         BeanDocumentFactory factory = new BeanDocumentFactory();
-        clearCompilerGeneratedClassCache();
         AttributesImpl attributes = new AttributesImpl();
-        attributes.addAttribute("", "class", "class", "CDATA", factory.getClass().getName());
+        attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
 
         Element element = factory.createElement(QName.get("configuredBean"), attributes);
         Object data = ((BeanElement) element).getData();
 
         assertThat(element).isInstanceOf(BeanElement.class);
         assertThat(element.getName()).isEqualTo("configuredBean");
+        assertThat(data).isInstanceOf(BeanDocumentFactory.class);
         assertThat(data).isNotSameAs(factory);
-        assertThat(data.getClass()).isEqualTo(factory.getClass());
-    }
-
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        Field field = BeanDocumentFactory.class.getDeclaredField("class$org$dom4j$bean$BeanDocumentFactory");
-        field.setAccessible(true);
-        field.set(null, null);
     }
 }
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/BeanElementTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
index 6c5ecfad5c..99165375df 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/BeanElementTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/BeanElementTest.java
@@ -8,44 +8,27 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Field;
-
-import org.dom4j.QName;
+import org.dom4j.Element;
 import org.dom4j.bean.BeanDocumentFactory;
 import org.dom4j.bean.BeanElement;
-import org.dom4j.tree.NamespaceStack;
+import org.dom4j.io.SAXContentHandler;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.helpers.AttributesImpl;
 
 public class BeanElementTest {
     @Test
-    void compilerGeneratedClassLookupResolvesBeanElementType() throws Throwable {
-        MethodHandle classLookup = MethodHandles.privateLookupIn(BeanElement.class, MethodHandles.lookup())
-                .findStatic(BeanElement.class, "class$", MethodType.methodType(Class.class, String.class));
-
-        Class<?> resolvedClass = (Class<?>) classLookup.invoke(BeanElement.class.getName());
-
-        assertThat(resolvedClass).isEqualTo(BeanElement.class);
-    }
-
-    @Test
-    void saxClassAttributeInitializesBackingBean() throws Exception {
-        clearCompilerGeneratedClassCache();
-        BeanElement element = new BeanElement(QName.get("configuredBean"));
+    void saxContentHandlerInitializesBackingBeanFromClassAttribute() throws Exception {
+        SAXContentHandler handler = new SAXContentHandler(BeanDocumentFactory.getInstance());
         AttributesImpl attributes = new AttributesImpl();
         attributes.addAttribute("", "class", "class", "CDATA", BeanDocumentFactory.class.getName());
 
-        element.setAttributes(attributes, new NamespaceStack(), false);
-
-        assertThat(element.getData()).isInstanceOf(BeanDocumentFactory.class);
-    }
+        handler.startDocument();
+        handler.startElement("", "configuredBean", "configuredBean", attributes);
+        handler.endElement("", "configuredBean", "configuredBean");
+        handler.endDocument();
 
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        Field field = BeanElement.class.getDeclaredField("class$org$dom4j$bean$BeanElement");
-        field.setAccessible(true);
-        field.set(null, null);
+        Element rootElement = handler.getDocument().getRootElement();
+        assertThat(rootElement).isInstanceOf(BeanElement.class);
+        assertThat(((BeanElement) rootElement).getData()).isInstanceOf(BeanDocumentFactory.class);
     }
 }
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
index b87be9b228..c0f2363d18 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/ConcurrentReaderHashMapTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Map;
@@ -19,14 +20,14 @@ import org.junit.jupiter.api.Test;
 
 public class ConcurrentReaderHashMapTest {
     @Test
-    void serializesUriCacheEntries() throws Exception {
+    void serializesUriCacheEntries() throws IOException, ClassNotFoundException {
         ExposedNamespaceCache namespaceCache = new ExposedNamespaceCache();
-        Map uriCache = namespaceCache.getExposedURICache("urn:dom4j-cache-test");
+        Map<String, String> uriCache = namespaceCache.getExposedURICache("urn:dom4j-serialization-test");
         uriCache.clear();
         uriCache.put("first-prefix", "first-uri");
         uriCache.put("second-prefix", "second-uri");
 
-        Map restored = roundTrip(uriCache);
+        Map<String, String> restored = roundTrip(uriCache);
 
         assertThat(restored).isNotSameAs(uriCache);
         assertThat(restored).containsEntry("first-prefix", "first-uri");
@@ -34,20 +35,38 @@ public class ConcurrentReaderHashMapTest {
         assertThat(restored).hasSize(2);
     }
 
-    private static Map roundTrip(Map cache) throws Exception {
+    @Test
+    void uriCacheTracksMutableEntries() {
+        ExposedNamespaceCache namespaceCache = new ExposedNamespaceCache();
+        Map<String, String> uriCache = namespaceCache.getExposedURICache("urn:dom4j-cache-test");
+        uriCache.clear();
+
+        uriCache.put("first-prefix", "first-uri");
+        uriCache.put("second-prefix", "second-uri");
+        Object removed = uriCache.remove("first-prefix");
+
+        assertThat(removed).isEqualTo("first-uri");
+        assertThat(uriCache).containsEntry("second-prefix", "second-uri");
+        assertThat(uriCache).doesNotContainKey("first-prefix");
+        assertThat(uriCache).hasSize(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> roundTrip(Map<String, String> cache) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
             out.writeObject(cache);
         }
 
         try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-            return (Map) in.readObject();
+            return (Map<String, String>) in.readObject();
         }
     }
 
     private static class ExposedNamespaceCache extends NamespaceCache {
-        Map getExposedURICache(String uri) {
-            return getURICache(uri);
+        @SuppressWarnings("unchecked")
+        Map<String, String> getExposedURICache(String uri) {
+            return (Map<String, String>) getURICache(uri);
         }
     }
 }
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/DOMWriterTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
index 2214dbf186..a72fbdde02 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/DOMWriterTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DOMWriterTest.java
@@ -8,28 +8,46 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
+
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.dom.DOMDocument;
 import org.dom4j.io.DOMWriter;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(OrderAnnotation.class)
 public class DOMWriterTest {
     @Test
-    void resolvesAndInstantiatesDomDocuments() throws Exception {
+    @Order(1)
+    void resolvesDefaultDomDocumentClassThroughPublicAccessor() throws Exception {
+        clearCompilerGeneratedClassCache();
         DOMWriter defaultWriter = new DOMWriter();
 
         Class<?> defaultDocumentClass = defaultWriter.getDomDocumentClass();
 
+        assertThat(defaultDocumentClass).isNotNull();
         assertThat(org.w3c.dom.Document.class.isAssignableFrom(defaultDocumentClass))
                 .isTrue();
+    }
 
+    @Test
+    @Order(2)
+    void resolvesNamedDomDocumentClass() throws Exception {
         DOMWriter namedWriter = new DOMWriter();
         namedWriter.setDomDocumentClassName(DOMDocument.class.getName());
+
         assertThat(namedWriter.getDomDocumentClass()).isEqualTo(DOMDocument.class);
+    }
 
+    @Test
+    @Order(3)
+    void instantiatesConfiguredAndFallbackDomDocuments() throws Exception {
         org.w3c.dom.Document configuredDocument = new DOMWriter(RecordingDomDocument.class)
                 .write(sampleDocument());
         assertDomDocument(configuredDocument, RecordingDomDocument.class);
@@ -56,6 +74,12 @@ public class DOMWriterTest {
                 .isEqualTo("child");
     }
 
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = DOMWriter.class.getDeclaredField("class$org$dom4j$io$DOMWriter");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
     public static final class RecordingDomDocument extends DOMDocument {
         public RecordingDomDocument() {
             super();
diff --git 1/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
new file mode 100644
index 0000000000..3db4f25390
--- /dev/null
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/DocumentFactoryTest.java
@@ -0,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dom4j.dom4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.FutureTask;
+
+import org.dom4j.DocumentFactory;
+import org.junit.jupiter.api.Test;
+
+public class DocumentFactoryTest {
+    @Test
+    void getInstanceCreatesDefaultFactoryWhenClassLiteralCacheIsEmpty() throws Exception {
+        clearCompilerGeneratedClassCache();
+
+        FutureTask<DocumentFactory> task = new FutureTask<>(DocumentFactory::getInstance);
+        Thread thread = new Thread(task);
+        thread.start();
+        DocumentFactory factory = task.get();
+
+        assertThat(factory).isInstanceOf(DocumentFactory.class);
+        assertThat(factory.createElement("root").getName()).isEqualTo("root");
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        Field field = DocumentFactory.class.getDeclaredField("class$org$dom4j$DocumentFactory");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+}
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
index 9870cb2d73..75445a2cb4 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/PerThreadSingletonTest.java
@@ -8,57 +8,25 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dom4j.dtd.AttributeDecl;
-import org.dom4j.dtd.ElementDecl;
-import org.dom4j.util.PerThreadSingleton;
+import org.dom4j.DocumentFactory;
+import org.dom4j.Element;
+import org.dom4j.util.IndexedDocumentFactory;
+import org.dom4j.util.IndexedElement;
 import org.junit.jupiter.api.Test;
 
 public class PerThreadSingletonTest {
     @Test
-    void createsAndCachesInstanceLoadedByContextClassLoader() {
-        PerThreadSingleton singleton = new PerThreadSingleton();
-        singleton.setSingletonClassName(ElementDecl.class.getName());
-
-        Object first = singleton.instance();
-        Object second = singleton.instance();
-
-        assertThat(first).isInstanceOf(ElementDecl.class);
-        assertThat(second).isSameAs(first);
-    }
-
-    @Test
-    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
-        String className = AttributeDecl.class.getName();
-        Thread thread = Thread.currentThread();
-        ClassLoader originalClassLoader = thread.getContextClassLoader();
-        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
-
-        try {
-            PerThreadSingleton singleton = new PerThreadSingleton();
-            singleton.setSingletonClassName(className);
-
-            Object instance = singleton.instance();
-
-            assertThat(instance).isInstanceOf(AttributeDecl.class);
-        } finally {
-            thread.setContextClassLoader(originalClassLoader);
-        }
-    }
-}
-
-final class RejectingContextClassLoader extends ClassLoader {
-    private final String rejectedClassName;
-
-    RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
-        super(parent);
-        this.rejectedClassName = rejectedClassName;
-    }
-
-    @Override
-    public Class<?> loadClass(String name) throws ClassNotFoundException {
-        if (rejectedClassName.equals(name)) {
-            throw new ClassNotFoundException(name);
-        }
-        return super.loadClass(name);
+    void indexedDocumentFactorySingletonCreatesIndexedElements() {
+        DocumentFactory firstFactory = IndexedDocumentFactory.getInstance();
+        DocumentFactory secondFactory = IndexedDocumentFactory.getInstance();
+
+        Element root = firstFactory.createElement("root");
+        root.addAttribute("id", "sample");
+        root.addElement("child").addAttribute("name", "first");
+
+        assertThat(secondFactory).isSameAs(firstFactory);
+        assertThat(root).isInstanceOf(IndexedElement.class);
+        assertThat(root.attribute(0).getValue()).isEqualTo("sample");
+        assertThat(root.element("child").attribute(0).getValue()).isEqualTo("first");
     }
 }
diff --git 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/SimpleSingletonTest.java 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
index 77823054f8..d682d69dcb 100644
--- 1/tests/src/dom4j/dom4j/1.6.1/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
+++ 2/tests/src/dom4j/dom4j/20040902.021138/src/test/java/dom4j/dom4j/SimpleSingletonTest.java
@@ -8,57 +8,43 @@ package dom4j.dom4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dom4j.dtd.AttributeDecl;
-import org.dom4j.dtd.ElementDecl;
-import org.dom4j.util.SimpleSingleton;
+import org.dom4j.Attribute;
+import org.dom4j.DocumentFactory;
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.dom4j.util.NonLazyDocumentFactory;
+import org.dom4j.util.NonLazyElement;
+import org.dom4j.util.UserDataAttribute;
+import org.dom4j.util.UserDataDocumentFactory;
+import org.dom4j.util.UserDataElement;
 import org.junit.jupiter.api.Test;
 
 public class SimpleSingletonTest {
     @Test
-    void createsAndReusesSingletonInstanceLoadedByContextClassLoader() {
-        SimpleSingleton singleton = new SimpleSingleton();
-        singleton.setSingletonClassName(ElementDecl.class.getName());
+    void nonLazyDocumentFactorySingletonCreatesNonLazyElements() {
+        DocumentFactory firstFactory = NonLazyDocumentFactory.getInstance();
+        DocumentFactory secondFactory = NonLazyDocumentFactory.getInstance();
 
-        Object first = singleton.instance();
-        Object second = singleton.instance();
+        Element root = firstFactory.createElement("root");
+        root.addElement("child").addText("value");
 
-        assertThat(first).isInstanceOf(ElementDecl.class);
-        assertThat(second).isSameAs(first);
+        assertThat(secondFactory).isSameAs(firstFactory);
+        assertThat(root).isInstanceOf(NonLazyElement.class);
+        assertThat(root.element("child").getText()).isEqualTo("value");
     }
 
     @Test
-    void fallsBackToClassForNameWhenContextClassLoaderCannotLoadClass() {
-        String className = AttributeDecl.class.getName();
-        Thread thread = Thread.currentThread();
-        ClassLoader originalClassLoader = thread.getContextClassLoader();
-        thread.setContextClassLoader(new RejectingContextClassLoader(originalClassLoader, className));
-
-        try {
-            SimpleSingleton singleton = new SimpleSingleton();
-            singleton.setSingletonClassName(className);
-
-            Object instance = singleton.instance();
-
-            assertThat(instance).isInstanceOf(AttributeDecl.class);
-        } finally {
-            thread.setContextClassLoader(originalClassLoader);
-        }
-    }
-
-    private static final class RejectingContextClassLoader extends ClassLoader {
-        private final String rejectedClassName;
-
-        private RejectingContextClassLoader(ClassLoader parent, String rejectedClassName) {
-            super(parent);
-            this.rejectedClassName = rejectedClassName;
-        }
-
-        @Override
-        public Class<?> loadClass(String name) throws ClassNotFoundException {
-            if (rejectedClassName.equals(name)) {
-                throw new ClassNotFoundException(name);
-            }
-            return super.loadClass(name);
-        }
+    void userDataDocumentFactoryCreatesUserDataNodes() {
+        DocumentFactory factory = UserDataDocumentFactory.getInstance();
+        Element element = factory.createElement("entry");
+        Attribute attribute = factory.createAttribute(element, QName.get("id"), "42");
+
+        ((UserDataElement) element).setData("element-data");
+        ((UserDataAttribute) attribute).setData("attribute-data");
+
+        assertThat(element).isInstanceOf(UserDataElement.class);
+        assertThat(attribute).isInstanceOf(UserDataAttribute.class);
+        assertThat(((UserDataElement) element).getData()).isEqualTo("element-data");
+        assertThat(((UserDataAttribute) attribute).getData()).isEqualTo("attribute-data");
     }
 }

```
