### PR TITLE
[GenAI] Test fix for org.apache.httpcomponents:httpcore:4.4.12 using gpt-5.5

### DIFF
--- a/metadata/org.apache.httpcomponents/httpcore/4.4.12/reachability-metadata.json
+++ b/metadata/org.apache.httpcomponents/httpcore/4.4.12/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.ExceptionUtils"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "initCause",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.VersionInfo"
+      },
+      "glob": "org/apache/http/version.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -1,5 +1,15 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "4.4.12",
+    "tested-versions" : [
+      "4.4.12"
+    ],
+    "allowed-packages" : [
+      "org.apache.http"
+    ]
+  },
+  {
     "metadata-version" : "4.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",
@@ -42,7 +52,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "4.4.11",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.12",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.12/httpcore-4.4.12-sources.jar",
+    "repository-url" : "https://github.com/apache/httpcomponents-core",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.12/httpcore-4.4.12-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.12/httpcore-4.4.12-javadoc.jar",
+    "description" : "Apache HttpCore provides low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
     "tested-versions" : [
       "4.4.12"
     ],

--- a/stats/org.apache.httpcomponents/httpcore/4.4.12/execution-metrics.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.12/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-04-30": {
+    "timestamp": "2026-04-30T03:05:30.978496Z",
+    "library": "org.apache.httpcomponents:httpcore:4.4.12",
+    "starting_commit": "089f7c80a1523b0cfa6dc0f25848f5ebdd7db35b",
+    "ending_commit": "3d970d0b4470ddf04124d1c894780cca7f50ff5d",
+    "previous_library": "org.apache.httpcomponents:httpcore:4.4.11",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.12",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24556,
+          "ratio": 0.013102,
+          "total": 24882
+        },
+        "line": {
+          "covered": 85,
+          "missed": 6065,
+          "ratio": 0.013821,
+          "total": 6150
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1408,
+          "ratio": 0.015385,
+          "total": 1430
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.4.11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24447,
+          "ratio": 0.013159,
+          "total": 24773
+        },
+        "line": {
+          "covered": 85,
+          "missed": 6051,
+          "ratio": 0.013853,
+          "total": 6136
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1404,
+          "ratio": 0.015428,
+          "total": 1426
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 29913,
+      "cached_input_tokens_used": 199680,
+      "output_tokens_used": 1694,
+      "iterations": 1,
+      "cost_usd": 0.1506,
+      "tested_library_loc": 85,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 1.38,
+      "previous_library_coverage_percent": 1.39
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java",
+      "metadata_file": "metadata/org.apache.httpcomponents/httpcore/4.4.12/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.httpcomponents/httpcore/4.4.12/stats.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.12/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.12",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 326,
+        "missed" : 24556,
+        "ratio" : 0.013102,
+        "total" : 24882
+      },
+      "line" : {
+        "covered" : 85,
+        "missed" : 6065,
+        "ratio" : 0.013821,
+        "total" : 6150
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 1408,
+        "ratio" : 0.015385,
+        "total" : 1430
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/.gitignore
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/build.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.httpcomponents:httpcore:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.httpcomponents:httpcore:4.4.12
+library.version = 4.4.12
+metadata.dir = org.apache.httpcomponents/httpcore/4.4.12/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/settings.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.httpcomponents.httpcore_tests'

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class ExceptionUtilsTest {
+
+    @Test
+    void initCauseAssignsTheProvidedCause() {
+        IllegalArgumentException throwable = new IllegalArgumentException("outer");
+        IllegalStateException cause = new IllegalStateException("inner");
+
+        ExceptionUtils.initCause(throwable, cause);
+
+        assertThat(throwable).hasCause(cause);
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.entity.SerializableEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializableEntityTest {
+
+    @Test
+    void bufferizedEntitySerializesContentWhenCreated() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta"));
+
+        SerializableEntity entity = new SerializableEntity(payload, true);
+        byte[] expectedBytes = serialize(payload);
+
+        assertThat(entity.isRepeatable()).isTrue();
+        assertThat(entity.isStreaming()).isFalse();
+        assertThat(entity.getContentLength()).isEqualTo(expectedBytes.length);
+        assertThat(readAllBytes(entity.getContent())).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    void streamingEntityWritesSerializedObjectToOutputStream() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("gamma", "delta"));
+
+        SerializableEntity entity = new SerializableEntity(payload);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        assertThat(entity.isStreaming()).isTrue();
+
+        entity.writeTo(out);
+
+        assertThat(out.toByteArray()).isEqualTo(serialize(payload));
+    }
+
+    private static byte[] readAllBytes(InputStream content) throws IOException {
+        try (InputStream inputStream = content) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionInfoTest {
+
+    @Test
+    void loadVersionInfoReadsPackagedVersionProperties() {
+        ClassLoader classLoader = VersionInfo.class.getClassLoader();
+        VersionInfo versionInfo = VersionInfo.loadVersionInfo("org.apache.http", classLoader);
+
+        assertThat(versionInfo).isNotNull();
+        assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
+        assertThat(versionInfo.getModule()).isEqualTo("httpcore");
+        assertThat(versionInfo.getRelease()).isEqualTo("4.4.11");
+        assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
+        assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
+    }
+
+    @Test
+    void getUserAgentUsesThePackagedRelease() {
+        String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
+
+        assertThat(userAgent)
+                .isEqualTo("httpcore-test/4.4.11 (Java/" + System.getProperty("java.version") + ")");
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionInfoTest {
 
+    private static final String EXPECTED_RELEASE = "4.4.12";
+
     @Test
     void loadVersionInfoReadsPackagedVersionProperties() {
         ClassLoader classLoader = VersionInfo.class.getClassLoader();
@@ -21,7 +23,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.11");
+        assertThat(versionInfo.getRelease()).isEqualTo(EXPECTED_RELEASE);
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +33,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.11 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/" + EXPECTED_RELEASE + " (Java/" + System.getProperty("java.version") + ")");
     }
 }

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.12/user-code-filter.json
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.12/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3486

This PR provides test fixes and new metadata for org.apache.httpcomponents:httpcore:4.4.12, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 29913
- Cached input tokens: 199680
- Output tokens: 1694
- Entries found: 7
- Iterations: 1
- Library coverage percentage: 1.38
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 1.39

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1bc4d0904f01134a9ffffc5307dfcefc0f1f3c2b`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.httpcomponents:httpcore:4.4.11: 4/4 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.12: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.httpcomponents:httpcore:4.4.11: 3/3 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.12: 3/3 covered calls (100.00%)

**Resources:**
- org.apache.httpcomponents:httpcore:4.4.11: 1/1 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.12: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.httpcomponents:httpcore:4.4.11: 326/24773 (1.32%)
- org.apache.httpcomponents:httpcore:4.4.12: 326/24882 (1.31%)

**Line:**
- org.apache.httpcomponents:httpcore:4.4.11: 85/6136 (1.39%)
- org.apache.httpcomponents:httpcore:4.4.12: 85/6150 (1.38%)

**Method:**
- org.apache.httpcomponents:httpcore:4.4.11: 22/1426 (1.54%)
- org.apache.httpcomponents:httpcore:4.4.12: 22/1430 (1.54%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java 2/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
index 5a5ce49b83..eafdd6ab3b 100644
--- 1/tests/src/org.apache.httpcomponents/httpcore/4.4.11/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ 2/tests/src/org.apache.httpcomponents/httpcore/4.4.12/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionInfoTest {
 
+    private static final String EXPECTED_RELEASE = "4.4.12";
+
     @Test
     void loadVersionInfoReadsPackagedVersionProperties() {
         ClassLoader classLoader = VersionInfo.class.getClassLoader();
@@ -21,7 +23,7 @@ class VersionInfoTest {
         assertThat(versionInfo).isNotNull();
         assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
         assertThat(versionInfo.getModule()).isEqualTo("httpcore");
-        assertThat(versionInfo.getRelease()).isEqualTo("4.4.11");
+        assertThat(versionInfo.getRelease()).isEqualTo(EXPECTED_RELEASE);
         assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
         assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
     }
@@ -31,6 +33,6 @@ class VersionInfoTest {
         String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
 
         assertThat(userAgent)
-                .isEqualTo("httpcore-test/4.4.11 (Java/" + System.getProperty("java.version") + ")");
+                .isEqualTo("httpcore-test/" + EXPECTED_RELEASE + " (Java/" + System.getProperty("java.version") + ")");
     }
 }

```
