### PR TITLE
[Automation] Generated metadata for org.springframework.boot:spring-boot-configuration-processor:3.4.0

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-configuration-processor/3.4.0/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-configuration-processor/3.4.0/reachability-metadata.json
@@ -1,0 +1,216 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Tree"
+      },
+      "type" : "com.sun.source.tree.ClassTree",
+      "methods" : [
+        {
+          "name" : "getMembers",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.ExpressionTree"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.LiteralTree",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.MemberSelectTree",
+      "methods" : [
+        {
+          "name" : "getExpression",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getIdentifier",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.MethodInvocationTree",
+      "methods" : [
+        {
+          "name" : "getArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.VariableTree"
+      },
+      "type" : "com.sun.source.tree.ModifiersTree",
+      "methods" : [
+        {
+          "name" : "getFlags",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.NewArrayTree",
+      "methods" : [
+        {
+          "name" : "getInitializers",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.ExpressionTree"
+      },
+      "type" : "com.sun.source.tree.Tree",
+      "methods" : [
+        {
+          "name" : "getKind",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Tree"
+      },
+      "type" : "com.sun.source.tree.Tree",
+      "methods" : [
+        {
+          "name" : "accept",
+          "parameterTypes" : [
+            "com.sun.source.tree.TreeVisitor",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Tree"
+      },
+      "type" : "com.sun.source.tree.TreeVisitor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.VariableTree"
+      },
+      "type" : "com.sun.source.tree.VariableTree",
+      "methods" : [
+        {
+          "name" : "getInitializer",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getModifiers",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Trees"
+      },
+      "type" : "com.sun.source.util.Trees",
+      "methods" : [
+        {
+          "name" : "getTree",
+          "parameterTypes" : [
+            "javax.lang.model.element.Element"
+          ]
+        },
+        {
+          "name" : "instance",
+          "parameterTypes" : [
+            "javax.annotation.processing.ProcessingEnvironment"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Trees"
+      },
+      "type" : "com.sun.tools.javac.api.JavacTrees",
+      "methods" : [
+        {
+          "name" : "instance",
+          "parameterTypes" : [
+            "javax.annotation.processing.ProcessingEnvironment"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Trees"
+      },
+      "type" : "javax.annotation.processing.ProcessingEnvironment"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.Tree"
+      },
+      "type" : {
+        "proxy" : [
+          "com.sun.source.tree.TreeVisitor"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.JavaCompilerFieldValuesParser"
+      },
+      "module" : "java.base",
+      "glob" : "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.JavaCompilerFieldValuesParser"
+      },
+      "module" : "jdk.compiler",
+      "bundle" : "com.sun.tools.javac.resources.compiler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.configurationprocessor.fieldvalues.javac.JavaCompilerFieldValuesParser"
+      },
+      "module" : "jdk.compiler",
+      "bundle" : "com.sun.tools.javac.resources.javac"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-configuration-processor/index.json
+++ b/metadata/org.springframework.boot/spring-boot-configuration-processor/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.4.0",
+    "test-version" : "2.7.18",
+    "tested-versions" : [
+      "3.4.0"
+    ],
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-configuration-processor/3.4.0/spring-boot-configuration-processor-3.4.0-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v3.4.0/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-configuration-processor/3.4.0/spring-boot-configuration-processor-3.4.0-javadoc.jar",
+    "description" : "Spring Boot Configuration Processor is a compile-time Java annotation processor that generates configuration metadata from Spring Boot configuration property classes. The generated metadata helps IDEs and other tools provide contextual documentation, validation hints, and property completion for Spring Boot application configuration.",
+    "allowed-packages" : [
+      "org.springframework.boot.configurationprocessor"
+    ]
+  },
+  {
     "metadata-version" : "2.7.18",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-configuration-processor/2.7.18/spring-boot-configuration-processor-2.7.18-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/stats/org.springframework.boot/spring-boot-configuration-processor/3.4.0/stats.json
+++ b/stats/org.springframework.boot/spring-boot-configuration-processor/3.4.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.4.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.904762,
+          "coveredCalls" : 19,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 0.904762,
+      "coveredCalls" : 19,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 993,
+        "missed" : 9891,
+        "ratio" : 0.091235,
+        "total" : 10884
+      },
+      "line" : {
+        "covered" : 187,
+        "missed" : 2119,
+        "ratio" : 0.081093,
+        "total" : 2306
+      },
+      "method" : {
+        "covered" : 35,
+        "missed" : 530,
+        "ratio" : 0.061947,
+        "total" : 565
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3491

This PR provides new metadata needed for the org.springframework.boot:spring-boot-configuration-processor:3.4.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.springframework.boot:spring-boot-configuration-processor:2.7.18`): 29
- Metadata entries (new `org.springframework.boot:spring-boot-configuration-processor:3.4.0`): 37
- Library coverage (previous): 8.47%
- Library coverage (new): 8.11%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `00f60507d25115d26261afb20a9c36a372920086`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework.boot:spring-boot-configuration-processor:2.7.18: 19/19 covered calls (100.00%)
- org.springframework.boot:spring-boot-configuration-processor:3.4.0: 19/21 covered calls (90.48%)

**Reflection:**
- org.springframework.boot:spring-boot-configuration-processor:2.7.18: 19/19 covered calls (100.00%)
- org.springframework.boot:spring-boot-configuration-processor:3.4.0: 19/21 covered calls (90.48%)

#### Library coverage

**Instruction:**
- org.springframework.boot:spring-boot-configuration-processor:2.7.18: 975/10193 (9.57%)
- org.springframework.boot:spring-boot-configuration-processor:3.4.0: 993/10884 (9.12%)

**Line:**
- org.springframework.boot:spring-boot-configuration-processor:2.7.18: 184/2173 (8.47%)
- org.springframework.boot:spring-boot-configuration-processor:3.4.0: 187/2306 (8.11%)

**Method:**
- org.springframework.boot:spring-boot-configuration-processor:2.7.18: 35/518 (6.76%)
- org.springframework.boot:spring-boot-configuration-processor:3.4.0: 35/565 (6.19%)
