### PR TITLE
[GenAI] Add support for org.eclipse.jetty:jetty-alpn-server:11.0.24 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-alpn-server/11.0.24/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-server/11.0.24/reachability-metadata.json
@@ -1,0 +1,86 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Byte"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Double"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Float"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Long"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "java.lang.Short"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "type": "org.eclipse.jetty.util.TypeUtil",
+      "methods": [
+        {
+          "name": "getClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getCodeSourceLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getModuleLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getSystemClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.io.ssl.ALPNProcessor$Server"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-alpn-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-server/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "11.0.24",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-server/11.0.24/jetty-alpn-server-11.0.24-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-server/11.0.24/jetty-alpn-server-11.0.24-javadoc.jar",
+    "description" : "Jetty ALPN Server provides the server-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It integrates Jetty's server connector layer with ALPN so the server can select the correct protocol implementation for each secure connection.",
+    "tested-versions" : [
+      "11.0.24"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.alpn.server"
+    ]
+  }
+]

--- a/stats/org.eclipse.jetty/jetty-alpn-server/11.0.24/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-server/11.0.24/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T01:41:03.282828Z",
+    "library": "org.eclipse.jetty:jetty-alpn-server:11.0.24",
+    "starting_commit": "196906a5428be14546d3b34c1751a58324593acd",
+    "ending_commit": "dc5f7b89f1dfcaa2681fbc82ec5aa2f10b4cd3ed",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.0.24",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 131,
+          "missed": 201,
+          "ratio": 0.394578,
+          "total": 332
+        },
+        "line": {
+          "covered": 37,
+          "missed": 36,
+          "ratio": 0.506849,
+          "total": 73
+        },
+        "method": {
+          "covered": 6,
+          "missed": 3,
+          "ratio": 0.666667,
+          "total": 9
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 159423,
+      "cached_input_tokens_used": 1255424,
+      "output_tokens_used": 17664,
+      "iterations": 3,
+      "cost_usd": 1.1576,
+      "generated_loc": 381,
+      "tested_library_loc": 37,
+      "metadata_entries": 13,
+      "code_coverage_percent": 50.68
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-alpn-server/11.0.24/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-alpn-server/11.0.24/stats.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-server/11.0.24/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "11.0.24",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 131,
+        "missed" : 201,
+        "ratio" : 0.394578,
+        "total" : 332
+      },
+      "line" : {
+        "covered" : 37,
+        "missed" : 36,
+        "ratio" : 0.506849,
+        "total" : 73
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 3,
+        "ratio" : 0.666667,
+        "total" : 9
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-alpn-server:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-alpn-server:11.0.24
+library.version = 11.0.24
+metadata.dir = org.eclipse.jetty/jetty-alpn-server/11.0.24/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-alpn-server_tests'

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
@@ -121,6 +121,21 @@ public class Jetty_alpn_serverTest {
     }
 
     @Test
+    void selectedProtocolWithoutConnectionFactoryClosesEndpoint() {
+        TestConnectionFactory http11Factory = new TestConnectionFactory(HTTP_1_1);
+        TestFixture fixture = new TestFixture(http11Factory);
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2), HTTP_1_1);
+        fixture.endPoint.setConnection(connection);
+
+        connection.select(List.of(HTTP_2));
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isEqualTo(HTTP_2);
+        assertThat(fixture.endPoint.isOpen()).isFalse();
+        assertThat(http11Factory.createdConnections).isEmpty();
+    }
+
+    @Test
     void serverConnectionFactoryReportsUnavailableProcessorWhenNoProviderIsPresent() {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> new ALPNServerConnectionFactory(" h2, http/1.1 "))

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_alpn_server;
+
+import org.junit.jupiter.api.Test;
+
+class Jetty_alpn_serverTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
@@ -81,6 +81,21 @@ public class Jetty_alpn_serverTest {
     }
 
     @Test
