### PR TITLE
[GenAI] Test fix for javax.validation:validation-api:2.0.0.Final using gpt-5.5

### DIFF
--- a/metadata/javax.validation/validation-api/2.0.0.Final/reachability-metadata.json
+++ b/metadata/javax.validation/validation-api/2.0.0.Final/reachability-metadata.json
@@ -1,0 +1,21 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.validation.Validation$GetValidationProviderListAction"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.validation.Validation$GetValidationProviderListAction"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    }
+  ]
+}

--- a/metadata/javax.validation/validation-api/index.json
+++ b/metadata/javax.validation/validation-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0.Final",
+    "tested-versions" : [
+      "2.0.0.Final"
+    ],
+    "allowed-packages" : [
+      "javax.validation"
+    ]
+  },
+  {
     "metadata-version" : "1.1.0.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final-sources.jar",
     "repository-url" : "https://github.com/jakartaee/validation",

--- a/metadata/javax.validation/validation-api/index.json
+++ b/metadata/javax.validation/validation-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/javax/validation/validation-api/2.0.0.Final/validation-api-2.0.0.Final-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/validation",
+    "test-code-url" : "https://github.com/jakartaee/validation/tree/2.0.0.Final/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/javax/validation/validation-api/2.0.0.Final/validation-api-2.0.0.Final-javadoc.jar",
+    "description" : "Bean Validation API defines the standard Java annotations and interfaces for declaring and inspecting constraints on objects, properties, method parameters, return values, and container elements. It provides the JSR 380 contracts that validation providers implement so applications can use a portable validation model without depending on a specific provider.",
     "tested-versions" : [
       "2.0.0.Final"
     ],

--- a/stats/javax.validation/validation-api/2.0.0.Final/execution-metrics.json
+++ b/stats/javax.validation/validation-api/2.0.0.Final/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T02:48:41.890728Z",
+    "library": "javax.validation:validation-api:2.0.0.Final",
+    "starting_commit": "7a53cf2a75fe986ca6d8db0fe5946e46a8cecaa5",
+    "ending_commit": "eab4c1cd38eda97e528c6b594565d2c632746699",
+    "previous_library": "javax.validation:validation-api:1.1.0.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 203,
+          "missed": 696,
+          "ratio": 0.225806,
+          "total": 899
+        },
+        "line": {
+          "covered": 58,
+          "missed": 155,
+          "ratio": 0.2723,
+          "total": 213
+        },
+        "method": {
+          "covered": 18,
+          "missed": 55,
+          "ratio": 0.246575,
+          "total": 73
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.1.0.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 143,
+          "missed": 579,
+          "ratio": 0.198061,
+          "total": 722
+        },
+        "line": {
+          "covered": 41,
+          "missed": 125,
+          "ratio": 0.246988,
+          "total": 166
+        },
+        "method": {
+          "covered": 10,
+          "missed": 40,
+          "ratio": 0.2,
+          "total": 50
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 75088,
+      "cached_input_tokens_used": 543744,
+      "output_tokens_used": 6482,
+      "iterations": 2,
+      "cost_usd": 0.4664,
+      "tested_library_loc": 58,
+      "metadata_entries": 3,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 27.23,
+      "previous_library_coverage_percent": 24.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java",
+      "metadata_file": "metadata/javax.validation/validation-api/2.0.0.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/javax.validation/validation-api/2.0.0.Final/stats.json
+++ b/stats/javax.validation/validation-api/2.0.0.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 203,
+        "missed" : 696,
+        "ratio" : 0.225806,
+        "total" : 899
+      },
+      "line" : {
+        "covered" : 58,
+        "missed" : 155,
+        "ratio" : 0.2723,
+        "total" : 213
+      },
+      "method" : {
+        "covered" : 18,
+        "missed" : 55,
+        "ratio" : 0.246575,
+        "total" : 73
+      }
+    }
+  } ]
+}

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/.gitignore
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/build.gradle
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "javax.validation:validation-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/gradle.properties
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = javax.validation:validation-api:2.0.0.Final
+library.version = 2.0.0.Final
+metadata.dir = javax.validation/validation-api/2.0.0.Final/

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/settings.gradle
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'javax.validation.validation-api_tests'

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_validation.validation_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.validation.BootstrapConfiguration;
+import javax.validation.Configuration;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorContext;
+import javax.validation.ValidatorFactory;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+import org.junit.jupiter.api.Test;
+
+public class ValidationInnerDefaultValidationProviderResolverTest {
+
+    private static final String SERVICES_FILE = "META-INF/services/" + ValidationProvider.class.getName();
+
+    @Test
+    void defaultResolverLoadsProviderWithContextClassLoader() throws Exception {
+        Path providerDefinition = writeProviderDefinition();
+        ClassLoader providerClassLoader = new ProviderDefinitionClassLoader(
+                parentClassLoader(),
+                providerDefinition.toUri().toURL()
+        );
+
+        try {
+            TestValidationConfiguration configuration = configureWith(providerClassLoader);
+
+            assertDiscoveredProvider(configuration);
+        } finally {
+            Files.deleteIfExists(providerDefinition);
+        }
+    }
+
+    @Test
+    void defaultResolverDiscoversProviderFromContextClassLoaderAndFallsBackToCallerClassLoader() throws Exception {
+        Path providerDefinition = writeProviderDefinition();
+        ClassLoader providerClassLoader = new FailingProviderDefinitionClassLoader(
+                parentClassLoader(),
+                providerDefinition.toUri().toURL()
+        );
+
+        try {
+            TestValidationConfiguration configuration = configureWith(providerClassLoader);
+
+            assertDiscoveredProvider(configuration);
+        } finally {
+            Files.deleteIfExists(providerDefinition);
+        }
+    }
+
+    private ClassLoader parentClassLoader() {
+        ClassLoader parentClassLoader = Thread.currentThread().getContextClassLoader();
+        if (parentClassLoader == null) {
+            return getClass().getClassLoader();
+        }
+        return parentClassLoader;
+    }
+
+    private static TestValidationConfiguration configureWith(ClassLoader providerClassLoader) {
+        TestValidationProvider.reset();
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(providerClassLoader);
+            return (TestValidationConfiguration) Validation.byDefaultProvider().configure();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static void assertDiscoveredProvider(TestValidationConfiguration configuration) {
+        assertThat(TestValidationProvider.instantiationCount).isEqualTo(1);
+        assertThat(TestValidationProvider.lastInstance).isNotNull();
+        assertThat(configuration.provider()).isSameAs(TestValidationProvider.lastInstance);
+        assertThat(configuration.bootstrapState()).isNotNull();
+    }
+
+    private static Path writeProviderDefinition() throws IOException {
+        Path providerDefinition = Files.createTempFile("validation-provider", ".services");
+        Files.write(
+                providerDefinition,
+                Collections.singleton(TestValidationProvider.class.getName()),
+                StandardCharsets.UTF_8
+        );
+        return providerDefinition;
+    }
+
+    private static class ProviderDefinitionClassLoader extends ClassLoader {
+
+        private final URL providerDefinition;
+
+        private ProviderDefinitionClassLoader(ClassLoader parent, URL providerDefinition) {
+            super(parent);
+            this.providerDefinition = providerDefinition;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (SERVICES_FILE.equals(name)) {
+                return Collections.enumeration(Collections.singleton(providerDefinition));
+            }
+            return super.getResources(name);
+        }
+    }
+
+    private static final class FailingProviderDefinitionClassLoader extends ProviderDefinitionClassLoader {
+
+        private FailingProviderDefinitionClassLoader(ClassLoader parent, URL providerDefinition) {
+            super(parent, providerDefinition);
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (TestValidationProvider.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+    }
+
+    public interface TestValidationConfiguration extends Configuration<TestValidationConfiguration> {
+
+        TestValidationProvider provider();
+
+        BootstrapState bootstrapState();
+    }
+
+    public static final class TestValidationProvider implements ValidationProvider<TestValidationConfiguration> {
+
+        private static int instantiationCount;
+        private static TestValidationProvider lastInstance;
+
+        public TestValidationProvider() {
+            instantiationCount++;
+            lastInstance = this;
+        }
+
+        static void reset() {
+            instantiationCount = 0;
+            lastInstance = null;
+        }
+
+        @Override
+        public TestValidationConfiguration createSpecializedConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public Configuration<?> createGenericConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidationConfigurationImpl implements TestValidationConfiguration {
+
+        private final TestValidationProvider provider;
+        private final BootstrapState bootstrapState;
+
+        private TestValidationConfigurationImpl(TestValidationProvider provider, BootstrapState bootstrapState) {
+            this.provider = provider;
+            this.bootstrapState = bootstrapState;
+        }
+
+        @Override
+        public TestValidationProvider provider() {
+            return provider;
+        }
+
+        @Override
+        public BootstrapState bootstrapState() {
+            return bootstrapState;
+        }
+
+        @Override
+        public TestValidationConfiguration ignoreXmlConfiguration() {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration messageInterpolator(MessageInterpolator interpolator) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration traversableResolver(TraversableResolver resolver) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration constraintValidatorFactory(
+                ConstraintValidatorFactory constraintValidatorFactory
+        ) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addMapping(InputStream stream) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addProperty(String name, String value) {
+            return this;
+        }
+
+        @Override
+        public MessageInterpolator getDefaultMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getDefaultTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getDefaultConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getDefaultParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public BootstrapConfiguration getBootstrapConfiguration() {
+            return null;
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory() {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidatorFactory implements ValidatorFactory {
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public ValidatorContext usingContext() {
+            return null;
+        }
+
+        @Override
+        public MessageInterpolator getMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            throw new ValidationException("No provider-specific API available for " + type.getName());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 
 import javax.validation.BootstrapConfiguration;
+import javax.validation.ClockProvider;
 import javax.validation.Configuration;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -31,6 +32,7 @@ import javax.validation.ValidatorFactory;
 import javax.validation.spi.BootstrapState;
 import javax.validation.spi.ConfigurationState;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 import org.junit.jupiter.api.Test;
 
 public class ValidationInnerDefaultValidationProviderResolverTest {
@@ -226,6 +228,16 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
         }
 
         @Override
+        public TestValidationConfiguration clockProvider(ClockProvider clockProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+            return this;
+        }
+
+        @Override
         public TestValidationConfiguration addMapping(InputStream stream) {
             return this;
         }
@@ -252,6 +264,11 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
 
         @Override
         public ParameterNameProvider getDefaultParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getDefaultClockProvider() {
             return null;
         }
 
@@ -295,6 +312,11 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
 
         @Override
         public ParameterNameProvider getParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getClockProvider() {
             return null;
         }
 

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerNewProviderInstanceTest.java
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerNewProviderInstanceTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_validation.validation_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
+import javax.validation.BootstrapConfiguration;
+import javax.validation.ClockProvider;
+import javax.validation.Configuration;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorContext;
+import javax.validation.ValidatorFactory;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
+import org.junit.jupiter.api.Test;
+
+public class ValidationInnerNewProviderInstanceTest {
+
+    @Test
+    void byProviderConfigureInstantiatesTheRequestedProvider() {
+        TestValidationProvider.reset();
+
+        TestValidationConfiguration configuration = Validation.byProvider(TestValidationProvider.class).configure();
+
+        assertThat(TestValidationProvider.instantiationCount).isEqualTo(1);
+        assertThat(TestValidationProvider.lastInstance).isNotNull();
+        assertThat(configuration.provider()).isSameAs(TestValidationProvider.lastInstance);
+        assertThat(configuration.bootstrapState()).isNotNull();
+    }
+
+    public interface TestValidationConfiguration extends Configuration<TestValidationConfiguration> {
+
+        TestValidationProvider provider();
+
+        BootstrapState bootstrapState();
+    }
+
+    public static final class TestValidationProvider implements ValidationProvider<TestValidationConfiguration> {
+
+        private static int instantiationCount;
+        private static TestValidationProvider lastInstance;
+
+        public TestValidationProvider() {
+            instantiationCount++;
+            lastInstance = this;
+        }
+
+        static void reset() {
+            instantiationCount = 0;
+            lastInstance = null;
+        }
+
+        @Override
+        public TestValidationConfiguration createSpecializedConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public Configuration<?> createGenericConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidationConfigurationImpl implements TestValidationConfiguration {
+
+        private final TestValidationProvider provider;
+        private final BootstrapState bootstrapState;
+
+        private TestValidationConfigurationImpl(TestValidationProvider provider, BootstrapState bootstrapState) {
+            this.provider = provider;
+            this.bootstrapState = bootstrapState;
+        }
+
+        @Override
+        public TestValidationProvider provider() {
+            return provider;
+        }
+
+        @Override
+        public BootstrapState bootstrapState() {
+            return bootstrapState;
+        }
+
+        @Override
+        public TestValidationConfiguration ignoreXmlConfiguration() {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration messageInterpolator(MessageInterpolator interpolator) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration traversableResolver(TraversableResolver resolver) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration constraintValidatorFactory(
+                ConstraintValidatorFactory constraintValidatorFactory
+        ) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration clockProvider(ClockProvider clockProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addMapping(InputStream stream) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addProperty(String name, String value) {
+            return this;
+        }
+
+        @Override
+        public MessageInterpolator getDefaultMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getDefaultTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getDefaultConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getDefaultParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getDefaultClockProvider() {
+            return null;
+        }
+
+        @Override
+        public BootstrapConfiguration getBootstrapConfiguration() {
+            return null;
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory() {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidatorFactory implements ValidatorFactory {
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public ValidatorContext usingContext() {
+            return null;
+        }
+
+        @Override
+        public MessageInterpolator getMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getClockProvider() {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            throw new ValidationException("No provider-specific API available for " + type.getName());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.validation.Validation$DefaultValidationProviderResolver"
+      },
+      "type" : "javax_validation.validation_api.ValidationInnerDefaultValidationProviderResolverTest$TestValidationProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.validation.Validation$GetValidationProviderListAction"
+      },
+      "type" : "javax_validation.validation_api.ValidationInnerDefaultValidationProviderResolverTest$TestValidationProvider"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.validation.Validation$GetValidationProviderListAction"
+      },
+      "glob" : "META-INF/services/javax.validation.spi.ValidationProvider"
+    }
+  ]
+}

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,18 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "javax.validation.Validation$NewProviderInstance"
+      },
+      "type" : "javax_validation.validation_api.ValidationInnerNewProviderInstanceTest$TestValidationProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "javax.validation.Validation$DefaultValidationProviderResolver"
       },
       "type" : "javax_validation.validation_api.ValidationInnerDefaultValidationProviderResolverTest$TestValidationProvider",

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/services/javax.validation.spi.ValidationProvider
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/resources/META-INF/services/javax.validation.spi.ValidationProvider
@@ -1,0 +1,1 @@
+javax_validation.validation_api.ValidationInnerDefaultValidationProviderResolverTest$TestValidationProvider

--- a/tests/src/javax.validation/validation-api/2.0.0.Final/user-code-filter.json
+++ b/tests/src/javax.validation/validation-api/2.0.0.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.validation.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3484

This PR provides test fixes and new metadata for javax.validation:validation-api:2.0.0.Final, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 75088
- Cached input tokens: 543744
- Output tokens: 6482
- Entries found: 3
- Iterations: 2
- Library coverage percentage: 27.23
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 24.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1bc4d0904f01134a9ffffc5307dfcefc0f1f3c2b`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- javax.validation:validation-api:1.1.0.Final: 0/0 covered calls (100.00%)
- javax.validation:validation-api:2.0.0.Final: 1/1 covered calls (100.00%)

**Reflection:**
- javax.validation:validation-api:1.1.0.Final: N/A
- javax.validation:validation-api:2.0.0.Final: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- javax.validation:validation-api:1.1.0.Final: 143/722 (19.81%)
- javax.validation:validation-api:2.0.0.Final: 203/899 (22.58%)

**Line:**
- javax.validation:validation-api:1.1.0.Final: 41/166 (24.70%)
- javax.validation:validation-api:2.0.0.Final: 58/213 (27.23%)

**Method:**
- javax.validation:validation-api:1.1.0.Final: 10/50 (20.00%)
- javax.validation:validation-api:2.0.0.Final: 18/73 (24.66%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/javax.validation/validation-api/1.1.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java 2/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
index 6867b2f233..0558ba4398 100644
--- 1/tests/src/javax.validation/validation-api/1.1.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
+++ 2/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerDefaultValidationProviderResolverTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 
 import javax.validation.BootstrapConfiguration;
+import javax.validation.ClockProvider;
 import javax.validation.Configuration;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -31,6 +32,7 @@ import javax.validation.ValidatorFactory;
 import javax.validation.spi.BootstrapState;
 import javax.validation.spi.ConfigurationState;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 import org.junit.jupiter.api.Test;
 
 public class ValidationInnerDefaultValidationProviderResolverTest {
@@ -225,6 +227,16 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
             return this;
         }
 
+        @Override
+        public TestValidationConfiguration clockProvider(ClockProvider clockProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+            return this;
+        }
+
         @Override
         public TestValidationConfiguration addMapping(InputStream stream) {
             return this;
@@ -255,6 +267,11 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
             return null;
         }
 
+        @Override
+        public ClockProvider getDefaultClockProvider() {
+            return null;
+        }
+
         @Override
         public BootstrapConfiguration getBootstrapConfiguration() {
             return null;
@@ -298,6 +315,11 @@ public class ValidationInnerDefaultValidationProviderResolverTest {
             return null;
         }
 
+        @Override
+        public ClockProvider getClockProvider() {
+            return null;
+        }
+
         @Override
         public <T> T unwrap(Class<T> type) {
             throw new ValidationException("No provider-specific API available for " + type.getName());
diff --git 1/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerNewProviderInstanceTest.java 2/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerNewProviderInstanceTest.java
new file mode 100644
index 0000000000..e577ff6bfd
--- /dev/null
+++ 2/tests/src/javax.validation/validation-api/2.0.0.Final/src/test/java/javax_validation/validation_api/ValidationInnerNewProviderInstanceTest.java
@@ -0,0 +1,232 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_validation.validation_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
+import javax.validation.BootstrapConfiguration;
+import javax.validation.ClockProvider;
+import javax.validation.Configuration;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorContext;
+import javax.validation.ValidatorFactory;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
+import org.junit.jupiter.api.Test;
+
+public class ValidationInnerNewProviderInstanceTest {
+
+    @Test
+    void byProviderConfigureInstantiatesTheRequestedProvider() {
+        TestValidationProvider.reset();
+
+        TestValidationConfiguration configuration = Validation.byProvider(TestValidationProvider.class).configure();
+
+        assertThat(TestValidationProvider.instantiationCount).isEqualTo(1);
+        assertThat(TestValidationProvider.lastInstance).isNotNull();
+        assertThat(configuration.provider()).isSameAs(TestValidationProvider.lastInstance);
+        assertThat(configuration.bootstrapState()).isNotNull();
+    }
+
+    public interface TestValidationConfiguration extends Configuration<TestValidationConfiguration> {
+
+        TestValidationProvider provider();
+
+        BootstrapState bootstrapState();
+    }
+
+    public static final class TestValidationProvider implements ValidationProvider<TestValidationConfiguration> {
+
+        private static int instantiationCount;
+        private static TestValidationProvider lastInstance;
+
+        public TestValidationProvider() {
+            instantiationCount++;
+            lastInstance = this;
+        }
+
+        static void reset() {
+            instantiationCount = 0;
+            lastInstance = null;
+        }
+
+        @Override
+        public TestValidationConfiguration createSpecializedConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public Configuration<?> createGenericConfiguration(BootstrapState state) {
+            return new TestValidationConfigurationImpl(this, state);
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidationConfigurationImpl implements TestValidationConfiguration {
+
+        private final TestValidationProvider provider;
+        private final BootstrapState bootstrapState;
+
+        private TestValidationConfigurationImpl(TestValidationProvider provider, BootstrapState bootstrapState) {
+            this.provider = provider;
+            this.bootstrapState = bootstrapState;
+        }
+
+        @Override
+        public TestValidationProvider provider() {
+            return provider;
+        }
+
+        @Override
+        public BootstrapState bootstrapState() {
+            return bootstrapState;
+        }
+
+        @Override
+        public TestValidationConfiguration ignoreXmlConfiguration() {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration messageInterpolator(MessageInterpolator interpolator) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration traversableResolver(TraversableResolver resolver) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration constraintValidatorFactory(
+                ConstraintValidatorFactory constraintValidatorFactory
+        ) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration clockProvider(ClockProvider clockProvider) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addMapping(InputStream stream) {
+            return this;
+        }
+
+        @Override
+        public TestValidationConfiguration addProperty(String name, String value) {
+            return this;
+        }
+
+        @Override
+        public MessageInterpolator getDefaultMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getDefaultTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getDefaultConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getDefaultParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getDefaultClockProvider() {
+            return null;
+        }
+
+        @Override
+        public BootstrapConfiguration getBootstrapConfiguration() {
+            return null;
+        }
+
+        @Override
+        public ValidatorFactory buildValidatorFactory() {
+            return new TestValidatorFactory();
+        }
+    }
+
+    private static final class TestValidatorFactory implements ValidatorFactory {
+
+        @Override
+        public Validator getValidator() {
+            return null;
+        }
+
+        @Override
+        public ValidatorContext usingContext() {
+            return null;
+        }
+
+        @Override
+        public MessageInterpolator getMessageInterpolator() {
+            return null;
+        }
+
+        @Override
+        public TraversableResolver getTraversableResolver() {
+            return null;
+        }
+
+        @Override
+        public ConstraintValidatorFactory getConstraintValidatorFactory() {
+            return null;
+        }
+
+        @Override
+        public ParameterNameProvider getParameterNameProvider() {
+            return null;
+        }
+
+        @Override
+        public ClockProvider getClockProvider() {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            throw new ValidationException("No provider-specific API available for " + type.getName());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

```
