### PR TITLE
[GenAI] Add support for tools.jackson.core:jackson-databind:3.0.0-rc2 using gpt-5.5

### DIFF
--- a/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
+++ b/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
@@ -1,0 +1,124 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "char[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "char[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.std.ReferenceTypeDeserializer"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "java.math.BigDecimal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "java.math.BigDecimal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.util.ImmutableCollections$MapN"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.MapSerializer"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.util.ClassUtil"
+      },
+      "type" : "tools.jackson.databind.PropertyNamingStrategies$SnakeCaseStrategy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/tools.jackson.core/jackson-databind/index.json
+++ b/metadata/tools.jackson.core/jackson-databind/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0.0-rc2",
+    "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.0.0-rc2/jackson-databind-3.0.0-rc2-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-3.0.0-rc2",
+    "test-code-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-3.0.0-rc2/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.0.0-rc2/jackson-databind-3.0.0-rc2-javadoc.jar",
+    "description" : "Jackson Databind provides object mapping between Java types and JSON using Jackson's streaming core. It supplies data-binding, serialization, deserialization, and annotation-driven configuration for Java applications.",
+    "tested-versions" : [
+      "3.0.0-rc2"
+    ],
+    "allowed-packages" : [
+      "tools.jackson.databind"
+    ]
+  }
+]

--- a/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/execution-metrics.json
+++ b/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-04-29": {
+    "timestamp": "2026-04-29T23:12:45.236401Z",
+    "library": "tools.jackson.core:jackson-databind:3.0.0-rc2",
+    "starting_commit": "f1335dcc3be7c615828a0f24d0029a61f2d5bec9",
+    "ending_commit": "1603b7e2444cc113abecd26c5cbea925b8f2f9dc",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0-rc2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.234375,
+            "coveredCalls": 15,
+            "totalCalls": 64
+          }
+        },
+        "coverageRatio": 0.234375,
+        "coveredCalls": 15,
+        "totalCalls": 64
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 36172,
+          "missed": 109293,
+          "ratio": 0.248665,
+          "total": 145465
+        },
+        "line": {
+          "covered": 9095,
+          "missed": 25371,
+          "ratio": 0.263883,
+          "total": 34466
+        },
+        "method": {
+          "covered": 2141,
+          "missed": 5802,
+          "ratio": 0.269546,
+          "total": 7943
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 176919,
+      "cached_input_tokens_used": 1473536,
+      "output_tokens_used": 21359,
+      "iterations": 5,
+      "cost_usd": 1.3776,
+      "generated_loc": 387,
+      "tested_library_loc": 9095,
+      "metadata_entries": 20,
+      "code_coverage_percent": 26.39
+    },
+    "artifacts": {
+      "test_file": "tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java",
+      "metadata_file": "metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
+++ b/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0-rc2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.234375,
+          "coveredCalls" : 15,
+          "totalCalls" : 64
+        }
+      },
+      "coverageRatio" : 0.234375,
+      "coveredCalls" : 15,
+      "totalCalls" : 64
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 36172,
+        "missed" : 109293,
+        "ratio" : 0.248665,
+        "total" : 145465
+      },
+      "line" : {
+        "covered" : 9095,
+        "missed" : 25371,
+        "ratio" : 0.263883,
+        "total" : 34466
+      },
+      "method" : {
+        "covered" : 2141,
+        "missed" : 5802,
+        "ratio" : 0.269546,
+        "total" : 7943
+      }
+    }
+  } ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -11,7 +11,10 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
+    testImplementation("tools.jackson.core:jackson-databind:$libraryVersion") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+    }
+    testImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.20'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = tools.jackson.core:jackson-databind:3.0.0-rc2
+library.version = 3.0.0-rc2
+metadata.dir = tools.jackson.core/jackson-databind/3.0.0-rc2/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'tools.jackson.core.jackson-databind_tests'

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tools_jackson_core.jackson_databind;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_databindTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonView;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationFeature;
@@ -225,6 +226,45 @@ public class Jackson_databindTest {
     }
 
     @Test
