### PR TITLE
[GenAI] Test fix for org.yaml:snakeyaml:2.0 using gpt-5.5

### DIFF
--- a/metadata/org.yaml/snakeyaml/2.0/reachability-metadata.json
+++ b/metadata/org.yaml/snakeyaml/2.0/reachability-metadata.json
@@ -1,0 +1,77 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertyUtils"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.constructor.BaseConstructor"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.GenericProperty"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.nodes.Tag"
+      },
+      "type" : "java.sql.Date"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.nodes.Tag"
+      },
+      "type" : "java.sql.Timestamp"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "java.util.Date"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.internal.Logger"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.internal.Logger"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.internal.Logger"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle" : "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.yaml/snakeyaml/index.json
+++ b/metadata/org.yaml/snakeyaml/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0-sources.jar",
+    "repository-url" : "https://bitbucket.org/snakeyaml/snakeyaml",
+    "test-code-url" : "https://bitbucket.org/snakeyaml/snakeyaml/src/snakeyaml-2.0/src/test/",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0-javadoc.jar",
+    "description" : "SnakeYAML is a Java library for parsing and emitting YAML 1.1 documents. It lets applications load YAML into Java objects and serialize Java data structures back to YAML.",
     "tested-versions" : [
       "2.0"
     ],

--- a/metadata/org.yaml/snakeyaml/index.json
+++ b/metadata/org.yaml/snakeyaml/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0",
+    "tested-versions" : [
+      "2.0"
+    ],
+    "allowed-packages" : [
+      "org.yaml.snakeyaml"
+    ]
+  },
+  {
     "metadata-version" : "1.32",
     "source-code-url" : "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.32/snakeyaml-1.32-sources.jar",
     "repository-url" : "https://bitbucket.org/snakeyaml/snakeyaml",

--- a/stats/org.yaml/snakeyaml/2.0/execution-metrics.json
+++ b/stats/org.yaml/snakeyaml/2.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T23:31:26.967418Z",
+    "library": "org.yaml:snakeyaml:2.0",
+    "starting_commit": "c76908cdab22138f7c1beb12764713ab1cb89b42",
+    "ending_commit": "eb75e5c6c2a69224e5c24a7a5e968bb6416250fa",
+    "previous_library": "org.yaml:snakeyaml:1.32",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 36,
+            "totalCalls": 36
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 36,
+        "totalCalls": 36
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9302,
+          "missed": 21203,
+          "ratio": 0.304934,
+          "total": 30505
+        },
+        "line": {
+          "covered": 2049,
+          "missed": 4274,
+          "ratio": 0.324055,
+          "total": 6323
+        },
+        "method": {
+          "covered": 464,
+          "missed": 620,
+          "ratio": 0.428044,
+          "total": 1084
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.32",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 37,
+            "totalCalls": 37
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 37,
+        "totalCalls": 37
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9099,
+          "missed": 21383,
+          "ratio": 0.298504,
+          "total": 30482
+        },
+        "line": {
+          "covered": 1990,
+          "missed": 4318,
+          "ratio": 0.315472,
+          "total": 6308
+        },
+        "method": {
+          "covered": 454,
+          "missed": 654,
+          "ratio": 0.409747,
+          "total": 1108
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 52146,
+      "cached_input_tokens_used": 682496,
+      "output_tokens_used": 4886,
+      "iterations": 1,
+      "cost_usd": 0.4878,
+      "tested_library_loc": 2049,
+      "metadata_entries": 14,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 32.41,
+      "previous_library_coverage_percent": 31.55
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/BaseConstructorTest.java",
+      "metadata_file": "metadata/org.yaml/snakeyaml/2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.yaml/snakeyaml/2.0/stats.json
+++ b/stats/org.yaml/snakeyaml/2.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 36,
+          "totalCalls" : 36
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 36,
+      "totalCalls" : 36
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9302,
+        "missed" : 21203,
+        "ratio" : 0.304934,
+        "total" : 30505
+      },
+      "line" : {
+        "covered" : 2049,
+        "missed" : 4274,
+        "ratio" : 0.324055,
+        "total" : 6323
+      },
+      "method" : {
+        "covered" : 464,
+        "missed" : 620,
+        "ratio" : 0.428044,
+        "total" : 1084
+      }
+    }
+  } ]
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/.gitignore
+++ b/tests/src/org.yaml/snakeyaml/2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.yaml/snakeyaml/2.0/build.gradle
+++ b/tests/src/org.yaml/snakeyaml/2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.yaml:snakeyaml:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/gradle.properties
+++ b/tests/src/org.yaml/snakeyaml/2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.yaml:snakeyaml:2.0
+library.version = 2.0
+metadata.dir = org.yaml/snakeyaml/2.0/

