### PR TITLE
[GenAI] Add support for org.clojure:google-closure-library-third-party:0.0-20150505-021ed5b3 using gpt-5.5

### DIFF
--- a/metadata/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/reachability-metadata.json
+++ b/metadata/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "glob" : "goog/**"
+    },
+    {
+      "glob" : "README.md"
+    },
+    {
+      "glob" : "AUTHORS"
+    },
+    {
+      "glob" : "LICENSE"
+    }
+  ]
+}

--- a/metadata/org.clojure/google-closure-library-third-party/index.json
+++ b/metadata/org.clojure/google-closure-library-third-party/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.0-20150505-021ed5b3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/google-closure-library-third-party-0.0-20150505-021ed5b3-sources.jar",
+    "repository-url" : "https://github.com/google/closure-library",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/google-closure-library-third-party-0.0-20150505-021ed5b3-sources.jar",
+    "documentation-url" : "https://github.com/google/closure-library/blob/021ed5b313da392a7139d0d3cf7011999ac8b672/README.md",
+    "description" : "Google Closure Library Third-Party Extensions packages optional third-party modules used with the Google Closure Library, including browser-side utilities such as Caja HTML handling, MochiKit async helpers, lorem ipsum data, SVG pan support, and Dojo DOM query code. This artifact is a ClojureScript-maintained Maven distribution of those JavaScript files for consumers that resolve dependencies through Maven.",
+    "tested-versions" : [
+      "0.0-20150505-021ed5b3"
+    ],
+    "allowed-packages" : [
+      "org.clojure"
+    ]
+  }
+]

