### PR TITLE
[GenAI] Test fix for org.immutables:value:2.9.0 using gpt-5.5

### DIFF
--- a/metadata/org.immutables/value/2.9.0/reachability-metadata.json
+++ b/metadata/org.immutables/value/2.9.0/reachability-metadata.json
@@ -1,0 +1,377 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Platform"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ObjectArrays"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ArrayListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ArrayListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$HashMultiset"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$HashMultiset",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ImmutableListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.io.$Closer$SuppressingSuppressor"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
+        {
+          "name" : "addSuppressed",
+          "parameterTypes" : [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "java.util.AbstractMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$SerializationProxy",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.ArrayDeque",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.Collections$ReverseComparator",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.HashSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "java.util.LinkedHashSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "java.util.TreeSet",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$generator$.$AnnotationMirrors$GetTypeAnnotations"
+      },
+      "type" : "javax.lang.model.type.TypeMirror",
+      "methods" : [
+        {
+          "name" : "getAnnotationMirrors",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableMultimap",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization$FieldSetter"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableMultimap",
+      "fields" : [
+        {
+          "name" : "map"
+        },
+        {
+          "name" : "size"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "emptySet"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Serialization"
+      },
+      "type" : "org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.processor.ProxyProcessor"
+      },
+      "type" : "org.immutables.value.internal.$processor$.$Processor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.base.$Throwables"
+      },
+      "type" : "sun.misc.SharedSecrets"
+    }
+  ],
+  "serialization" : [
+    {
+      "type" : "java.util.CollSer"
+    },
+    {
+      "type" : "java.util.Collections$UnmodifiableMap"
+    },
+    {
+      "type" : "java.util.ImmutableCollections$List12"
+    },
+    {
+      "type" : "java.util.ImmutableCollections$MapN"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractListMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractMapBasedMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractMapBasedMultiset"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractSetMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$AbstractSortedSetMultimap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$AbstractSerializationProxy"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$MapMakerInternalMap$SerializationProxy"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence$Equals"
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.base.$Equivalence$Identity"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$generator$.$ExtensionLoader$1"
+      },
+      "glob" : "META-INF/annotations/org.immutables.value.immutable"
+    }
+  ]
+}

--- a/metadata/org.immutables/value/index.json
+++ b/metadata/org.immutables/value/index.json
@@ -1,13 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.9.0",
+    "tested-versions" : [
+      "2.9.0"
+    ],
+    "allowed-packages" : [
+      "org.immutables"
+    ]
+  },
+  {
     "metadata-version" : "2.8.9-ea-0",
+    "test-version" : "2.8.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-sources.jar",
     "repository-url" : "https://github.com/immutables/immutables",
     "test-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-tests.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.8.9-ea-0/value-2.8.9-ea-0-javadoc.jar",
     "description" : "Immutables Value provides compile-time annotations and an annotation processor that generate consistent immutable value objects from abstract classes, interfaces, or annotations. It helps Java projects define type-safe, fluent value types with less handwritten boilerplate.",
-    "test-version" : "2.8.6",
     "tested-versions" : [
       "2.8.9-ea-0"
     ],

--- a/metadata/org.immutables/value/index.json
+++ b/metadata/org.immutables/value/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.9.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.9.0/value-2.9.0-sources.jar",
+    "repository-url" : "https://github.com/immutables/immutables",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.9.0/value-2.9.0-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/immutables/value/2.9.0/value-2.9.0-javadoc.jar",
+    "description" : "Immutables Value provides compile-time annotations and an annotation processor that generate consistent immutable value objects from abstract classes, interfaces, or annotations. It helps Java projects define type-safe, fluent value types with less handwritten boilerplate.",
     "tested-versions" : [
       "2.9.0"
     ],

--- a/stats/org.immutables/value/2.9.0/execution-metrics.json
+++ b/stats/org.immutables/value/2.9.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T02:55:22.265764Z",
+    "library": "org.immutables:value:2.9.0",
+    "starting_commit": "7f129c8cdc59e5158fb0d3d3717f34d363318d08",
+    "ending_commit": "74688c1d2bc54dbdb50237f0f82ed41219b87b08",
+    "previous_library": "org.immutables:value:2.8.6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 49,
+            "totalCalls": 49
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 50,
+        "totalCalls": 50
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6656,
+          "missed": 301346,
+          "ratio": 0.02161,
+          "total": 308002
+        },
+        "line": {
+          "covered": 1600,
+          "missed": 60913,
+          "ratio": 0.025595,
+          "total": 62513
+        },
+        "method": {
+          "covered": 649,
+          "missed": 9767,
+          "ratio": 0.062308,
+          "total": 10416
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.8.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 50,
+            "totalCalls": 50
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 51,
+        "totalCalls": 51
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6540,
+          "missed": 289223,
+          "ratio": 0.022112,
+          "total": 295763
+        },
+        "line": {
+          "covered": 1578,
+          "missed": 58957,
+          "ratio": 0.026068,
+          "total": 60535
+        },
+        "method": {
+          "covered": 646,
+          "missed": 9604,
+          "ratio": 0.063024,
+          "total": 10250
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 111058,
+      "cached_input_tokens_used": 1170944,
+      "output_tokens_used": 7650,
+      "iterations": 2,
+      "cost_usd": 0.815,
+      "tested_library_loc": 1600,
+      "metadata_entries": 82,
+      "previous_library_metadata_entries": 78,
+      "code_coverage_percent": 2.56,
+      "previous_library_coverage_percent": 2.61
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.immutables/value/2.9.0/src/test/java/org/eclipse/fake/ProxyProcessorCaller.java",
+      "metadata_file": "metadata/org.immutables/value/2.9.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.immutables/value/2.9.0/stats.json
+++ b/stats/org.immutables/value/2.9.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.9.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 49,
+          "totalCalls" : 49
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 50,
+      "totalCalls" : 50
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6656,
+        "missed" : 301346,
+        "ratio" : 0.02161,
+        "total" : 308002
+      },
+      "line" : {
+        "covered" : 1600,
+        "missed" : 60913,
+        "ratio" : 0.025595,
+        "total" : 62513
+      },
+      "method" : {
+        "covered" : 649,
+        "missed" : 9767,
+        "ratio" : 0.062308,
+        "total" : 10416
+      }
+    }
+  } ]
+}

