### PR TITLE
Fix triage for unlabeled library requests

### DIFF
--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -11,17 +11,68 @@ permissions:
 jobs:
   verify-new-issue:
     name: "🔎 Verify new issue"
-    if: ${{ github.event.issue.pull_request == null && contains(github.event.issue.labels.*.name, 'library-new-request')}}
+    if: ${{ github.event.issue.pull_request == null }}
     runs-on: ubuntu-latest
     outputs:
       coords: ${{ steps.extract.outputs.coords }}
       should_expand: ${{ steps.expand.outputs.should_expand }}
 
     steps:
+      - name: "Ensure unlabeled library request has triage labels"
+        id: classify
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const issue = context.payload.issue;
+            const labelNames = (issue.labels || []).map((label) =>
+              typeof label === "string" ? label : label?.name
+            ).filter(Boolean);
+            const hasLibraryNewRequestLabel = labelNames.includes("library-new-request");
+
+            function extractCoordinatesFromBody(body) {
+              const lines = String(body || "").replace(/\r/g, "").split("\n");
+              let foundHeader = false;
+              for (const line of lines) {
+                if (foundHeader) {
+                  if (line.trim() === "") {
+                    continue;
+                  }
+                  return line.trim();
+                }
+                if (/^###[ \t]+Full Maven coordinates[ \t]*$/.test(line)) {
+                  foundHeader = true;
+                }
+              }
+              return null;
+            }
+
+            const coords = extractCoordinatesFromBody(issue.body);
+            const hasLibraryRequestTitle = Boolean(coords) && issue.title === `Support for ${coords}`;
+            const isUnlabeledLibraryRequest = labelNames.length === 0 && hasLibraryRequestTitle;
+            if (isUnlabeledLibraryRequest) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ["library-new-request", "priority"]
+              });
+              core.info("Added library-new-request and priority labels to unlabeled library request.");
+            }
+
+            core.setOutput(
+              "should_triage",
+              hasLibraryNewRequestLabel || isUnlabeledLibraryRequest ? "true" : "false"
+            );
+
       - name: "Checkout repository"
+        if: ${{ steps.classify.outputs.should_triage == 'true' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: "Extract Maven coordinates"
+        if: ${{ steps.classify.outputs.should_triage == 'true' }}
         id: extract
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -36,6 +87,7 @@ jobs:
           echo "coords=$COORDS" >> "$GITHUB_OUTPUT"
 
       - name: "Validate coordinates format"
+        if: ${{ steps.classify.outputs.should_triage == 'true' }}
         id: validate
         run: |
           set -Eeuo pipefail
@@ -48,7 +100,7 @@ jobs:
           fi
 
       - name: "Close issue - invalid coordinates format"
-        if: ${{ steps.validate.outputs.invalid == 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid == 'true' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -79,7 +131,7 @@ jobs:
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
       - name: "Close issue - duplicate request for exact coordinates"
-        if: ${{ steps.validate.outputs.invalid != 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' }}
         id: duplicate
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -141,7 +193,7 @@ jobs:
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
       - name: "Check if library/version is already supported by the repository"
-        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' }}
         id: support
         run: |
           set -Eeuo pipefail
@@ -160,7 +212,7 @@ jobs:
           echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
 
       - name: "Close issue - already supported by the Reachability Metadata Repository"
-        if: ${{ steps.support.outputs.supported == 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.support.outputs.supported == 'true' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -178,7 +230,7 @@ jobs:
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
       - name: "Mark issue eligible for dependency graph expansion"
-        if: ${{ steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
         id: expand
         run: |
           set -Eeuo pipefail

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -50,6 +50,14 @@ Workflows for style and security:
 - [.github/workflows/scan-docker-images.yml](../.github/workflows/scan-docker-images.yml): scans allowed Docker images on PR/schedule.
 - [.github/workflows/sync-docker-tags.yml](../.github/workflows/sync-docker-tags.yml): automatically synchronizes Docker image tags across the repository when Dependabot updates `allowed-docker-images`. Commits replacements directly into the Dependabot PR, making it merge-ready.
 
+## Issue triage automation
+
+[.github/workflows/triage-new-issues.yml](../.github/workflows/triage-new-issues.yml) runs when a GitHub issue is opened. It ignores pull requests and only proceeds for new-library requests.
+
+For normal user-created issues, the `library-new-request` label from the issue template makes the workflow eligible for triage. For automated issues created by native-build-tools without labels, such as issues opened by non-maintainers, the workflow first checks whether the issue has no labels, uses the standard `Support for groupId:artifactId:version` title, and contains a `### Full Maven coordinates` section. If it matches that shape, the workflow adds `library-new-request` and `priority` before continuing.
+
+Once eligible, the workflow extracts the requested Maven coordinates, validates the `groupId:artifactId:version` format, closes invalid requests, closes duplicate exact-coordinate requests, and closes requests for versions already supported by the repository. If the request remains eligible, it generates a deps.dev dependency graph and opens or reuses `library-new-request` issues for unsupported transitive dependencies, linking them as blockers of the original request.
+
 ## Native Build Tools snapshot setup
 
 The `setup-native-build-tools` action automatically publishes and uses an NBT snapshot if a branch with the same name exists in the native-build-tools repository. To test against a specific NBT branch, simply ensure both branches share the same name.


### PR DESCRIPTION
Fixes #3528.

This updates triage-new-issues so unlabeled native-build-tools-created library request issues are recognized by their standard title/body shape, labeled with library-new-request and priority, and then sent through the existing triage flow.

It also documents the issue triage workflow in docs/CI.md.