+    void cipherDiscriminatorUsesSslSessionWhenHandshakeSessionIsUnavailable() {
+        DiscriminatingConnectionFactory acceptedHttp2 = new DiscriminatingConnectionFactory(HTTP_2, true);
+        TestSslSession sslSession = new TestSslSession("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        TestFixture fixture = new TestFixture(sslSession, null, acceptedHttp2, new TestConnectionFactory(HTTP_1_1));
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+
+        connection.select(List.of(HTTP_2));
+
+        assertThat(connection.getProtocol()).isEqualTo(HTTP_2);
+        assertThat(acceptedHttp2.checkedProtocols).containsExactly(HTTP_2);
+        assertThat(acceptedHttp2.checkedTlsProtocols).containsExactly("TLSv1.2");
+        assertThat(acceptedHttp2.checkedCipherSuites).containsExactly("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+    }
+
+    @Test
     void selectFailsWhenClientAndServerHaveNoProtocolInCommon() {
         TestFixture fixture = new TestFixture(new TestConnectionFactory(HTTP_2), new TestConnectionFactory(HTTP_1_1));
         ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
@@ -118,12 +133,17 @@ public class Jetty_alpn_serverTest {
         private final TestSslEngine sslEngine;
 
         private TestFixture(TestConnectionFactory... factories) {
+            this(
+                    new TestSslSession("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                    new TestSslSession("TLSv1.3", "TLS_AES_128_GCM_SHA256"),
+                    factories);
+        }
+
+        private TestFixture(SSLSession session, SSLSession handshakeSession, TestConnectionFactory... factories) {
             Server server = new Server();
             this.connector = new ServerConnector(server, factories);
             this.endPoint = new ByteArrayEndPoint();
-            this.sslEngine = new TestSslEngine(
-                    new TestSslSession("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
-                    new TestSslSession("TLSv1.3", "TLS_AES_128_GCM_SHA256"));
+            this.sslEngine = new TestSslEngine(session, handshakeSession);
         }
 
         private ALPNServerConnection newAlpnConnection(List<String> protocols, String defaultProtocol) {

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_server/Jetty_alpn_serverTest.java
@@ -6,11 +6,431 @@
  */
 package org_eclipse_jetty.jetty_alpn_server;
 
+import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+
+import org.eclipse.jetty.alpn.server.ALPNServerConnection;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.AbstractConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.NegotiatingServerConnection.CipherDiscriminator;
 import org.junit.jupiter.api.Test;
 
-class Jetty_alpn_serverTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class Jetty_alpn_serverTest {
+    private static final String HTTP_2 = "h2";
+    private static final String HTTP_1_1 = "http/1.1";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void serverPreferenceDeterminesSelectedProtocol() {
+        TestFixture fixture = new TestFixture(new TestConnectionFactory(HTTP_2), new TestConnectionFactory(HTTP_1_1));
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+
+        connection.select(List.of(HTTP_1_1, HTTP_2));
+
+        assertThat(connection.getProtocol()).isEqualTo(HTTP_2);
+        assertThat(connection.getProtocols()).containsExactly(HTTP_2, HTTP_1_1);
+        assertThat(connection.getDefaultProtocol()).isEqualTo(HTTP_1_1);
+        assertThat(connection.getConnector()).isSameAs(fixture.connector);
+        assertThat(connection.getSSLEngine()).isSameAs(fixture.sslEngine);
+    }
+
+    @Test
+    void cipherDiscriminatorCanRejectAnOtherwiseMatchingProtocol() {
+        DiscriminatingConnectionFactory rejectedHttp2 = new DiscriminatingConnectionFactory(HTTP_2, false);
+        DiscriminatingConnectionFactory acceptedHttp11 = new DiscriminatingConnectionFactory(HTTP_1_1, true);
+        TestFixture fixture = new TestFixture(rejectedHttp2, acceptedHttp11);
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+
+        connection.select(List.of(HTTP_2, HTTP_1_1));
+
+        assertThat(connection.getProtocol()).isEqualTo(HTTP_1_1);
+        assertThat(rejectedHttp2.checkedProtocols).containsExactly(HTTP_2);
+        assertThat(rejectedHttp2.checkedTlsProtocols).containsExactly("TLSv1.3");
+        assertThat(rejectedHttp2.checkedCipherSuites).containsExactly("TLS_AES_128_GCM_SHA256");
+        assertThat(acceptedHttp11.checkedProtocols).containsExactly(HTTP_1_1);
+    }
+
+    @Test
+    void unsupportedAlpnFallsBackToDefaultProtocol() {
+        TestFixture fixture = new TestFixture(new TestConnectionFactory(HTTP_2), new TestConnectionFactory(HTTP_1_1));
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+
+        connection.unsupported();
+
+        assertThat(connection.getProtocol()).isEqualTo(HTTP_1_1);
+    }
+
+    @Test
+    void selectFailsWhenClientAndServerHaveNoProtocolInCommon() {
+        TestFixture fixture = new TestFixture(new TestConnectionFactory(HTTP_2), new TestConnectionFactory(HTTP_1_1));
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> connection.select(List.of("acme-tls/1")));
+        assertThat(connection.getProtocol()).isNull();
+    }
+
+    @Test
+    void selectedProtocolUpgradesEndpointToMatchingConnectionFactory() {
+        TestConnectionFactory http2Factory = new TestConnectionFactory(HTTP_2);
+        TestFixture fixture = new TestFixture(http2Factory, new TestConnectionFactory(HTTP_1_1));
+        ALPNServerConnection connection = fixture.newAlpnConnection(List.of(HTTP_2, HTTP_1_1), HTTP_1_1);
+        fixture.endPoint.setConnection(connection);
+
+        connection.select(List.of(HTTP_2));
+        connection.onFillable();
+
+        assertThat(fixture.endPoint.getConnection()).isInstanceOf(RecordingConnection.class);
+        assertThat(http2Factory.createdConnections).hasSize(1);
+        assertThat(http2Factory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void serverConnectionFactoryReportsUnavailableProcessorWhenNoProviderIsPresent() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> new ALPNServerConnectionFactory(" h2, http/1.1 "))
+                .withMessage("No Server ALPNProcessors!");
+    }
+
+    private static final class TestFixture {
+        private final ByteArrayEndPoint endPoint;
+        private final ServerConnector connector;
+        private final TestSslEngine sslEngine;
+
+        private TestFixture(TestConnectionFactory... factories) {
+            Server server = new Server();
+            this.connector = new ServerConnector(server, factories);
+            this.endPoint = new ByteArrayEndPoint();
+            this.sslEngine = new TestSslEngine(
+                    new TestSslSession("TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+                    new TestSslSession("TLSv1.3", "TLS_AES_128_GCM_SHA256"));
+        }
+
+        private ALPNServerConnection newAlpnConnection(List<String> protocols, String defaultProtocol) {
+            return new ALPNServerConnection(connector, endPoint, sslEngine, protocols, defaultProtocol);
+        }
+    }
+
+    private static class TestConnectionFactory extends AbstractConnectionFactory {
+        private final List<RecordingConnection> createdConnections = new ArrayList<>();
+
+        private TestConnectionFactory(String protocol) {
+            super(protocol);
+        }
+
+        @Override
+        public Connection newConnection(Connector connector, EndPoint endPoint) {
+            RecordingConnection connection = new RecordingConnection(endPoint, connector.getExecutor());
+            createdConnections.add(connection);
+            return connection;
+        }
+    }
+
+    private static final class DiscriminatingConnectionFactory extends TestConnectionFactory implements CipherDiscriminator {
+        private final boolean acceptable;
+        private final List<String> checkedProtocols = new ArrayList<>();
+        private final List<String> checkedTlsProtocols = new ArrayList<>();
+        private final List<String> checkedCipherSuites = new ArrayList<>();
+
+        private DiscriminatingConnectionFactory(String protocol, boolean acceptable) {
+            super(protocol);
+            this.acceptable = acceptable;
+        }
+
+        @Override
+        public boolean isAcceptable(String protocol, String tlsProtocol, String tlsCipher) {
+            checkedProtocols.add(protocol);
+            checkedTlsProtocols.add(tlsProtocol);
+            checkedCipherSuites.add(tlsCipher);
+            return acceptable;
+        }
+    }
+
+    private static final class RecordingConnection extends AbstractConnection {
+        private boolean opened;
+
+        private RecordingConnection(EndPoint endPoint, Executor executor) {
+            super(endPoint, executor);
+        }
+
+        @Override
+        public void onOpen() {
+            super.onOpen();
+            opened = true;
+        }
+
+        @Override
+        public void onFillable() {
+        }
+    }
+
+    private static final class TestSslEngine extends SSLEngine {
+        private final SSLSession session;
+        private final SSLSession handshakeSession;
+        private boolean outboundClosed;
+        private boolean inboundClosed;
+
+        private TestSslEngine(SSLSession session, SSLSession handshakeSession) {
+            this.session = session;
+            this.handshakeSession = handshakeSession;
+        }
+
+        @Override
+        public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) throws SSLException {
+            return result();
+        }
+
+        @Override
+        public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) throws SSLException {
+            return result();
+        }
+
+        @Override
+        public Runnable getDelegatedTask() {
+            return null;
+        }
+
+        @Override
+        public void closeInbound() throws SSLException {
+            inboundClosed = true;
+        }
+
+        @Override
+        public boolean isInboundDone() {
+            return inboundClosed;
+        }
+
+        @Override
+        public void closeOutbound() {
+            outboundClosed = true;
+        }
+
+        @Override
+        public boolean isOutboundDone() {
+            return outboundClosed;
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return getEnabledCipherSuites();
+        }
+
+        @Override
+        public String[] getEnabledCipherSuites() {
+            return new String[] {"TLS_AES_128_GCM_SHA256"};
+        }
+
+        @Override
+        public void setEnabledCipherSuites(String[] suites) {
+        }
+
+        @Override
+        public String[] getSupportedProtocols() {
+            return getEnabledProtocols();
+        }
+
+        @Override
+        public String[] getEnabledProtocols() {
+            return new String[] {"TLSv1.3"};
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+        }
+
+        @Override
+        public SSLSession getSession() {
+            return session;
+        }
+
+        @Override
+        public SSLSession getHandshakeSession() {
+            return handshakeSession;
+        }
+
+        @Override
+        public void beginHandshake() throws SSLException {
+        }
+
+        @Override
+        public SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+            return SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+        }
+
+        @Override
+        public void setUseClientMode(boolean mode) {
+        }
+
+        @Override
+        public boolean getUseClientMode() {
+            return false;
+        }
+
+        @Override
+        public void setNeedClientAuth(boolean need) {
+        }
+
+        @Override
+        public boolean getNeedClientAuth() {
+            return false;
+        }
+
+        @Override
+        public void setWantClientAuth(boolean want) {
+        }
+
+        @Override
+        public boolean getWantClientAuth() {
+            return false;
+        }
+
+        @Override
+        public void setEnableSessionCreation(boolean flag) {
+        }
+
+        @Override
+        public boolean getEnableSessionCreation() {
+            return true;
+        }
+
+        private SSLEngineResult result() {
+            return new SSLEngineResult(
+                    SSLEngineResult.Status.OK,
+                    SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING,
+                    0,
+                    0);
+        }
+    }
+
+    private static final class TestSslSession implements SSLSession {
+        private final String protocol;
+        private final String cipherSuite;
+
+        private TestSslSession(String protocol, String cipherSuite) {
+            this.protocol = protocol;
+            this.cipherSuite = cipherSuite;
+        }
+
+        @Override
+        public byte[] getId() {
+            return new byte[] {1, 2, 3};
+        }
+
+        @Override
+        public SSLSessionContext getSessionContext() {
+            return null;
+        }
+
+        @Override
+        public long getCreationTime() {
+            return 0L;
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return 0L;
+        }
+
+        @Override
+        public void invalidate() {
+        }
+
+        @Override
+        public boolean isValid() {
+            return true;
+        }
+
+        @Override
+        public void putValue(String name, Object value) {
+        }
+
+        @Override
+        public Object getValue(String name) {
+            return null;
+        }
+
+        @Override
+        public void removeValue(String name) {
+        }
+
+        @Override
+        public String[] getValueNames() {
+            return new String[0];
+        }
+
+        @Override
+        public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
+            throw new SSLPeerUnverifiedException("peer is not verified");
+        }
+
+        @Override
+        public Certificate[] getLocalCertificates() {
+            return new Certificate[0];
+        }
+
+        @Override
+        public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+            throw new SSLPeerUnverifiedException("peer is not verified");
+        }
+
+        @Override
+        public Principal getLocalPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getCipherSuite() {
+            return cipherSuite;
+        }
+
+        @Override
+        public String getProtocol() {
+            return protocol;
+        }
+
+        @Override
+        public String getPeerHost() {
+            return "localhost";
+        }
+
+        @Override
+        public int getPeerPort() {
+            return 443;
+        }
+
+        @Override
+        public int getPacketBufferSize() {
+            return 16 * 1024;
+        }
+
+        @Override
+        public int getApplicationBufferSize() {
+            return 16 * 1024;
+        }
+
+        @Override
+        public String toString() {
+            return "TestSslSession" + Arrays.asList(protocol, cipherSuite);
+        }
     }
 }

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.jetty.alpn.server.**"
+      "includeClasses" : "org.eclipse.jetty.alpn.server.**"
     }
   ]
 }

--- a/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-server/11.0.24/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.alpn.server.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2787

This PR introduces tests and metadata for org.eclipse.jetty:jetty-alpn-server:11.0.24, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 159423
- Cached input tokens: 1255424
- Output tokens: 17664
- Entries: 13
- Iterations: 3
- Library coverage percentage: 50.68
- Generated lines of code: 381
- Tested library lines of code: 37

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `492ac270689457c121e18e3a61053735827dee93`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 131/332 (39.46%)
- Line: 37/73 (50.68%)
- Method: 6/9 (66.67%)