+    void jsonViewsConstrainSerializationAndDeserializationByActiveView() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                .disable(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES)
+                .build();
+        AccountProfile profile = new AccountProfile(
+                "acct-1",
+                "Ada Lovelace",
+                "ada@example.test",
+                "reset-token");
+
+        JsonNode publicTree = mapper.readTree(mapper.writerWithView(PublicView.class).writeValueAsString(profile));
+        JsonNode supportTree = mapper.readTree(mapper.writerWithView(SupportView.class).writeValueAsString(profile));
+
+        assertThat(publicTree.get("accountId").stringValue()).isEqualTo("acct-1");
+        assertThat(publicTree.get("displayName").stringValue()).isEqualTo("Ada Lovelace");
+        assertThat(publicTree.has("emailAddress")).isFalse();
+        assertThat(publicTree.has("recoveryToken")).isFalse();
+        assertThat(supportTree.get("emailAddress").stringValue()).isEqualTo("ada@example.test");
+        assertThat(supportTree.has("recoveryToken")).isFalse();
+
+        AccountProfile restored = mapper.readerFor(AccountProfile.class)
+                .withView(SupportView.class)
+                .readValue("""
+                        {
+                          "accountId": "acct-2",
+                          "displayName": "Grace Hopper",
+                          "emailAddress": "grace@example.test",
+                          "recoveryToken": "ignored-by-support-view"
+                        }
+                        """);
+
+        assertThat(restored.accountId).isEqualTo("acct-2");
+        assertThat(restored.displayName).isEqualTo("Grace Hopper");
+        assertThat(restored.emailAddress).isEqualTo("grace@example.test");
+        assertThat(restored.recoveryToken).isNull();
+    }
+
+    @Test
     void recordsOptionalsAndPrettyPrintingUseBuiltInSerializers() throws Exception {
         Receipt receipt = new Receipt(
                 "R-1",
@@ -338,6 +378,39 @@ public class Jackson_databindTest {
         public GiftCard(String code, BigDecimal balance) {
             this.code = code;
             this.balance = balance;
+        }
+    }
+
+    public interface PublicView {
+    }
+
+    public interface SupportView extends PublicView {
+    }
+
+    public interface InternalView extends SupportView {
+    }
+
+    public static class AccountProfile {
+        @JsonView(PublicView.class)
+        public String accountId;
+
+        @JsonView(PublicView.class)
+        public String displayName;
+
+        @JsonView(SupportView.class)
+        public String emailAddress;
+
+        @JsonView(InternalView.class)
+        public String recoveryToken;
+
+        public AccountProfile() {
+        }
+
+        public AccountProfile(String accountId, String displayName, String emailAddress, String recoveryToken) {
+            this.accountId = accountId;
+            this.displayName = displayName;
+            this.emailAddress = emailAddress;
+            this.recoveryToken = recoveryToken;
         }
     }
 

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -283,6 +285,32 @@ public class Jackson_databindTest {
         assertThat(restored.payments()).containsExactly(new Money(new BigDecimal("2.50"), CurrencyCode.USD));
     }
 
+    @Test
+    void anyGetterAndSetterBindExtensionPropertiesBesideDeclaredFields() throws Exception {
+        CatalogItem item = MAPPER.readValue("""
+                {
+                  "sku": "beans-ethiopia",
+                  "roastLevel": "medium",
+                  "organic": true,
+                  "inventory": 12
+                }
+                """, CatalogItem.class);
+
+        assertThat(item.sku).isEqualTo("beans-ethiopia");
+        assertThat(item.attributes())
+                .containsEntry("roastLevel", "medium")
+                .containsEntry("organic", true)
+                .containsEntry("inventory", 12);
+
+        JsonNode tree = MAPPER.readTree(MAPPER.writeValueAsString(item));
+
+        assertThat(tree.get("sku").asText()).isEqualTo("beans-ethiopia");
+        assertThat(tree.get("roastLevel").asText()).isEqualTo("medium");
+        assertThat(tree.get("organic").booleanValue()).isTrue();
+        assertThat(tree.get("inventory").intValue()).isEqualTo(12);
+        assertThat(tree.has("attributes")).isFalse();
+    }
+
     private static CoffeeOrder coffeeOrder(String id, String customer, String itemName, String city) {
         CoffeeOrder order = new CoffeeOrder();
         order.id = id;
@@ -415,6 +443,22 @@ public class Jackson_databindTest {
     }
 
     public record Receipt(String id, Optional<Money> discount, List<Money> payments) {
+    }
+
+    public static class CatalogItem {
+        public String sku;
+
+        private final Map<String, Object> attributes = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void putAttribute(String name, Object value) {
+            attributes.put(name, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> attributes() {
+            return attributes;
+        }
     }
 
     public record Money(BigDecimal amount, CurrencyCode currency) {

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -6,11 +6,349 @@
  */
 package tools_jackson_core.jackson_databind;
 
-import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-class Jackson_databindTest {
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.annotation.JsonNaming;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jackson_databindTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void annotatedBeanRoundTripHonorsAliasesInclusionAndIgnoredProperties() throws Exception {
+        String json = """
+                {
+                  "order_id": "A-100",
+                  "customer_name": "Ada",
+                  "lineItems": {"espresso": 2.50, "croissant": 4.25},
+                  "delivery": {"street": "Main Street", "city": "Belgrade"},
+                  "metadata": {"priority": true, "table": 7},
+                  "internalToken": "not-for-api"
+                }
+                """;
+
+        CoffeeOrder order = MAPPER.readValue(json, CoffeeOrder.class);
+
+        assertThat(order.id).isEqualTo("A-100");
+        assertThat(order.customer).isEqualTo("Ada");
+        assertThat(order.lineItems).containsEntry("espresso", new BigDecimal("2.50"));
+        assertThat(order.delivery.city).isEqualTo("Belgrade");
+        assertThat(order.metadata).containsEntry("priority", true);
+        assertThat(order.internalToken).isEqualTo("generated-only");
+
+        String serialized = MAPPER.writeValueAsString(order);
+        JsonNode serializedTree = MAPPER.readTree(serialized);
+
+        assertThat(serializedTree.get("order_id").asText()).isEqualTo("A-100");
+        assertThat(serializedTree.get("customer").asText()).isEqualTo("Ada");
+        assertThat(serializedTree.has("notes")).isFalse();
+        assertThat(serializedTree.has("internalToken")).isFalse();
+    }
+
+    @Test
+    void namingStrategyAndCaseInsensitiveEnumMappingWorkTogether() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .build();
+
+        DrinkPreference preference = mapper.readValue("""
+                {
+                  "drink_size": "large",
+                  "bean_origin": "Ethiopia",
+                  "serving_temperature": 68
+                }
+                """, DrinkPreference.class);
+
+        assertThat(preference.drinkSize).isEqualTo(DrinkSize.LARGE);
+        assertThat(preference.beanOrigin).isEqualTo("Ethiopia");
+        assertThat(preference.servingTemperature).isEqualTo(68);
+        JsonNode serializedPreference = mapper.readTree(mapper.writeValueAsString(preference));
+        assertThat(serializedPreference.get("drink_size").asText()).isEqualTo("LARGE");
+        assertThat(serializedPreference.get("bean_origin").asText()).isEqualTo("Ethiopia");
+        assertThat(serializedPreference.get("serving_temperature").intValue()).isEqualTo(68);
+    }
+
+    @Test
+    void genericReadersAndWritersPreserveNestedContainerTypes() throws Exception {
+        CoffeeOrder first = coffeeOrder("A-101", "Grace", "latte", "Tirana");
+        CoffeeOrder second = coffeeOrder("A-102", "Linus", "tea", "Helsinki");
+        List<CoffeeOrder> orders = List.of(first, second);
+
+        ObjectWriter writer = MAPPER.writerFor(new TypeReference<List<CoffeeOrder>>() {});
+        String json = writer.writeValueAsString(orders);
+
+        ObjectReader reader = MAPPER.readerFor(new TypeReference<List<CoffeeOrder>>() {});
+        List<CoffeeOrder> restored = reader.readValue(json);
+
+        assertThat(restored).hasSize(2);
+        assertThat(restored.get(0).lineItems).containsEntry("latte", new BigDecimal("3.40"));
+        assertThat(restored.get(1).delivery.city).isEqualTo("Helsinki");
+
+        JavaType valueType = MAPPER.getTypeFactory().constructParametricType(ApiEnvelope.class, CoffeeOrder.class);
+        JavaType mapType = MAPPER.getTypeFactory()
+                .constructMapType(LinkedHashMap.class, MAPPER.constructType(String.class), valueType);
+        String envelopesJson = """
+                {
+                  "first": {"status": "ok", "payload": {"order_id": "A-103", "customer": "Katherine"}},
+                  "second": {"status": "queued", "payload": {"order_id": "A-104", "customer": "Margaret"}}
+                }
+                """;
+        Map<String, ApiEnvelope<CoffeeOrder>> envelopes = MAPPER.readValue(envelopesJson, mapType);
+
+        assertThat(envelopes.get("first").payload.id).isEqualTo("A-103");
+        assertThat(envelopes.get("second").payload.customer).isEqualTo("Margaret");
+    }
+
+    @Test
+    void treeModelSupportsMutationPointersAndPojoConversion() throws Exception {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("order_id", "A-105");
+        root.put("customer", "Barbara");
+        ObjectNode delivery = root.putObject("delivery");
+        delivery.put("street", "Fifth Avenue");
+        delivery.put("city", "New York");
+        ArrayNode notes = root.putArray("notes");
+        notes.add("decaf");
+        notes.add("with oat milk");
+
+        assertThat(root.at("/delivery/city").asText()).isEqualTo("New York");
+        assertThat(root.findValuesAsString("customer")).containsExactly("Barbara");
+
+        CoffeeOrder order = MAPPER.treeToValue(root, CoffeeOrder.class);
+        JsonNode convertedBack = MAPPER.valueToTree(order);
+
+        assertThat(order.notes).containsExactly("decaf", "with oat milk");
+        assertThat(convertedBack.at("/delivery/street").asText()).isEqualTo("Fifth Avenue");
+        assertThat(convertedBack.get("notes").get(1).asText()).isEqualTo("with oat milk");
+    }
+
+    @Test
+    void updateReaderAndConversionModifyExistingObjectsWithoutLosingState() throws Exception {
+        CoffeeOrder order = coffeeOrder("A-106", "Edsger", "mocha", "Amsterdam");
+        order.notes = new ArrayList<>(List.of("window seat"));
+
+        CoffeeOrder updated = MAPPER.readerForUpdating(order).readValue("""
+                {
+                  "customer": "Evelyn",
+                  "delivery": {"city": "London"},
+                  "notes": ["quiet corner", "no sugar"]
+                }
+                """);
+
+        assertThat(updated).isSameAs(order);
+        assertThat(updated.id).isEqualTo("A-106");
+        assertThat(updated.customer).isEqualTo("Evelyn");
+        assertThat(updated.delivery.city).isEqualTo("London");
+        assertThat(updated.notes).containsExactly("quiet corner", "no sugar");
+
+        Map<String, Object> raw = new LinkedHashMap<>();
+        raw.put("status", "converted");
+        raw.put("payload", Map.of("order_id", "A-107", "customer", "Frances"));
+        ApiEnvelope<CoffeeOrder> envelope = MAPPER.convertValue(raw,
+                new TypeReference<ApiEnvelope<CoffeeOrder>>() {});
+
+        assertThat(envelope.status).isEqualTo("converted");
+        assertThat(envelope.payload.id).isEqualTo("A-107");
+        assertThat(envelope.payload.customer).isEqualTo("Frances");
+    }
+
+    @Test
+    void strictAndLenientDeserializationFeaturesAreConfigurable() throws Exception {
+        ObjectMapper strictMapper = JsonMapper.builder()
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        ObjectMapper lenientMapper = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                .build();
+
+        assertThatThrownBy(() -> strictMapper.readValue("""
+                {"order_id": "A-108", "customer": "Hedy", "unexpected": true}
+                """, CoffeeOrder.class))
+                .hasMessageContaining("unexpected");
+
+        CoffeeOrder order = lenientMapper.readValue("""
+                {"order_id": "A-108", "customer": "Hedy", "notes": "ring bell", "unexpected": true}
+                """, CoffeeOrder.class);
+
+        assertThat(order.notes).containsExactly("ring bell");
+    }
+
+    @Test
+    void polymorphicTypeInformationSelectsConcreteSubtypes() throws Exception {
+        List<PaymentMethod> methods = List.of(
+                new CreditCard("visa", "1234"),
+                new GiftCard("GIFT-7", new BigDecimal("15.00")));
+
+        String json = MAPPER.writerFor(new TypeReference<List<PaymentMethod>>() {}).writeValueAsString(methods);
+        List<PaymentMethod> restored = MAPPER.readValue(json, new TypeReference<List<PaymentMethod>>() {});
+
+        assertThat(MAPPER.readTree(json).get(0).get("kind").asText()).isEqualTo("card");
+        assertThat(restored).hasSize(2);
+        assertThat(restored.get(0)).isInstanceOfSatisfying(CreditCard.class, card -> {
+            assertThat(card.network).isEqualTo("visa");
+            assertThat(card.lastFour).isEqualTo("1234");
+        });
+        assertThat(restored.get(1)).isInstanceOfSatisfying(GiftCard.class, giftCard -> {
+            assertThat(giftCard.code).isEqualTo("GIFT-7");
+            assertThat(giftCard.balance).isEqualByComparingTo("15.00");
+        });
+    }
+
+    @Test
+    void recordsOptionalsAndPrettyPrintingUseBuiltInSerializers() throws Exception {
+        Receipt receipt = new Receipt(
+                "R-1",
+                Optional.of(new Money(new BigDecimal("9.99"), CurrencyCode.EUR)),
+                List.of(new Money(new BigDecimal("2.50"), CurrencyCode.USD)));
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .build();
+
+        String json = mapper.writeValueAsString(receipt);
+        Receipt restored = mapper.readValue(json, Receipt.class);
+
+        assertThat(json).contains(System.lineSeparator());
+        assertThat(restored.id()).isEqualTo("R-1");
+        assertThat(restored.discount()).hasValue(new Money(new BigDecimal("9.99"), CurrencyCode.EUR));
+        assertThat(restored.payments()).containsExactly(new Money(new BigDecimal("2.50"), CurrencyCode.USD));
+    }
+
+    private static CoffeeOrder coffeeOrder(String id, String customer, String itemName, String city) {
+        CoffeeOrder order = new CoffeeOrder();
+        order.id = id;
+        order.customer = customer;
+        order.delivery = new Address("Main Street", city);
+        order.lineItems = new LinkedHashMap<>();
+        order.lineItems.put(itemName, new BigDecimal("3.40"));
+        order.metadata = new LinkedHashMap<>();
+        order.metadata.put("takeaway", false);
+        return order;
+    }
+
+    @JsonPropertyOrder({"order_id", "customer", "lineItems", "delivery", "notes", "metadata"})
+    public static class CoffeeOrder {
+        @JsonProperty("order_id")
+        public String id;
+
+        @JsonAlias("customer_name")
+        public String customer;
+
+        public Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+
+        public Address delivery;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public List<String> notes = new ArrayList<>();
+
+        public Map<String, Object> metadata = new LinkedHashMap<>();
+
+        @JsonIgnore
+        public String internalToken = "generated-only";
+    }
+
+    public static class Address {
+        public String street;
+        public String city;
+
+        public Address() {
+        }
+
+        public Address(String street, String city) {
+            this.street = street;
+            this.city = city;
+        }
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class DrinkPreference {
+        public DrinkSize drinkSize;
+        public String beanOrigin;
+        public int servingTemperature;
+    }
+
+    public enum DrinkSize {
+        SMALL,
+        MEDIUM,
+        LARGE
+    }
+
+    public static class ApiEnvelope<T> {
+        public String status;
+        public T payload;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = CreditCard.class, name = "card"),
+            @JsonSubTypes.Type(value = GiftCard.class, name = "gift")
+    })
+    public interface PaymentMethod {
+    }
+
+    public static class CreditCard implements PaymentMethod {
+        public String network;
+        public String lastFour;
+
+        public CreditCard() {
+        }
+
+        public CreditCard(String network, String lastFour) {
+            this.network = network;
+            this.lastFour = lastFour;
+        }
+    }
+
+    public static class GiftCard implements PaymentMethod {
+        public String code;
+        public BigDecimal balance;
+
+        public GiftCard() {
+        }
+
+        public GiftCard(String code, BigDecimal balance) {
+            this.code = code;
+            this.balance = balance;
+        }
+    }
+
+    public record Receipt(String id, Optional<Money> discount, List<Money> payments) {
+    }
+
+    public record Money(BigDecimal amount, CurrencyCode currency) {
+    }
+
+    public enum CurrencyCode {
+        EUR,
+        USD
     }
 }

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,472 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$AccountProfile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectWriter$Prefetch"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$AccountProfile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$AccountProfile",
+      "fields" : [
+        {
+          "name" : "accountId"
+        },
+        {
+          "name" : "displayName"
+        },
+        {
+          "name" : "emailAddress"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.impl.FilteredBeanPropertyWriter$SingleView"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$AccountProfile",
+      "fields" : [
+        {
+          "name" : "accountId"
+        },
+        {
+          "name" : "displayName"
+        },
+        {
+          "name" : "emailAddress"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        },
+        {
+          "name" : "street"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        },
+        {
+          "name" : "street"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.CollectionSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        },
+        {
+          "name" : "street"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ApiEnvelope",
+      "fields" : [
+        {
+          "name" : "payload"
+        },
+        {
+          "name" : "status"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CatalogItem",
+      "fields" : [
+        {
+          "name" : "sku"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CatalogItem",
+      "methods" : [
+        {
+          "name" : "attributes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "putAttribute",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CoffeeOrder",
+      "fields" : [
+        {
+          "name" : "customer"
+        },
+        {
+          "name" : "delivery"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "lineItems"
+        },
+        {
+          "name" : "metadata"
+        },
+        {
+          "name" : "notes"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CoffeeOrder",
+      "fields" : [
+        {
+          "name" : "customer"
+        },
+        {
+          "name" : "delivery"
+        },
+        {
+          "name" : "notes"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CoffeeOrder",
+      "fields" : [
+        {
+          "name" : "customer"
+        },
+        {
+          "name" : "delivery"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "lineItems"
+        },
+        {
+          "name" : "metadata"
+        },
+        {
+          "name" : "notes"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.CollectionSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CoffeeOrder",
+      "fields" : [
+        {
+          "name" : "customer"
+        },
+        {
+          "name" : "delivery"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "lineItems"
+        },
+        {
+          "name" : "metadata"
+        },
+        {
+          "name" : "notes"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CreditCard",
+      "fields" : [
+        {
+          "name" : "lastFour"
+        },
+        {
+          "name" : "network"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CreditCard"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CreditCard",
+      "fields" : [
+        {
+          "name" : "lastFour"
+        },
+        {
+          "name" : "network"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.std.ReferenceTypeDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CurrencyCode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializerCache"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$CurrencyCode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$DrinkPreference",
+      "fields" : [
+        {
+          "name" : "beanOrigin"
+        },
+        {
+          "name" : "drinkSize"
+        },
+        {
+          "name" : "servingTemperature"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializerCache"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$DrinkSize"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.bean.BeanDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$GiftCard",
+      "fields" : [
+        {
+          "name" : "balance"
+        },
+        {
+          "name" : "code"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$GiftCard"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.bean.BeanSerializerBase"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$GiftCard",
+      "fields" : [
+        {
+          "name" : "balance"
+        },
+        {
+          "name" : "code"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.std.ReferenceTypeDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Money",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.math.BigDecimal",
+            "tools_jackson_core.jackson_databind.Jackson_databindTest$CurrencyCode"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.IndexedListSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Money",
+      "methods" : [
+        {
+          "name" : "amount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "currency",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.std.ReferenceTypeSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Money",
+      "methods" : [
+        {
+          "name" : "amount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "currency",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.deser.jdk.CollectionDeserializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$PaymentMethod"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$PaymentMethod"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$Receipt",
+      "methods" : [
+        {
+          "name" : "discount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "id",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "payments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "tools.jackson.databind.**"
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "tools.jackson.databind.**"
+      "includeClasses" : "tools.jackson.databind.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2157

This PR introduces tests and metadata for tools.jackson.core:jackson-databind:3.0.0-rc2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 176919
- Cached input tokens: 1473536
- Output tokens: 21359
- Entries: 20
- Iterations: 5
- Library coverage percentage: 26.39
- Generated lines of code: 387
- Tested library lines of code: 9095

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `992c095720ed2149ddcad7f3a8a0a773beb0780f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 15/64 covered calls (23.44%)
- Reflection: 15/64 covered calls (23.44%)

Library coverage:
- Instruction: 36172/145465 (24.87%)
- Line: 9095/34466 (26.39%)
- Method: 2141/7943 (26.95%)
