### PR TITLE
[GenAI] Add support for io.smallrye.common:smallrye-common-expression:2.2.0 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye.common/smallrye-common-expression/2.2.0/reachability-metadata.json
+++ b/metadata/io.smallrye.common/smallrye-common-expression/2.2.0/reachability-metadata.json
@@ -1,0 +1,27 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.expression.Messages"
+      },
+      "type": "io.smallrye.common.expression.Messages_$bundle",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.expression.Messages"
+      },
+      "type": "io.smallrye.common.expression.Messages_$bundle_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.expression.Messages"
+      },
+      "type": "io.smallrye.common.expression.Messages_$bundle_en_US"
+    }
+  ]
+}

--- a/metadata/io.smallrye.common/smallrye-common-expression/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-expression/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-expression/2.2.0/smallrye-common-expression-2.2.0-sources.jar",
+    "repository-url" : "https://github.com/smallrye/smallrye-common",
+    "test-code-url" : "https://github.com/smallrye/smallrye-common/tree/2.2.0/expression/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-expression/2.2.0/smallrye-common-expression-2.2.0-javadoc.jar",
+    "description" : "SmallRye Common Expression provides a Java API for compiling property-expansion expression strings that mix literal text with `${...}` segments. It evaluates those compiled expressions with custom resolvers or built-in system property and environment variable lookup, including support for defaults and recursion-related parsing flags.",
+    "tested-versions" : [
+      "2.2.0"
+    ],
+    "allowed-packages" : [
+      "io.smallrye.common.expression"
+    ]
+  }
+]