--- a/tests/src/org.yaml/snakeyaml/2.0/settings.gradle
+++ b/tests/src/org.yaml/snakeyaml/2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.yaml.snakeyaml_tests'

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/BaseConstructorTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/BaseConstructorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+public class BaseConstructorTest {
+
+    @Test
+    void constructsTypedStringArrayFromSequence() {
+        String[] values = new Yaml().loadAs(
+                """
+                - alpha
+                - beta
+                - gamma
+                """,
+                String[].class);
+
+        assertThat(values).containsExactly("alpha", "beta", "gamma");
+    }
+
+    @Test
+    void constructsBeanUsingPrivateNoArgConstructor() {
+        String yaml = """
+                name: Example
+                quantity: 7
+                """;
+
+        PrivateDefaultConstructorBean bean =
+                new Yaml().loadAs(yaml, PrivateDefaultConstructorBean.class);
+
+        assertThat(bean.wasCreatedByConstructor()).isTrue();
+        assertThat(bean.getName()).isEqualTo("Example");
+        assertThat(bean.getQuantity()).isEqualTo(7);
+    }
+
+    public static final class PrivateDefaultConstructorBean {
+        private final boolean createdByConstructor;
+        private String name;
+        private int quantity;
+
+        private PrivateDefaultConstructorBean() {
+            this.createdByConstructor = true;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+
+        public boolean wasCreatedByConstructor() {
+            return createdByConstructor;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CompactConstructorTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CompactConstructorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor;
+
+public class CompactConstructorTest {
+
+    @Test
+    void constructsCompactBeanUsingPrivateDeclaredStringConstructor() {
+        String yaml = "%s(exampleName)".formatted(PrivateCompactBean.class.getName());
+
+        PrivateCompactBean bean = new Yaml(new CompactConstructor()).load(yaml);
+
+        assertThat(bean.getName()).isEqualTo("exampleName");
+    }
+
+    @Test
+    void constructsCompactBeanAndAppliesNamedProperties() {
+        String yaml = "%s(exampleName, role=maintainer)"
+                .formatted(PrivateCompactBean.class.getName());
+
+        PrivateCompactBean bean = new Yaml(new CompactConstructor()).load(yaml);
+
+        assertThat(bean.getName()).isEqualTo("exampleName");
+        assertThat(bean.getRole()).isEqualTo("maintainer");
+    }
+
+    public static final class PrivateCompactBean {
+        private final String name;
+        private String role;
+
+        private PrivateCompactBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class ConstructorConstructScalarTest {
+
+    @Test
+    void constructsRootBeanWhenRootTypeIsProvidedAsClassName() throws ClassNotFoundException {
+        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName()));
+
+        RootBean bean = yaml.load(
+                """
+                name: Example
+                quantity: 7
+                """);
+
+        assertThat(bean.getName()).isEqualTo("Example");
+        assertThat(bean.getQuantity()).isEqualTo(7);
+    }
+
+    @Test
+    void constructsRootBeanWhenRootTypeClassNameUsesCustomLoaderOptions()
+            throws ClassNotFoundException {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName(), loaderOptions));
+
+        RootBean bean = yaml.load(
+                """
+                name: Another example
+                quantity: 11
+                """);
+
+        assertThat(bean.getName()).isEqualTo("Another example");
+        assertThat(bean.getQuantity()).isEqualTo(11);
+    }
+
+    @Test
+    void constructsTaggedBeanWhenContextClassLoaderCannotResolveTheTagClass() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader rejectingLoader = new ClassLoader(null) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (FallbackTaggedBean.class.getName().equals(name)) {
+                    throw new ClassNotFoundException(name);
+                }
+                return super.loadClass(name, resolve);
+            }
+        };
+
+        Thread.currentThread().setContextClassLoader(rejectingLoader);
+        try {
+            FallbackTaggedBean bean = new Yaml().load(
+                    """
+                    !!%s
+                    name: tagged
+                    quantity: 3
+                    """.formatted(FallbackTaggedBean.class.getName()));
+
+            assertThat(bean.getName()).isEqualTo("tagged");
+            assertThat(bean.getQuantity()).isEqualTo(3);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void constructsCustomScalarWithSingleDeclaredConstructor() {
+        SingleIntegerScalar value = new Yaml().loadAs("42", SingleIntegerScalar.class);
+
+        assertThat(value.getValue()).isEqualTo(42);
+    }
+
+    @Test
+    void constructsCustomScalarWithStringConstructorWhenMultipleDeclaredConstructorsExist() {
+        MultiConstructorScalar value = new Yaml().loadAs("007", MultiConstructorScalar.class);
+
+        assertThat(value.getConstructionPath()).isEqualTo("string:007");
+    }
+
+    @Test
+    void constructsDateSubclassWithPublicLongConstructor() {
+        String yaml = "2024-03-01T10:15:30Z";
+
+        Date expected = new Yaml().loadAs(yaml, Date.class);
+        TimestampWrapper actual = new Yaml().loadAs(yaml, TimestampWrapper.class);
+
+        assertThat(actual).isInstanceOf(TimestampWrapper.class);
+        assertThat(actual.getTime()).isEqualTo(expected.getTime());
+    }
+
+    public static final class RootBean {
+        private String name;
+        private int quantity;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+
+    public static final class FallbackTaggedBean {
+        private String name;
+        private int quantity;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+
+    public static final class SingleIntegerScalar {
+        private final int value;
+
+        private SingleIntegerScalar(Integer value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public static final class MultiConstructorScalar {
+        private final String constructionPath;
+
+        private MultiConstructorScalar(Integer value) {
+            this.constructionPath = "integer:" + value;
+        }
+
+        private MultiConstructorScalar(String value) {
+            this.constructionPath = "string:" + value;
+        }
+
+        public String getConstructionPath() {
+            return constructionPath;
+        }
+    }
+
+    public static final class TimestampWrapper extends Date {
+        public TimestampWrapper(long time) {
+            super(time);
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
@@ -9,16 +9,18 @@ package org_yaml.snakeyaml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 public class ConstructorConstructScalarTest {
 
     @Test
     void constructsRootBeanWhenRootTypeIsProvidedAsClassName() throws ClassNotFoundException {
-        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName()));
+        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName(), new LoaderOptions()));
 
         RootBean bean = yaml.load(
                 """
@@ -61,7 +63,8 @@ public class ConstructorConstructScalarTest {
 
         Thread.currentThread().setContextClassLoader(rejectingLoader);
         try {
-            FallbackTaggedBean bean = new Yaml().load(
+            Yaml yaml = new Yaml(new Constructor(trustedLoaderOptions(FallbackTaggedBean.class)));
+            FallbackTaggedBean bean = yaml.load(
                     """
                     !!%s
                     name: tagged
@@ -98,6 +101,13 @@ public class ConstructorConstructScalarTest {
 
         assertThat(actual).isInstanceOf(TimestampWrapper.class);
         assertThat(actual.getTime()).isEqualTo(expected.getTime());
+    }
+
+    private static LoaderOptions trustedLoaderOptions(Class<?> trustedType) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(
+                new TrustedPrefixesTagInspector(List.of(trustedType.getName())));
+        return loaderOptions;
     }
 
     public static final class RootBean {

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructSequenceTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructSequenceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+public class ConstructorConstructSequenceTest {
+
+    @Test
+    void constructsImmutableObjectFromSequenceUsingSingleDeclaredConstructor() {
+        SingleDeclaredConstructorSequenceBean bean = new Yaml().loadAs(
+                """
+                - Example
+                - 7
+                """,
+                SingleDeclaredConstructorSequenceBean.class);
+
+        assertThat(bean.getName()).isEqualTo("Example");
+        assertThat(bean.getQuantity()).isEqualTo(7);
+    }
+
+    @Test
+    void constructsImmutableObjectFromSequenceUsingMatchingConstructorAmongMultipleChoices() {
+        MultipleDeclaredConstructorsSequenceBean bean = new Yaml().loadAs(
+                """
+                - 12
+                - true
+                """,
+                MultipleDeclaredConstructorsSequenceBean.class);
+
+        assertThat(bean.getConstructionPath()).isEqualTo("primitive");
+        assertThat(bean.getQuantity()).isEqualTo(12);
+        assertThat(bean.isEnabled()).isTrue();
+    }
+
+    public static final class SingleDeclaredConstructorSequenceBean {
+        private final String name;
+        private final int quantity;
+
+        private SingleDeclaredConstructorSequenceBean(String name, Integer quantity) {
+            this.name = name;
+            this.quantity = quantity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+    }
+
+    public static final class MultipleDeclaredConstructorsSequenceBean {
+        private final String constructionPath;
+        private final int quantity;
+        private final boolean enabled;
+
+        private MultipleDeclaredConstructorsSequenceBean(String label, String state) {
+            this.constructionPath = label + ":" + state;
+            this.quantity = -1;
+            this.enabled = false;
+        }
+
+        private MultipleDeclaredConstructorsSequenceBean(int quantity, boolean enabled) {
+            this.constructionPath = "primitive";
+            this.quantity = quantity;
+            this.enabled = enabled;
+        }
+
+        public String getConstructionPath() {
+            return constructionPath;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+
+public class CustomClassLoaderConstructorTest {
+
+    @Test
+    void resolvesTaggedBeanWithProvidedClassLoaderWhenContextLoaderRejectsIt() {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader resolvingClassLoader =
+                new ResolvingClassLoader(CustomClassLoaderConstructorTest.class.getClassLoader());
+        ClassLoader rejectingContextClassLoader = new RejectingClassLoader(
+                CustomClassLoaderConstructorTest.class.getClassLoader(),
+                TaggedBean.class.getName());
+        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(resolvingClassLoader));
+
+        Thread.currentThread().setContextClassLoader(rejectingContextClassLoader);
+        try {
+            TaggedBean bean = yaml.load(
+                    """
+                    !!%s
+                    name: Example
+                    quantity: 7
+                    """.formatted(TaggedBean.class.getName()));
+
+            assertThat(bean.getName()).isEqualTo("Example");
+            assertThat(bean.getQuantity()).isEqualTo(7);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static final class ResolvingClassLoader extends ClassLoader {
+        private ResolvingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(ClassLoader parent, String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    public static final class TaggedBean {
+        private String name;
+        private int quantity;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
@@ -8,9 +8,12 @@ package org_yaml.snakeyaml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 public class CustomClassLoaderConstructorTest {
 
@@ -22,7 +25,10 @@ public class CustomClassLoaderConstructorTest {
         ClassLoader rejectingContextClassLoader = new RejectingClassLoader(
                 CustomClassLoaderConstructorTest.class.getClassLoader(),
                 TaggedBean.class.getName());
-        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(resolvingClassLoader));
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(
+                new TrustedPrefixesTagInspector(List.of(TaggedBean.class.getName())));
+        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(resolvingClassLoader, loaderOptions));
 
         Thread.currentThread().setContextClassLoader(rejectingContextClassLoader);
         try {

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/FieldPropertyTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/FieldPropertyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+public class FieldPropertyTest {
+
+    @Test
+    void writesInheritedPrivateFieldThroughFieldProperty() throws Exception {
+        Property property = new PropertyUtils().getProperty(
+                FieldBackedBean.class, "value", BeanAccess.FIELD);
+        FieldBackedBean bean = new FieldBackedBean();
+
+        property.set(bean, "updated");
+
+        assertThat(bean.readValue()).isEqualTo("updated");
+    }
+
+    @Test
+    void readsInheritedPrivateFieldThroughFieldProperty() {
+        Property property = new PropertyUtils().getProperty(
+                FieldBackedBean.class, "value", BeanAccess.FIELD);
+        FieldBackedBean bean = new FieldBackedBean();
+        bean.writeValue("loaded");
+
+        assertThat(property.get(bean)).isEqualTo("loaded");
+    }
+
+    private static class FieldBackedBase {
+        private String value;
+
+        String readValue() {
+            return value;
+        }
+
+        void writeValue(String value) {
+            this.value = value;
+        }
+    }
+
+    private static final class FieldBackedBean extends FieldBackedBase {
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/GenericPropertyTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/GenericPropertyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.introspector.GenericProperty;
+
+public class GenericPropertyTest {
+
+    @Test
+    void resolvesGenericArrayTypeArgumentsToArrayClasses() {
+        Type genericArrayArgument = new ClassComponentGenericArrayType(String.class);
+        Type propertyType = new SingleArgumentParameterizedType(List.class, genericArrayArgument);
+        GenericProperty property = new TestGenericProperty("items", List.class, propertyType);
+
+        Class<?>[] actualTypeArguments = property.getActualTypeArguments();
+
+        assertThat(actualTypeArguments).containsExactly(String[].class);
+        assertThat(property.getActualTypeArguments()).isSameAs(actualTypeArguments);
+    }
+
+    private static final class TestGenericProperty extends GenericProperty {
+        private TestGenericProperty(String name, Class<?> propertyClass, Type type) {
+            super(name, propertyClass, type);
+        }
+
+        @Override
+        public void set(Object object, Object value) {
+            throw new UnsupportedOperationException("set is not used in this test");
+        }
+
+        @Override
+        public Object get(Object object) {
+            throw new UnsupportedOperationException("get is not used in this test");
+        }
+
+        @Override
+        public List<Annotation> getAnnotations() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+            return null;
+        }
+    }
+
+    private static final class SingleArgumentParameterizedType implements ParameterizedType {
+        private final Type rawType;
+        private final Type actualTypeArgument;
+
+        private SingleArgumentParameterizedType(Type rawType, Type actualTypeArgument) {
+            this.rawType = rawType;
+            this.actualTypeArgument = actualTypeArgument;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return new Type[] {actualTypeArgument};
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+    }
+
+    private static final class ClassComponentGenericArrayType implements GenericArrayType {
+        private final Class<?> componentType;
+
+        private ClassComponentGenericArrayType(Class<?> componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/MethodPropertyTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/MethodPropertyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.introspector.MethodProperty;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+public class MethodPropertyTest {
+
+    @Test
+    void readsBeanValueThroughMethodPropertyGetter() {
+        Property property = new PropertyUtils().getProperty(AccessorBackedBean.class, "value");
+        AccessorBackedBean bean = new AccessorBackedBean();
+        bean.setValue("loaded");
+
+        assertThat(property).isInstanceOf(MethodProperty.class);
+        assertThat(property.get(bean)).isEqualTo("loaded");
+    }
+
+    @Test
+    void writesBeanValueThroughMethodPropertySetter() throws Exception {
+        Property property = new PropertyUtils().getProperty(AccessorBackedBean.class, "value");
+        AccessorBackedBean bean = new AccessorBackedBean();
+
+        property.set(bean, "updated");
+
+        assertThat(bean.getValue()).isEqualTo("updated");
+    }
+
+    public static final class AccessorBackedBean {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/PackageCompactConstructorTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/PackageCompactConstructorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.extensions.compactnotation.PackageCompactConstructor;
+
+public class PackageCompactConstructorTest {
+
+    @Test
+    void loadsCompactBeanBySimpleNameFromConfiguredPackage() {
+        String yaml = "PackageCompactBean(exampleName)";
+
+        PackageCompactBean bean = (PackageCompactBean) new Yaml(
+                new PackageCompactConstructor(PackageCompactBean.class.getPackageName())).load(yaml);
+
+        assertThat(bean.getName()).isEqualTo("exampleName");
+    }
+}
+
+final class PackageCompactBean {
+    private final String name;
+
+    private PackageCompactBean(String name) {
+        this.name = name;
+    }
+
+    String getName() {
+        return name;
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/PropertySubstituteTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/PropertySubstituteTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.introspector.PropertySubstitute;
+
+public class PropertySubstituteTest {
+
+    @Test
+    void usesInheritedPrivateReadAndWriteMethods() throws Exception {
+        PropertySubstitute property =
+                new PropertySubstitute("value", String.class, "readValue", "writeValue");
+        MethodBackedBean bean = new MethodBackedBean();
+
+        property.setTargetType(MethodBackedBean.class);
+        property.set(bean, "updated");
+
+        assertThat(property.get(bean)).isEqualTo("updated");
+    }
+
+    @Test
+    void usesInheritedPrivateFieldWhenNoAccessorMethodsExist() throws Exception {
+        PropertySubstitute property = new PropertySubstitute("fieldOnly", String.class);
+        FieldBackedBean bean = new FieldBackedBean();
+
+        property.setTargetType(FieldBackedBean.class);
+        property.set(bean, "field value");
+
+        assertThat(property.get(bean)).isEqualTo("field value");
+    }
+
+    @Test
+    void fillsCollectionValuesThroughSingleElementAdder() throws Exception {
+        PropertySubstitute property =
+                new PropertySubstitute("items", List.class, null, "addItem", String.class);
+        FillerBean bean = new FillerBean();
+
+        property.setTargetType(FillerBean.class);
+        property.set(bean, List.of("first", "second"));
+
+        assertThat(bean.items).containsExactly("first", "second");
+    }
+
+    @Test
+    void fillsMapValuesThroughKeyValueAdder() throws Exception {
+        PropertySubstitute property = new PropertySubstitute(
+                "entries", Map.class, null, "putEntry", String.class, Integer.class);
+        FillerBean bean = new FillerBean();
+        Map<String, Integer> entries = new LinkedHashMap<>();
+        entries.put("left", 1);
+        entries.put("right", 2);
+
+        property.setTargetType(FillerBean.class);
+        property.set(bean, entries);
+
+        assertThat(bean.entries).containsExactlyEntriesOf(entries);
+    }
+
+    @Test
+    void fillsArrayValuesThroughSingleElementAdder() throws Exception {
+        PropertySubstitute property =
+                new PropertySubstitute("items", List.class, null, "addItem", String.class);
+        FillerBean bean = new FillerBean();
+
+        property.setTargetType(FillerBean.class);
+        property.set(bean, new String[] {"alpha", "beta"});
+
+        assertThat(bean.items).containsExactly("alpha", "beta");
+    }
+
+    private static class MethodBackedBase {
+        private String value;
+
+        private String readValue() {
+            return value;
+        }
+
+        private void writeValue(String value) {
+            this.value = value;
+        }
+    }
+
+    private static final class MethodBackedBean extends MethodBackedBase {
+    }
+
+    private static class FieldBackedBase {
+        private String fieldOnly;
+    }
+
+    private static final class FieldBackedBean extends FieldBackedBase {
+    }
+
+    private static final class FillerBean {
+        private final List<String> items = new ArrayList<>();
+        private final Map<String, Integer> entries = new LinkedHashMap<>();
+
+        private void addItem(String item) {
+            items.add(item);
+        }
+
+        private void putEntry(String key, Integer value) {
+            entries.put(key, value);
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_yaml.snakeyaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class TypeDescriptionTest {
+
+    @Test
+    void constructsRootBeanUsingConfiguredImplementationDeclaredConstructor() {
+        TypeDescription rootType =
+                new TypeDescription(AbstractConfiguredBean.class, DeclaredConstructorBean.class);
+        Yaml yaml = new Yaml(new Constructor(rootType));
+
+        AbstractConfiguredBean bean = yaml.load(
+                """
+                name: Example
+                quantity: 7
+                """);
+
+        assertThat(bean).isInstanceOf(DeclaredConstructorBean.class);
+        assertThat(bean.getName()).isEqualTo("Example");
+        assertThat(bean.getQuantity()).isEqualTo(7);
+        assertThat(((DeclaredConstructorBean) bean).wasCreatedByDeclaredConstructor()).isTrue();
+    }
+
+    public abstract static class AbstractConfiguredBean {
+        private String name;
+        private int quantity;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+
+    public static final class DeclaredConstructorBean extends AbstractConfiguredBean {
+        private final boolean createdByDeclaredConstructor;
+
+        private DeclaredConstructorBean() {
+            this.createdByDeclaredConstructor = true;
+        }
+
+        public boolean wasCreatedByDeclaredConstructor() {
+            return createdByDeclaredConstructor;
+        }
+    }
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
@@ -9,6 +9,7 @@ package org_yaml.snakeyaml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -19,7 +20,7 @@ public class TypeDescriptionTest {
     void constructsRootBeanUsingConfiguredImplementationDeclaredConstructor() {
         TypeDescription rootType =
                 new TypeDescription(AbstractConfiguredBean.class, DeclaredConstructorBean.class);
-        Yaml yaml = new Yaml(new Constructor(rootType));
+        Yaml yaml = new Yaml(new Constructor(rootType, new LoaderOptions()));
 
         AbstractConfiguredBean bean = yaml.load(
                 """

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.PackageCompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.PackageCompactBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.yaml/snakeyaml/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -13,6 +13,409 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.BaseConstructorTest$PrivateDefaultConstructorBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.CompactConstructorTest$PrivateCompactBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setRole",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.CompactConstructorTest$PrivateCompactBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.CompactConstructorTest$PrivateCompactBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$FallbackTaggedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setQuantity",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$FallbackTaggedBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$FallbackTaggedBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$MultiConstructorScalar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$RootBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$RootBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setQuantity",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.constructor.Constructor"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$RootBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$RootBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$RootBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$SingleIntegerScalar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructScalarTest$TimestampWrapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructSequenceTest$MultipleDeclaredConstructorsSequenceBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.constructor.Constructor$ConstructSequence"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructSequenceTest$MultipleDeclaredConstructorsSequenceBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructSequenceTest$SingleDeclaredConstructorSequenceBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.constructor.Constructor$ConstructSequence"
+      },
+      "type" : "org_yaml.snakeyaml.ConstructorConstructSequenceTest$SingleDeclaredConstructorSequenceBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Integer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.CustomClassLoaderConstructorTest$TaggedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setQuantity",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.CustomClassLoaderConstructorTest$TaggedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.CustomClassLoaderConstructorTest$TaggedBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.CustomClassLoaderConstructorTest$TaggedBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.FieldProperty"
+      },
+      "type" : "org_yaml.snakeyaml.FieldPropertyTest$FieldBackedBase",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.MethodProperty"
+      },
+      "type" : "org_yaml.snakeyaml.MethodPropertyTest$AccessorBackedBean",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.PackageCompactBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.extensions.compactnotation.PackageCompactConstructor"
+      },
+      "type" : "org_yaml.snakeyaml.PackageCompactBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "org_yaml.snakeyaml.PropertySubstituteTest$FieldBackedBase",
+      "fields" : [
+        {
+          "name" : "fieldOnly"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "org_yaml.snakeyaml.PropertySubstituteTest$FieldBackedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "org_yaml.snakeyaml.PropertySubstituteTest$FillerBean",
+      "methods" : [
+        {
+          "name" : "addItem",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "putEntry",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Integer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "org_yaml.snakeyaml.PropertySubstituteTest$MethodBackedBase",
+      "methods" : [
+        {
+          "name" : "readValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "writeValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.introspector.PropertySubstitute"
+      },
+      "type" : "org_yaml.snakeyaml.PropertySubstituteTest$MethodBackedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.TypeDescriptionTest$AbstractConfiguredBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.Yaml"
+      },
+      "type" : "org_yaml.snakeyaml.TypeDescriptionTest$AbstractConfiguredBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setQuantity",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.TypeDescriptionTest$AbstractConfiguredBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.TypeDescriptionTest$AbstractConfiguredBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.yaml.snakeyaml.TypeDescription"
+      },
+      "type" : "org_yaml.snakeyaml.TypeDescriptionTest$DeclaredConstructorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
+++ b/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.yaml.snakeyaml.**"
+    }
+  ]
+}

--- a/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
+++ b/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.yaml.snakeyaml.**"
+      "includeClasses" : "org.yaml.snakeyaml.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #2004

This PR provides test fixes and new metadata for org.yaml:snakeyaml:2.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 52146
- Cached input tokens: 682496
- Output tokens: 4886
- Entries found: 14
- Iterations: 1
- Library coverage percentage: 32.41
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 31.55

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `76f652a1ef9418f23fde0adc421bdb52f2df1c15`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.yaml:snakeyaml:1.32: 37/37 covered calls (100.00%)
- org.yaml:snakeyaml:2.0: 36/36 covered calls (100.00%)

**Reflection:**
- org.yaml:snakeyaml:1.32: 37/37 covered calls (100.00%)
- org.yaml:snakeyaml:2.0: 36/36 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.yaml:snakeyaml:1.32: 9099/30482 (29.85%)
- org.yaml:snakeyaml:2.0: 9302/30505 (30.49%)

**Line:**
- org.yaml:snakeyaml:1.32: 1990/6308 (31.55%)
- org.yaml:snakeyaml:2.0: 2049/6323 (32.41%)

**Method:**
- org.yaml:snakeyaml:1.32: 454/1108 (40.97%)
- org.yaml:snakeyaml:2.0: 464/1084 (42.80%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
index c550edb92c..b292f001e0 100644
--- 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
+++ 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/ConstructorConstructScalarTest.java
@@ -9,16 +9,18 @@ package org_yaml.snakeyaml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 public class ConstructorConstructScalarTest {
 
     @Test
     void constructsRootBeanWhenRootTypeIsProvidedAsClassName() throws ClassNotFoundException {
-        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName()));
+        Yaml yaml = new Yaml(new Constructor(RootBean.class.getName(), new LoaderOptions()));
 
         RootBean bean = yaml.load(
                 """
@@ -61,7 +63,8 @@ public class ConstructorConstructScalarTest {
 
         Thread.currentThread().setContextClassLoader(rejectingLoader);
         try {
-            FallbackTaggedBean bean = new Yaml().load(
+            Yaml yaml = new Yaml(new Constructor(trustedLoaderOptions(FallbackTaggedBean.class)));
+            FallbackTaggedBean bean = yaml.load(
                     """
                     !!%s
                     name: tagged
@@ -100,6 +103,13 @@ public class ConstructorConstructScalarTest {
         assertThat(actual.getTime()).isEqualTo(expected.getTime());
     }
 
+    private static LoaderOptions trustedLoaderOptions(Class<?> trustedType) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(
+                new TrustedPrefixesTagInspector(List.of(trustedType.getName())));
+        return loaderOptions;
+    }
+
     public static final class RootBean {
         private String name;
         private int quantity;
diff --git 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
index c830bbadd3..1412ae9664 100644
--- 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
+++ 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/CustomClassLoaderConstructorTest.java
@@ -8,9 +8,12 @@ package org_yaml.snakeyaml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 public class CustomClassLoaderConstructorTest {
 
@@ -22,7 +25,10 @@ public class CustomClassLoaderConstructorTest {
         ClassLoader rejectingContextClassLoader = new RejectingClassLoader(
                 CustomClassLoaderConstructorTest.class.getClassLoader(),
                 TaggedBean.class.getName());
-        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(resolvingClassLoader));
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(
+                new TrustedPrefixesTagInspector(List.of(TaggedBean.class.getName())));
+        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(resolvingClassLoader, loaderOptions));
 
         Thread.currentThread().setContextClassLoader(rejectingContextClassLoader);
         try {
diff --git 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
index 528a274a7e..fbd6163774 100644
--- 1/tests/src/org.yaml/snakeyaml/1.32/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
+++ 2/tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/TypeDescriptionTest.java
@@ -9,6 +9,7 @@ package org_yaml.snakeyaml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -19,7 +20,7 @@ public class TypeDescriptionTest {
     void constructsRootBeanUsingConfiguredImplementationDeclaredConstructor() {
         TypeDescription rootType =
                 new TypeDescription(AbstractConfiguredBean.class, DeclaredConstructorBean.class);
-        Yaml yaml = new Yaml(new Constructor(rootType));
+        Yaml yaml = new Yaml(new Constructor(rootType, new LoaderOptions()));
 
         AbstractConfiguredBean bean = yaml.load(
                 """
diff --git 1/tests/src/org.yaml/snakeyaml/1.32/user-code-filter.json 2/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
index ff377eb22f..bf73fea4d2 100644
--- 1/tests/src/org.yaml/snakeyaml/1.32/user-code-filter.json
+++ 2/tests/src/org.yaml/snakeyaml/2.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.yaml.snakeyaml.**"
+      "includeClasses" : "org.yaml.snakeyaml.**"
     }
   ]
 }

```