--- a/stats/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/execution-metrics.json
+++ b/stats/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/execution-metrics.json
@@ -1,0 +1,36 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T05:21:28.939742Z",
+    "library": "org.clojure:google-closure-library-third-party:0.0-20150505-021ed5b3",
+    "starting_commit": "8b195933c12feb11a3350c8a0ac8f853d7685cde",
+    "ending_commit": "e4777fda64f3ca96abe7836551a16d7a30400d82",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0-20150505-021ed5b3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 140472,
+      "cached_input_tokens_used": 1245184,
+      "output_tokens_used": 17553,
+      "iterations": 3,
+      "cost_usd": 1.1492,
+      "generated_loc": 263,
+      "tested_library_loc": 0,
+      "metadata_entries": 4,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java",
+      "metadata_file": "metadata/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/stats.json
+++ b/stats/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/stats.json
@@ -1,0 +1,16 @@
+{
+  "versions" : [ {
+    "version" : "0.0-20150505-021ed5b3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : "N/A",
+      "line" : "N/A",
+      "method" : "N/A"
+    }
+  } ]
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/.gitignore
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/build.gradle
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.clojure:google-closure-library-third-party:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/gradle.properties
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.clojure:google-closure-library-third-party:0.0-20150505-021ed5b3
+library.version = 0.0-20150505-021ed5b3
+metadata.dir = org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/settings.gradle
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.clojure.google-closure-library-third-party_tests'

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_clojure.google_closure_library_third_party;
+
+import org.junit.jupiter.api.Test;
+
+class Google_closure_library_third_partyTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -12,12 +12,17 @@ import static org.assertj.core.api.Assertions.entry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class Google_closure_library_third_partyTest {
+    private static final Pattern JAVASCRIPT_OBJECT_ENTRY_PATTERN = Pattern.compile("'([^']+)'\\s*:\\s*([^,\\n]+)");
+
     private static final List<String> DISTRIBUTED_RESOURCES = List.of(
             "goog/caja/string/html/htmlparser.js",
             "goog/caja/string/html/htmlsanitizer.js",
@@ -180,6 +185,31 @@ public class Google_closure_library_third_partyTest {
     }
 
     @Test
+    void htmlSanitizerAttributePolicyCoversUrlNameAndScriptHandling() throws IOException {
+        Map<String, String> attributeTypes = extractJavascriptObjectEntries(
+                readResource("goog/caja/string/html/htmlsanitizer.js"),
+                "goog.string.html.HtmlSanitizer.Attributes = ");
+
+        assertThat(attributeTypes)
+                .contains(
+                        entry("a::href", "goog.string.html.HtmlSanitizer.AttributeType.URI"),
+                        entry("form::action", "goog.string.html.HtmlSanitizer.AttributeType.URI"),
+                        entry("img::src", "goog.string.html.HtmlSanitizer.AttributeType.URI"),
+                        entry("img::usemap", "goog.string.html.HtmlSanitizer.AttributeType.URI_FRAGMENT"),
+                        entry("*::id", "goog.string.html.HtmlSanitizer.AttributeType.ID"),
+                        entry("label::for", "goog.string.html.HtmlSanitizer.AttributeType.IDREF"),
+                        entry("td::headers", "goog.string.html.HtmlSanitizer.AttributeType.IDREFS"),
+                        entry("*::class", "goog.string.html.HtmlSanitizer.AttributeType.CLASSES"),
+                        entry("a::name", "goog.string.html.HtmlSanitizer.AttributeType.GLOBAL_NAME"),
+                        entry("input::name", "goog.string.html.HtmlSanitizer.AttributeType.LOCAL_NAME"),
+                        entry("*::onclick", "goog.string.html.HtmlSanitizer.AttributeType.SCRIPT"),
+                        entry("form::onsubmit", "goog.string.html.HtmlSanitizer.AttributeType.SCRIPT"),
+                        entry("*::style", "goog.string.html.HtmlSanitizer.AttributeType.STYLE"),
+                        entry("*::title", "0"))
+                .doesNotContainKey("script::src");
+    }
+
+    @Test
     void projectDocumentationAndLicenseArePackaged() throws IOException {
         assertThat(readResource("README.md"))
                 .contains("# Closure Library")
@@ -213,6 +243,34 @@ public class Google_closure_library_third_partyTest {
                         entry("goog/jpeg_encoder", 1L),
                         entry("goog/svgpan", 1L),
                         entry("goog/dojo", 3L));
+    }
+
+    private static Map<String, String> extractJavascriptObjectEntries(String source, String objectDeclaration) {
+        int objectDeclarationStart = source.indexOf(objectDeclaration);
+        assertThat(objectDeclarationStart)
+                .as("object declaration %s should exist", objectDeclaration)
+                .isNotNegative();
+
+        int objectBodyStart = source.indexOf('{', objectDeclarationStart);
+        int objectBodyEnd = source.indexOf("\n};", objectBodyStart);
+        assertThat(objectBodyStart)
+                .as("object declaration %s should have a body", objectDeclaration)
+                .isNotNegative();
+        assertThat(objectBodyEnd)
+                .as("object declaration %s should have a closing marker", objectDeclaration)
+                .isGreaterThan(objectBodyStart);
+
+        String objectBody = source.substring(objectBodyStart + 1, objectBodyEnd);
+        Matcher entryMatcher = JAVASCRIPT_OBJECT_ENTRY_PATTERN.matcher(objectBody);
+        Map<String, String> entries = new LinkedHashMap<>();
+        while (entryMatcher.find()) {
+            entries.put(entryMatcher.group(1), entryMatcher.group(2).trim());
+        }
+
+        assertThat(entries)
+                .as("object declaration %s should contain entries", objectDeclaration)
+                .isNotEmpty();
+        return entries;
     }
 
     private static String readResource(String resourcePath) throws IOException {

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -125,6 +125,22 @@ public class Google_closure_library_third_partyTest {
     }
 
     @Test
+    void htmlParserExposesStandardNamedEntityDecodingTable() throws IOException {
+        Map<String, String> namedEntities = extractJavascriptObjectEntries(
+                readResource("goog/caja/string/html/htmlparser.js"),
+                "goog.string.html.HtmlParser.Entities = ");
+
+        assertThat(namedEntities)
+                .contains(
+                        entry("lt", "'<'"),
+                        entry("gt", "'>'"),
+                        entry("amp", "'&'"),
+                        entry("nbsp", "'\\u00a0'"),
+                        entry("quot", "'\"'"),
+                        entry("apos", "'\\''"));
+    }
+
+    @Test
     void optionalBrowserUtilitiesRetainTheirEntryPoints() throws IOException {
         assertThat(readResource("goog/loremipsum/text/loremipsum.js"))
                 .contains("goog.text.LoremIpsum = function()")

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -6,11 +6,222 @@
  */
 package org_clojure.google_closure_library_third_party;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-class Google_closure_library_third_partyTest {
+public class Google_closure_library_third_partyTest {
+    private static final List<String> DISTRIBUTED_RESOURCES = List.of(
+            "goog/caja/string/html/htmlparser.js",
+            "goog/caja/string/html/htmlsanitizer.js",
+            "goog/osapi/osapi.js",
+            "goog/mochikit/async/deferred.js",
+            "goog/mochikit/async/deferredlist.js",
+            "goog/mochikit/async/deferred_test.html",
+            "goog/mochikit/async/deferred_async_test.html",
+            "goog/mochikit/async/deferredlist_test.html",
+            "goog/loremipsum/text/loremipsum.js",
+            "goog/loremipsum/text/loremipsum_test.html",
+            "goog/jpeg_encoder/jpeg_encoder_basic.js",
+            "goog/svgpan/svgpan.js",
+            "goog/dojo/dom/query.js",
+            "goog/dojo/dom/query_test.js",
+            "goog/dojo/dom/query_test.html",
+            "README.md",
+            "AUTHORS",
+            "LICENSE");
+
+    private static final Map<String, List<String>> MODULE_PROVIDES = Map.of(
+            "goog/caja/string/html/htmlparser.js",
+            List.of(
+                    "goog.string.html",
+                    "goog.string.html.HtmlParser",
+                    "goog.string.html.HtmlParser.EFlags",
+                    "goog.string.html.HtmlParser.Elements",
+                    "goog.string.html.HtmlParser.Entities",
+                    "goog.string.html.HtmlSaxHandler"),
+            "goog/caja/string/html/htmlsanitizer.js",
+            List.of(
+                    "goog.string.html.HtmlSanitizer",
+                    "goog.string.html.HtmlSanitizer.AttributeType",
+                    "goog.string.html.HtmlSanitizer.Attributes",
+                    "goog.string.html.htmlSanitize"),
+            "goog/osapi/osapi.js",
+            List.of("goog.osapi"),
+            "goog/mochikit/async/deferred.js",
+            List.of(
+                    "goog.async.Deferred",
+                    "goog.async.Deferred.AlreadyCalledError",
+                    "goog.async.Deferred.CanceledError"),
+            "goog/mochikit/async/deferredlist.js",
+            List.of("goog.async.DeferredList"),
+            "goog/loremipsum/text/loremipsum.js",
+            List.of("goog.text.LoremIpsum"),
+            "goog/jpeg_encoder/jpeg_encoder_basic.js",
+            List.of("goog.crypt.JpegEncoder"),
+            "goog/svgpan/svgpan.js",
+            List.of("svgpan.SvgPan"),
+            "goog/dojo/dom/query.js",
+            List.of("goog.dom.query"));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void distributedResourceSetIsAvailableOnTheClasspath() throws IOException {
+        for (String resourcePath : DISTRIBUTED_RESOURCES) {
+            String resource = readResource(resourcePath);
+
+            assertThat(resource)
+                    .as("resource %s should be packaged and readable", resourcePath)
+                    .isNotBlank();
+        }
+    }
+
+    @Test
+    void closureModulesDeclareExpectedPublicNamespaces() throws IOException {
+        for (Map.Entry<String, List<String>> module : MODULE_PROVIDES.entrySet()) {
+            String source = readResource(module.getKey());
+
+            for (String providedNamespace : module.getValue()) {
+                assertThat(source)
+                        .as("%s should provide %s", module.getKey(), providedNamespace)
+                        .contains("goog.provide('" + providedNamespace + "')");
+            }
+        }
+    }
+
+    @Test
+    void closureModulesKeepExpectedThirdPartyIntegrationPoints() throws IOException {
+        assertThat(readResource("goog/caja/string/html/htmlparser.js"))
+                .contains("@fileoverview A Html SAX parser.")
+                .contains("goog.string.html.HtmlParser = function()")
+                .contains("goog.string.html.HtmlSaxHandler.prototype.startTag");
+
+        assertThat(readResource("goog/caja/string/html/htmlsanitizer.js"))
+                .contains("goog.require('goog.string.html.HtmlParser')")
+                .contains("goog.string.html.htmlSanitize = function(")
+                .contains("goog.string.html.HtmlSanitizer.prototype.sanitize");
+
+        assertThat(readResource("goog/mochikit/async/deferred.js"))
+                .contains("goog.require('goog.Promise')")
+                .contains("goog.async.Deferred.prototype.callback")
+                .contains("goog.async.Deferred.prototype.errback")
+                .contains("goog.async.Deferred.prototype.cancel");
+
+        assertThat(readResource("goog/mochikit/async/deferredlist.js"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("goog.async.DeferredList.prototype.handleCallback_")
+                .contains("goog.async.DeferredList.gatherResults");
+    }
+
+    @Test
+    void optionalBrowserUtilitiesRetainTheirEntryPoints() throws IOException {
+        assertThat(readResource("goog/loremipsum/text/loremipsum.js"))
+                .contains("goog.text.LoremIpsum = function()")
+                .contains("goog.text.LoremIpsum.prototype.generateParagraph")
+                .contains("goog.text.LoremIpsum.prototype.generateSentence");
+
+        assertThat(readResource("goog/jpeg_encoder/jpeg_encoder_basic.js"))
+                .contains("JPEG encoder ported to JavaScript")
+                .contains("goog.crypt.JpegEncoder = function(opt_quality)")
+                .contains("this.encode = function(image,opt_quality)");
+
+        assertThat(readResource("goog/svgpan/svgpan.js"))
+                .contains("SVGPan library 1.2.2")
+                .contains("svgpan.SvgPan.prototype.setPanEnabled")
+                .contains("svgpan.SvgPan.prototype.setupHandlers_");
+
+        assertThat(readResource("goog/dojo/dom/query.js"))
+                .contains("goog.dom.query = (function()")
+                .contains("This code was ported from the Dojo Toolkit")
+                .contains("querySelectorAll");
+
+        assertThat(readResource("goog/osapi/osapi.js"))
+                .contains("Base OSAPI binding")
+                .contains("goog.exportSymbol('osapi', osapi)")
+                .contains("goog.osapi.handleGadgetRpcMethod = function(requests)")
+                .contains("goog.osapi.init = function()");
+    }
+
+    @Test
+    void bundledJavascriptFixturesReferenceThePackagedModules() throws IOException {
+        assertThat(readResource("goog/mochikit/async/deferred_test.html"))
+                .contains("Closure Unit Tests - goog.async.Deferred")
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("function testUndefinedResultAndCallbackSequence()");
+
+        assertThat(readResource("goog/mochikit/async/deferred_async_test.html"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("goog.testing.AsyncTestCase")
+                .contains("function testErrorStack()");
+
+        assertThat(readResource("goog/mochikit/async/deferredlist_test.html"))
+                .contains("Closure Unit Tests - goog.async.DeferredList")
+                .contains("goog.require('goog.async.DeferredList')")
+                .contains("function testGatherResults()");
+
+        assertThat(readResource("goog/loremipsum/text/loremipsum_test.html"))
+                .contains("goog.require('goog.text.LoremIpsum')")
+                .contains("function testLoremIpsum()");
+
+        assertThat(readResource("goog/dojo/dom/query_test.html"))
+                .contains("goog.require('goog.dom.query')")
+                .contains("<script src=\"query_test.js\"></script>");
+
+        assertThat(readResource("goog/dojo/dom/query_test.js"))
+                .contains("function testBasicSelectors()")
+                .contains("function testNthChild()")
+                .contains("function testAttributes()");
+    }
+
+    @Test
+    void projectDocumentationAndLicenseArePackaged() throws IOException {
+        assertThat(readResource("README.md"))
+                .contains("# Closure Library")
+                .contains("Google Developers")
+                .contains("Generated API Documentation");
+
+        assertThat(readResource("AUTHORS"))
+                .contains("Closure Library")
+                .contains("Google Inc.");
+
+        assertThat(readResource("LICENSE"))
+                .contains("Apache License")
+                .contains("Version 2.0, January 2004")
+                .contains("TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION");
+    }
+
+    @Test
+    void packagedModulesRemainInExpectedThirdPartyGroups() {
+        Map<String, Long> resourceCountsByGroup = DISTRIBUTED_RESOURCES.stream()
+                .filter(resourcePath -> resourcePath.startsWith("goog/"))
+                .collect(Collectors.groupingBy(
+                        resourcePath -> resourcePath.substring(0, resourcePath.indexOf('/', "goog/".length())),
+                        Collectors.counting()));
+
+        assertThat(resourceCountsByGroup)
+                .contains(
+                        entry("goog/caja", 2L),
+                        entry("goog/osapi", 1L),
+                        entry("goog/mochikit", 5L),
+                        entry("goog/loremipsum", 2L),
+                        entry("goog/jpeg_encoder", 1L),
+                        entry("goog/svgpan", 1L),
+                        entry("goog/dojo", 3L));
+    }
+
+    private static String readResource(String resourcePath) throws IOException {
+        ClassLoader classLoader = Google_closure_library_third_partyTest.class.getClassLoader();
+        try (InputStream resourceStream = classLoader.getResourceAsStream(resourcePath)) {
+            assertThat(resourceStream)
+                    .as("resource %s should exist", resourcePath)
+                    .isNotNull();
+            return new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/user-code-filter.json
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.clojure.**"
+      "includeClasses" : "org.clojure.**"
     }
   ]
 }

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/user-code-filter.json
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20150505-021ed5b3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.clojure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2762

This PR introduces tests and metadata for org.clojure:google-closure-library-third-party:0.0-20150505-021ed5b3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 140472
- Cached input tokens: 1245184
- Output tokens: 17553
- Entries: 4
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 263
- Tested library lines of code: 0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c9894c6018446ea1b7366191a007bc60f2fcb3e7`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: N/A
- Line: N/A
- Method: N/A