--- a/stats/io.smallrye.common/smallrye-common-expression/2.2.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-expression/2.2.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T00:14:05.480792Z",
+    "library": "io.smallrye.common:smallrye-common-expression:2.2.0",
+    "starting_commit": "00b50b8c0e3e81f3a84ca14079b9e11e327c034a",
+    "ending_commit": "790bace8f21f88208bfc1895a1cc28a62ee4388e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1433,
+          "missed": 304,
+          "ratio": 0.824986,
+          "total": 1737
+        },
+        "line": {
+          "covered": 335,
+          "missed": 76,
+          "ratio": 0.815085,
+          "total": 411
+        },
+        "method": {
+          "covered": 65,
+          "missed": 7,
+          "ratio": 0.902778,
+          "total": 72
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 347301,
+      "cached_input_tokens_used": 3123712,
+      "output_tokens_used": 21939,
+      "iterations": 5,
+      "cost_usd": 2.2201,
+      "generated_loc": 299,
+      "tested_library_loc": 335,
+      "metadata_entries": 4,
+      "code_coverage_percent": 81.51
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java",
+      "metadata_file": "metadata/io.smallrye.common/smallrye-common-expression/2.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye.common/smallrye-common-expression/2.2.0/stats.json
+++ b/stats/io.smallrye.common/smallrye-common-expression/2.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1433,
+        "missed" : 304,
+        "ratio" : 0.824986,
+        "total" : 1737
+      },
+      "line" : {
+        "covered" : 335,
+        "missed" : 76,
+        "ratio" : 0.815085,
+        "total" : 411
+      },
+      "method" : {
+        "covered" : 65,
+        "missed" : 7,
+        "ratio" : 0.902778,
+        "total" : 72
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/.gitignore
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/build.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye.common:smallrye-common-expression:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/gradle.properties
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye.common:smallrye-common-expression:2.2.0
+library.version = 2.2.0
+metadata.dir = io.smallrye.common/smallrye-common-expression/2.2.0/

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/settings.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.common.smallrye-common-expression_tests'

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
@@ -6,11 +6,312 @@
  */
 package io_smallrye_common.smallrye_common_expression;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.common.expression.Expression;
+import io.smallrye.common.expression.ResolveContext;
 import org.junit.jupiter.api.Test;
 
-class Smallrye_common_expressionTest {
+public class Smallrye_common_expressionTest {
+    private static final String SYSTEM_PROPERTY_KEY = "smallrye.expression.test.value";
+    private static final String MISSING_SYSTEM_PROPERTY_KEY = "smallrye.expression.test.missing";
+    private static final String MISSING_ENVIRONMENT_KEY = "SMALLRYE_EXPRESSION_TEST_MISSING_4B53E942";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void literalsAreTrimmedByDefaultAndCanPreserveWhitespace() {
+        final Expression empty = Expression.compile("   ");
+        final Expression literal = Expression.compile("  SmallRye expression literal  ");
+        final Expression untrimmed = Expression.compile("  SmallRye expression literal  ", Expression.Flag.NO_TRIM);
+
+        assertThat(evaluateWithoutResolutions(empty)).isEmpty();
+        assertThat(evaluateWithoutResolutions(literal)).isEqualTo("SmallRye expression literal");
+        assertThat(evaluateWithoutResolutions(untrimmed)).isEqualTo("  SmallRye expression literal  ");
+        assertThat(literal.getReferencedStrings()).isEmpty();
+    }
+
+    @Test
+    void expressionsResolveInsideLiteralTextAndExposeReferencedStrings() {
+        final Expression expression = Expression.compile("http://${host}:${port}/service");
+        final List<String> resolvedKeys = new ArrayList<>();
+
+        final String result = expression.evaluate((context, builder) -> {
+            final String key = context.getKey();
+            resolvedKeys.add(key);
+            switch (key) {
+                case "host":
+                    builder.append("localhost");
+                    return;
+                case "port":
+                    builder.append("8080");
+                    return;
+                default:
+                    throw new IllegalArgumentException("Unexpected key: " + key);
+            }
+        });
+
+        assertThat(result).isEqualTo("http://localhost:8080/service");
+        assertThat(resolvedKeys).containsExactly("host", "port");
+        assertThat(expression.getReferencedStrings()).containsExactlyInAnyOrder("host", "port");
+        assertThatThrownBy(() -> expression.getReferencedStrings().add("path"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void defaultValuesCanBeExpandedIntoCurrentOrSeparateBuilders() {
+        final Expression expression = Expression.compile(
+                "primary=${primary:${secondary:fallback}};optional=${optional:}");
+        final List<String> resolvedKeys = new ArrayList<>();
+
+        final String result = expression.evaluate((context, builder) -> {
+            final String key = context.getKey();
+            resolvedKeys.add(key);
+            switch (key) {
+                case "primary":
+                    assertThat(context.hasDefault()).isTrue();
+                    assertThat(context.getExpandedDefault()).isEqualTo("resolved-secondary");
+                    context.expandDefault();
+                    return;
+                case "secondary":
+                    assertThat(context.hasDefault()).isTrue();
+                    assertThat(context.getExpandedDefault()).isEqualTo("fallback");
+                    builder.append("resolved-secondary");
+                    return;
+                case "optional":
+                    assertThat(context.hasDefault()).isTrue();
+                    assertThat(context.getExpandedDefault()).isEmpty();
+                    context.expandDefault(builder);
+                    return;
+                default:
+                    throw new IllegalArgumentException("Unexpected key: " + key);
+            }
+        });
+
+        assertThat(result).isEqualTo("primary=resolved-secondary;optional=");
+        assertThat(resolvedKeys).containsExactly("primary", "secondary", "secondary", "optional");
+        assertThat(expression.getReferencedStrings()).containsExactlyInAnyOrder("primary", "secondary", "optional");
+    }
+
+    @Test
+    void recursiveKeyAndDefaultExpansionCanBeEnabledOrDisabled() {
+        final Expression recursive = Expression.compile("${${tenant}.url:${fallback.value}}");
+        final String recursiveResult = recursive.evaluate((context, builder) -> {
+            final String key = context.getKey();
+            switch (key) {
+                case "tenant":
+                    builder.append("acme");
+                    return;
+                case "acme.url":
+                    context.expandDefault();
+                    return;
+                case "fallback.value":
+                    builder.append("https://fallback.example");
+                    return;
+                default:
+                    throw new IllegalArgumentException("Unexpected key: " + key);
+            }
+        });
+
+        final Expression nonRecursiveKey = Expression.compile("${${tenant}.url}", Expression.Flag.NO_RECURSE_KEY);
+        final String keyResult = nonRecursiveKey.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("${tenant}.url");
+            builder.append("literal-key");
+        });
+
+        final Expression nonRecursiveDefault = Expression.compile("${missing:${fallback}}",
+                Expression.Flag.NO_RECURSE_DEFAULT);
+        final String defaultResult = nonRecursiveDefault.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("missing");
+            assertThat(context.getExpandedDefault()).isEqualTo("${fallback}");
+            context.expandDefault();
+        });
+
+        assertThat(recursiveResult).isEqualTo("https://fallback.example");
+        assertThat(recursive.getReferencedStrings()).containsExactlyInAnyOrder("tenant", "fallback.value");
+        assertThat(keyResult).isEqualTo("literal-key");
+        assertThat(defaultResult).isEqualTo("${fallback}");
+    }
+
+    @Test
+    void checkedExceptionsPropagateFromEvaluateException() {
+        final Expression expression = Expression.compile("token=${secret}");
+
+        assertThatThrownBy(() -> expression.<TestExpansionException>evaluateException((context, builder) -> {
+            throw new TestExpansionException("Refusing key " + context.getKey());
+        })).isInstanceOf(TestExpansionException.class)
+                .hasMessage("Refusing key secret");
+    }
+
+    @Test
+    void builtInPropertyAndEnvironmentResolversUseValuesDefaultsAndFailures() {
+        final String previousProperty = System.getProperty(SYSTEM_PROPERTY_KEY);
+        final String previousMissingProperty = System.getProperty(MISSING_SYSTEM_PROPERTY_KEY);
+        try {
+            System.setProperty(SYSTEM_PROPERTY_KEY, "configured");
+            System.clearProperty(MISSING_SYSTEM_PROPERTY_KEY);
+
+            final Expression properties = Expression.compile(
+                    "value=${" + SYSTEM_PROPERTY_KEY + "};missing=${" + MISSING_SYSTEM_PROPERTY_KEY + ":fallback}");
+            final Expression combined = Expression.compile("property=${" + SYSTEM_PROPERTY_KEY + "};environment=${env."
+                    + MISSING_ENVIRONMENT_KEY + ":env-fallback}");
+            final Expression emptyMissing = Expression.compile("before-${" + MISSING_SYSTEM_PROPERTY_KEY + "}-after");
+            final Expression failingProperty = Expression.compile("${" + MISSING_SYSTEM_PROPERTY_KEY + "}");
+            final Expression failingEnvironment = Expression.compile("${" + MISSING_ENVIRONMENT_KEY + "}");
+
+            assertThat(properties.evaluateWithProperties(true)).isEqualTo("value=configured;missing=fallback");
+            assertThat(combined.evaluateWithPropertiesAndEnvironment(true))
+                    .isEqualTo("property=configured;environment=env-fallback");
+            assertThat(emptyMissing.evaluateWithProperties(false)).isEqualTo("before--after");
+            assertThat(Expression.compile("${" + MISSING_ENVIRONMENT_KEY + ":env-fallback}")
+                    .evaluateWithEnvironment(true)).isEqualTo("env-fallback");
+            assertThatThrownBy(() -> failingProperty.evaluateWithProperties(true))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(MISSING_SYSTEM_PROPERTY_KEY);
+            assertThatThrownBy(() -> failingEnvironment.evaluateWithEnvironment(true))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(MISSING_ENVIRONMENT_KEY);
+        } finally {
+            restoreSystemProperty(SYSTEM_PROPERTY_KEY, previousProperty);
+            restoreSystemProperty(MISSING_SYSTEM_PROPERTY_KEY, previousMissingProperty);
+        }
+    }
+
+    @Test
+    void miniExpressionsEscapesAndLenientSyntaxChangeParsingRules() {
+        final Expression miniExpressions = Expression.compile("price=$$;close=$};colon=$:;letter=$x",
+                Expression.Flag.MINI_EXPRS);
+        final Expression literalDollar = Expression.compile("price=$$");
+        final Expression escaped = Expression.compile("line\\ncol\\tpath\\\\end", Expression.Flag.ESCAPES,
+                Expression.Flag.NO_TRIM);
+        final Expression lenient = Expression.compile("broken=$ and escaped=\\q", Expression.Flag.LENIENT_SYNTAX,
+                Expression.Flag.ESCAPES, Expression.Flag.NO_TRIM);
+
+        final String miniResult = miniExpressions.evaluate((context, builder) -> builder.append('<')
+                .append(context.getKey()).append('>'));
+
+        assertThat(miniResult).isEqualTo("price=<$>;close=<}>;colon=<:>;letter=<x>");
+        assertThat(evaluateWithoutResolutions(literalDollar)).isEqualTo("price=$");
+        assertThat(evaluateWithoutResolutions(escaped)).isEqualTo("line\ncol\tpath\\end");
+        assertThat(evaluateWithoutResolutions(lenient)).isEqualTo("broken=$ and escaped=q");
+    }
+
+    @Test
+    void smartBracesKeepBracedDefaultContentTogetherUnlessDisabled() {
+        final Expression smartBraces = Expression.compile("${missing:{one:two}}");
+        final Expression noSmartBraces = Expression.compile("${missing:{one:two}}", Expression.Flag.NO_SMART_BRACES);
+        final List<String> expandedDefaults = new ArrayList<>();
+
+        final String smartResult = smartBraces.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("missing");
+            expandedDefaults.add(context.getExpandedDefault());
+            context.expandDefault();
+        });
+        final String noSmartResult = noSmartBraces.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("missing");
+            expandedDefaults.add(context.getExpandedDefault());
+            context.expandDefault();
+        });
+
+        assertThat(smartResult).isEqualTo("{one:two}");
+        assertThat(noSmartResult).isEqualTo("{one:two}");
+        assertThat(expandedDefaults).containsExactly("{one:two}", "{one:two");
+    }
+
+    @Test
+    void generalExpansionDoubleColonAndEnumSetCompilationAreSupported() {
+        final Expression general = Expression.compile("${{policy.key}}/${name}", Expression.Flag.GENERAL_EXPANSION);
+        final Expression doubleColonKey = Expression.compile("${handler::method:ignored}",
+                Expression.Flag.DOUBLE_COLON);
+        final Expression doubleColonDefault = Expression.compile("${handler:method::name}",
+                EnumSet.of(Expression.Flag.DOUBLE_COLON));
+
+        final String generalResult = general.evaluate((context, builder) -> {
+            final String key = context.getKey();
+            if (key.equals("policy.key")) {
+                builder.append("allowed");
+            } else if (key.equals("name")) {
+                builder.append("alice");
+            } else {
+                throw new IllegalArgumentException("Unexpected key: " + key);
+            }
+        });
+        final String keyResult = doubleColonKey.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("handler::method:ignored");
+            assertThat(context.hasDefault()).isFalse();
+            builder.append("resolved-handler");
+        });
+        final String defaultResult = doubleColonDefault.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("handler");
+            assertThat(context.hasDefault()).isTrue();
+            context.expandDefault();
+        });
+
+        assertThat(generalResult).isEqualTo("allowed/alice");
+        assertThat(keyResult).isEqualTo("resolved-handler");
+        assertThat(defaultResult).isEqualTo("method::name");
+    }
+
+    @Test
+    void invalidSyntaxThrowsUnlessLenientSyntaxIsEnabled() {
+        assertThatThrownBy(() -> Expression.compile("$")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid expression syntax");
+        assertThatThrownBy(() -> Expression.compile("${unterminated")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid expression syntax");
+        assertThatThrownBy(() -> Expression.compile("bad\\", Expression.Flag.ESCAPES))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid expression syntax");
+
+        final Expression lenientExpression = Expression.compile("${unterminated", Expression.Flag.LENIENT_SYNTAX);
+        final String result = lenientExpression.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("unterminated");
+            builder.append("resolved");
+        });
+
+        assertThat(result).isEqualTo("resolved");
+    }
+
+    @Test
+    void resolveContextIsOnlyUsableDuringResolution() {
+        final AtomicReference<ResolveContext<RuntimeException>> capturedContext = new AtomicReference<>();
+        final Expression expression = Expression.compile("${key:default}");
+
+        final String result = expression.evaluate((context, builder) -> {
+            capturedContext.set(context);
+            assertThat(context.getKey()).isEqualTo("key");
+            assertThat(context.getExpandedDefault()).isEqualTo("default");
+            builder.append("resolved");
+        });
+
+        assertThat(result).isEqualTo("resolved");
+        assertThat(capturedContext.get()).isNotNull();
+        assertThatThrownBy(() -> capturedContext.get().getKey()).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> capturedContext.get().expandDefault()).isInstanceOf(IllegalStateException.class);
+    }
+
+    private static String evaluateWithoutResolutions(final Expression expression) {
+        return expression.evaluate((context, builder) -> {
+            throw new AssertionError("No expressions should be resolved");
+        });
+    }
+
+    private static void restoreSystemProperty(final String key, final String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previousValue);
+        }
+    }
+
+    private static final class TestExpansionException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        private TestExpansionException(final String message) {
+            super(message);
+        }
     }
 }

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
@@ -213,6 +213,22 @@ public class Smallrye_common_expressionTest {
     }
 
     @Test