--- a/tests/src/org.immutables/value/2.9.0/.gitignore
+++ b/tests/src/org.immutables/value/2.9.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.immutables/value/2.9.0/build.gradle
+++ b/tests/src/org.immutables/value/2.9.0/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.immutables:value:$libraryVersion"
+    testAnnotationProcessor "org.immutables:value:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ["-processor", "org.immutables.processor.ProxyProcessor"]
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/gradle.properties
+++ b/tests/src/org.immutables/value/2.9.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.immutables:value:2.9.0
+library.version = 2.9.0
+metadata.dir = org.immutables/value/2.9.0/

--- a/tests/src/org.immutables/value/2.9.0/settings.gradle
+++ b/tests/src/org.immutables/value/2.9.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.immutables.value_tests'

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org/eclipse/fake/ProxyProcessorCaller.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org/eclipse/fake/ProxyProcessorCaller.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.eclipse.fake;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.immutables.processor.ProxyProcessor;
+
+public final class ProxyProcessorCaller implements Supplier<Set<String>> {
+
+    @Override
+    public Set<String> get() {
+        return new ProxyProcessor().getSupportedAnnotationTypes();
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org/eclipse/jdt/internal/compiler/apt/model/ElementImpl.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org/eclipse/jdt/internal/compiler/apt/model/ElementImpl.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.eclipse.jdt.internal.compiler.apt.model;
+
+public class ElementImpl {
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$AnnotationMirrors$GetTypeAnnotationsTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$AnnotationMirrors$GetTypeAnnotationsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+import org.immutables.value.internal.$generator$.$AnnotationMirrors;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnnotationMirrorsGetTypeAnnotationsTest {
+
+    @Test
+    void fromUsesTypeMirrorGetAnnotationMirrorsWhenAvailable() {
+        AnnotationMirror annotationMirror = new SimpleAnnotationMirror();
+        List<AnnotationMirror> annotationMirrors = List.of(annotationMirror);
+        RecordingTypeMirror typeMirror = new RecordingTypeMirror(annotationMirrors);
+        List<? extends AnnotationMirror> returnedMirrors = $AnnotationMirrors.from(typeMirror);
+
+        assertThat(returnedMirrors).hasSize(1);
+        assertThat(returnedMirrors.get(0)).isSameAs(annotationMirror);
+        assertThat(typeMirror.invocationCount()).isEqualTo(1);
+    }
+
+    private static final class RecordingTypeMirror implements TypeMirror {
+        private final List<? extends AnnotationMirror> annotationMirrors;
+        private int invocationCount;
+
+        private RecordingTypeMirror(List<? extends AnnotationMirror> annotationMirrors) {
+            this.annotationMirrors = annotationMirrors;
+        }
+
+        int invocationCount() {
+            return invocationCount;
+        }
+
+        @Override
+        public TypeKind getKind() {
+            return TypeKind.DECLARED;
+        }
+
+        @Override
+        public <R, P> R accept(TypeVisitor<R, P> visitor, P parameter) {
+            return visitor.visitUnknown(this, parameter);
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAnnotationMirrors() {
+            invocationCount++;
+            return annotationMirrors;
+        }
+
+        @Override
+        public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+            return null;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+            return (A[]) new Annotation[0];
+        }
+    }
+
+    private static final class SimpleAnnotationMirror implements AnnotationMirror {
+
+        @Override
+        public DeclaredType getAnnotationType() {
+            throw new UnsupportedOperationException("Not needed for this test");
+        }
+
+        @Override
+        public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValues() {
+            return Map.of();
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.immutables.value.internal.$guava$.io.$Closer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class CloserSuppressingSuppressorTest {
+
+    @Test
+    void closeAddsLaterCloseFailuresAsSuppressedExceptions() {
+        List<String> closedResources = new ArrayList<>();
+        $Closer closer = $Closer.create();
+
+        closer.register(new FailingCloseable("secondary", closedResources));
+        closer.register(new FailingCloseable("primary", closedResources));
+
+        IOException thrown = catchThrowableOfType(closer::close, IOException.class);
+
+        assertThat(closedResources).containsExactly("primary", "secondary");
+        assertThat(thrown)
+                .isNotNull()
+                .hasMessage("primary");
+        assertThat(thrown.getSuppressed())
+                .singleElement()
+                .isInstanceOfSatisfying(IOException.class, suppressed -> assertThat(suppressed).hasMessage("secondary"));
+    }
+
+    private static final class FailingCloseable implements Closeable {
+        private final String name;
+        private final List<String> closedResources;
+
+        private FailingCloseable(String name, List<String> closedResources) {
+            this.name = name;
+            this.closedResources = closedResources;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closedResources.add(name);
+            throw new IOException(name);
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
@@ -6,51 +6,50 @@
  */
 package org_immutables.value;
 
-import java.io.Closeable;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.immutables.value.internal.$guava$.io.$Closer;
+import org.immutables.value.internal.$guava$.io.$CharStreams;
+import org.immutables.value.internal.$guava$.io.$LineProcessor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
-class CloserSuppressingSuppressorTest {
+class CharStreamsLineProcessorTest {
 
     @Test
-    void closeAddsLaterCloseFailuresAsSuppressedExceptions() {
-        List<String> closedResources = new ArrayList<>();
-        $Closer closer = $Closer.create();
+    void readLinesStopsWhenProcessorReturnsFalse() throws IOException {
+        CapturingLineProcessor processor = new CapturingLineProcessor(2);
 
-        closer.register(new FailingCloseable("secondary", closedResources));
-        closer.register(new FailingCloseable("primary", closedResources));
+        List<String> processedLines = $CharStreams.readLines(new StringReader("alpha\nbeta\ngamma\n"), processor);
 
-        IOException thrown = catchThrowableOfType(closer::close, IOException.class);
-
-        assertThat(closedResources).containsExactly("primary", "secondary");
-        assertThat(thrown)
-                .isNotNull()
-                .hasMessage("primary");
-        assertThat(thrown.getSuppressed())
-                .singleElement()
-                .isInstanceOfSatisfying(IOException.class, suppressed -> assertThat(suppressed).hasMessage("secondary"));
+        assertThat(processedLines).containsExactly("alpha", "beta");
+        assertThat(processor.seenLines()).containsExactly("alpha", "beta");
     }
 
-    private static final class FailingCloseable implements Closeable {
-        private final String name;
-        private final List<String> closedResources;
+    private static final class CapturingLineProcessor implements $LineProcessor<List<String>> {
+        private final int maximumLines;
+        private final List<String> seenLines = new ArrayList<>();
 
-        private FailingCloseable(String name, List<String> closedResources) {
-            this.name = name;
-            this.closedResources = closedResources;
+        private CapturingLineProcessor(int maximumLines) {
+            this.maximumLines = maximumLines;
         }
 
         @Override
-        public void close() throws IOException {
-            closedResources.add(name);
-            throw new IOException(name);
+        public boolean processLine(String line) {
+            seenLines.add(line);
+            return seenLines.size() < maximumLines;
+        }
+
+        @Override
+        public List<String> getResult() {
+            return List.copyOf(seenLines);
+        }
+
+        private List<String> seenLines() {
+            return List.copyOf(seenLines);
         }
     }
 }

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$EnumsTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$EnumsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.lang.reflect.Field;
+
+import org.immutables.value.internal.$guava$.base.$Enums;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnumsTest {
+
+    @Test
+    void getFieldReturnsDeclaredEnumFieldForRegularAndConstantSpecificEnumConstants() {
+        Field readyField = $Enums.getField(SampleStatus.READY);
+        Field customizedField = $Enums.getField(SampleStatus.CUSTOMIZED);
+
+        assertThat(readyField.getName()).isEqualTo("READY");
+        assertThat(readyField.getDeclaringClass()).isEqualTo(SampleStatus.class);
+        assertThat(readyField.isEnumConstant()).isTrue();
+
+        assertThat(customizedField.getName()).isEqualTo("CUSTOMIZED");
+        assertThat(customizedField.getDeclaringClass()).isEqualTo(SampleStatus.class);
+        assertThat(customizedField.isEnumConstant()).isTrue();
+        assertThat(SampleStatus.CUSTOMIZED.customized()).isTrue();
+    }
+
+    private enum SampleStatus {
+        READY,
+        CUSTOMIZED {
+            @Override
+            boolean customized() {
+                return true;
+            }
+        };
+
+        boolean customized() {
+            return false;
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$ObjectArraysTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$ObjectArraysTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import org.immutables.value.internal.$guava$.collect.$ObjectArrays;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectArraysTest {
+
+    @Test
+    void newArrayCreatesTypedArrayOfRequestedLength() {
+        String[] values = $ObjectArrays.newArray(String.class, 3);
+
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).hasSize(3);
+        assertThat(values).containsOnlyNulls();
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$ThrowablesTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$ThrowablesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+import org.immutables.value.internal.$guava$.base.$Throwables;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThrowablesTest {
+
+    @Test
+    void utilityMethodsExposeCausalChainAndStackTraceText() {
+        IllegalArgumentException root = new IllegalArgumentException("root cause");
+        IllegalStateException middle = new IllegalStateException("middle cause", root);
+        RuntimeException top = new RuntimeException("top level", middle);
+
+        assertThat($Throwables.getRootCause(top)).isSameAs(root);
+        assertThat($Throwables.getCausalChain(top)).containsExactly(top, middle, root);
+        assertThat($Throwables.getStackTraceAsString(top))
+                .contains(RuntimeException.class.getName())
+                .contains("top level")
+                .contains(ThrowablesTest.class.getName());
+    }
+
+    @Test
+    void invokeAccessibleNonThrowingMethodInvokesProvidedMethod() throws Throwable {
+        MethodHandle invokeAccessibleNonThrowingMethod = MethodHandles.privateLookupIn($Throwables.class, MethodHandles.lookup())
+                .findStatic(
+                        $Throwables.class,
+                        "invokeAccessibleNonThrowingMethod",
+                        MethodType.methodType(Object.class, Method.class, Object.class, Object[].class)
+                );
+        Method slice = SliceTarget.class.getMethod("slice", int.class, int.class);
+
+        Object result = (Object) invokeAccessibleNonThrowingMethod.invokeExact(
+                slice,
+                (Object) new SliceTarget(),
+                new Object[]{1, 5}
+        );
+
+        assertThat(result).isEqualTo("over");
+    }
+
+    public static final class SliceTarget {
+
+        public String slice(int beginIndex, int endIndex) {
+            return "coverage".substring(beginIndex, endIndex);
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ImmutableListMultimapTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ImmutableListMultimapTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import org.immutables.value.internal.$guava$.collect.$ImmutableListMultimap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImmutableListMultimapTest {
+
+    @Test
+    void immutableListMultimapRestoresKeysValuesAndOrderAcrossRoundTrip() throws Exception {
+        $ImmutableListMultimap<String, String> original = $ImmutableListMultimap.<String, String>builder()
+                .put("team", "ada")
+                .put("team", "grace")
+                .put("language", "java")
+                .put("language", "kotlin")
+                .build();
+
+        $ImmutableListMultimap<String, String> restored = roundTrip(original, $ImmutableListMultimap.class);
+
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.get("team")).containsExactly("ada", "grace");
+        assertThat(restored.get("language")).containsExactly("java", "kotlin");
+        assertThat(restored.inverse().get("ada")).containsExactly("team");
+        assertThat(restored.inverse().get("java")).containsExactly("language");
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomListMultimapTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomListMultimapTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.immutables.value.internal.$guava$.base.$Supplier;
+import org.immutables.value.internal.$guava$.collect.$ListMultimap;
+import org.immutables.value.internal.$guava$.collect.$Multimaps;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultimapsCustomListMultimapTest {
+
+    @Test
+    void customListMultimapRestoresFactoryAndEntriesAcrossRoundTrip() throws Exception {
+        $ListMultimap<String, String> original = $Multimaps.newListMultimap(
+                new LinkedHashMap<>(),
+                new SerializableArrayListSupplier<>()
+        );
+        original.put("team", "ada");
+        original.put("team", "grace");
+        original.put("language", "java");
+
+        assertThat(original.getClass().getName())
+                .isEqualTo("org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap");
+
+        $ListMultimap<String, String> restored = roundTrip((Serializable) original, $ListMultimap.class);
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace");
+        assertThat(restored.get("language")).containsExactly("java");
+        assertThat(restored.keySet()).containsExactly("team", "language");
+
+        restored.put("team", "margaret");
+        restored.put("database", "postgres");
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace", "margaret");
+        assertThat(restored.get("database")).containsExactly("postgres");
+        assertThat(restored.keySet()).containsExactly("team", "language", "database");
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static final class SerializableArrayListSupplier<T> implements $Supplier<List<T>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public List<T> get() {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomMultimapTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomMultimapTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+import org.immutables.value.internal.$guava$.base.$Supplier;
+import org.immutables.value.internal.$guava$.collect.$Multimap;
+import org.immutables.value.internal.$guava$.collect.$Multimaps;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultimapsCustomMultimapTest {
+
+    @Test
+    void customMultimapRestoresFactoryAndEntriesAcrossRoundTrip() throws Exception {
+        $Multimap<String, String> original = $Multimaps.newMultimap(
+                new LinkedHashMap<>(),
+                new SerializableArrayDequeSupplier<>()
+        );
+        original.put("team", "ada");
+        original.put("team", "grace");
+        original.put("language", "java");
+
+        assertThat(original.getClass().getName())
+                .isEqualTo("org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap");
+
+        $Multimap<String, String> restored = roundTrip((Serializable) original, $Multimap.class);
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace");
+        assertThat(restored.get("language")).containsExactly("java");
+        assertThat(restored.keySet()).containsExactly("team", "language");
+
+        restored.put("team", "margaret");
+        restored.put("database", "postgres");
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace", "margaret");
+        assertThat(restored.get("database")).containsExactly("postgres");
+        assertThat(restored.keySet()).containsExactly("team", "language", "database");
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static final class SerializableArrayDequeSupplier<T> implements $Supplier<Collection<T>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Collection<T> get() {
+            return new ArrayDeque<>();
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomSetMultimapTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomSetMultimapTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.immutables.value.internal.$guava$.base.$Supplier;
+import org.immutables.value.internal.$guava$.collect.$Multimaps;
+import org.immutables.value.internal.$guava$.collect.$SetMultimap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultimapsCustomSetMultimapTest {
+
+    @Test
+    void customSetMultimapRestoresFactoryAndEntriesAcrossRoundTrip() throws Exception {
+        $SetMultimap<String, String> original = $Multimaps.newSetMultimap(
+                new LinkedHashMap<>(),
+                new SerializableLinkedHashSetSupplier<>()
+        );
+        original.put("team", "ada");
+        original.put("team", "grace");
+        original.put("team", "ada");
+        original.put("language", "java");
+
+        assertThat(original.getClass().getName())
+                .isEqualTo("org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap");
+
+        $SetMultimap<String, String> restored = roundTrip((Serializable) original, $SetMultimap.class);
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace");
+        assertThat(restored.get("language")).containsExactly("java");
+        assertThat(restored.keySet()).containsExactly("team", "language");
+
+        restored.put("team", "margaret");
+        restored.put("team", "ada");
+        restored.put("database", "postgres");
+
+        assertThat(restored.get("team")).containsExactly("ada", "grace", "margaret");
+        assertThat(restored.get("database")).containsExactly("postgres");
+        assertThat(restored.keySet()).containsExactly("team", "language", "database");
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static final class SerializableLinkedHashSetSupplier<T> implements $Supplier<Set<T>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Set<T> get() {
+            return new LinkedHashSet<>();
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomSortedSetMultimapTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/MultimapsCustomSortedSetMultimapTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.immutables.value.internal.$guava$.base.$Supplier;
+import org.immutables.value.internal.$guava$.collect.$Multimaps;
+import org.immutables.value.internal.$guava$.collect.$SortedSetMultimap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultimapsCustomSortedSetMultimapTest {
+
+    @Test
+    void customSortedSetMultimapRestoresComparatorFactoryAndEntriesAcrossRoundTrip() throws Exception {
+        $SortedSetMultimap<String, String> original = $Multimaps.newSortedSetMultimap(
+                new LinkedHashMap<>(),
+                new SerializableReverseOrderStringTreeSetSupplier()
+        );
+        original.put("team", "alpha");
+        original.put("team", "gamma");
+        original.put("team", "beta");
+        original.put("team", "alpha");
+        original.put("language", "groovy");
+        original.put("language", "java");
+
+        assertThat(original.getClass().getName())
+                .isEqualTo("org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap");
+
+        $SortedSetMultimap<String, String> restored = roundTrip((Serializable) original, $SortedSetMultimap.class);
+
+        assertThat(restored.valueComparator()).isNotNull();
+        assertThat(restored.valueComparator().compare("alpha", "beta")).isGreaterThan(0);
+        assertThat(restored.get("team")).containsExactly("gamma", "beta", "alpha");
+        assertThat(restored.get("language")).containsExactly("java", "groovy");
+        assertThat(restored.keySet()).containsExactly("team", "language");
+
+        restored.put("team", "delta");
+        restored.put("team", "beta");
+        restored.put("database", "mysql");
+        restored.put("database", "postgres");
+
+        assertThat(restored.get("team")).containsExactly("gamma", "delta", "beta", "alpha");
+        assertThat(restored.get("database")).containsExactly("postgres", "mysql");
+        assertThat(restored.keySet()).containsExactly("team", "language", "database");
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static final class SerializableReverseOrderStringTreeSetSupplier
+            implements $Supplier<SortedSet<String>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public SortedSet<String> get() {
+            return new TreeSet<>(Comparator.reverseOrder());
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ProxyProcessorProxyClassLoaderTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ProxyProcessorProxyClassLoaderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.immutables.processor.ProxyProcessor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyProcessorProxyClassLoaderTest {
+
+    private static final String OSGI_ARCH_PROPERTY = "osgi.arch";
+    private static final String SUPPLIER_SERVICE_RESOURCE = "META-INF/services/java.util.function.Supplier";
+    private static final String ECLIPSE_COMPILER_ELEMENT_IMPL = "org.eclipse.jdt.internal.compiler.apt.model.ElementImpl";
+    private static final String ECLIPSE_PACKAGE_PREFIX = "org.eclipse.";
+    private static final String IMMUTABLES_PACKAGE_PREFIX = "org.immutables.";
+
+    @Test
+    void proxyProcessorLoadsEclipseTypesFromTheContextClassLoader() throws Exception {
+        String previousOsgiArch = System.getProperty(OSGI_ARCH_PROPERTY);
+        Thread currentThread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = currentThread.getContextClassLoader();
+
+        URL[] urls = {
+                codeSourceUrl(ProxyProcessorProxyClassLoaderTest.class),
+                resourceRootUrl(SUPPLIER_SERVICE_RESOURCE),
+                codeSourceUrl(ProxyProcessor.class)
+        };
+
+        try (ChildFirstClassLoader isolatedClassLoader = new ChildFirstClassLoader(urls, previousContextClassLoader)) {
+            System.setProperty(OSGI_ARCH_PROPERTY, "test-arch");
+            currentThread.setContextClassLoader(previousContextClassLoader);
+
+            Object supportedAnnotationTypes = ServiceLoader.load(Supplier.class, isolatedClassLoader)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected an isolated ProxyProcessor supplier"))
+                    .get();
+
+            assertThat(supportedAnnotationTypes).isInstanceOf(Set.class);
+            assertThat((Set<?>) supportedAnnotationTypes)
+                    .isNotEmpty()
+                    .allSatisfy(annotationType -> assertThat(annotationType).isInstanceOf(String.class).isNotEqualTo(""));
+
+            ClassLoader proxyClassLoader = supportedAnnotationTypes.getClass().getClassLoader();
+            assertThat(proxyClassLoader).isNotNull();
+            Class<?> eclipseCompilerType = proxyClassLoader.loadClass(ECLIPSE_COMPILER_ELEMENT_IMPL);
+            assertThat(eclipseCompilerType.getName()).isEqualTo(ECLIPSE_COMPILER_ELEMENT_IMPL);
+        } finally {
+            currentThread.setContextClassLoader(previousContextClassLoader);
+            restoreSystemProperty(previousOsgiArch);
+        }
+    }
+
+    private static URL codeSourceUrl(Class<?> type) {
+        CodeSource codeSource = type.getProtectionDomain().getCodeSource();
+        assertThat(codeSource).isNotNull();
+        return codeSource.getLocation();
+    }
+
+    private static URL resourceRootUrl(String resourceName) throws Exception {
+        URL resource = ProxyProcessorProxyClassLoaderTest.class.getClassLoader().getResource(resourceName);
+        assertThat(resource).isNotNull();
+        String resourceUrl = resource.toExternalForm();
+        assertThat(resourceUrl).endsWith(resourceName);
+        return java.net.URI.create(resourceUrl.substring(0, resourceUrl.length() - resourceName.length())).toURL();
+    }
+
+    private static void restoreSystemProperty(String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(OSGI_ARCH_PROPERTY);
+        } else {
+            System.setProperty(OSGI_ARCH_PROPERTY, previousValue);
+        }
+    }
+
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+
+        private ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    if (isChildFirst(name)) {
+                        try {
+                            loadedClass = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loadedClass = super.loadClass(name, false);
+                        }
+                    } else {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private boolean isChildFirst(String className) {
+            return className.startsWith(ECLIPSE_PACKAGE_PREFIX) || className.startsWith(IMMUTABLES_PACKAGE_PREFIX);
+        }
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/SerializationTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/SerializationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import org.immutables.value.Value;
+import org.immutables.value.internal.$guava$.collect.$ArrayListMultimap;
+import org.immutables.value.internal.$guava$.collect.$HashMultiset;
+import org.immutables.value.internal.$guava$.collect.$ImmutableSetMultimap;
+import org.immutables.value.internal.$guava$.collect.$MapMaker;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializationTest {
+    private static final MethodHandle WRITE_MAP = serializationMethod(
+            "writeMap",
+            MethodType.methodType(void.class, Map.class, ObjectOutputStream.class)
+    );
+    private static final MethodHandle POPULATE_MAP = serializationMethod(
+            "populateMap",
+            MethodType.methodType(void.class, Map.class, ObjectInputStream.class)
+    );
+
+    @Test
+    void serializableImmutableWithMapAttributePreservesEntriesAcrossRoundTrip() throws Exception {
+        ImmutableSerializableScoreboard original = ImmutableSerializableScoreboard.builder()
+                .putScores("wins", 12)
+                .putScores("losses", 2)
+                .build();
+
+        ImmutableSerializableScoreboard restored = roundTrip(original, ImmutableSerializableScoreboard.class);
+
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.scores()).containsExactlyInAnyOrderEntriesOf(original.scores());
+    }
+
+    @Test
+    void mapMakerWeakKeyMapPreservesEntriesAcrossRoundTripWhenKeysRemainStronglyReachable() throws Exception {
+        String alpha = new String("alpha");
+        String beta = new String("beta");
+        ConcurrentMap<String, Integer> original = new $MapMaker()
+                .weakKeys()
+                .makeMap();
+        original.put(alpha, 1);
+        original.put(beta, 2);
+
+        SerializableWeakKeyMapHolder restored = roundTrip(
+                new SerializableWeakKeyMapHolder(original, List.of(alpha, beta)),
+                SerializableWeakKeyMapHolder.class
+        );
+
+        assertThat(restored.keys).containsExactlyInAnyOrder("alpha", "beta");
+        assertThat(restored.map).hasSize(2);
+        assertThat(restored.map.values()).containsExactlyInAnyOrder(1, 2);
+        assertThat(restored.map.keySet()).containsExactlyInAnyOrderElementsOf(restored.keys);
+    }
+
+    @Test
+    void packagePrivateMapSerializationHelpersRoundTripLinkedHashMapEntries() throws Throwable {
+        LinkedHashMap<String, Integer> original = new LinkedHashMap<>();
+        original.put("wins", 12);
+        original.put("losses", 2);
+
+        LinkedHashMap<String, Integer> restored = new LinkedHashMap<>();
+        populateMapPayload(restored, serializeMapPayload(original));
+
+        assertThat(restored).containsExactlyEntriesOf(original);
+    }
+
+    @Test
+    void mutableArrayListMultimapPreservesKeysAndValueOrderAcrossRoundTrip() throws Exception {
+        $ArrayListMultimap<String, String> original = $ArrayListMultimap.create();
+        original.put("team", "ada");
+        original.put("team", "grace");
+        original.put("language", "java");
+
+        $ArrayListMultimap<String, String> restored = roundTrip(original, $ArrayListMultimap.class);
+
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.get("team")).containsExactly("ada", "grace");
+        assertThat(restored.get("language")).containsExactly("java");
+    }
+
+    @Test
+    void mutableHashMultisetPreservesDistinctElementCountsAcrossRoundTrip() throws Exception {
+        $HashMultiset<String> original = $HashMultiset.create();
+        original.add("alpha", 3);
+        original.add("beta", 1);
+
+        $HashMultiset<String> restored = roundTrip(original, $HashMultiset.class);
+
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.count("alpha")).isEqualTo(3);
+        assertThat(restored.count("beta")).isEqualTo(1);
+        assertThat(restored.elementSet()).containsExactlyInAnyOrder("alpha", "beta");
+    }
+
+    @Test
+    void immutableSetMultimapRebuildsInverseStateAcrossRoundTrip() throws Exception {
+        $ImmutableSetMultimap<String, String> original = $ImmutableSetMultimap.<String, String>builder()
+                .put("team", "ada")
+                .put("team", "grace")
+                .put("language", "java")
+                .build();
+
+        $ImmutableSetMultimap<String, String> restored = roundTrip(original, $ImmutableSetMultimap.class);
+
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.get("team")).containsExactlyInAnyOrder("ada", "grace");
+        assertThat(restored.inverse().get("ada")).containsExactly("team");
+    }
+
+    private static void populateMapPayload(Map<?, ?> target, byte[] serialized) throws Throwable {
+        Map<?, ?> map = target;
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            POPULATE_MAP.invokeExact(map, objectInputStream);
+        }
+    }
+
+    private static byte[] serializeMapPayload(Map<?, ?> value) throws Throwable {
+        Map<?, ?> map = value;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            WRITE_MAP.invokeExact(map, objectOutputStream);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static MethodHandle serializationMethod(String methodName, MethodType methodType) {
+        try {
+            Class<?> serializationClass = Class.forName("org.immutables.value.internal.$guava$.collect.$Serialization");
+            return MethodHandles.privateLookupIn(serializationClass, MethodHandles.lookup())
+                    .findStatic(serializationClass, methodName, methodType);
+        } catch (ReflectiveOperationException exception) {
+            throw new AssertionError(exception);
+        }
+    }
+
+    private static <T> T roundTrip(Serializable value, Class<T> expectedType) throws IOException, ClassNotFoundException {
+        byte[] serialized = serialize(value);
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object restored = objectInputStream.readObject();
+            assertThat(restored).isInstanceOf(expectedType);
+            return expectedType.cast(restored);
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static final class SerializableWeakKeyMapHolder implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        final ConcurrentMap<String, Integer> map;
+        final List<String> keys;
+
+        private SerializableWeakKeyMapHolder(ConcurrentMap<String, Integer> map, List<String> keys) {
+            this.map = map;
+            this.keys = keys;
+        }
+    }
+}
+
+@Value.Immutable
+interface SerializableScoreboard extends Serializable {
+    Map<String, Integer> scores();
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ValueTest.java
+++ b/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/ValueTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_immutables.value;
+
+import org.immutables.value.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ValueTest {
+
+    @BeforeEach
+    void resetLazyCounter() {
+        ValidatedRange.resetLazyCalls();
+    }
+
+    @Test
+    void immutableBuilderSupportsDefaultsDerivedValuesCollectionsAndCopying() {
+        List<String> seedTags = new ArrayList<>(List.of("core"));
+        Map<String, Integer> seedScores = new LinkedHashMap<>();
+        seedScores.put("math", 10);
+
+        ImmutablePerson person = ImmutablePerson.builder()
+                .name("Ada")
+                .nickname("Ace")
+                .addTags("founder")
+                .addAllTags(seedTags)
+                .putAllScores(seedScores)
+                .putScores("logic", 9)
+                .secret("hidden")
+                .build();
+
+        seedTags.add("mutated-after-build");
+        seedScores.put("mutated-after-build", 0);
+
+        assertThat(person.name()).isEqualTo("Ada");
+        assertThat(person.age()).isEqualTo(18);
+        assertThat(person.nickname()).contains("Ace");
+        assertThat(person.tags()).containsExactly("founder", "core");
+        assertThat(person.scores()).containsEntry("math", 10).containsEntry("logic", 9);
+        assertThat(person.label()).isEqualTo("Ada:18");
+        assertThat(person.toString())
+                .contains("name=Ada")
+                .contains("age=18")
+                .contains("nickname=Ace")
+                .contains("label=Ada:18")
+                .doesNotContain("hidden")
+                .doesNotContain("secret");
+
+        assertThatThrownBy(() -> person.tags().add("extra"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> person.scores().put("extra", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        ImmutablePerson updated = person.withAge(21)
+                .withNickname(Optional.empty())
+                .withTags(List.of("replaced"))
+                .withScores(Map.of("science", 11));
+
+        assertThat(updated).isNotSameAs(person);
+        assertThat(updated.age()).isEqualTo(21);
+        assertThat(updated.nickname()).isEmpty();
+        assertThat(updated.tags()).containsExactly("replaced");
+        assertThat(updated.scores()).containsExactly(Map.entry("science", 11));
+        assertThat(updated.label()).isEqualTo("Ada:21");
+
+        assertThat(ImmutablePerson.copyOf(person)).isSameAs(person);
+        assertThat(ImmutablePerson.builder().from(person).age(22).build())
+                .usingRecursiveComparison()
+                .isEqualTo(person.withAge(22));
+    }
+
+    @Test
+    void immutableBuilderReportsMissingRequiredAttributes() {
+        assertThatThrownBy(() -> ImmutablePerson.builder().build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("name")
+                .hasMessageContaining("secret");
+    }
+
+    @Test
+    void parameterFactoriesAndSingletonInstancesRemainConvenientAndStable() {
+        ImmutablePair pair = ImmutablePair.of(3, 4);
+
+        assertThat(pair.left()).isEqualTo(3);
+        assertThat(pair.right()).isEqualTo(4);
+        assertThat(pair).isEqualTo(ImmutablePair.builder().left(3).right(4).build());
+        assertThat(ImmutablePair.copyOf(pair)).isSameAs(pair);
+        assertThat(ImmutablePair.builder().from(pair).right(7).build())
+                .isEqualTo(ImmutablePair.of(3, 7));
+        assertThat(pair.withLeft(8)).isEqualTo(ImmutablePair.of(8, 4));
+
+        ImmutableMarker singleton = ImmutableMarker.of();
+        assertThat(ImmutableMarker.builder().build()).isSameAs(singleton);
+        assertThat(ImmutableMarker.copyOf(singleton)).isSameAs(singleton);
+        assertThat(singleton.toString()).isEqualTo("Marker{}");
+    }
+
+    @Test
+    void checkMethodsAndLazyAttributesValidateAndCacheComputedState() {
+        ImmutableValidatedRange range = ImmutableValidatedRange.builder()
+                .min(2)
+                .max(5)
+                .build();
+
+        assertThat(range.span()).isEqualTo(3);
+        assertThat(range.span()).isEqualTo(3);
+        assertThat(ValidatedRange.lazyCalls()).isEqualTo(1);
+
+        ImmutableValidatedRange expanded = ImmutableValidatedRange.builder()
+                .from(range)
+                .max(8)
+                .build();
+
+        assertThat(expanded.span()).isEqualTo(6);
+        assertThat(ValidatedRange.lazyCalls()).isEqualTo(2);
+        assertThat(expanded).isEqualTo(range.withMax(8));
+        assertThat(ImmutableValidatedRange.copyOf(range)).isSameAs(range);
+
+        assertThatThrownBy(() -> ImmutableValidatedRange.builder().min(9).max(4).build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("min must not exceed max");
+    }
+
+    @Test
+    void internedImmutableCanonicalizesEqualInstancesAcrossSeparateBuilds() {
+        ImmutableInternedPoint first = ImmutableInternedPoint.builder()
+                .x(3)
+                .y(5)
+                .build();
+        ImmutableInternedPoint same = ImmutableInternedPoint.builder()
+                .x(3)
+                .y(5)
+                .build();
+
+        ImmutableInternedPoint changed = first.withY(8);
+        ImmutableInternedPoint rebuiltChanged = ImmutableInternedPoint.builder()
+                .x(3)
+                .y(8)
+                .build();
+
+        assertThat(same).isSameAs(first);
+        assertThat(changed).isNotSameAs(first);
+        assertThat(rebuiltChanged).isSameAs(changed);
+    }
+
+    @Test
+    void modifiableObjectsTrackInitializationAndMergeStateIncrementally() {
+        ModifiableEditableProfile profile = ModifiableEditableProfile.create();
+        ModifiableEditableProfile incoming = ModifiableEditableProfile.create();
+
+        assertThat(profile.isInitialized()).isFalse();
+        assertThat(profile.nameIsSet()).isFalse();
+        assertThat(profile).isNotEqualTo(incoming);
+        assertThat(profile.toString()).contains("name=?");
+
+        profile.setTitle("Lead")
+                .addTags("core")
+                .setName("Ada");
+
+        assertThat(profile.isInitialized()).isTrue();
+        assertThat(profile.name()).isEqualTo("Ada");
+        assertThat(profile.title()).contains("Lead");
+        assertThat(profile.tags()).containsExactly("core");
+
+        incoming.setName("Grace")
+                .addTags("ops");
+
+        profile.from(incoming);
+
+        assertThat(profile.name()).isEqualTo("Grace");
+        assertThat(profile.title()).contains("Lead");
+        assertThat(profile.tags()).containsExactly("core", "ops");
+
+        profile.unsetName();
+        assertThat(profile.isInitialized()).isFalse();
+        assertThat(profile.nameIsSet()).isFalse();
+
+        profile.clear();
+        assertThat(profile.title()).isEmpty();
+        assertThat(profile.tags()).isEmpty();
+        assertThat(profile.nameIsSet()).isFalse();
+    }
+}
+
+@Value.Immutable
+interface Person {
+    String name();
+
+    @Value.Default
+    default int age() {
+        return 18;
+    }
+
+    Optional<String> nickname();
+
+    List<String> tags();
+
+    Map<String, Integer> scores();
+
+    @Value.Redacted
+    String secret();
+
+    @Value.Derived
+    default String label() {
+        return name() + ":" + age();
+    }
+}
+
+@Value.Immutable
+interface Pair {
+    @Value.Parameter
+    int left();
+
+    @Value.Parameter
+    int right();
+}
+
+@Value.Immutable(singleton = true)
+interface Marker {
+}
+
+@Value.Modifiable
+interface EditableProfile {
+    String name();
+
+    Optional<String> title();
+
+    List<String> tags();
+}
+
+@Value.Immutable(intern = true)
+interface InternedPoint {
+    int x();
+
+    int y();
+}
+
+@Value.Immutable
+abstract class ValidatedRange {
+    private static final AtomicInteger LAZY_CALLS = new AtomicInteger();
+
+    abstract int min();
+
+    abstract int max();
+
+    @Value.Check
+    protected void validate() {
+        if (min() > max()) {
+            throw new IllegalStateException("min must not exceed max");
+        }
+    }
+
+    @Value.Lazy
+    int span() {
+        LAZY_CALLS.incrementAndGet();
+        return max() - min();
+    }
+
+    static int lazyCalls() {
+        return LAZY_CALLS.get();
+    }
+
+    static void resetLazyCalls() {
+        LAZY_CALLS.set(0);
+    }
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,102 @@
+{
+  "reflection" : [
+    {
+      "type" : "org_immutables.value.ImmutableSerializableScoreboard",
+      "serializable" : true
+    },
+    {
+      "type" : "org_immutables.value.SerializationTest$SerializableWeakKeyMapHolder",
+      "serializable" : true
+    },
+    {
+      "type" : "org.immutables.value.internal.$guava$.collect.$Serialization",
+      "methods" : [
+        {
+          "name" : "writeMap",
+          "parameterTypes" : [
+            "java.util.Map",
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name" : "populateMap",
+          "parameterTypes" : [
+            "java.util.Map",
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org_immutables.value.MultimapsCustomListMultimapTest$SerializableArrayListSupplier",
+      "serializable" : true
+    },
+    {
+      "type" : "org_immutables.value.MultimapsCustomMultimapTest$SerializableArrayDequeSupplier",
+      "serializable" : true
+    },
+    {
+      "type" : "org_immutables.value.MultimapsCustomSetMultimapTest$SerializableLinkedHashSetSupplier",
+      "serializable" : true
+    },
+    {
+      "type" : "org_immutables.value.MultimapsCustomSortedSetMultimapTest$SerializableReverseOrderStringTreeSetSupplier",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.processor.ProxyProcessor"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.apt.model.ElementImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.base.$Enums"
+      },
+      "type" : "org_immutables.value.EnumsTest$SampleStatus"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomListMultimap"
+      },
+      "type" : "org_immutables.value.MultimapsCustomListMultimapTest$SerializableArrayListSupplier",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomMultimap"
+      },
+      "type" : "org_immutables.value.MultimapsCustomMultimapTest$SerializableArrayDequeSupplier",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSetMultimap"
+      },
+      "type" : "org_immutables.value.MultimapsCustomSetMultimapTest$SerializableLinkedHashSetSupplier",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.collect.$Multimaps$CustomSortedSetMultimap"
+      },
+      "type" : "org_immutables.value.MultimapsCustomSortedSetMultimapTest$SerializableReverseOrderStringTreeSetSupplier",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.immutables.value.internal.$guava$.base.$Throwables"
+      },
+      "type" : "org_immutables.value.ThrowablesTest$SliceTarget",
+      "methods" : [
+        {
+          "name" : "slice",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -9,25 +9,6 @@
       "serializable" : true
     },
     {
-      "type" : "org.immutables.value.internal.$guava$.collect.$Serialization",
-      "methods" : [
-        {
-          "name" : "writeMap",
-          "parameterTypes" : [
-            "java.util.Map",
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name" : "populateMap",
-          "parameterTypes" : [
-            "java.util.Map",
-            "java.io.ObjectInputStream"
-          ]
-        }
-      ]
-    },
-    {
       "type" : "org_immutables.value.MultimapsCustomListMultimapTest$SerializableArrayListSupplier",
       "serializable" : true
     },

--- a/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/services/java.util.function.Supplier
+++ b/tests/src/org.immutables/value/2.9.0/src/test/resources/META-INF/services/java.util.function.Supplier
@@ -1,0 +1,1 @@
+org.eclipse.fake.ProxyProcessorCaller

--- a/tests/src/org.immutables/value/2.9.0/user-code-filter.json
+++ b/tests/src/org.immutables/value/2.9.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.immutables.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3487

This PR provides test fixes and new metadata for org.immutables:value:2.9.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 111058
- Cached input tokens: 1170944
- Output tokens: 7650
- Entries found: 82
- Iterations: 2
- Library coverage percentage: 2.56
- Previous library version metadata entries: 78
- Previous library version coverage percentage: 2.61

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1bc4d0904f01134a9ffffc5307dfcefc0f1f3c2b`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.immutables:value:2.8.6: 51/51 covered calls (100.00%)
- org.immutables:value:2.9.0: 50/50 covered calls (100.00%)

**Reflection:**
- org.immutables:value:2.8.6: 50/50 covered calls (100.00%)
- org.immutables:value:2.9.0: 49/49 covered calls (100.00%)

**Resources:**
- org.immutables:value:2.8.6: 1/1 covered calls (100.00%)
- org.immutables:value:2.9.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.immutables:value:2.8.6: 6540/295763 (2.21%)
- org.immutables:value:2.9.0: 6656/308002 (2.16%)

**Line:**
- org.immutables:value:2.8.6: 1578/60535 (2.61%)
- org.immutables:value:2.9.0: 1600/62513 (2.56%)

**Method:**
- org.immutables:value:2.8.6: 646/10250 (6.30%)
- org.immutables:value:2.9.0: 649/10416 (6.23%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.immutables/value/2.8.6/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java 2/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
index d12eef85b0..a8c44f1ea3 100644
--- 1/tests/src/org.immutables/value/2.8.6/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
+++ 2/tests/src/org.immutables/value/2.9.0/src/test/java/org_immutables/value/$Closer$SuppressingSuppressorTest.java
@@ -6,51 +6,50 @@
  */
 package org_immutables.value;
 
-import java.io.Closeable;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.immutables.value.internal.$guava$.io.$Closer;
+import org.immutables.value.internal.$guava$.io.$CharStreams;
+import org.immutables.value.internal.$guava$.io.$LineProcessor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
-class CloserSuppressingSuppressorTest {
+class CharStreamsLineProcessorTest {
 
     @Test
-    void closeAddsLaterCloseFailuresAsSuppressedExceptions() {
-        List<String> closedResources = new ArrayList<>();
-        $Closer closer = $Closer.create();
-
-        closer.register(new FailingCloseable("secondary", closedResources));
-        closer.register(new FailingCloseable("primary", closedResources));
-
-        IOException thrown = catchThrowableOfType(closer::close, IOException.class);
-
-        assertThat(closedResources).containsExactly("primary", "secondary");
-        assertThat(thrown)
-                .isNotNull()
-                .hasMessage("primary");
-        assertThat(thrown.getSuppressed())
-                .singleElement()
-                .isInstanceOfSatisfying(IOException.class, suppressed -> assertThat(suppressed).hasMessage("secondary"));
+    void readLinesStopsWhenProcessorReturnsFalse() throws IOException {
+        CapturingLineProcessor processor = new CapturingLineProcessor(2);
+
+        List<String> processedLines = $CharStreams.readLines(new StringReader("alpha\nbeta\ngamma\n"), processor);
+
+        assertThat(processedLines).containsExactly("alpha", "beta");
+        assertThat(processor.seenLines()).containsExactly("alpha", "beta");
     }
 
-    private static final class FailingCloseable implements Closeable {
-        private final String name;
-        private final List<String> closedResources;
+    private static final class CapturingLineProcessor implements $LineProcessor<List<String>> {
+        private final int maximumLines;
+        private final List<String> seenLines = new ArrayList<>();
 
-        private FailingCloseable(String name, List<String> closedResources) {
-            this.name = name;
-            this.closedResources = closedResources;
+        private CapturingLineProcessor(int maximumLines) {
+            this.maximumLines = maximumLines;
         }
 
         @Override
-        public void close() throws IOException {
-            closedResources.add(name);
-            throw new IOException(name);
+        public boolean processLine(String line) {
+            seenLines.add(line);
+            return seenLines.size() < maximumLines;
+        }
+
+        @Override
+        public List<String> getResult() {
+            return List.copyOf(seenLines);
+        }
+
+        private List<String> seenLines() {
+            return List.copyOf(seenLines);
         }
     }
 }

```
