### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
@@ -1,0 +1,73 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getRecordComponents",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ArrayReader"
+      },
+      "type" : "java.lang.Class[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.ValueIterator"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ArrayReader"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ArrayReader"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ArrayReader"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.reflect.RecordComponent",
+      "methods" : [
+        {
+          "name" : "getType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.21.0",
+    "tested-versions" : [
+      "2.21.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
+    ]
+  },
+  {
     "metadata-version" : "2.17.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.17.0/jackson-jr-objects-2.17.0-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jr",

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.21.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.21.0/jackson-jr-objects-2.21.0-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-2.21.0/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/2.21.0/jackson-jr-objects-2.21.0-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module that reads JSON into maps, lists, strings, primitive wrappers, arrays, and Java beans, and writes those values back as JSON. It builds directly on jackson-core with minimal dependencies and also provides builder-style APIs for composing JSON output.",
     "tested-versions" : [
       "2.21.0"
     ],

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-04-29": {
+    "timestamp": "2026-04-29T23:48:32.330704Z",
+    "library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0",
+    "starting_commit": "12cfb8f38f400d9f730e6cfa3684af58b9c6ea2c",
+    "ending_commit": "3d836885ff219e11a4363c8f3f91bcc1821262c5",
+    "previous_library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.21.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5526,
+          "missed": 8184,
+          "ratio": 0.403063,
+          "total": 13710
+        },
+        "method": {
+          "covered": 296,
+          "missed": 409,
+          "ratio": 0.419858,
+          "total": 705
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4596,
+          "missed": 7891,
+          "ratio": 0.368063,
+          "total": 12487
+        },
+        "method": {
+          "covered": 255,
+          "missed": 411,
+          "ratio": 0.382883,
+          "total": 666
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 1174546,
+      "cached_input_tokens_used": 17382400,
+      "output_tokens_used": 124202,
+      "iterations": 23,
+      "cost_usd": 12.4173,
+      "tested_library_loc": 0,
+      "metadata_entries": 14,
+      "previous_library_metadata_entries": 4,
+      "code_coverage_percent": 40.31,
+      "previous_library_coverage_percent": 36.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
@@ -1,0 +1,32 @@
+{
+  "versions" : [ {
+    "version" : "2.21.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5526,
+        "missed" : 8184,
+        "ratio" : 0.403063,
+        "total" : 13710
+      },
+      "line" : "N/A",
+      "method" : {
+        "covered" : 296,
+        "missed" : 409,
+        "ratio" : 0.419858,
+        "total" : 705
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jr:jackson-jr-objects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0
+library.version = 2.21.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jr.jackson-jr-objects_tests'

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @BeforeEach
+    void resetConstructorCounters() {
+        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
+        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+
+        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+        constructors.forceAccess();
+
+        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        Object createBean() throws Exception {
+            return create();
+        }
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -19,31 +19,29 @@ public class BeanConstructorsDynamicAccessTest {
 
     @BeforeEach
     void resetConstructorCounters() {
-        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
-        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
-        PublicRecordBean.CONSTRUCTOR_CALLS.set(0);
+        BeanConstructorsDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        BeanConstructorsRecordBean.CONSTRUCTOR_CALLS.set(0);
     }
 
     @Test
-    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
-        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
-
-        assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+    void createsBeansThroughDefaultConstructorsWhenReadingObjects() throws Exception {
+        BeanConstructorsDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(BeanConstructorsDefaultCtorBean.class,
                 "{\"name\":\"Ada\"}");
 
         assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(BeanConstructorsDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsLibraryBeansThroughDefaultConstructorsWhenReadingObjects() throws Exception {
+        JSON json = JSON.std.beanFrom(JSON.class, "{}");
+
+        assertThat(json).isNotNull();
     }
 
     @Test
     void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
-        PublicRecordBean bean = JSON.std.beanFrom(PublicRecordBean.class, """
+        BeanConstructorsRecordBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(BeanConstructorsRecordBean.class, """
                 {
                   "name": "Ada",
                   "quantity": 3,
@@ -54,34 +52,24 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(bean.name()).isEqualTo("Ada");
         assertThat(bean.quantity()).isEqualTo(3);
         assertThat(bean.stocked()).isTrue();
-        assertThat(PublicRecordBean.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(BeanConstructorsRecordBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
+}
 
-    public static final class PublicDefaultCtorBean {
-        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+final class BeanConstructorsDefaultCtorBean {
+    static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
 
-        public String name;
+    String name;
 
-        public PublicDefaultCtorBean() {
-            CONSTRUCTOR_CALLS.incrementAndGet();
-        }
+    BeanConstructorsDefaultCtorBean() {
+        CONSTRUCTOR_CALLS.incrementAndGet();
     }
+}
 
-    public static final class PrivateDefaultCtorBean {
-        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+record BeanConstructorsRecordBean(String name, int quantity, boolean stocked) {
+    static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
 
-        public String name;
-
-        private PrivateDefaultCtorBean() {
-            CONSTRUCTOR_CALLS.incrementAndGet();
-        }
-    }
-
-    public record PublicRecordBean(String name, int quantity, boolean stocked) {
-        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
-
-        public PublicRecordBean {
-            CONSTRUCTOR_CALLS.incrementAndGet();
-        }
+    BeanConstructorsRecordBean {
+        CONSTRUCTOR_CALLS.incrementAndGet();
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,11 +6,9 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,31 +21,7 @@ public class BeanConstructorsDynamicAccessTest {
     void resetConstructorCounters() {
         PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
         PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
-    }
-
-    @Test
-    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
-        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
-
-        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
-
-        assertThat(bean).isNotNull();
-        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
-        constructors.forceAccess();
-
-        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
-
-        assertThat(bean).isNotNull();
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+        PublicRecordBean.CONSTRUCTOR_CALLS.set(0);
     }
 
     @Test
@@ -67,14 +41,20 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
-    static final class AccessibleBeanConstructors extends BeanConstructors {
-        AccessibleBeanConstructors(Class<?> valueType) {
-            super(valueType);
-        }
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        PublicRecordBean bean = JSON.std.beanFrom(PublicRecordBean.class, """
+                {
+                  "name": "Ada",
+                  "quantity": 3,
+                  "stocked": true
+                }
+                """);
 
-        Object createBean() throws Exception {
-            return create();
-        }
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.quantity()).isEqualTo(3);
+        assertThat(bean.stocked()).isTrue();
+        assertThat(PublicRecordBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     public static final class PublicDefaultCtorBean {
@@ -93,6 +73,14 @@ public class BeanConstructorsDynamicAccessTest {
         public String name;
 
         private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public record PublicRecordBean(String name, int quantity, boolean stocked) {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public PublicRecordBean {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -59,7 +59,7 @@ public class BeanConstructorsDynamicAccessTest {
 final class BeanConstructorsDefaultCtorBean {
     static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
 
-    String name;
+    public String name;
 
     BeanConstructorsDefaultCtorBean() {
         CONSTRUCTOR_CALLS.incrementAndGet();

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyIntrospectorDynamicAccessTest {
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON_WITH_FORCE_ACCESS.with(
+            JSON.Feature.USE_FIELD_MATCHING_GETTERS);
+
+    @Test
+    void collectsDeclaredConstructorsForDeserialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
+
+        IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
+                "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
+        IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(objectBean.getName()).isEqualTo("Ada");
+        assertThat(objectBean.isActive()).isTrue();
+        assertThat(objectBean.visible).isEqualTo(7);
+        assertThat(stringBean.getName()).isEqualTo("Ada");
+        assertThat(longBean.visible).isEqualTo(7);
+    }
+
+    @Test
+    void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
+
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
+
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
+
+        assertThat(json).contains("\"title\":\"Ada\"");
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class BaseBean {
+        public int visible;
+    }
+
+    static final class IntrospectedBean extends BaseBean {
+        private String name;
+        private boolean active;
+
+        private IntrospectedBean() {
+        }
+
+        private IntrospectedBean(String name) {
+            this.name = name;
+        }
+
+        private IntrospectedBean(long visible) {
+            this.visible = (int) visible;
+        }
+
+        static IntrospectedBean create(String name, boolean active, int visible) {
+            IntrospectedBean bean = new IntrospectedBean();
+            bean.name = name;
+            bean.active = active;
+            bean.visible = visible;
+            return bean;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    static final class FieldNamedGetterBean {
+        private final String title;
+
+        FieldNamedGetterBean(String title) {
+            this.title = title;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -36,7 +36,8 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
         IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
-        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+        IntConstructorBean intBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntConstructorBean.class, "13");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7000000000");
 
         assertThat(definition.constructors()).isNotNull();
         assertThat(libraryDefinition.constructors()).isNotNull();
@@ -46,7 +47,8 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
         assertThat(stringBean.getName()).isEqualTo("Ada");
-        assertThat(longBean.visible).isEqualTo(7);
+        assertThat(intBean.visible).isEqualTo(13);
+        assertThat(longBean.visible).isEqualTo(700000000);
     }
 
     @Test
@@ -75,9 +77,24 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
     @Test
     void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                FieldNamedGetterBean.class);
         String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
 
+        assertThat(propertyNames(definition)).isEmpty();
         assertThat(json).contains("\"title\":\"Ada\"");
+    }
+
+    @Test
+    void introspectsInheritedDeclaredFieldsAndMethods() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                InheritedAccessBean.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(new InheritedAccessBean("Ada", 7));
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("count", "name");
+        assertThat(property(definition, "count").field).isNotNull();
+        assertThat(property(definition, "name").getter).isNotNull();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"count\":7");
     }
 
     private static List<String> propertyNames(POJODefinition definition) {
@@ -106,8 +123,12 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.name = name;
         }
 
+        private IntrospectedBean(int visible) {
+            this.visible = visible;
+        }
+
         private IntrospectedBean(long visible) {
-            this.visible = (int) visible;
+            this.visible = (int) (visible / 10L);
         }
 
         static IntrospectedBean create(String name, boolean active, int visible) {
@@ -132,6 +153,35 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         public void setActive(boolean active) {
             this.active = active;
+        }
+    }
+
+    static final class IntConstructorBean {
+        private final int visible;
+
+        private IntConstructorBean(int visible) {
+            this.visible = visible;
+        }
+    }
+
+    static class InheritedBaseBean {
+        private final String name;
+
+        InheritedBaseBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    static final class InheritedAccessBean extends InheritedBaseBean {
+        public final int count;
+
+        InheritedAccessBean(String name, int count) {
+            super(name);
+            this.count = count;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -52,6 +52,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     }
 
     @Test
+    void registersSupportedNonRecordConstructorsFromDeclaredConstructors() {
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(ConstructorSelectionBean.class);
+
+        BeanPropertyIntrospector.addNonRecordConstructors(ConstructorSelectionBean.class, constructors);
+
+        assertThat(constructors.hasNoArgsConstructor()).isTrue();
+        assertThat(constructors.hasStringConstructor()).isTrue();
+        assertThat(constructors.hasIntegerConstructor()).isTrue();
+        assertThat(constructors.hasLongConstructor()).isTrue();
+    }
+
+    @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
         POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
@@ -161,6 +173,45 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         private IntConstructorBean(int visible) {
             this.visible = visible;
+        }
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        boolean hasNoArgsConstructor() {
+            return _noArgsCtor != null;
+        }
+
+        boolean hasStringConstructor() {
+            return _stringCtor != null;
+        }
+
+        boolean hasIntegerConstructor() {
+            return _intCtor != null;
+        }
+
+        boolean hasLongConstructor() {
+            return _longCtor != null;
+        }
+    }
+
+    public static final class ConstructorSelectionBean {
+        public ConstructorSelectionBean() {
+        }
+
+        public ConstructorSelectionBean(String value) {
+        }
+
+        public ConstructorSelectionBean(Integer value) {
+        }
+
+        public ConstructorSelectionBean(Long value) {
+        }
+
+        public ConstructorSelectionBean(double value) {
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldBackedBeanProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
+    }
+
+    @Test
+    void populatesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFluentSetterBackedProperties() throws Exception {
+        FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class FieldBackedReaderBean {
+        private boolean constructed;
+        public int x;
+        public int y;
+
+        public FieldBackedReaderBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PublicSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public PublicSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class FluentSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public FluentSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public FluentSetterBackedReaderBean setName(String name) {
+            this.name = name;
+            setterCalls++;
+            return this;
+        }
+    }
+
+    public static final class SetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public SetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,6 +7,7 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +28,29 @@ public class BeanPropertyReaderDynamicAccessTest {
     void invokesPublicSetterBackedProperties() throws Exception {
         PublicSetterBackedReaderBean bean = JSON.std.beanFrom(PublicSetterBackedReaderBean.class,
                 "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null, -1);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class), -1);
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,7 +7,6 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,23 +15,18 @@ public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
-        FieldBackedReaderBean bean = new FieldBackedReaderBean();
-
-        reader.setValueFor(bean, new Object[]{3});
+    void populatesPublicFieldBackedProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON.std.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
 
         assertThat(bean.isConstructed()).isTrue();
         assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
     }
 
     @Test
-    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
-        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
-
-        reader.setValueFor(bean, new Object[]{"Ada"});
+    void invokesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON.std.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyWriterDynamicAccessTest {
+    private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.USE_FIELDS);
+    private static final JSON JSON_WITH_GETTER_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.WRITE_READONLY_BEAN_PROPERTIES);
+
+    @Test
+    void serializesFieldBackedProperties() throws Exception {
+        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
+
+        assertThat(json).isEqualTo("{\"id\":3}");
+    }
+
+    @Test
+    void serializesGetterBackedProperties() throws Exception {
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+        String json = JSON_WITH_GETTER_ACCESS.asString(bean);
+
+        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+    }
+
+    public static final class GetterBackedWriterBean {
+        private int getterCalls;
+        private final String name;
+
+        public GetterBackedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            getterCalls++;
+            return name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -35,15 +35,15 @@ public class BeanPropertyWriterDynamicAccessTest {
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 
-    public static final class FieldBackedWriterBean {
+    static final class FieldBackedWriterBean {
         public int id = 3;
     }
 
-    public static final class GetterBackedWriterBean {
+    static final class GetterBackedWriterBean {
         private int getterCalls;
         private final String name;
 
-        public GetterBackedWriterBean(String name) {
+        GetterBackedWriterBean(String name) {
             this.name = name;
         }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,7 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,15 +39,44 @@ public class BeanPropertyWriterDynamicAccessTest {
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 
-    static final class FieldBackedWriterBean {
-        public int id = 3;
+    @Test
+    void readsFieldAccessorValuesThroughBeanPropertyWriter() throws Exception {
+        Field field = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
+
+        Object value = writer.getValueFor(new FieldBackedWriterBean(13));
+
+        assertThat(value).isEqualTo(13);
     }
 
-    static final class GetterBackedWriterBean {
+    @Test
+    void invokesGetterAccessorValuesThroughBeanPropertyWriter() throws Exception {
+        Method getter = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getter);
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Grace");
+
+        Object value = writer.getValueFor(bean);
+
+        assertThat(value).isEqualTo("Grace");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+
+        public FieldBackedWriterBean() {
+        }
+
+        public FieldBackedWriterBean(int id) {
+            this.id = id;
+        }
+    }
+
+    public static final class GetterBackedWriterBean {
         private int getterCalls;
         private final String name;
 
-        GetterBackedWriterBean(String name) {
+        public GetterBackedWriterBean(String name) {
             this.name = name;
         }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionBuilderDynamicAccessTest {
+    @Test
+    void createsEmptyTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray(elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+
+        assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+
+        assertThat(values).containsExactly("solo");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
+        return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<String> runtimeStringType() throws Exception {
+        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    }
+
+    public static final class ArrayElement {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -82,6 +82,27 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
+    void usesInheritedTypedArrayHelpersWhenJsonApiHasCustomBuilder() throws Exception {
+        RecordingCollectionBuilder builder = new RecordingCollectionBuilder();
+        JSON json = JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+        Class<String> elementType = runtimeStringType();
+
+        String[] emptyValues = json.arrayOfFrom(elementType, "[]");
+        String[] singletonValues = json.arrayOfFrom(elementType, "[\"solo\"]");
+        String[] multipleValues = json.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(emptyValues).isEmpty();
+        assertThat(emptyValues).isInstanceOf(String[].class);
+        assertThat(singletonValues).containsExactly("solo");
+        assertThat(singletonValues).isInstanceOf(String[].class);
+        assertThat(multipleValues).containsExactly("left", "right");
+        assertThat(multipleValues).isInstanceOf(String[].class);
+        assertThat(builder.startedCollections).isEqualTo(1);
+    }
+
+    @Test
     void readsEmptyTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
 
@@ -126,6 +147,7 @@ public class CollectionBuilderDynamicAccessTest {
 
     private static final class RecordingCollectionBuilder extends CollectionBuilder {
         private Collection<Object> values;
+        private int startedCollections;
 
         private RecordingCollectionBuilder() {
             this(0, null);
@@ -147,6 +169,7 @@ public class CollectionBuilderDynamicAccessTest {
 
         @Override
         public CollectionBuilder start() {
+            startedCollections++;
             values = new ArrayList<>();
             return this;
         }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -6,6 +6,9 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
@@ -18,9 +21,10 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.emptyArray(elementType);
+        ArrayElement[] values = builder.emptyArray(elementType);
 
         assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
@@ -29,10 +33,11 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+        ArrayElement[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
 
         assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values[0].name).isEqualTo("solo");
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
@@ -41,15 +46,39 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.start()
+        ArrayElement[] values = builder.start()
                 .add(new ArrayElement("left"))
                 .add(new ArrayElement("right"))
                 .buildArray(elementType);
 
         assertThat(values).hasSize(2);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
-        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values[0].name).isEqualTo("left");
+        assertThat(values[1].name).isEqualTo("right");
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void inheritedTypedArrayHelpersSupportCustomBuilders() throws Exception {
+        CollectionBuilder builder = new RecordingCollectionBuilder();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+        ArrayElement solo = new ArrayElement("solo");
+
+        ArrayElement[] emptyValues = builder.emptyArray(elementType);
+        ArrayElement[] singletonValues = builder.singletonArray(elementType, solo);
+        ArrayElement[] multipleValues = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(emptyValues).isEmpty();
+        assertThat(emptyValues).isInstanceOf(ArrayElement[].class);
+        assertThat(singletonValues).containsExactly(solo);
+        assertThat(singletonValues).isInstanceOf(ArrayElement[].class);
+        assertThat(multipleValues).hasSize(2);
+        assertThat(multipleValues[0].name).isEqualTo("left");
+        assertThat(multipleValues[1].name).isEqualTo("right");
+        assertThat(multipleValues).isInstanceOf(ArrayElement[].class);
     }
 
     @Test
@@ -93,6 +122,47 @@ public class CollectionBuilderDynamicAccessTest {
     @SuppressWarnings("unchecked")
     private static Class<String> runtimeStringType() throws Exception {
         return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    }
+
+    private static final class RecordingCollectionBuilder extends CollectionBuilder {
+        private Collection<Object> values;
+
+        private RecordingCollectionBuilder() {
+            this(0, null);
+        }
+
+        private RecordingCollectionBuilder(int features, Class<?> collectionType) {
+            super(features, collectionType);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new RecordingCollectionBuilder(features, _collectionType);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new RecordingCollectionBuilder(_features, collectionType);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            values = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            values.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> result = values;
+            values = null;
+            return result;
+        }
     }
 
     public static final class ArrayElement {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -8,6 +8,7 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
@@ -99,7 +100,7 @@ public class CollectionBuilderDynamicAccessTest {
         assertThat(singletonValues).isInstanceOf(String[].class);
         assertThat(multipleValues).containsExactly("left", "right");
         assertThat(multipleValues).isInstanceOf(String[].class);
-        assertThat(builder.startedCollections).isEqualTo(1);
+        assertThat(builder.startedCollections.get()).isEqualTo(1);
     }
 
     @Test
@@ -146,30 +147,31 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     private static final class RecordingCollectionBuilder extends CollectionBuilder {
+        private final AtomicInteger startedCollections;
         private Collection<Object> values;
-        private int startedCollections;
 
         private RecordingCollectionBuilder() {
-            this(0, null);
+            this(0, null, new AtomicInteger());
         }
 
-        private RecordingCollectionBuilder(int features, Class<?> collectionType) {
+        private RecordingCollectionBuilder(int features, Class<?> collectionType, AtomicInteger startedCollections) {
             super(features, collectionType);
+            this.startedCollections = startedCollections;
         }
 
         @Override
         public CollectionBuilder newBuilder(int features) {
-            return new RecordingCollectionBuilder(features, _collectionType);
+            return new RecordingCollectionBuilder(features, _collectionType, startedCollections);
         }
 
         @Override
         public CollectionBuilder newBuilder(Class<?> collectionType) {
-            return new RecordingCollectionBuilder(_features, collectionType);
+            return new RecordingCollectionBuilder(_features, collectionType, startedCollections);
         }
 
         @Override
         public CollectionBuilder start() {
-            startedCollections++;
+            startedCollections.incrementAndGet();
             values = new ArrayList<>();
             return this;
         }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBuilderDefaultDynamicAccessTest {
+    @BeforeEach
+    void resetConstructorCalls() {
+        ConstructorTrackingMap.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void readsMultiEntryJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"alpha\":1,\"beta\":2}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsEmptyJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsSingletonJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"only\":99}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
+        MapBuilder builder = configuredMapBuilder();
+
+        Map<String, Object> counts = builder.start()
+                .put("discarded", true)
+                .start()
+                .put("kept", true)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).hasSize(1);
+        assertThat(counts).containsEntry("kept", true);
+        assertThat(counts).doesNotContainKey("discarded");
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    private static JSON jsonWithConfiguredMaps() {
+        return JSON.builder()
+                .mapBuilder(configuredMapBuilder())
+                .build();
+    }
+
+    private static MapBuilder configuredMapBuilder() {
+        return MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
+    }
+
+    public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public ConstructorTrackingMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -50,6 +50,22 @@ public class MapBuilderDefaultDynamicAccessTest {
     }
 
     @Test
+    void readsTypedMapSubclassThroughDefaultMapBuilder() throws Exception {
+        ConstructorTrackingMap counts = JSON.std.beanFrom(ConstructorTrackingMap.class, "{\"alpha\":1,\"beta\":2}");
+
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsTypedEmptyMapSubclassThroughDefaultMapBuilder() throws Exception {
+        ConstructorTrackingMap counts = JSON.std.beanFrom(ConstructorTrackingMap.class, "{}");
+
+        assertThat(counts).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
     void createsEmptyMapWithConfiguredMapImplementation() throws Exception {
         Map<String, Object> counts = configuredMapBuilder().emptyMap();
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -50,6 +50,23 @@ public class MapBuilderDefaultDynamicAccessTest {
     }
 
     @Test
+    void createsEmptyMapWithConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().emptyMap();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsSingletonMapWithConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
     void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
         MapBuilder builder = configuredMapBuilder();
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_RECORD_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+
+    @Test
+    void deserializesRecordThroughCanonicalConstructor() throws Exception {
+        DeserializableInventoryItem item = JSON.std.beanFrom(DeserializableInventoryItem.class, """
+                {
+                  "quantity": 4,
+                  "stocked": true,
+                  "sku": "SKU-13"
+                }
+                """);
+
+        assertThat(item.sku()).isEqualTo("SKU-13");
+        assertThat(item.quantity()).isEqualTo(4);
+        assertThat(item.stocked()).isTrue();
+        assertThat(item.getDisplayName()).isEqualTo("SKU-13 x 4");
+    }
+
+    @Test
+    void serializesRecordInDeclarationOrder() throws Exception {
+        InventoryItem item = new InventoryItem("SKU-21", 7, false);
+
+        String json = JSON_WITH_RECORD_DECLARATION_ORDER.asString(item);
+
+        assertThat(json).isEqualTo("{\"sku\":\"SKU-21\",\"quantity\":7,\"stocked\":false}");
+    }
+
+    public record DeserializableInventoryItem(String sku, int quantity, boolean stocked) {
+        public String getDisplayName() {
+            return sku + " x " + quantity;
+        }
+    }
+
+    public record InventoryItem(String sku, int quantity, boolean stocked) {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -6,7 +6,15 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,8 +24,27 @@ public class RecordsHelpersDynamicAccessTest {
             JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
 
     @Test
+    void findsCanonicalConstructorForTopLevelRecord() {
+        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(RecordsHelpersConstructorItem.class);
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+    }
+
+    @Test
+    void resolvesRecordReaderFromDeclaredRecordFields() {
+        JSONReader reader = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, null).perOperationInstance(reader,
+                JSON.Feature.defaults());
+
+        ValueReader valueReader = locator.findReader(RecordsHelpersReadableItem.class);
+
+        assertThat(valueReader.valueType()).isEqualTo(RecordsHelpersReadableItem.class);
+    }
+
+    @Test
     void deserializesRecordThroughCanonicalConstructor() throws Exception {
-        DeserializableInventoryItem item = JSON.std.beanFrom(DeserializableInventoryItem.class, """
+        RecordsHelpersReadableItem item = JSON.std.beanFrom(RecordsHelpersReadableItem.class, """
                 {
                   "quantity": 4,
                   "stocked": true,
@@ -28,24 +55,23 @@ public class RecordsHelpersDynamicAccessTest {
         assertThat(item.sku()).isEqualTo("SKU-13");
         assertThat(item.quantity()).isEqualTo(4);
         assertThat(item.stocked()).isTrue();
-        assertThat(item.getDisplayName()).isEqualTo("SKU-13 x 4");
     }
 
     @Test
     void serializesRecordInDeclarationOrder() throws Exception {
-        InventoryItem item = new InventoryItem("SKU-21", 7, false);
+        RecordsHelpersInventoryItem item = new RecordsHelpersInventoryItem("SKU-21", 7, false);
 
         String json = JSON_WITH_RECORD_DECLARATION_ORDER.asString(item);
 
         assertThat(json).isEqualTo("{\"sku\":\"SKU-21\",\"quantity\":7,\"stocked\":false}");
     }
+}
 
-    public record DeserializableInventoryItem(String sku, int quantity, boolean stocked) {
-        public String getDisplayName() {
-            return sku + " x " + quantity;
-        }
-    }
+record RecordsHelpersConstructorItem(String sku, int quantity, boolean stocked) {
+}
 
-    public record InventoryItem(String sku, int quantity, boolean stocked) {
-    }
+record RecordsHelpersReadableItem(String sku, int quantity, boolean stocked) {
+}
+
+record RecordsHelpersInventoryItem(String sku, int quantity, boolean stocked) {
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void resolvesTopLevelClassesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+
+        assertThat(resolved).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
+                "{\"type\":\"" + className + "\"}");
+
+        assertThat(holder.type).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
+        String className = loadableClassName();
+
+        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
+                "{\"primary\":\"" + className + "\"}");
+        List<Class> classes = JSON.std.listOfFrom(Class.class,
+                "[\"" + className + "\"]");
+
+        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
+        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+    }
+
+    private static String loadableClassName() {
+        String propertyName = "simple.value.reader.class." + System.nanoTime();
+        System.setProperty(propertyName, LoadableType.class.getName());
+        return System.getProperty(propertyName);
+    }
+
+    public static final class TypeHolder {
+        public Class<?> type;
+    }
+
+    public static final class LoadableType {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.ValueIterator;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +46,28 @@ public class SimpleValueReaderDynamicAccessTest {
 
         assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
         assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedArrays() throws Exception {
+        String json = "[\"" + String.class.getName() + "\",\""
+                + Integer.class.getName() + "\"]";
+
+        Class[] classes = JSON.std.arrayOfFrom(Class.class, json);
+
+        assertThat(classes).containsExactly(String.class, Integer.class);
+    }
+
+    @Test
+    void resolvesClassValuesFromBeanSequences() throws Exception {
+        String json = "[\"" + String.class.getName() + "\",\""
+                + Integer.class.getName() + "\"]";
+
+        try (ValueIterator<Class> classes = JSON.std.beanSequenceFrom(Class.class, json)) {
+            assertThat(classes.next()).isEqualTo(String.class);
+            assertThat(classes.next()).isEqualTo(Integer.class);
+            assertThat(classes.hasNext()).isFalse();
+        }
     }
 
     private static String loadableClassName() {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -6,14 +6,21 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.ValueIterator;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
@@ -68,6 +75,37 @@ public class SimpleValueReaderDynamicAccessTest {
             assertThat(classes.next()).isEqualTo(Integer.class);
             assertThat(classes.hasNext()).isFalse();
         }
+    }
+
+    @Test
+    void directReaderResolvesRuntimeClassNamesFromParserValues() throws Exception {
+        Object resolved = readClassValue('"' + runtimeClassName(String.class) + '"');
+
+        assertThat(resolved).isEqualTo(String.class);
+    }
+
+    @Test
+    void directReaderReportsClassLoadingFailuresFromParserValues() {
+        assertThatThrownBy(() -> readClassValue('"' + missingClassName() + '"'))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to bind `java.lang.Class`");
+    }
+
+    private static Object readClassValue(String json) throws IOException {
+        try (JsonParser parser = new JsonFactory().createParser(json)) {
+            parser.nextToken();
+            return new SimpleValueReader(Class.class, ValueLocatorBase.SER_CLASS).read(null, parser);
+        }
+    }
+
+    private static String runtimeClassName(Class<?> type) {
+        String propertyName = "simple.value.reader.direct.class." + System.nanoTime();
+        System.setProperty(propertyName, type.getName());
+        return System.getProperty(propertyName);
+    }
+
+    private static String missingClassName() {
+        return "missing.simple.value.reader.Type" + System.nanoTime();
     }
 
     private static String loadableClassName() {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.type.ResolvedType;
+import com.fasterxml.jackson.jr.type.TypeBindings;
+import com.fasterxml.jackson.jr.type.TypeResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+        TypeResolver resolver = new TypeResolver();
+        Object runtimeComponentValue = runtimeComponentValue();
+        Class<?> componentClass = runtimeComponentValue.getClass();
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
+    }
+
+    @Test
+    void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType declaringType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                StringArrayContainer.class.getGenericSuperclass());
+        Type genericArrayType = GenericArrayContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
+    static class GenericArrayContainer<T> {
+        private T[] values;
+
+        public T[] getValues() {
+            return values;
+        }
+
+        public void setValues(T[] values) {
+            this.values = values;
+        }
+    }
+
+    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    private static Object runtimeComponentValue() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return Integer.valueOf(7);
+        }
+        return Thread.currentThread().getName();
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -49,6 +49,21 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
     }
 
+    @Test
+    void resolvesUnboundGenericArrayMethodReturnTypesToObjectArrays() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type genericArrayType = TypeResolverDynamicAccessTest.class
+                .getMethod("genericArrayMethodReturn")
+                .getGenericReturnType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(genericArrayType).isInstanceOf(GenericArrayType.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(Object[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(Object.class);
+    }
+
     static class GenericArrayContainer<T> {
         private T[] values;
 
@@ -69,6 +84,10 @@ public class TypeResolverDynamicAccessTest {
             return Integer.valueOf(7);
         }
         return Thread.currentThread().getName();
+    }
+
+    public static <T> T[] genericArrayMethodReturn() {
+        return null;
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +32,23 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.isArray()).isTrue();
         assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
+    }
+
+    @Test
+    void resolvesSyntheticGenericArrayTypesWithParameterizedComponents() {
+        TypeResolver resolver = new TypeResolver();
+        Type componentType = new SyntheticParameterizedType(List.class, String.class);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(List[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().typeParams())
+                .singleElement()
+                .extracting(ResolvedType::erasedType)
+                .isEqualTo(String.class);
     }
 
     @Test
@@ -100,6 +119,31 @@ public class TypeResolverDynamicAccessTest {
         @Override
         public Type getGenericComponentType() {
             return componentType;
+        }
+    }
+
+    static final class SyntheticParameterizedType implements ParameterizedType {
+        private final Type rawType;
+        private final Type[] typeArguments;
+
+        SyntheticParameterizedType(Type rawType, Type... typeArguments) {
+            this.rawType = rawType;
+            this.typeArguments = typeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueReaderLocatorDynamicAccessTest {
+    @Test
+    void readsEnumsFromModifierProvidedDefinitions() throws Exception {
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+
+        assertThat(direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+
+        assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitions() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
+
+        ValueReader reader = locator.findReader(Direction.class);
+
+        assertThat(reader).isNotNull();
+    }
+
+    private static JSON enumAwareJson(JSON.Feature... features) {
+        return JSON.builder()
+                .enable(features)
+                .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
+
+    public static class EnumDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class EnumDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != Direction.class) {
+                return null;
+            }
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+        }
+
+        private static POJODefinition.Prop[] enumProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp("go-north", "NORTH"),
+                    enumProp("go-south", "SOUTH")
+            };
+        }
+
+        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(String enumConstantName) {
+            try {
+                return Direction.class.getField(enumConstantName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -6,6 +6,7 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
@@ -55,10 +56,23 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader.valueType()).isEqualTo(RecordBackedBean.class);
     }
 
+    @Test
+    void readsModifierProvidedRecordDefinitionsThroughDeclaredRecordFields() throws Exception {
+        RecordBackedBean bean = recordAwareJson().beanFrom(RecordBackedBean.class, "{\"id\":\"record-7\"}");
+
+        assertThat(bean.id()).isEqualTo("record-7");
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
                 .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    private static JSON recordAwareJson() {
+        return JSON.builder()
+                .register(new RecordDefinitionExtension())
                 .build();
     }
 
@@ -74,6 +88,13 @@ public class ValueReaderLocatorDynamicAccessTest {
         @Override
         protected void register(ExtensionContext ctxt) {
             ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class RecordDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new RecordDefinitionModifier());
         }
     }
 
@@ -114,13 +135,21 @@ public class ValueReaderLocatorDynamicAccessTest {
                 return null;
             }
             return new POJODefinition(RecordBackedBean.class, recordProps(),
-                    new BeanConstructors(RecordBackedBean.class));
+                    new BeanConstructors(RecordBackedBean.class).addRecordConstructor(recordConstructor()));
         }
 
         private static POJODefinition.Prop[] recordProps() {
             return new POJODefinition.Prop[] {
                     new POJODefinition.Prop("id", "id", null, null, null, null, null)
             };
+        }
+
+        private static Constructor<?> recordConstructor() {
+            try {
+                return RecordBackedBean.class.getDeclaredConstructor(String.class);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalStateException(ex);
+            }
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -6,17 +6,18 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +46,15 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader).isNotNull();
     }
 
+    @Test
+    void resolvesModifierProvidedRecordPropertiesFromDeclaredRecordFields() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new RecordDefinitionModifier());
+
+        ValueReader reader = locator.findReader(RecordBackedBean.class);
+
+        assertThat(reader.valueType()).isEqualTo(RecordBackedBean.class);
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -55,6 +65,9 @@ public class ValueReaderLocatorDynamicAccessTest {
     public enum Direction {
         NORTH,
         SOUTH
+    }
+
+    public record RecordBackedBean(String id) {
     }
 
     public static class EnumDefinitionExtension extends JacksonJrExtension {
@@ -70,7 +83,7 @@ public class ValueReaderLocatorDynamicAccessTest {
             if (pojoType != Direction.class) {
                 return null;
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            return new POJODefinition(Direction.class, enumProps(), new BeanConstructors(Direction.class));
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -81,7 +94,8 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
 
         private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+            return new POJODefinition.Prop(externalName, externalName, enumField(enumConstantName),
+                    null, null, null, null);
         }
 
         private static Field enumField(String enumConstantName) {
@@ -90,6 +104,23 @@ public class ValueReaderLocatorDynamicAccessTest {
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }
+        }
+    }
+
+    public static class RecordDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != RecordBackedBean.class) {
+                return null;
+            }
+            return new POJODefinition(RecordBackedBean.class, recordProps(),
+                    new BeanConstructors(RecordBackedBean.class));
+        }
+
+        private static POJODefinition.Prop[] recordProps() {
+            return new POJODefinition.Prop[] {
+                    new POJODefinition.Prop("id", "id", null, null, null, null, null)
+            };
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,283 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$ConstructorTrackingMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "fields" : [
+        {
+          "name" : "NORTH"
+        },
+        {
+          "name" : "SOUTH"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,60 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$BaseBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldNamedGetterBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$InheritedAccessBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$InheritedBaseBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntConstructorBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -13,6 +13,13 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
       },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$ConstructorSelectionBean",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldNamedGetterBean",
       "allDeclaredFields" : true,
       "allDeclaredMethods" : true,

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -218,7 +218,7 @@
       "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDefaultCtorBean",
       "allDeclaredFields" : true,
       "allDeclaredMethods" : true,
       "allDeclaredConstructors" : true
@@ -227,7 +227,7 @@
       "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsRecordBean",
       "allDeclaredFields" : true,
       "allDeclaredMethods" : true,
       "allDeclaredConstructors" : true
@@ -236,7 +236,7 @@
       "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
-      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicRecordBean",
+      "type" : "com.fasterxml.jackson.jr.ob.JSON",
       "allDeclaredFields" : true,
       "allDeclaredMethods" : true,
       "allDeclaredConstructors" : true

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -234,15 +234,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
-      },
-      "type" : "com.fasterxml.jackson.jr.ob.JSON",
-      "allDeclaredFields" : true,
-      "allDeclaredMethods" : true,
-      "allDeclaredConstructors" : true
-    },
-    {
-      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
@@ -355,6 +346,185 @@
           "parameterTypes" : [
             "java.lang.String"
           ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersInventoryItem",
+      "methods" : [
+        {
+          "name" : "quantity",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "sku",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "stocked",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersInventoryItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersConstructorItem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersReadableItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersReadableItem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersReadableItem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersReadableItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.CollectionReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
         }
       ]
     }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -342,6 +342,13 @@
           "name" : "SOUTH"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$RecordBackedBean",
+      "allDeclaredFields" : true
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -219,24 +219,18 @@
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
       "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
       "condition" : {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -240,6 +240,15 @@
     },
     {
       "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicRecordBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -348,7 +348,15 @@
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$RecordBackedBean",
-      "allDeclaredFields" : true
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jr.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2564

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 1174546
- Cached input tokens: 17382400
- Output tokens: 124202
- Entries found: 14
- Iterations: 23
- Library coverage percentage: 40.31
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 36.81

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `992c095720ed2149ddcad7f3a8a0a773beb0780f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

**Reflection:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 4596/12487 (36.81%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 5526/13710 (40.31%)

**Line:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: N/A
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: N/A

**Method:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 255/666 (38.29%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 296/705 (41.99%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
index 4b9e6fc27b..c7ad77eeb2 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,11 +6,9 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,79 +19,57 @@ public class BeanConstructorsDynamicAccessTest {
 
     @BeforeEach
     void resetConstructorCounters() {
-        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
-        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        BeanConstructorsDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        BeanConstructorsRecordBean.CONSTRUCTOR_CALLS.set(0);
     }
 
     @Test
-    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
-        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
-
-        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
-
-        assertThat(bean).isNotNull();
-        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
-        constructors.forceAccess();
-
-        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
-
-        assertThat(bean).isNotNull();
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
-        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+    void createsBeansThroughDefaultConstructorsWhenReadingObjects() throws Exception {
+        BeanConstructorsDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(BeanConstructorsDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
 
         assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(BeanConstructorsDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
-    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
-                "{\"name\":\"Ada\"}");
+    void createsLibraryBeansThroughDefaultConstructorsWhenReadingObjects() throws Exception {
+        JSON json = JSON.std.beanFrom(JSON.class, "{}");
 
-        assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(json).isNotNull();
     }
 
-    static final class AccessibleBeanConstructors extends BeanConstructors {
-        AccessibleBeanConstructors(Class<?> valueType) {
-            super(valueType);
-        }
-
-        Object createBean() throws Exception {
-            return create();
-        }
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        BeanConstructorsRecordBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(BeanConstructorsRecordBean.class, """
+                {
+                  "name": "Ada",
+                  "quantity": 3,
+                  "stocked": true
+                }
+                """);
+
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.quantity()).isEqualTo(3);
+        assertThat(bean.stocked()).isTrue();
+        assertThat(BeanConstructorsRecordBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
+}
 
-    public static final class PublicDefaultCtorBean {
-        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+final class BeanConstructorsDefaultCtorBean {
+    static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
 
-        public String name;
+    public String name;
 
-        public PublicDefaultCtorBean() {
-            CONSTRUCTOR_CALLS.incrementAndGet();
-        }
+    BeanConstructorsDefaultCtorBean() {
+        CONSTRUCTOR_CALLS.incrementAndGet();
     }
+}
 
-    public static final class PrivateDefaultCtorBean {
-        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
-
-        public String name;
+record BeanConstructorsRecordBean(String name, int quantity, boolean stocked) {
+    static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
 
-        private PrivateDefaultCtorBean() {
-            CONSTRUCTOR_CALLS.incrementAndGet();
-        }
+    BeanConstructorsRecordBean {
+        CONSTRUCTOR_CALLS.incrementAndGet();
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
index bd54ecaf2c..c463b6a88a 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -36,7 +36,8 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
         IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
-        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+        IntConstructorBean intBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntConstructorBean.class, "13");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7000000000");
 
         assertThat(definition.constructors()).isNotNull();
         assertThat(libraryDefinition.constructors()).isNotNull();
@@ -46,7 +47,20 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
         assertThat(stringBean.getName()).isEqualTo("Ada");
-        assertThat(longBean.visible).isEqualTo(7);
+        assertThat(intBean.visible).isEqualTo(13);
+        assertThat(longBean.visible).isEqualTo(700000000);
+    }
+
+    @Test
+    void registersSupportedNonRecordConstructorsFromDeclaredConstructors() {
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(ConstructorSelectionBean.class);
+
+        BeanPropertyIntrospector.addNonRecordConstructors(ConstructorSelectionBean.class, constructors);
+
+        assertThat(constructors.hasNoArgsConstructor()).isTrue();
+        assertThat(constructors.hasStringConstructor()).isTrue();
+        assertThat(constructors.hasIntegerConstructor()).isTrue();
+        assertThat(constructors.hasLongConstructor()).isTrue();
     }
 
     @Test
@@ -75,11 +89,26 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
     @Test
     void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                FieldNamedGetterBean.class);
         String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
 
+        assertThat(propertyNames(definition)).isEmpty();
         assertThat(json).contains("\"title\":\"Ada\"");
     }
 
+    @Test
+    void introspectsInheritedDeclaredFieldsAndMethods() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                InheritedAccessBean.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(new InheritedAccessBean("Ada", 7));
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("count", "name");
+        assertThat(property(definition, "count").field).isNotNull();
+        assertThat(property(definition, "name").getter).isNotNull();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"count\":7");
+    }
+
     private static List<String> propertyNames(POJODefinition definition) {
         return definition.getProperties().stream().map(prop -> prop.name).toList();
     }
@@ -106,8 +135,12 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             this.name = name;
         }
 
+        private IntrospectedBean(int visible) {
+            this.visible = visible;
+        }
+
         private IntrospectedBean(long visible) {
-            this.visible = (int) visible;
+            this.visible = (int) (visible / 10L);
         }
 
         static IntrospectedBean create(String name, boolean active, int visible) {
@@ -135,6 +168,74 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         }
     }
 
+    static final class IntConstructorBean {
+        private final int visible;
+
+        private IntConstructorBean(int visible) {
+            this.visible = visible;
+        }
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        boolean hasNoArgsConstructor() {
+            return _noArgsCtor != null;
+        }
+
+        boolean hasStringConstructor() {
+            return _stringCtor != null;
+        }
+
+        boolean hasIntegerConstructor() {
+            return _intCtor != null;
+        }
+
+        boolean hasLongConstructor() {
+            return _longCtor != null;
+        }
+    }
+
+    public static final class ConstructorSelectionBean {
+        public ConstructorSelectionBean() {
+        }
+
+        public ConstructorSelectionBean(String value) {
+        }
+
+        public ConstructorSelectionBean(Integer value) {
+        }
+
+        public ConstructorSelectionBean(Long value) {
+        }
+
+        public ConstructorSelectionBean(double value) {
+        }
+    }
+
+    static class InheritedBaseBean {
+        private final String name;
+
+        InheritedBaseBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    static final class InheritedAccessBean extends InheritedBaseBean {
+        public final int count;
+
+        InheritedAccessBean(String name, int count) {
+            super(name);
+            this.count = count;
+        }
+    }
+
     static final class FieldNamedGetterBean {
         private final String title;
 
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
index ff55ef0382..c3330dfc32 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -15,9 +15,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
+    @Test
+    void populatesPublicFieldBackedProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON.std.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
+    }
+
+    @Test
+    void invokesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON.std.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
     @Test
     void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null, -1);
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
         reader.setValueFor(bean, new Object[]{3});
@@ -29,7 +47,7 @@ public class BeanPropertyReaderDynamicAccessTest {
     @Test
     void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
         BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class), -1);
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
         reader.setValueFor(bean, new Object[]{"Ada"});
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
index dd41a65a32..beebbebf13 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,7 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,8 +39,37 @@ public class BeanPropertyWriterDynamicAccessTest {
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 
+    @Test
+    void readsFieldAccessorValuesThroughBeanPropertyWriter() throws Exception {
+        Field field = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
+
+        Object value = writer.getValueFor(new FieldBackedWriterBean(13));
+
+        assertThat(value).isEqualTo(13);
+    }
+
+    @Test
+    void invokesGetterAccessorValuesThroughBeanPropertyWriter() throws Exception {
+        Method getter = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getter);
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Grace");
+
+        Object value = writer.getValueFor(bean);
+
+        assertThat(value).isEqualTo("Grace");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
     public static final class FieldBackedWriterBean {
         public int id = 3;
+
+        public FieldBackedWriterBean() {
+        }
+
+        public FieldBackedWriterBean(int id) {
+            this.id = id;
+        }
     }
 
     public static final class GetterBackedWriterBean {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
index 994dafe71d..16fdc89401 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -6,6 +6,10 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
@@ -18,9 +22,10 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.emptyArray(elementType);
+        ArrayElement[] values = builder.emptyArray(elementType);
 
         assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
@@ -29,10 +34,11 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+        ArrayElement[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
 
         assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values[0].name).isEqualTo("solo");
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
@@ -41,17 +47,62 @@ public class CollectionBuilderDynamicAccessTest {
         CollectionBuilder builder = CollectionBuilder.defaultImpl();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
-        Object[] values = builder.start()
+        ArrayElement[] values = builder.start()
                 .add(new ArrayElement("left"))
                 .add(new ArrayElement("right"))
                 .buildArray(elementType);
 
         assertThat(values).hasSize(2);
-        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
-        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values[0].name).isEqualTo("left");
+        assertThat(values[1].name).isEqualTo("right");
+        assertThat(values).isInstanceOf(ArrayElement[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
+    @Test
+    void inheritedTypedArrayHelpersSupportCustomBuilders() throws Exception {
+        CollectionBuilder builder = new RecordingCollectionBuilder();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+        ArrayElement solo = new ArrayElement("solo");
+
+        ArrayElement[] emptyValues = builder.emptyArray(elementType);
+        ArrayElement[] singletonValues = builder.singletonArray(elementType, solo);
+        ArrayElement[] multipleValues = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(emptyValues).isEmpty();
+        assertThat(emptyValues).isInstanceOf(ArrayElement[].class);
+        assertThat(singletonValues).containsExactly(solo);
+        assertThat(singletonValues).isInstanceOf(ArrayElement[].class);
+        assertThat(multipleValues).hasSize(2);
+        assertThat(multipleValues[0].name).isEqualTo("left");
+        assertThat(multipleValues[1].name).isEqualTo("right");
+        assertThat(multipleValues).isInstanceOf(ArrayElement[].class);
+    }
+
+    @Test
+    void usesInheritedTypedArrayHelpersWhenJsonApiHasCustomBuilder() throws Exception {
+        RecordingCollectionBuilder builder = new RecordingCollectionBuilder();
+        JSON json = JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+        Class<String> elementType = runtimeStringType();
+
+        String[] emptyValues = json.arrayOfFrom(elementType, "[]");
+        String[] singletonValues = json.arrayOfFrom(elementType, "[\"solo\"]");
+        String[] multipleValues = json.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(emptyValues).isEmpty();
+        assertThat(emptyValues).isInstanceOf(String[].class);
+        assertThat(singletonValues).containsExactly("solo");
+        assertThat(singletonValues).isInstanceOf(String[].class);
+        assertThat(multipleValues).containsExactly("left", "right");
+        assertThat(multipleValues).isInstanceOf(String[].class);
+        assertThat(builder.startedCollections.get()).isEqualTo(1);
+    }
+
     @Test
     void readsEmptyTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
@@ -95,6 +146,50 @@ public class CollectionBuilderDynamicAccessTest {
         return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
     }
 
+    private static final class RecordingCollectionBuilder extends CollectionBuilder {
+        private final AtomicInteger startedCollections;
+        private Collection<Object> values;
+
+        private RecordingCollectionBuilder() {
+            this(0, null, new AtomicInteger());
+        }
+
+        private RecordingCollectionBuilder(int features, Class<?> collectionType, AtomicInteger startedCollections) {
+            super(features, collectionType);
+            this.startedCollections = startedCollections;
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new RecordingCollectionBuilder(features, _collectionType, startedCollections);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new RecordingCollectionBuilder(_features, collectionType, startedCollections);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            startedCollections.incrementAndGet();
+            values = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            values.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> result = values;
+            values = null;
+            return result;
+        }
+    }
+
     public static final class ArrayElement {
         public String name;
 
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
index 2d801978bc..5cd534674c 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -49,6 +49,39 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void readsTypedMapSubclassThroughDefaultMapBuilder() throws Exception {
+        ConstructorTrackingMap counts = JSON.std.beanFrom(ConstructorTrackingMap.class, "{\"alpha\":1,\"beta\":2}");
+
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsTypedEmptyMapSubclassThroughDefaultMapBuilder() throws Exception {
+        ConstructorTrackingMap counts = JSON.std.beanFrom(ConstructorTrackingMap.class, "{}");
+
+        assertThat(counts).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsEmptyMapWithConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().emptyMap();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsSingletonMapWithConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
     @Test
     void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
         MapBuilder builder = configuredMapBuilder();
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
new file mode 100644
index 0000000000..748bc30bb8
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -0,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_RECORD_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+
+    @Test
+    void findsCanonicalConstructorForTopLevelRecord() {
+        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(RecordsHelpersConstructorItem.class);
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+    }
+
+    @Test
+    void resolvesRecordReaderFromDeclaredRecordFields() {
+        JSONReader reader = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, null).perOperationInstance(reader,
+                JSON.Feature.defaults());
+
+        ValueReader valueReader = locator.findReader(RecordsHelpersReadableItem.class);
+
+        assertThat(valueReader.valueType()).isEqualTo(RecordsHelpersReadableItem.class);
+    }
+
+    @Test
+    void deserializesRecordThroughCanonicalConstructor() throws Exception {
+        RecordsHelpersReadableItem item = JSON.std.beanFrom(RecordsHelpersReadableItem.class, """
+                {
+                  "quantity": 4,
+                  "stocked": true,
+                  "sku": "SKU-13"
+                }
+                """);
+
+        assertThat(item.sku()).isEqualTo("SKU-13");
+        assertThat(item.quantity()).isEqualTo(4);
+        assertThat(item.stocked()).isTrue();
+    }
+
+    @Test
+    void serializesRecordInDeclarationOrder() throws Exception {
+        RecordsHelpersInventoryItem item = new RecordsHelpersInventoryItem("SKU-21", 7, false);
+
+        String json = JSON_WITH_RECORD_DECLARATION_ORDER.asString(item);
+
+        assertThat(json).isEqualTo("{\"sku\":\"SKU-21\",\"quantity\":7,\"stocked\":false}");
+    }
+}
+
+record RecordsHelpersConstructorItem(String sku, int quantity, boolean stocked) {
+}
+
+record RecordsHelpersReadableItem(String sku, int quantity, boolean stocked) {
+}
+
+record RecordsHelpersInventoryItem(String sku, int quantity, boolean stocked) {
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
index 9cb0bb785b..f692e8a033 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -6,13 +6,21 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.ValueIterator;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
@@ -47,6 +55,59 @@ public class SimpleValueReaderDynamicAccessTest {
         assertThat(classes).singleElement().isEqualTo(LoadableType.class);
     }
 
+    @Test
+    void resolvesClassesInsideTypedArrays() throws Exception {
+        String json = "[\"" + String.class.getName() + "\",\""
+                + Integer.class.getName() + "\"]";
+
+        Class[] classes = JSON.std.arrayOfFrom(Class.class, json);
+
+        assertThat(classes).containsExactly(String.class, Integer.class);
+    }
+
+    @Test
+    void resolvesClassValuesFromBeanSequences() throws Exception {
+        String json = "[\"" + String.class.getName() + "\",\""
+                + Integer.class.getName() + "\"]";
+
+        try (ValueIterator<Class> classes = JSON.std.beanSequenceFrom(Class.class, json)) {
+            assertThat(classes.next()).isEqualTo(String.class);
+            assertThat(classes.next()).isEqualTo(Integer.class);
+            assertThat(classes.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void directReaderResolvesRuntimeClassNamesFromParserValues() throws Exception {
+        Object resolved = readClassValue('"' + runtimeClassName(String.class) + '"');
+
+        assertThat(resolved).isEqualTo(String.class);
+    }
+
+    @Test
+    void directReaderReportsClassLoadingFailuresFromParserValues() {
+        assertThatThrownBy(() -> readClassValue('"' + missingClassName() + '"'))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to bind `java.lang.Class`");
+    }
+
+    private static Object readClassValue(String json) throws IOException {
+        try (JsonParser parser = new JsonFactory().createParser(json)) {
+            parser.nextToken();
+            return new SimpleValueReader(Class.class, ValueLocatorBase.SER_CLASS).read(null, parser);
+        }
+    }
+
+    private static String runtimeClassName(Class<?> type) {
+        String propertyName = "simple.value.reader.direct.class." + System.nanoTime();
+        System.setProperty(propertyName, type.getName());
+        return System.getProperty(propertyName);
+    }
+
+    private static String missingClassName() {
+        return "missing.simple.value.reader.Type" + System.nanoTime();
+    }
+
     private static String loadableClassName() {
         String propertyName = "simple.value.reader.class." + System.nanoTime();
         System.setProperty(propertyName, LoadableType.class.getName());
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
index 9e15382236..8caa39178d 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.jr.type.TypeResolver;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +34,23 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
     }
 
+    @Test
+    void resolvesSyntheticGenericArrayTypesWithParameterizedComponents() {
+        TypeResolver resolver = new TypeResolver();
+        Type componentType = new SyntheticParameterizedType(List.class, String.class);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(List[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().typeParams())
+                .singleElement()
+                .extracting(ResolvedType::erasedType)
+                .isEqualTo(String.class);
+    }
+
     @Test
     void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
         TypeResolver resolver = new TypeResolver();
@@ -49,6 +68,21 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
     }
 
+    @Test
+    void resolvesUnboundGenericArrayMethodReturnTypesToObjectArrays() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type genericArrayType = TypeResolverDynamicAccessTest.class
+                .getMethod("genericArrayMethodReturn")
+                .getGenericReturnType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(genericArrayType).isInstanceOf(GenericArrayType.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(Object[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(Object.class);
+    }
+
     static class GenericArrayContainer<T> {
         private T[] values;
 
@@ -71,6 +105,10 @@ public class TypeResolverDynamicAccessTest {
         return Thread.currentThread().getName();
     }
 
+    public static <T> T[] genericArrayMethodReturn() {
+        return null;
+    }
+
     static final class SyntheticGenericArrayType implements GenericArrayType {
         private final Type componentType;
 
@@ -83,4 +121,29 @@ public class TypeResolverDynamicAccessTest {
             return componentType;
         }
     }
+
+    static final class SyntheticParameterizedType implements ParameterizedType {
+        private final Type rawType;
+        private final Type[] typeArguments;
+
+        SyntheticParameterizedType(Type rawType, Type... typeArguments) {
+            this.rawType = rawType;
+            this.typeArguments = typeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
index 703886be9a..f7b1ca0167 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -6,18 +6,20 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ValueReaderLocatorDynamicAccessTest {
@@ -45,6 +47,22 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader).isNotNull();
     }
 
+    @Test
+    void resolvesModifierProvidedRecordPropertiesFromDeclaredRecordFields() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new RecordDefinitionModifier());
+
+        ValueReader reader = locator.findReader(RecordBackedBean.class);
+
+        assertThat(reader.valueType()).isEqualTo(RecordBackedBean.class);
+    }
+
+    @Test
+    void readsModifierProvidedRecordDefinitionsThroughDeclaredRecordFields() throws Exception {
+        RecordBackedBean bean = recordAwareJson().beanFrom(RecordBackedBean.class, "{\"id\":\"record-7\"}");
+
+        assertThat(bean.id()).isEqualTo("record-7");
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -52,11 +70,20 @@ public class ValueReaderLocatorDynamicAccessTest {
                 .build();
     }
 
+    private static JSON recordAwareJson() {
+        return JSON.builder()
+                .register(new RecordDefinitionExtension())
+                .build();
+    }
+
     public enum Direction {
         NORTH,
         SOUTH
     }
 
+    public record RecordBackedBean(String id) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -64,13 +91,20 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
     }
 
+    public static class RecordDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new RecordDefinitionModifier());
+        }
+    }
+
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
             if (pojoType != Direction.class) {
                 return null;
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            return new POJODefinition(Direction.class, enumProps(), new BeanConstructors(Direction.class));
         }
 
         private static POJODefinition.Prop[] enumProps() {
@@ -81,7 +115,8 @@ public class ValueReaderLocatorDynamicAccessTest {
         }
 
         private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+            return new POJODefinition.Prop(externalName, externalName, enumField(enumConstantName),
+                    null, null, null, null);
         }
 
         private static Field enumField(String enumConstantName) {
@@ -92,4 +127,29 @@ public class ValueReaderLocatorDynamicAccessTest {
             }
         }
     }
+
+    public static class RecordDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != RecordBackedBean.class) {
+                return null;
+            }
+            return new POJODefinition(RecordBackedBean.class, recordProps(),
+                    new BeanConstructors(RecordBackedBean.class).addRecordConstructor(recordConstructor()));
+        }
+
+        private static POJODefinition.Prop[] recordProps() {
+            return new POJODefinition.Prop[] {
+                    new POJODefinition.Prop("id", "id", null, null, null, null, null)
+            };
+        }
+
+        private static Constructor<?> recordConstructor() {
+            try {
+                return RecordBackedBean.class.getDeclaredConstructor(String.class);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
 }

```