+    void escapesAreAppliedInsideDefaultValues() {
+        final String expectedDefault = "line\rnext\btab\fslash\\end";
+        final Expression expression = Expression.compile("${missing:line\\rnext\\btab\\fslash\\\\end}",
+                Expression.Flag.ESCAPES);
+
+        final String result = expression.evaluate((context, builder) -> {
+            assertThat(context.getKey()).isEqualTo("missing");
+            assertThat(context.hasDefault()).isTrue();
+            assertThat(context.getExpandedDefault()).isEqualTo(expectedDefault);
+            context.expandDefault(builder);
+        });
+
+        assertThat(result).isEqualTo(expectedDefault);
+    }
+
+    @Test
     void smartBracesKeepBracedDefaultContentTogetherUnlessDisabled() {
         final Expression smartBraces = Expression.compile("${missing:{one:two}}");
         final Expression noSmartBraces = Expression.compile("${missing:{one:two}}", Expression.Flag.NO_SMART_BRACES);

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye_common.smallrye_common_expression;
+
+import org.junit.jupiter.api.Test;
+
+class Smallrye_common_expressionTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/src/test/java/io_smallrye_common/smallrye_common_expression/Smallrye_common_expressionTest.java
@@ -182,6 +182,18 @@ public class Smallrye_common_expressionTest {
     }
 
     @Test
+    void environmentResolverExpandsExistingRuntimeVariables() {
+        final String path = System.getenv("PATH");
+        assertThat(path).isNotBlank();
+
+        final Expression environment = Expression.compile("path=${PATH}");
+        final Expression combined = Expression.compile("path=${env.PATH}");
+
+        assertThat(environment.evaluateWithEnvironment(true)).isEqualTo("path=" + path);
+        assertThat(combined.evaluateWithPropertiesAndEnvironment(true)).isEqualTo("path=" + path);
+    }
+
+    @Test
     void miniExpressionsEscapesAndLenientSyntaxChangeParsingRules() {
         final Expression miniExpressions = Expression.compile("price=$$;close=$};colon=$:;letter=$x",
                 Expression.Flag.MINI_EXPRS);

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.smallrye.common.expression.**"
+      "includeClasses" : "io.smallrye.common.expression.**"
     }
   ]
 }

--- a/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-expression/2.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.smallrye.common.expression.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3306

This PR introduces tests and metadata for io.smallrye.common:smallrye-common-expression:2.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 347301
- Cached input tokens: 3123712
- Output tokens: 21939
- Entries: 4
- Iterations: 5
- Library coverage percentage: 81.51
- Generated lines of code: 299
- Tested library lines of code: 335

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1436967e465dd952417dd7ee29a48a8d1c725d9c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1433/1737 (82.50%)
- Line: 335/411 (81.51%)
- Method: 65/72 (90.28%)
