### PR TITLE
Restructure Forge docs and verify Markdown links

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -68,6 +68,23 @@ jobs:
       - name: "Run Spotless"
         run: ./gradlew spotlessCheck --console=plain
 
+  doc-links:
+    name: "🔗 Check documentation links"
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 5
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: "🔧 Setup java"
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'graalvm'
+          java-version: '21'
+
+      - name: "Verify repo-local Markdown links"
+        run: ./gradlew checkDocLinks --console=plain
+
   checkstyle-coordinates:
     name: "📋 Checkstyle ${{ matrix.coordinates }}"
     if: needs.detect-relevant-changes.outputs.relevant-files-changed == 'true' && needs.detect-relevant-changes.outputs.changed-empty != 'true'
@@ -97,6 +114,7 @@ jobs:
       - detect-relevant-changes
       - spotless
       - checkstyle-coordinates
+      - doc-links
     runs-on: "ubuntu-22.04"
     timeout-minutes: 1
     steps:
@@ -104,7 +122,8 @@ jobs:
         if: |
           needs.detect-relevant-changes.result == 'success' &&
           (needs.spotless.result == 'success' || needs.spotless.result == 'skipped') &&
-          (needs.checkstyle-coordinates.result == 'success' || needs.checkstyle-coordinates.result == 'skipped')
+          (needs.checkstyle-coordinates.result == 'success' || needs.checkstyle-coordinates.result == 'skipped') &&
+          needs.doc-links.result == 'success'
         run: exit 0
 
       - name: "Style checks failed"
@@ -112,5 +131,6 @@ jobs:
           needs.detect-relevant-changes.result == 'failure' ||
           needs.detect-relevant-changes.result == 'cancelled' ||
           needs.spotless.result == 'failure' || needs.spotless.result == 'cancelled' ||
-          needs.checkstyle-coordinates.result == 'failure' || needs.checkstyle-coordinates.result == 'cancelled'
+          needs.checkstyle-coordinates.result == 'failure' || needs.checkstyle-coordinates.result == 'cancelled' ||
+          needs.doc-links.result == 'failure' || needs.doc-links.result == 'cancelled'
         run: exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ apply plugin: "org.graalvm.internal.tck-harness"
 
 tasks.named("check").configure {
     dependsOn("validateLibraryStats")
+    dependsOn("checkDocLinks")
 }
 
 static List<Map> testInfraCommands(String gradleCmd, String target) {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -24,16 +24,16 @@ Workflows testing metadata using [ci.json](../ci.json):
   - Triggers: manual (workflow_dispatch) and PRs that touch [ci.json](../ci.json).
   - Uses: generateMatrixBatchedCoordinates to build a matrix (java + os). Runs full tests, pulls only allowed Docker images, then disables Docker networking for deterministic runs.
 - Test changed metadata ([.github/workflows/test-changed-metadata.yml](../.github/workflows/test-changed-metadata.yml))
-  - Triggers: PRs to master touching [metadata/](metadata/) or [tests/src/](tests/src/).
+  - Triggers: PRs to master touching [metadata/](../metadata/) or [tests/src/](../tests/src/).
   - Uses: [`generateChangedMetadataTestMatrix`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) with base/head SHAs to test only what changed. It batches each changed metadata version's [`tested-versions`](../metadata/com.google.protobuf/protobuf-java-util/index.json) into chunks of up to 30 versions per job, then pulls allowed images, disables Docker networking, validates config, and runs only that batch.
 - Test new library versions ([.github/workflows/test-new-library-versions.yml](../.github/workflows/test-new-library-versions.yml))
   - Triggers: PRs to master touching artifact-level [metadata/**/index.json](../metadata/).
   - Uses: [`generateChangedTestedVersionsMatrix`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to compute only newly added [`tested-versions`](../metadata/com.google.protobuf/protobuf-java-util/index.json) from the base/head diff and pairs them with the matching [`metadata-version`](../metadata/com.google.protobuf/protobuf-java-util/index.json), then runs [`run-consecutive-tests.sh`](../.github/workflows/scripts/run-consecutive-tests.sh) only for those added versions.
 - Test changed build logic ([.github/workflows/test-changed-infrastructure.yml](../.github/workflows/test-changed-infrastructure.yml))
-  - Triggers: PRs to master touching [tests/tck-build-logic/](tests/tck-build-logic/), [gradle/](gradle/), [build.gradle](../build.gradle), [settings.gradle](../settings.gradle), or [gradle.properties](../gradle.properties).
+  - Triggers: PRs to master touching [tests/tck-build-logic/](../tests/tck-build-logic/), [gradle/](../gradle/), [build.gradle](../build.gradle), [settings.gradle](../settings.gradle), or [gradle.properties](../gradle.properties).
   - Uses: generateInfrastructureChangedCoordinatesMatrix. Pulls allowed images, disables Docker networking, validates config, then runs tests.
 - Test affected Spring AOT smoke tests ([.github/workflows/test-affected-spring-aot-main.yml](../.github/workflows/test-affected-spring-aot-main.yml))
-  - Triggers: PRs to master touching [metadata/](metadata/).
+  - Triggers: PRs to master touching [metadata/](../metadata/).
   - Uses: generateAffectedSpringTestMatrix to compute impacted Spring AOT projects and produce a matrix; runs triaged native tests via [.github/workflows/scripts/run-spring-aot-triaged-test.sh](../.github/workflows/scripts/run-spring-aot-triaged-test.sh).
 - Validate library stats ([.github/workflows/library-stats-validation.yml](../.github/workflows/library-stats-validation.yml))
   - Triggers: PRs to master that change exploded stats files under [stats/](../stats/), [stats/schemas/library-stats-schema-v1.0.2.json](../stats/schemas/library-stats-schema-v1.0.2.json), or mirrored files under [metadata/](../metadata/).
@@ -48,7 +48,7 @@ Workflows for style and security:
 - [.github/workflows/library-stats-validation.yml](../.github/workflows/library-stats-validation.yml): validates and sorts mirrored stats files under [stats/](../stats/), checks schema.
 - [.github/workflows/publish-scheduled-coverage.yml](../.github/workflows/publish-scheduled-coverage.yml): scheduled/manual workflow that generates repository coverage badges and the coverage dashboard from exploded stats files under [stats/](../stats/) and repository [metadata/**/index.json](../metadata/), then force-pushes the published artifacts to the `stats/coverage` branch. The published branch only keeps `latest/badges.json`, `latest/metrics-over-time.svg`, and `history/history.json`.
 - [.github/workflows/scan-docker-images.yml](../.github/workflows/scan-docker-images.yml): scans allowed Docker images on PR/schedule.
-- [.github/workflows/sync-docker-tags.yml](../.github/workflows/sync-docker-tags.yml): automatically synchronizes Docker image tags across the repository when Dependabot updates `allowed-docker-images`. Commits replacements directly into the Dependabot PR, making it merge-ready.
+- [.github/workflows/sync-docker-images.yml](../.github/workflows/sync-docker-images.yml): automatically synchronizes Docker image tags across the repository when Dependabot updates `allowed-docker-images`. Commits replacements directly into the Dependabot PR, making it merge-ready.
 
 ## Native Build Tools snapshot setup
 

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -19,7 +19,7 @@ Reachability metadata describes reflection, JNI, resource access, serialization,
 | **Application developer** using GraalVM Native Image | Build a native image of an application that depends on third-party libraries without writing reachability metadata by hand; check whether a given library is supported; request support for a missing library. | Consumes metadata indirectly — the GraalVM Gradle/Maven plugin downloads it from this repository at build time. Checks support via `curl … check-library-support.sh \| bash -s "<group>:<artifact>:<version>"` or by browsing [the libraries-and-frameworks page](https://www.graalvm.org/native-image/libraries-and-frameworks/). Requests a new library by filing a [`01_support_new_library`](../.github/ISSUE_TEMPLATE/01_support_new_library.yml) issue, or updates an existing one via [`02_update_existing_library`](../.github/ISSUE_TEMPLATE/02_update_existing_library.yml). |
 | **Community contributor** | Add support for a missing library or update an existing entry to a newer library version. | Files a "library-new-request" or "update existing library" issue; the automation picks it up, optionally guided by custom instructions the contributor supplies. |
 | **Reviewer / Maintainer** of this repo | Sign off on PRs after automated review has enforced licensing, security, and metadata quality rules. | Agents run the review skills under [skills/](../skills/) (e.g. `review-library-new-request`, `review-fixes-javac-fail`, `review-fixes-java-run-fail`, `review-fixes-native-image-run-fail`, `review-library-bulk-update`, `close-new-library-support-pr`) against the [REVIEWING.md](REVIEWING.md) checklist; CI runs the same gates. The reviewer does the final human check before merge. |
-| **Repository automation (Metadata Forge)** | Generate or repair metadata using LLM-driven pipelines. | Per coordinate, the toolkit can: (1) **add support for a new library** — generate a JUnit / Kotlin / Scala test suite, scaffold metadata, and iterate until JVM-mode tests pass and dynamic-access is collected ([`add_new_library_support.py`](../forge/ai_workflows/add_new_library_support.py)); (2) **fix a Java compilation (`javac`) failure** raised by a library version bump ([`fix_javac_fail.py`](../forge/ai_workflows/fix_javac_fail.py)); (3) **fix a JVM-mode (`javaTest`) runtime failure** raised by a version bump ([`fix_java_run_fail.py`](../forge/ai_workflows/fix_java_run_fail.py)); (4) **fix a `native-image` runtime failure** raised by a version bump ([`fix_ni_run.py`](../forge/ai_workflows/fix_ni_run.py)); (5) **improve dynamic-access coverage** of already-supported libraries by targeting uncovered call sites; (6) **post-generation repair** of the metadata produced by a previous run ([`fix_post_generation_pi.py`](../forge/ai_workflows/fix_post_generation_pi.py), [`fix_metadata_codex.py`](../forge/ai_workflows/fix_metadata_codex.py)). Each task runs Gradle tasks against a worktree of this repo, appends a schema-validated metrics record, and — when invoked through [`forge/git_scripts/make_pr_*.py`](../forge/git_scripts/) — opens a PR for human review. See [forge/docs/overview.md](../forge/docs/overview.md). |
+| **Repository automation (Metadata Forge)** | Generate or repair metadata using LLM-driven pipelines. | Per coordinate, the toolkit can: (1) **add support for a new library** — generate a JUnit / Kotlin / Scala test suite, scaffold metadata, and iterate until JVM-mode tests pass and dynamic-access is collected ([`add_new_library_support.py`](../forge/ai_workflows/add_new_library_support.py)); (2) **fix a Java compilation (`javac`) failure** raised by a library version bump ([`fix_javac_fail.py`](../forge/ai_workflows/fix_javac_fail.py)); (3) **fix a JVM-mode (`javaTest`) runtime failure** raised by a version bump ([`fix_java_run_fail.py`](../forge/ai_workflows/fix_java_run_fail.py)); (4) **fix a `native-image` runtime failure** raised by a version bump ([`fix_ni_run.py`](../forge/ai_workflows/fix_ni_run.py)); (5) **improve dynamic-access coverage** of already-supported libraries by targeting uncovered call sites; (6) **post-generation repair** of the metadata produced by a previous run ([`fix_post_generation_pi.py`](../forge/ai_workflows/fix_post_generation_pi.py), [`fix_metadata_codex.py`](../forge/ai_workflows/fix_metadata_codex.py)). Each task runs Gradle tasks against a worktree of this repo, appends a schema-validated metrics record, and — when invoked through [`forge/git_scripts/make_pr_*.py`](../forge/git_scripts/) — opens a PR for human review. See [forge/docs/architecture.md](../forge/docs/architecture.md). |
 
 ## 3. Hard Constraints
 
@@ -27,7 +27,7 @@ Application developers consume this repository indirectly: native-build-tools re
 
 > **Adding this repository to a user's build must never change how the user's code runs.** The metadata is purely additive — it can only fill in registrations `native-image` would otherwise miss; it cannot alter class initialization, replace user bytecode, or execute code at image-build time.
 
-Two properties make this achievable: the reachability-metadata schema is itself additive (every entry is gated on `typeReachable`, FR-M-2), and `native-image` defaults to runtime initialization when no build-time directives are supplied. The hard constraints below preserve that additivity — they are not editorial scope choices but direct consequences of the invariant. See [ADR 0002](adr/0002-metadata-must-not-break-user-code.md) for the full rationale.
+Two properties make this achievable: the reachability-metadata schema is itself additive (every entry is gated on `typeReachable`, FR-M-2), and `native-image` defaults to runtime initialization when no build-time directives are supplied. The hard constraints below preserve that additivity — they are not editorial scope choices but direct consequences of the invariant.
 
 - **HC-1 No build-time-initialization tweaks.** Metadata bundles must not ship `native-image.properties` or any other directive that moves class `<clinit>` execution into the image builder. Build-time initialization captures state from a non-user environment into the image and breaks additivity. Every library is runtime-initialized by default (FR-M-1).
 - **HC-2 No library patching.** No substitutions, bytecode rewrites, or shaded forks of upstream libraries. Patching ships a different version than the one the user resolved through Maven Central, is invisible at the dependency-resolution layer, and is unstable across upstream releases.
@@ -86,7 +86,7 @@ The `forge/` toolkit composes LLM agents (Aider, Codex, Pi) with deterministic G
 3. **Fix native-image runtime failures** raised by a library version bump.
 4. **Improve coverage** of already-supported libraries by targeting uncovered dynamic-access call sites.
 
-Each Forge run produces a schema-validated metrics record (under `metrics_repo/...`) and, when invoked through `complete_pipelines/` or `git_scripts/make_pr_*.py`, opens a PR ready for human review. See [forge/README.md](../forge/README.md) and [forge/docs/overview.md](../forge/docs/overview.md).
+Each Forge run produces a schema-validated metrics record (under `metrics_repo/...`) and, when invoked through `complete_pipelines/` or `git_scripts/make_pr_*.py`, opens a PR ready for human review. See [forge/README.md](../forge/README.md) and [forge/docs/architecture.md](../forge/docs/architecture.md).
 
 ### 4.7 Consumption by native-build-tools
 
@@ -207,7 +207,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 - **FR-CI-2** Docker images used in tests are pre-pulled from `allowed-docker-images`, after which the runner disables Docker networking for deterministic, isolated test runs.
 - **FR-CI-3** The release workflow runs `spotlessCheck` before packaging.
 - **FR-CI-4** The Spring AOT smoke matrix runs only when `metadata/` changes affect a Spring AOT project.
-- **FR-CI-5** `verify-new-library-version-compatibility` caps each scheduled run at a fixed library budget and at most 30 newer versions per library (see [ADR 0001](adr/0001-cap-newer-versions-per-library.md)), expanding across the configured GraalVM JDK/OS combinations, and creates one aggregated GitHub issue per failed `(library, version)` pair.
+- **FR-CI-5** `verify-new-library-version-compatibility` caps each scheduled run at a fixed library budget and at most 30 newer versions per library, expanding across the configured GraalVM JDK/OS combinations, and creates one aggregated GitHub issue per failed `(library, version)` pair.
 - **FR-CI-6** Dependabot updates to `allowed-docker-images` trigger `sync-docker-tags.yml`, which back-commits the synchronized tags into the Dependabot PR.
 
 ### 5.5 Native-image modes (FR-NI)
@@ -217,7 +217,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 
 ### 5.6 Metadata Forge (FR-F)
 
-Forge's functional requirements are specified in [forge/docs/overview.md §10](../forge/docs/overview.md#10-functional-requirements-fr-f).
+Forge's functional requirements are specified in [forge/docs/functional-spec.md](../forge/docs/functional-spec.md).
 
 ## 6. Non-Functional Requirements
 
@@ -258,4 +258,4 @@ Forge's functional requirements are specified in [forge/docs/overview.md §10](.
 - [CollectingMetadata.md](CollectingMetadata.md) — using the Native Image Agent to collect metadata.
 - [SECURITY.md](SECURITY.md) — vulnerability disclosure.
 - [forge/README.md](../forge/README.md) — Metadata Forge user manual.
-- [forge/docs/overview.md](../forge/docs/overview.md) — Forge architecture and contracts.
+- [forge/docs/architecture.md](../forge/docs/architecture.md) — Forge architecture and contracts.

--- a/forge/AGENTS.md
+++ b/forge/AGENTS.md
@@ -10,7 +10,6 @@ Agents MUST read and strictly adhere to the following before making any changes:
 
 - [Functional Spec](docs/functional-spec.md) — what the system must do.
 - [Architecture](docs/architecture.md) — how the system is structured.
-- [ADRs](docs/adr/) — recorded architectural decisions; do not contradict them.
 
 ## Do
 - Read README.md and DEVELOPING.md before acting.

--- a/forge/AGENTS.md
+++ b/forge/AGENTS.md
@@ -4,6 +4,14 @@ Minimal guidelines for automation agents contributing to this repository.
 
 Purpose: ensure safe, focused, and reviewable changes.
 
+## Required Reading
+
+Agents MUST read and strictly adhere to the following before making any changes:
+
+- [Functional Spec](docs/functional-spec.md) — what the system must do.
+- [Architecture](docs/architecture.md) — how the system is structured.
+- [ADRs](docs/adr/) — recorded architectural decisions; do not contradict them.
+
 ## Do
 - Read README.md and DEVELOPING.md before acting.
 - Before adding code, search the repository to see whether the behavior already exists or belongs in an existing module. Prefer `rg` for code and file discovery.

--- a/forge/DEVELOPING.md
+++ b/forge/DEVELOPING.md
@@ -88,7 +88,7 @@ Purpose:
 - Iteratively generate a meaningful, cohesive JUnit test suite for library using AI.
 - Keep indices up to date and create the versioned metadata directory.
 - Generates metadata for the new library.
-- Script results are written in the [`output/results.json`](output/results.json:1).
+- Script results are written in `output/results.json`.
 
 Usage:
 ```bash

--- a/forge/README.md
+++ b/forge/README.md
@@ -95,5 +95,6 @@ forge/
 - `utility_scripts/`: shared support code.
 - `docs/`: design notes, workflow specifications, and testing guidance.
 
-See `DEVELOPING.md` for command-level workflow details and
-`docs/overview.md` for the architecture overview.
+See `DEVELOPING.md` for command-level workflow details,
+`docs/overview.md` for the functional specification, and
+`docs/architecture.md` for the architecture overview.

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -215,7 +215,7 @@ historical behaviour). Concrete interventions:
 | Name | Implementation | Role |
 | --- | --- | --- |
 | `codex_then_pi` | wraps [`fix_metadata_codex`](../ai_workflows/fix_metadata_codex.py) and [`fix_post_generation_pi`](../ai_workflows/fix_post_generation_pi.py) | Run Codex on missing metadata; if tests still fail, run Pi to remove failing tests and emit an intervention report. Yields `SUCCESS_WITH_INTERVENTION_STATUS` on the Pi path. |
-| `native_trace_collect` | wraps [`utility_scripts/native_metadata_exploration.py`](../utility_scripts/native_metadata_exploration.py) plus the codex/pi cascade | Build with `MetadataTracingSupport`, run, merge, optionally verify with `--exact-reachability-metadata`, then route the result (every status, including `BUILD_FAILED`) into Codex with the trace dir as context, falling back to Pi. |
+| `native_trace_collect` | wraps `utility_scripts/native_metadata_exploration.py` plus the codex/pi cascade | Build with `MetadataTracingSupport`, run, merge, optionally verify with `--exact-reachability-metadata`, then route the result (every status, including `BUILD_FAILED`) into Codex with the trace dir as context, falling back to Pi. |
 | `noop` | — | Skip recovery; treat any test failure as hard failure. |
 
 The intervention contract (`InterventionContext` → `InterventionResult`)

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -1,0 +1,321 @@
+# Metadata Forge — Architecture
+
+> **See also:** [Functional specification](functional-spec.md)
+
+This document describes **how** Metadata Forge runs. The
+[functional spec](functional-spec.md) covers **what** it does and the contracts
+it must satisfy. Components are grouped by responsibility; each is described
+once and referenced from the diagrams.
+
+## 1. Component Layout
+
+```text
+forge/
+├─ do-work.sh                  # Long-running worker loop
+├─ do_up_to_date_work.sh       # One cycle: pull, dispatch, sleep
+├─ forge_metadata.py           # Top-level dispatcher (issues, PRs, reviews)
+├─ ai_workflows/
+│  ├─ add_new_library_support.py   # Entry: new-library generation
+│  ├─ fix_javac_fail.py            # Entry: fix Java compile failures
+│  ├─ fix_java_run_fail.py         # Entry: fix JVM runtime failures
+│  ├─ fix_ni_run.py                # Entry: fix native-image runtime failures
+│  ├─ fix_metadata_codex.py        # Post-gen: Codex metadata repair
+│  ├─ fix_post_generation_pi.py    # Post-gen: Pi intervention fallback
+│  ├─ agents/                      # Pluggable LLM agents (pi, codex)
+│  └─ workflow_strategies/         # Pluggable control loops
+├─ git_scripts/                # Branch/commit/PR + GitHub helpers
+├─ utility_scripts/            # Shared support modules (paths, metrics, …)
+├─ strategies/
+│  └─ predefined_strategies.json   # Named agent + workflow + prompts bundles
+├─ prompt_templates/           # Loaded by strategies at runtime
+├─ schemas/                    # JSON schemas for run metrics
+└─ docs/                       # Specifications and this document
+```
+
+## 2. High-Level Architecture
+
+```mermaid
+flowchart TB
+    subgraph Drivers["Drivers"]
+        DoWork["do-work.sh<br/>(loop)"]
+        DoCycle["do_up_to_date_work.sh<br/>(one cycle)"]
+        Dispatcher["forge_metadata.py<br/>(dispatcher)"]
+    end
+
+    subgraph Workflows["AI Workflows (entry scripts)"]
+        AddNew["add_new_library_support"]
+        FixJavac["fix_javac_fail"]
+        FixJavaRun["fix_java_run_fail"]
+        FixNI["fix_ni_run"]
+    end
+
+    subgraph Strategies["Workflow Strategies"]
+        Basic["basic_iterative"]
+        Dyn["dynamic_access_iterative"]
+        Opt["optimistic_dynamic_access"]
+        Inc["increase_dynamic_access_coverage"]
+        JFix["javac_iterative / java_run_iterative"]
+    end
+
+    subgraph Agents["Agents"]
+        Pi["pi (PiAgent + RPC)"]
+        Codex["codex (CodexAgent + AppServer)"]
+    end
+
+    subgraph PostGen["Post-Generation Intervention"]
+        CodexFix["fix_metadata_codex"]
+        PiFix["fix_post_generation_pi"]
+    end
+
+    subgraph ReviewPRs["PR Review Queues (by label)"]
+        RvNew["library-new-request"]
+        RvJavac["fixes-javac-fail"]
+        RvJavaRun["fixes-java-run-fail"]
+        RvNI["fixes-native-image-run-fail"]
+        RvBulk["library-bulk-update"]
+    end
+
+    subgraph Shared["Shared Utilities"]
+        Paths["repo_path_resolver"]
+        Setup["workflow_setup<br/>(GraalVM, validation)"]
+        SrcCtx["source_context"]
+        StratLoad["strategy_loader"]
+        DynRpt["dynamic_access_report"]
+        Metrics["metrics_writer + schema_validator"]
+        Quality["test_quality_checks + style_checks"]
+        Final["library_finalization"]
+        Stage["stage_logger / task_logs"]
+    end
+
+    subgraph External["External Systems"]
+        Repo[("Reachability repo<br/>Gradle")]
+        GH[("GitHub<br/>issues, PRs, projects")]
+        MetricsStore[("Metrics store<br/>stats/.../execution-metrics.json")]
+    end
+
+    DoWork --> DoCycle --> Dispatcher
+    Dispatcher -->|claim issue + label| GH
+    Dispatcher --> AddNew
+    Dispatcher --> FixJavac
+    Dispatcher --> FixJavaRun
+    Dispatcher --> FixNI
+    Dispatcher --> ReviewPRs
+    ReviewPRs -->|submit review| GH
+
+    AddNew --> Strategies
+    FixJavac --> JFix
+    FixJavaRun --> JFix
+    FixNI --> Strategies
+
+    Strategies --> Agents
+    Strategies --> Repo
+    Strategies --> DynRpt
+    Strategies --> PostGen
+
+    Workflows --> Shared
+    PostGen --> Repo
+
+    Workflows -->|validated record| Metrics
+    Metrics --> MetricsStore
+
+    Dispatcher --> GitScripts["git_scripts/make_pr_*.py"]
+    GitScripts --> GH
+```
+
+Key invariants (unchanged from the functional spec):
+
+- Agents **never** invoke Gradle directly. Strategies issue build/test
+  commands through `agent.run_test_command(...)` and analyze the combined
+  output.
+- Generated changes must live under the per-library directory
+  `tests/src/<group>/<artifact>/<version>` in the reachability repo, plus the
+  library's `metadata/<group>/<artifact>/index.json`.
+- Every successful run writes a metrics record validated against
+  [schemas/](../schemas/) before any PR is opened.
+
+## 3. Components
+
+### 3.1 Drivers
+
+- **[do-work.sh](../do-work.sh)** — long-running loop. Updates the Forge
+  checkout, runs one cycle, sleeps `DO_WORK_SLEEP_SECONDS`, repeats. Reads
+  per-queue limits from `FORGE_*` env vars and forwards them to the cycle
+  script.
+- **[do_up_to_date_work.sh](../do_up_to_date_work.sh)** — one cycle.
+  Materializes env vars and invokes `forge_metadata.py` to drain each
+  configured work queue once.
+- **[forge_metadata.py](../forge_metadata.py)** — dispatcher. Fetches GitHub
+  issues by label, claims them via optimistic locking (assignee + verify),
+  creates an isolated worktree, routes the claim to the matching workflow
+  entry script, and afterwards either opens a PR or preserves failed work and
+  posts a human-intervention comment. Also runs the PR review queues.
+
+### 3.2 AI Workflow Entry Scripts
+
+Each script is a thin orchestrator over the shared utilities and a workflow
+strategy. They share a common skeleton: resolve paths and GraalVM, scaffold
+the per-library directory, prepare source contexts, load the strategy, run
+it, optionally apply post-generation intervention, validate and write
+metrics.
+
+| Script | GitHub label | Workflow concern |
+| --- | --- | --- |
+| [add_new_library_support.py](../ai_workflows/add_new_library_support.py) | `library-new-request` | Generate tests + metadata for an unsupported library. |
+| [fix_javac_fail.py](../ai_workflows/fix_javac_fail.py) | `fixes-javac-fail` | Repair test sources that no longer compile. |
+| [fix_java_run_fail.py](../ai_workflows/fix_java_run_fail.py) | `fixes-java-run-fail` | Repair JVM runtime test failures. |
+| [fix_ni_run.py](../ai_workflows/fix_ni_run.py) | `fixes-native-image-run-fail` | Refresh metadata for `nativeTest` failures. |
+
+### 3.3 Agents
+
+Agents implement the [`Agent`](../ai_workflows/agents/agent.py) base
+interface (`send_prompt`, `run_test_command`, `fork`, context management,
+token tracking) and self-register via `@Agent.register("name")`.
+
+- **[`pi`](../ai_workflows/agents/pi_agent.py)** — uses
+  [`PiRpcClient`](../ai_workflows/agents/pi_rpc_client.py) over JSON-RPC.
+- **[`codex`](../ai_workflows/agents/codex_agent.py)** — uses
+  [`CodexAppServerClient`](../ai_workflows/agents/codex_app_server.py) over
+  HTTP.
+
+A predefined strategy names the agent it requires; the entry script
+instantiates it through the registry.
+
+### 3.4 Workflow Strategies
+
+> Detailed reference: [Workflow strategies](workflow-strategies.md) — base
+> class contract, per-strategy loop semantics, predefined-strategy bundles,
+> and how to add a new one.
+
+Strategies inherit from
+[`WorkflowStrategy`](../ai_workflows/workflow_strategies/workflow_strategy.py)
+and self-register via `@WorkflowStrategy.register("name")`. The base class
+validates required prompts/parameters and exposes the post-generation
+intervention hook.
+
+| Name | Implementation | Role |
+| --- | --- | --- |
+| `basic_iterative` | [basic_iterative_strategy.py](../ai_workflows/workflow_strategies/basic_iterative_strategy.py) | Run-test → on failure, send error to agent → loop until pass or max iterations. |
+| `dynamic_access_iterative` | [dynamic_access_iterative_strategy.py](../ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py) | Coverage-driven loop using the dynamic-access report; targets uncovered call sites. |
+| `optimistic_dynamic_access` | [optimistic_dynamic_access_strategy.py](../ai_workflows/workflow_strategies/optimistic_dynamic_access_strategy.py) | Variant of dynamic-access that primes coverage from source analysis. |
+| `increase_dynamic_access_coverage` | [increase_dynamic_access_coverage_strategy.py](../ai_workflows/workflow_strategies/increase_dynamic_access_coverage_strategy.py) | Composite: chain a primary workflow with a coverage-improvement phase. |
+| `javac_iterative`, `java_run_iterative` | [java_fix_iterative_strategy.py](../ai_workflows/workflow_strategies/java_fix_iterative_strategy.py) | Specializations of a shared base for compile vs. runtime fixes. |
+
+### 3.5 Post-Generation Intervention
+
+Triggered when the strategy declares a `post_generation_intervention` and the
+primary loop succeeded but downstream gates (e.g. native test) still fail.
+
+- **[fix_metadata_codex.py](../ai_workflows/fix_metadata_codex.py)** — runs
+  the `codex exec` skill to patch missing reachability metadata entries.
+- **[fix_post_generation_pi.py](../ai_workflows/fix_post_generation_pi.py)**
+  — fallback when Codex cannot converge: Pi removes the failing tests and
+  writes an intervention report. Yields `SUCCESS_WITH_INTERVENTION_STATUS`.
+
+### 3.6 Shared Utilities (`utility_scripts/`)
+
+| Module | Role |
+| --- | --- |
+| `repo_path_resolver` | Resolve and validate Forge, reachability, and metrics repo paths. |
+| `workflow_setup` | Resolve `GRAALVM_HOME`/`JAVA_HOME`, validate environment, drive metadata fixup orchestration. |
+| `source_context` | Fetch library source / tests / docs JARs and prepare read-only context for the agent. |
+| `strategy_loader` | Load named entries from `predefined_strategies.json` and substitute prompt template variables. |
+| `dynamic_access_report` | Parse `dynamic-access-coverage.json`, compute deltas, format prompts. |
+| `library_finalization` | Run final Gradle metadata-collection and validation tasks. |
+| `metrics_writer` | Assemble the per-run record (tokens, iterations, coverage, timestamps). |
+| `schema_validator` | Validate metrics against [schemas/](../schemas/). |
+| `test_quality_checks` | Detect/remove scaffold-only placeholder tests. |
+| `style_checks` | Style and lint guards. |
+| `library_stats` | Test LOC, artifact counts, and other per-library statistics. |
+| `stage_logger`, `task_logs`, `pi_logs` | Stage transitions and per-task log paths. |
+| `count_native_image_config_entries`, `count_reachability_entries` | Count metadata entries (legacy and current formats). |
+| `jacoco_parser` | Parse JaCoCo coverage reports. |
+
+### 3.7 Git Scripts (`git_scripts/`)
+
+- **[common_git.py](../git_scripts/common_git.py)** — GitHub API helpers:
+  fetch issues/PRs, optimistic-lock claim, comments, labels, branch names,
+  `gh` auth checks.
+- **`make_pr_*.py`** — one per workflow
+  ([new_library_support](../git_scripts/make_pr_new_library_support.py),
+  [javac_fix](../git_scripts/make_pr_javac_fix.py),
+  [java_run_fix](../git_scripts/make_pr_java_run_fix.py),
+  [ni_run_fix](../git_scripts/make_pr_ni_run_fix.py)). Each stages changes,
+  commits with metrics embedded in the message, and opens a PR with a
+  formatted description.
+
+### 3.8 Configuration & Templates
+
+- **[strategies/predefined_strategies.json](../strategies/predefined_strategies.json)**
+  is the central wiring file. Each entry binds an agent + workflow strategy +
+  model + prompt template paths + parameters into a name passed via
+  `--strategy-name`.
+- **[prompt_templates/](../prompt_templates/)** holds the templates loaded by
+  `strategy_loader` (initial scaffold, post-pass refinement, post-fail
+  recovery, dynamic-access iteration, javac/java-run failure prompts).
+- **[schemas/](../schemas/)** holds the JSON Schemas for run metrics and
+  benchmark records.
+
+## 4. Top-Level Run Sequence (`library-new-request`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User / CI
+    participant Loop as do-work.sh
+    participant Disp as forge_metadata.py
+    participant GH as GitHub
+    participant Entry as add_new_library_support.py
+    participant Util as workflow_setup / source_context
+    participant Strat as Workflow strategy
+    participant Agent as Registered agent
+    participant Repo as Reachability repo (Gradle)
+    participant Post as Post-gen intervention
+    participant Met as Metrics store
+    participant PR as git_scripts/make_pr_*
+
+    U->>Loop: ./do-work.sh
+    Loop->>Disp: do_up_to_date_work.sh → forge_metadata.py
+    Disp->>GH: Fetch issues, claim by label
+    Disp->>Entry: Invoke with --coordinates, --strategy-name
+    Entry->>Util: Resolve paths, GraalVM/Java home
+    Entry->>Repo: Create branch, run scaffold task
+    Entry->>Util: prepare_source_contexts(...)
+    Entry->>Strat: Instantiate from predefined_strategies.json
+    Entry->>Agent: Initialize via Agent.get_class(name)
+    Entry->>Strat: run(agent, checkpoint_commit_hash)
+    loop iteration
+        Strat->>Agent: send_prompt / run_test_command
+        Agent->>Repo: Edit files; Strat triggers Gradle
+    end
+    alt strategy declares post-generation intervention
+        Strat->>Post: Codex metadata fix
+        opt Codex did not converge
+            Post->>Post: Pi removes failing tests
+        end
+    end
+    Strat-->>Entry: status, iteration counts
+    Entry->>Met: Validated run-metrics record
+    alt success / success-with-intervention
+        Disp->>PR: make_pr_new_library_support
+        PR->>GH: Commit + open PR
+        Disp->>GH: Project status → Done, unassign
+    else failure
+        Disp->>GH: Push preserve branch + human-intervention comment
+        Disp->>GH: Project status → Todo, unassign
+    end
+    Entry-->>U: Exit 0 (success or success-with-intervention) / 1 (failure)
+```
+
+## 5. Extension Points
+
+- **Add an agent**: implement `Agent`, decorate with
+  `@Agent.register("name")`, reference it in a `predefined_strategies.json`
+  entry.
+- **Add a workflow strategy**: subclass `WorkflowStrategy`, decorate with
+  `@WorkflowStrategy.register("name")`, declare required prompts/parameters.
+- **Add a workflow type**: add an entry script under `ai_workflows/`, wire a
+  matching `make_pr_*.py`, and register the label routing in
+  `forge_metadata.py`.
+- **Add a predefined strategy**: append an entry to
+  `strategies/predefined_strategies.json` referencing existing agent +
+  workflow names and prompt templates.

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -62,9 +62,10 @@ flowchart TB
         Codex["codex (CodexAgent + AppServer)"]
     end
 
-    subgraph PostGen["Post-Generation Intervention"]
-        CodexFix["fix_metadata_codex"]
-        PiFix["fix_post_generation_pi"]
+    subgraph PostGen["PostGenerationIntervention (registry)"]
+        IntNoop["noop"]
+        IntCodex["codex_then_pi (default)<br/>fix_metadata_codex → fix_post_generation_pi"]
+        IntTrace["native_trace_collect<br/>native_metadata_exploration → codex"]
     end
 
     subgraph ReviewPRs["PR Review Queues (by label)"]
@@ -110,7 +111,7 @@ flowchart TB
     Strategies --> Agents
     Strategies --> Repo
     Strategies --> DynRpt
-    Strategies --> PostGen
+    Strategies -->|dispatch by name<br/>per strategy config| PostGen
 
     Workflows --> Shared
     PostGen --> Repo
@@ -200,16 +201,30 @@ intervention hook.
 | `increase_dynamic_access_coverage` | [increase_dynamic_access_coverage_strategy.py](../ai_workflows/workflow_strategies/increase_dynamic_access_coverage_strategy.py) | Composite: chain a primary workflow with a coverage-improvement phase. |
 | `javac_iterative`, `java_run_iterative` | [java_fix_iterative_strategy.py](../ai_workflows/workflow_strategies/java_fix_iterative_strategy.py) | Specializations of a shared base for compile vs. runtime fixes. |
 
-### 3.5 Post-Generation Intervention
+### 3.5 Post-Generation Interventions
 
-Triggered when the strategy declares a `post_generation_intervention` and the
-primary loop succeeded but downstream gates (e.g. native test) still fail.
+> Detailed reference: [workflow-strategies.md §5](workflow-strategies.md#5-post-generation-interventions) ·
+> Trace-loop spec: [native-metadata-exploration.md](native-metadata-exploration.md).
 
-- **[fix_metadata_codex.py](../ai_workflows/fix_metadata_codex.py)** — runs
-  the `codex exec` skill to patch missing reachability metadata entries.
-- **[fix_post_generation_pi.py](../ai_workflows/fix_post_generation_pi.py)**
-  — fallback when Codex cannot converge: Pi removes the failing tests and
-  writes an intervention report. Yields `SUCCESS_WITH_INTERVENTION_STATUS`.
+`PostGenerationIntervention` is a separate plug-in registry from
+`WorkflowStrategy`. The base class `_run_test_with_retry` dispatches to the
+intervention named in each predefined strategy's
+`post-generation-intervention` block. Default: `codex_then_pi` (preserves
+historical behaviour). Concrete interventions:
+
+| Name | Implementation | Role |
+| --- | --- | --- |
+| `codex_then_pi` | wraps [`fix_metadata_codex`](../ai_workflows/fix_metadata_codex.py) and [`fix_post_generation_pi`](../ai_workflows/fix_post_generation_pi.py) | Run Codex on missing metadata; if tests still fail, run Pi to remove failing tests and emit an intervention report. Yields `SUCCESS_WITH_INTERVENTION_STATUS` on the Pi path. |
+| `native_trace_collect` | wraps [`utility_scripts/native_metadata_exploration.py`](../utility_scripts/native_metadata_exploration.py) plus the codex/pi cascade | Build with `MetadataTracingSupport`, run, merge, optionally verify with `--exact-reachability-metadata`, then route the result (every status, including `BUILD_FAILED`) into Codex with the trace dir as context, falling back to Pi. |
+| `noop` | — | Skip recovery; treat any test failure as hard failure. |
+
+The intervention contract (`InterventionContext` → `InterventionResult`)
+and concrete sub-step semantics are documented in
+[workflow-strategies.md §5.1](workflow-strategies.md#51-interface). The
+shared trace-loop primitive used by `native_trace_collect` is fully
+specified in [native-metadata-exploration.md](native-metadata-exploration.md)
+— including the convergence rule, status enum, Gradle task surface, and the
+codex hand-off contract for non-`SUCCESS` outcomes.
 
 ### 3.6 Shared Utilities (`utility_scripts/`)
 

--- a/forge/docs/dynamic-access-workflow.md
+++ b/forge/docs/dynamic-access-workflow.md
@@ -1,6 +1,6 @@
 # Dynamic-Access Workflow Specification
 
-> **See also:** [Project overview](overview.md) ·
+> **See also:** [Architecture](architecture.md) ·
 > [Native metadata exploration phase](native-metadata-exploration.md) ·
 > [Java fail-fix workflow](fix-java-run-fail.md)
 

--- a/forge/docs/fix-java-run-fail.md
+++ b/forge/docs/fix-java-run-fail.md
@@ -1,6 +1,6 @@
 # fix-java-fails
 
-> **See also:** [Project overview](../docs/overview.md) ·
+> **See also:** [Architecture](architecture.md) ·
 > [Dynamic-access workflow](../docs/dynamic-access-workflow.md) ·
 > [Native metadata exploration phase](../docs/native-metadata-exploration.md)
 

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -1,26 +1,36 @@
-# Metadata Forge — Specification
+# Metadata Forge — Functional Specification
+
+> **See also:** [Architecture](architecture.md)
 
 ## 1. Purpose
 
 Metadata Forge automates the production and maintenance of GraalVM
-**reachability metadata** for community Java/Kotlin/Scala libraries. It composes
-LLM-based code-generation agents with deterministic build, test, and reporting
-pipelines from the
-[`oracle/graalvm-reachability-metadata`](https://github.com/oracle/graalvm-reachability-metadata)
-repository (hereafter "the reachability repo") to produce metadata, tests, and
-PRs ready for human review.
+**reachability metadata** for community Java/Kotlin/Scala libraries. It lives
+inside the [`oracle/graalvm-reachability-metadata`](https://github.com/oracle/graalvm-reachability-metadata)
+repository (hereafter "the reachability repo") and composes LLM-based
+code-generation agents with the repo's own build, test, and reporting
+pipelines to produce metadata, tests, and PRs ready for human review.
 
 ## 2. Scope
 
 The project covers three primary task families:
 
-1. **New library support** — generate a JUnit (or Kotlin/Scala) test suite,
-   produce reachability metadata, and open a PR for a previously unsupported
-   library.
-2. **Library version bumps** — fix Java compilation and runtime failures that
-   occur when raising a tested library to a new version.
-3. **Coverage improvement** — increase dynamic-access coverage of
-   already-supported libraries.
+1. **New library support** (`library-new-request`) — generate a JUnit (or
+   Kotlin/Scala) test suite, produce reachability metadata, and open a PR for
+   a previously unsupported library.
+2. **Java compilation fixes** (`fixes-javac-fail`) — repair test sources that
+   no longer compile against a bumped library version.
+3. **Java runtime fixes** (`fixes-java-run-fail`) — repair JVM-mode test
+   failures that surface when raising a tested library to a new version.
+4. **Native-image runtime fixes** (`fixes-native-image-run-fail`) — update
+   reachability metadata so `nativeTest` passes against the new library
+   version, using the native metadata exploration phase.
+5. **Bulk version updates** (`library-bulk-update`) — record newly tested
+   upstream versions for already-supported libraries when no fix is required.
+6. **Coverage improvement** (`library-update-request`) — increase
+   dynamic-access coverage of already-supported libraries.
+7. **Docker image updates** (`docker`) — refresh the allowed Docker images
+   used by tests, including vulnerability rescans and version bumps.
 
 Out of scope: anything that does not produce reachability metadata or its
 supporting tests for the reachability repo.
@@ -40,82 +50,9 @@ supporting tests for the reachability repo.
 | **Dynamic-access report** | JSON written by Gradle task `generateDynamicAccessCoverageReport` to `tests/src/<group>/<artifact>/<version>/build/reports/dynamic-access/dynamic-access-coverage.json`, listing classes and per-class call sites that require dynamic-access metadata, marked covered/uncovered. |
 | **Source context** | Read-only files supplied to the agent. Types: `main` (library source), `test` (upstream tests), `documentation` (Javadoc). Selected by the strategy parameter `source-context-types`. |
 
-## 4. Component Layout
+## 4. Configuration Contracts
 
-```text
-forge/
-├─ ai_workflows/          # Workflow entry points and pluggable agents/strategies
-│  ├─ agents/             # Agent implementations (aider, codex, pi)
-│  └─ workflow_strategies/# Strategy implementations (basic_iterative, dynamic_access_iterative, ...)
-├─ complete_pipelines/    # End-to-end: workflow + PR creation
-├─ git_scripts/           # Branch, push, and PR-opening helpers
-├─ utility_scripts/       # Source-context, metrics, schema, and report helpers
-├─ strategies/            # `predefined_strategies.json`
-├─ prompt_templates/      # Templates loaded by strategies
-├─ schemas/               # JSON schemas for metrics validation
-└─ docs/                  # This specification
-```
-
-## 5. High-Level Architecture
-
-```mermaid
-flowchart LR
-    User[User / CI] -->|--coordinates, --strategy-name| Entry[ai_workflows entry script]
-    Entry --> Strat[Workflow strategy]
-    Entry --> Source[utility_scripts/source_context.py]
-    Strat --> Agent[Registered agent]
-    Strat --> Gradle[Reachability repo / Gradle]
-    Source --> Reachability[(Reachability repo)]
-    Gradle --> Reachability
-    Agent --> Reachability
-    Strat --> Metrics[(Metrics repo: results.json)]
-    Entry -.optional.-> Pipeline[complete_pipelines/*]
-    Pipeline --> GitScripts[git_scripts/make_pr_*.py]
-    GitScripts --> GitHub[(GitHub PR)]
-```
-
-Key invariants:
-
-- The agent **never** invokes Gradle directly. Build/test commands are issued
-  by the strategy via `agent.run_test_command(...)`, which returns combined
-  output to the strategy for analysis.
-- All generated changes must live under the per-library directory
-  `tests/src/<group>/<artifact>/<version>` of the reachability repo, plus that
-  library's `metadata/<group>/<artifact>/index.json`.
-- Every successful run writes a metrics record that validates against
-  [schemas/evaluation_output_schema.json](../schemas/).
-
-## 6. Top-Level Run Sequence
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant U as User / CI
-    participant Entry as ai_workflows/<workflow>.py
-    participant Setup as utility_scripts (paths, env, source ctx)
-    participant Strat as Workflow strategy
-    participant Agent as Registered agent
-    participant Repo as Reachability repo (Gradle)
-    participant Metrics as Metrics repo
-
-    U->>Entry: Invoke with --coordinates, --strategy-name
-    Entry->>Setup: Resolve repo paths, GraalVM/Java home
-    Entry->>Setup: Load predefined strategy
-    Entry->>Repo: Create feature branch, run scaffold
-    Entry->>Setup: populateArtifactURLs + prepare_source_contexts
-    Entry->>Strat: Instantiate strategy with context + source ctx
-    Entry->>Agent: Initialize agent with editable + read-only files
-    Entry->>Strat: run(agent, checkpoint_commit_hash)
-    Strat->>Agent: send_prompt / run_test_command (loop)
-    Strat->>Repo: Gradle build, test, report, metadata tasks
-    Strat-->>Entry: status, iteration counts
-    Entry->>Metrics: Append validated run-metrics record
-    Entry-->>U: Exit code 0 (success) or 1 (failure)
-```
-
-## 7. Configuration Contracts
-
-### 7.1 CLI inputs (common to all entry scripts)
+### 4.1 CLI inputs (common to all entry scripts)
 
 - `--coordinates <group:artifact:version>` — required.
 - `--reachability-metadata-path` — overrides default reachability-repo clone.
@@ -130,7 +67,7 @@ sequenceDiagram
 - `--keep-tests-without-dynamic-access` — only honored by dynamic-access
   strategies; see [dynamic-access-workflow.md](dynamic-access-workflow.md).
 
-### 7.2 Predefined strategy schema
+### 4.2 Predefined strategy schema
 
 Each entry in `strategies/predefined_strategies.json` must provide:
 
@@ -145,7 +82,7 @@ Each entry in `strategies/predefined_strategies.json` must provide:
   `source-context-types`, etc.).
 - `mcps` — optional list of MCP server names.
 
-### 7.3 Environment
+### 4.3 Environment
 
 - Either `GRAALVM_HOME` or `JAVA_HOME` must point to a GraalVM distribution.
   Both variables are then aligned to that distribution. If neither does, the
@@ -153,7 +90,7 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - `gh` CLI authenticated against the reachability repo is required for any
   script in `git_scripts/` or `complete_pipelines/`.
 
-## 8. Outputs
+## 5. Outputs
 
 - **Per-run metrics record** appended to
   `<metrics_repo>/{script_run_metrics,benchmark_run_metrics}/<workflow>.json`,
@@ -164,7 +101,7 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - **Pull request** (only when invoked through `complete_pipelines/` or
   `git_scripts/make_pr_*.py`).
 
-## 9. Failure Semantics
+## 6. Failure Semantics
 
 Every workflow returns one of three statuses:
 
@@ -176,7 +113,7 @@ Every workflow returns one of three statuses:
 
 The exit code is `0` for the first two and `1` for failure.
 
-## 10. Workflow Specifications
+## 7. Workflow Specifications
 
 - [Dynamic access workflow](dynamic-access-workflow.md) — guided test
   generation driven by the dynamic-access coverage report.

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -46,6 +46,7 @@ supporting tests for the reachability repo.
 | **Agent** | LLM-driven code editor (Aider, Codex, or Pi) registered through [ai_workflows/agents/](../ai_workflows/agents/). Each implements `send_prompt`, `run_test_command`, `clear_context`. |
 | **Workflow strategy** | A registered control loop in [ai_workflows/workflow_strategies/](../ai_workflows/workflow_strategies/) (e.g. `basic_iterative`, `dynamic_access_iterative`). |
 | **Predefined strategy** | Named, fully parameterized combination of agent + workflow strategy + prompts + parameters in [strategies/predefined_strategies.json](../strategies/predefined_strategies.json). Selected via `--strategy-name`. |
+| **Post-generation intervention** | Recovery step a strategy invokes when the post-iteration `./gradlew test` still fails. Pluggable via the `PostGenerationIntervention` registry. Configured per predefined strategy (`post-generation-intervention.name`). Concrete implementations: `noop`, `codex_then_pi` (default), `native_trace_collect`. See [workflow-strategies.md §5](workflow-strategies.md#5-post-generation-interventions). |
 | **Dynamic access** | Reflection, JNI, resource access, serialization, or proxy use that GraalVM `native-image` cannot determine statically. |
 | **Dynamic-access report** | JSON written by Gradle task `generateDynamicAccessCoverageReport` to `tests/src/<group>/<artifact>/<version>/build/reports/dynamic-access/dynamic-access-coverage.json`, listing classes and per-class call sites that require dynamic-access metadata, marked covered/uncovered. |
 | **Source context** | Read-only files supplied to the agent. Types: `main` (library source), `test` (upstream tests), `documentation` (Javadoc). Selected by the strategy parameter `source-context-types`. |
@@ -81,6 +82,11 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - `parameters` — workflow-specific parameters (iteration limits,
   `source-context-types`, etc.).
 - `mcps` — optional list of MCP server names.
+- `post-generation-intervention` — optional. Selects the recovery step
+  invoked when the post-iteration `./gradlew test` fails. Shape:
+  `{ "name": "<registered intervention>", "parameters": { … } }`. Omitted
+  entries default to `codex_then_pi`. See
+  [workflow-strategies.md §5](workflow-strategies.md#5-post-generation-interventions).
 
 ### 4.3 Environment
 
@@ -108,22 +114,25 @@ Every workflow returns one of three statuses:
 | Status | Meaning |
 | --- | --- |
 | `RUN_STATUS_SUCCESS` | All gates passed; metadata and tests committed. |
-| `SUCCESS_WITH_INTERVENTION_STATUS` | Tests succeeded after a post-generation manual or scripted intervention; PR-eligible. |
+| `SUCCESS_WITH_INTERVENTION_STATUS` | Tests succeeded after the configured `PostGenerationIntervention` modified the working tree (e.g. `codex_then_pi` removing failing tests via Pi). The intervention's record is included in the run-metrics and PR description. PR-eligible. |
 | `RUN_STATUS_FAILURE` | The workflow could not converge or a quality gate failed; the feature branch is reset to the scaffold checkpoint and no PR is opened. |
 
 The exit code is `0` for the first two and `1` for failure.
 
 ## 7. Workflow Specifications
 
+- [Workflow strategies](workflow-strategies.md) — registry of strategies
+  and post-generation interventions, including the
+  [`native_trace_collect`](workflow-strategies.md#53-native_trace_collect)
+  intervention that drives the trace loop.
 - [Dynamic access workflow](dynamic-access-workflow.md) — guided test
   generation driven by the dynamic-access coverage report.
-- [Native metadata exploration phase](native-metadata-exploration.md) —
-  reusable phase that traces the test binary with `MetadataTracingSupport`
-  and writes its results to a caller-supplied output directory. Used by the
-  dynamic-access workflow after every iteration and by the native-run
-  failure fix workflow.
+- [Native metadata exploration](native-metadata-exploration.md) —
+  specification for the iterative trace loop (Gradle task contract,
+  convergence rule, status enum, codex hand-off). Implements the
+  `native_trace_collect` intervention.
 - [Java compilation / runtime failure fix workflow](fix-java-run-fail.md)
   — version-bump fix workflow shared by `fix_javac_fail` and
-  `fix_java_run_fail`. Integrates with the metadata exploration phase when
-  the failure surfaces under `nativeTest`.
+  `fix_java_run_fail`. Strategies in this family route through the
+  configured post-generation intervention when `nativeTest` still fails.
 - (Future) Basic iterative workflow.

--- a/forge/docs/native-metadata-exploration.md
+++ b/forge/docs/native-metadata-exploration.md
@@ -1,4 +1,11 @@
-# Native Metadata Exploration Phase — Specification
+# Native Metadata Exploration — Specification
+
+> Implementation backing the
+> [`native_trace_collect`](workflow-strategies.md#53-native_trace_collect)
+> post-generation intervention. Strategies opt in by setting
+> `"post-generation-intervention": { "name": "native_trace_collect" }` in
+> their predefined-strategy entry; this document defines the underlying
+> trace loop the intervention runs.
 
 At a glance:
 
@@ -30,22 +37,30 @@ At a glance:
               (every status, including BUILD_FAILED)
 ```
 
-> **See also:** [Project overview](overview.md) ·
+> **See also:** [Functional spec](functional-spec.md) ·
+> [Architecture](architecture.md) ·
+> [Workflow strategies & interventions](workflow-strategies.md) ·
 > [Dynamic-access workflow](dynamic-access-workflow.md) ·
 > [Java fail-fix workflow](fix-java-run-fail.md)
 
 ## 1. Purpose
 
-This phase produces reachability metadata for the target library by **running a
-native image with metadata tracing enabled** rather than by static analysis or
-agent inference. The traced metadata is written to a caller-supplied output
-directory (see §4) and is then available to downstream steps — notably the
-codex metadata fixup — as additional, ground-truth context.
+This document specifies the iterative native-image metadata-tracing loop
+that produces reachability metadata for the target library by **running a
+native image with metadata tracing enabled** rather than by static analysis
+or agent inference. The traced metadata is written to a caller-supplied
+output directory (see §4) and is then available to downstream steps —
+notably the codex metadata fixup — as additional, ground-truth context.
 
-The phase is reusable and self-contained: it has no knowledge of which
-workflow invokes it. Callers are responsible for sequencing it with their own
-steps; this spec only describes the phase contract. Integration is documented
-in the calling specs (linked above and listed in §8).
+The loop is reusable and self-contained: it has no knowledge of which
+intervention or workflow invokes it. The single caller in production is the
+[`native_trace_collect`](workflow-strategies.md#53-native_trace_collect)
+post-generation intervention, which wraps this driver, runs codex with the
+result, and falls back to Pi when codex cannot recover (mirroring
+`codex_then_pi`). Strategies that want trace-driven recovery activate it by
+configuring `"post-generation-intervention": { "name": "native_trace_collect" }`
+in their predefined-strategy entry; nothing else changes inside the
+strategy.
 
 ## 2. Execution Model
 
@@ -156,7 +171,7 @@ committed as a metadata release. It is a build artifact consumed by:
 The canonical metadata under `metadata/<group>/<artifact>/<version>/` continues
 to be produced by `generateMetadata`.
 
-## 5. Phase Workflow
+## 5. Loop Workflow
 
 ```mermaid
 flowchart TD
@@ -226,13 +241,15 @@ diagnostics become part of codex's input — see §9 for the contract.
 
 ## 6. Reusable Implementation Surface
 
-A new module owns this phase:
+A deterministic, side-effect-free Python module owns the loop and is the
+sole non-Gradle implementation surface:
 
 ```text
 utility_scripts/native_metadata_exploration.py
 ```
 
-Public entry:
+The `native_trace_collect` intervention imports this module; it is not
+called from anywhere else. Public entry:
 
 ```python
 def run_native_metadata_exploration(
@@ -273,9 +290,10 @@ Even when `status == BUILD_FAILED`, `output_dir` is still populated
 whenever earlier iterations produced accepted traces; callers must inspect
 both `failure` and `output_dir`.
 
-The module must not depend on any workflow strategy. Sequencing with
-`generateMetadata`, codex fixup, agent hand-off, etc. is the caller's
-responsibility and is documented in the calling specs (see §8).
+The module must not depend on any workflow strategy or intervention.
+Sequencing with `generateMetadata`, codex fixup, agent hand-off, etc. is
+the responsibility of the `native_trace_collect` intervention that wraps
+it (see §8 and §9).
 
 ## 7. Required Gradle Support
 
@@ -368,16 +386,28 @@ for implementation.
 
 ## 8. Callers
 
-This phase is invoked from the following workflows. Each calling spec owns
-its own sequencing diagram and its own rules for what to do with each
-status; this list is informational only.
+The sole production caller is the
+[`native_trace_collect`](workflow-strategies.md#53-native_trace_collect)
+post-generation intervention. Strategies do not invoke this loop directly;
+they enable it by setting `post-generation-intervention.name` to
+`native_trace_collect` in their `predefined_strategies.json` entry. The
+intervention is responsible for sequencing the trace loop with codex
+fixup and the Pi fall-through; this spec only defines the loop contract.
 
-| Caller | Where the integration is specified |
+Workflow-specific guidance on when to choose `native_trace_collect` over
+`codex_then_pi` lives with each strategy spec:
+
+| Strategy / workflow | Where the routing decision is documented |
 | --- | --- |
-| Dynamic-access workflow — after every per-class iteration, and as a precondition for codex fixup inside finalization | [dynamic-access-workflow.md §6.4 and §6.6](dynamic-access-workflow.md) |
-| Native-run failure fix workflow — first corrective action when `nativeTest` fails | [fix-java-run-fail.md](fix-java-run-fail.md) |
+| Dynamic-access workflow | [dynamic-access-workflow.md](dynamic-access-workflow.md) |
+| Native-run failure fix workflow | [fix-java-run-fail.md](fix-java-run-fail.md) |
 
 ## 9. Failure Handoff to Codex Fixup
+
+> The hand-off is owned by the `native_trace_collect` intervention. This
+> section specifies what diagnostics the loop must surface and how the
+> intervention is required to use them; it does **not** mean the trace
+> loop itself shells out to codex (see §10).
 
 A failed exploration is **not** evidence that the problem is purely a
 metadata gap. The Gradle tasks fail for a wide range of reasons:
@@ -395,10 +425,10 @@ Therefore the phase produces a **diagnostic-rich result on every status**
 and the calling specs must treat every status as eligible for codex
 fixup.
 
-### 9.1 Phase responsibilities
+### 9.1 Loop responsibilities
 
-The phase itself never invokes codex (this remains a hard rule — see
-§10). On any non-`SUCCESS` outcome it must:
+The trace loop itself never invokes codex (this remains a hard rule —
+see §10). On any non-`SUCCESS` outcome it must:
 
 1. Persist the full Gradle stdout/stderr of the failing task to a stable
    absolute path under the runs directory.
@@ -408,10 +438,13 @@ The phase itself never invokes codex (this remains a hard rule — see
    `result.output_dir` carries whatever partial signal exists.
 4. Return; the caller decides how to use the result.
 
-### 9.2 Caller responsibilities
+### 9.2 Intervention responsibilities
 
-When a caller routes the result to `run_codex_metadata_fix(...)`, the
-codex invocation must receive, at minimum:
+The `native_trace_collect` intervention routes the result to
+`run_codex_metadata_fix(...)` for **every** status — including `SUCCESS`,
+where the merged trace dir becomes ground-truth context for codex, and
+`BUILD_FAILED`, where it becomes diagnostics. The codex invocation must
+receive, at minimum:
 
 - The coordinate.
 - `result.output_dir` (added to read-only context, even if empty or
@@ -452,6 +485,11 @@ task; this spec defines the contract.
 
 ### 9.3 Routing rule
 
+The intervention always chains: trace loop → codex fixup → Pi fall-through
+(when codex cannot recover). The only reason this chain does not run is
+that the post-iteration `./gradlew test` already passed, in which case
+`_run_test_with_retry` does not invoke any intervention.
+
 ```mermaid
 flowchart LR
     Explore[run_native_metadata_exploration] --> Status{status}
@@ -459,11 +497,12 @@ flowchart LR
     Status -- "SUCCESS_UNVERIFIED" --> CodexCtx2[codex fixup with output_dir + verifier_output]
     Status -- "BUDGET_EXHAUSTED" --> CodexCtx3[codex fixup with partial output_dir + budget note]
     Status -- "BUILD_FAILED" --> CodexFail[codex fixup with partial output_dir + failure diagnostics<br/>see §9.2]
+    CodexCtx --> PiFall[Pi fall-through if tests still fail]
+    CodexCtx2 --> PiFall
+    CodexCtx3 --> PiFall
+    CodexFail --> PiFall
+    PiFall --> Result[InterventionResult: passed / passed_with_intervention / failed]
 ```
-
-There is no longer a "skip codex" branch. The only reason for a caller
-not to call codex is that the test already passed without intervention
-(in which case the exploration phase is not invoked in the first place).
 
 ## 10. Acceptance Criteria
 
@@ -509,6 +548,7 @@ A `run_native_metadata_exploration(...)` invocation is correct iff:
 11. The function returns the status enum, the absolute output directory,
     the absolute per-run directory, and (on failure) the diagnostic
     fields described in §6 and §9.
-12. No code path inside the phase shells out to the codex fixup, the
-    agent, or any LLM. The phase is purely deterministic. Routing the
-    result to codex is the caller's responsibility.
+12. No code path inside the loop shells out to codex fixup, the agent,
+    or any LLM. The loop is purely deterministic. Routing the result to
+    codex (and the Pi fall-through) is the responsibility of the
+    `native_trace_collect` intervention that wraps it.

--- a/forge/docs/workflow-strategies.md
+++ b/forge/docs/workflow-strategies.md
@@ -20,7 +20,7 @@ flowchart TB
     subgraph Base["WorkflowStrategy (abstract base)"]
         Reg["@register(name) registry"]
         Validate["REQUIRED_PROMPTS<br/>REQUIRED_PARAMS validation"]
-        TestRetry["_run_test_with_retry<br/>(post-gen hook)"]
+        TestRetry["_run_test_with_retry<br/>(dispatches to configured intervention)"]
         Finalize["_finalize_successful_iteration<br/>(generateMetadata + commit)"]
         AllowedPkg["_run_check_metadata_files_<br/>with_allowed_packages_fix"]
     end
@@ -50,7 +50,12 @@ flowchart TB
     subgraph Collaborators["Collaborators"]
         Agent["Agent<br/>(pi / codex)"]
         Repo[("Reachability repo<br/>./gradlew test, generateMetadata,<br/>checkMetadataFiles, splitTestOnlyMetadata")]
-        PostGen["Post-generation:<br/>fix_metadata_codex<br/>fix_post_generation_pi"]
+    end
+
+    subgraph Interventions["PostGenerationIntervention (registry)"]
+        Noop["noop<br/>(skip post-gen)"]
+        Codex["codex_then_pi<br/>(default)<br/>fix_metadata_codex → fix_post_generation_pi"]
+        Trace["native_trace_collect<br/>iterative trace loop → codex"]
     end
 
     subgraph Finalization["Library Finalization (utility_scripts/library_finalization)"]
@@ -71,8 +76,9 @@ flowchart TB
 
     Concrete --> Agent
     Concrete --> Repo
-    TestRetry --> PostGen
-    PostGen --> Repo
+    TestRetry -->|dispatch by name| Interventions
+    Interventions --> Repo
+    Trace -.->|gradlew nativeTraceImage,<br/>runNativeTraceImage,<br/>mergeNativeTraceMetadata| Repo
     Finalize --> Finalization
     Finalization --> Repo
 
@@ -85,7 +91,7 @@ flowchart TB
     Concrete --> Status
     Concrete --> Iters
     Concrete --> Checkpoint
-    TestRetry --> Intervention
+    Interventions -->|record| Intervention
 ```
 
 ## 2. Base Class Contract
@@ -102,14 +108,15 @@ provides:
   context (`library`, `version`, …) plus per-iteration extras into templates
   loaded by [`strategy_loader`](../utility_scripts/strategy_loader.py).
 - **Post-generation hook**: `_run_test_with_retry(library)` runs
-  `./gradlew test`. On failure it invokes
-  [`fix_metadata_codex`](../ai_workflows/fix_metadata_codex.py); if Codex
-  doesn't converge, it falls back to
-  [`fix_post_generation_pi`](../ai_workflows/fix_post_generation_pi.py),
-  which removes failing tests and writes an intervention report. Returns
-  `RUN_STATUS_SUCCESS`, `RUN_STATUS_FAILURE`, or
-  `SUCCESS_WITH_INTERVENTION_STATUS` and populates
-  `self.post_generation_intervention`.
+  `./gradlew test`. On failure it dispatches to the
+  [`PostGenerationIntervention`](#5-post-generation-interventions) named in
+  the strategy config's `post-generation-intervention` block (default
+  [`codex_then_pi`](#52-codex_then_pi-default), preserving historical
+  behaviour). The intervention returns one of `passed`,
+  `passed_with_intervention`, `skipped`, or `failed`, which the base maps to
+  `RUN_STATUS_SUCCESS`, `SUCCESS_WITH_INTERVENTION_STATUS`,
+  `RUN_STATUS_FAILURE`, and populates `self.post_generation_intervention`
+  with the intervention's record.
 - **Iteration finalization**: `_finalize_successful_iteration` runs
   `generateMetadata` (with `--agentAllowedPackages=fromJar`),
   `_run_test_with_retry`, then delegates to
@@ -234,7 +241,104 @@ Naming convention: `<workflow>_<source-context>_<agent>_<model>`. The
 `source-context` segment selects which JARs (main / tests / documentation /
 combinations) `source_context` materializes for the agent.
 
-## 5. Adding a New Strategy
+## 5. Post-Generation Interventions
+
+A *post-generation intervention* is the recovery step that runs whenever
+`_run_test_with_retry` observes a failing `./gradlew test`. Interventions are
+a separate plug-in registry from workflow strategies — same lifecycle as
+`Agent` and `WorkflowStrategy`. The active intervention is selected per
+predefined-strategy entry; today's behaviour is preserved by defaulting to
+[`codex_then_pi`](#52-codex_then_pi-default) when no entry is set.
+
+### 5.1 Interface
+
+```python
+class PostGenerationIntervention(ABC):
+    _registry: dict[str, type["PostGenerationIntervention"]]
+
+    @classmethod
+    def register(cls, name): ...        # decorator
+    @classmethod
+    def get_class(cls, name): ...
+
+    def __init__(self, config: dict | None = None): ...
+
+    @abstractmethod
+    def run(self, ctx: InterventionContext) -> InterventionResult: ...
+```
+
+`InterventionContext` carries `library`, `reachability_repo_path`,
+`test_output`, `failed_task`, and `model_name`. `InterventionResult` carries
+a status (`passed` / `passed_with_intervention` / `skipped` / `failed`) and
+an optional `record` dict serialized into the run-metrics
+`post_generation_intervention` field and the PR description.
+
+Selection in `predefined_strategies.json`:
+
+```json
+"post-generation-intervention": {
+  "name": "codex_then_pi",
+  "parameters": { "post-generation-timeout-seconds": 600 }
+}
+```
+
+Strategies that should never run a recovery step pin
+`{"name": "noop"}`. Strategies that want trace-driven recovery pin
+`{"name": "native_trace_collect"}` (see §5.3).
+
+### 5.2 `codex_then_pi` (default)
+
+Mirrors the historical cascade. Runs
+[`run_codex_metadata_fix(repo, library)`](../ai_workflows/fix_metadata_codex.py);
+if Codex passes and tests now pass, returns `passed`. Otherwise runs
+[`run_pi_post_generation_fix(...)`](../ai_workflows/fix_post_generation_pi.py)
+which removes failing tests and writes an intervention report; the result is
+`passed_with_intervention` (record = `{stage, intervention_file,
+analysis_markdown}`) when the rerun finally passes, `failed` otherwise.
+
+Configurable parameters:
+
+- `post-generation-timeout-seconds` (default 600)
+- `post-generation-test-output-chars` (default 12000)
+
+### 5.3 `native_trace_collect`
+
+Runs the native-image metadata-tracing loop specified in
+[native-metadata-exploration.md](native-metadata-exploration.md), then hands
+the result to Codex. Sequence:
+
+1. Invoke the reusable trace driver
+   ([`utility_scripts/native_metadata_exploration.py`](../utility_scripts/native_metadata_exploration.py))
+   with the failing library's coordinate. The driver iterates
+   `nativeTraceImage` → `runNativeTraceImage` → optional
+   `mergeNativeTraceMetadata` until convergence, build failure, or the
+   iteration budget is exhausted.
+2. Run `run_codex_metadata_fix` with the merged trace dir as additional
+   read-only context (the diagnostic-rich result follows the contract in
+   [native-metadata-exploration.md §9](native-metadata-exploration.md#9-failure-handoff-to-codex-fixup)).
+3. If tests still fail, fall through to `run_pi_post_generation_fix` exactly
+   like `codex_then_pi`. This guarantees the codex fall-back behaviour the
+   strategy contract relies on, regardless of whether the trace loop
+   converged.
+
+The record dict additionally carries `trace_status`,
+`trace_iterations_used`, and `trace_output_dir` so the PR body and metrics
+can show what tracing produced.
+
+Configurable parameters:
+
+- `max-trace-iterations` (default 5)
+- `trace-condition-packages` (default = `[group]`)
+- `verify-exact-after-merge` (default true)
+- `post-generation-timeout-seconds`,
+  `post-generation-test-output-chars` — forwarded to the codex/pi sub-steps.
+
+### 5.4 `noop`
+
+Returns `skipped` immediately. Used when the strategy should treat any
+test failure as a hard failure without invoking codex or pi.
+
+## 6. Adding a New Strategy
 
 1. Subclass `WorkflowStrategy` under
    [`ai_workflows/workflow_strategies/`](../ai_workflows/workflow_strategies/).

--- a/forge/docs/workflow-strategies.md
+++ b/forge/docs/workflow-strategies.md
@@ -1,0 +1,251 @@
+# Workflow Strategies
+
+> **See also:** [Architecture](architecture.md) · [Functional spec](functional-spec.md) ·
+> [Dynamic-access strategy](dynamic-access-strategy.md)
+
+A *workflow strategy* is the control loop that drives an
+[`Agent`](../ai_workflows/agents/agent.py) through generation, build, and test
+iterations for one library. Each entry script in `ai_workflows/` instantiates
+exactly one strategy (resolved via `--strategy-name` against
+[`predefined_strategies.json`](../strategies/predefined_strategies.json)) and
+calls its `run(agent, ...)` method.
+
+This document describes the strategy registry, the responsibilities shared by
+the base class, and the concrete strategies shipped today.
+
+## 1. Component Diagram
+
+```mermaid
+flowchart TB
+    subgraph Base["WorkflowStrategy (abstract base)"]
+        Reg["@register(name) registry"]
+        Validate["REQUIRED_PROMPTS<br/>REQUIRED_PARAMS validation"]
+        TestRetry["_run_test_with_retry<br/>(post-gen hook)"]
+        Finalize["_finalize_successful_iteration<br/>(generateMetadata + commit)"]
+        AllowedPkg["_run_check_metadata_files_<br/>with_allowed_packages_fix"]
+    end
+
+    subgraph Concrete["Concrete Strategies"]
+        Basic["basic_iterative<br/>(scaffold → test → fix loop)"]
+        Dyn["dynamic_access_iterative<br/>(per-class DA coverage)"]
+        Opt["optimistic_dynamic_access<br/>(full DA report each turn)"]
+        Inc["increase_dynamic_access_coverage<br/>(composite)"]
+        JFix["java_fix_iterative<br/>↳ javac_iterative<br/>↳ java_run_iterative"]
+    end
+
+    subgraph Inputs["Strategy Inputs"]
+        Predef[("predefined_strategies.json<br/>agent + model + prompts + params")]
+        Templates[("prompt_templates/")]
+        DAReport[("dynamic-access-coverage.json")]
+        SrcCtx["source_context files<br/>(main / tests / docs)"]
+    end
+
+    subgraph Outputs["Strategy Outputs"]
+        Status["status:<br/>success / failure /<br/>success_with_intervention"]
+        Iters["iteration counts"]
+        Checkpoint["checkpoint commit hash"]
+        Intervention["post_generation_intervention<br/>(intervention report)"]
+    end
+
+    subgraph Collaborators["Collaborators"]
+        Agent["Agent<br/>(pi / codex)"]
+        Repo[("Reachability repo<br/>./gradlew test, generateMetadata,<br/>checkMetadataFiles, splitTestOnlyMetadata")]
+        PostGen["Post-generation:<br/>fix_metadata_codex<br/>fix_post_generation_pi"]
+    end
+
+    subgraph Finalization["Library Finalization (utility_scripts/library_finalization)"]
+        FinSplit["splitTestOnlyMetadata"]
+        FinCheck["checkMetadataFiles<br/>+ allowed-packages auto-repair"]
+        FinStyle["style_checks<br/>(run_style_fix_and_checks)"]
+        FinStats["generateLibraryStats"]
+        FinSplit --> FinCheck --> FinStyle --> FinStats
+    end
+
+    Concrete -. inherit .-> Base
+
+    Predef --> Concrete
+    Templates --> Concrete
+    DAReport --> Dyn
+    DAReport --> Opt
+    SrcCtx --> Concrete
+
+    Concrete --> Agent
+    Concrete --> Repo
+    TestRetry --> PostGen
+    PostGen --> Repo
+    Finalize --> Finalization
+    Finalization --> Repo
+
+    Inc -->|delegates primary| JFix
+    Inc -->|delegates primary| Opt
+    Inc -->|coverage phase| Dyn
+    Dyn -->|fallback when no DA report| Basic
+    Opt -->|fallback when no DA report| Basic
+
+    Concrete --> Status
+    Concrete --> Iters
+    Concrete --> Checkpoint
+    TestRetry --> Intervention
+```
+
+## 2. Base Class Contract
+
+[`WorkflowStrategy`](../ai_workflows/workflow_strategies/workflow_strategy.py)
+provides:
+
+- **Registry**: `@WorkflowStrategy.register("name")` adds the subclass to
+  `_registry`; `WorkflowStrategy.get_class("name")` resolves it.
+- **Validation**: subclasses declare `REQUIRED_PROMPTS` and `REQUIRED_PARAMS`;
+  `__init__` raises if the strategy config from `predefined_strategies.json`
+  is missing any.
+- **Prompt rendering**: `_load_prompt` / `_render_prompt` substitute base
+  context (`library`, `version`, …) plus per-iteration extras into templates
+  loaded by [`strategy_loader`](../utility_scripts/strategy_loader.py).
+- **Post-generation hook**: `_run_test_with_retry(library)` runs
+  `./gradlew test`. On failure it invokes
+  [`fix_metadata_codex`](../ai_workflows/fix_metadata_codex.py); if Codex
+  doesn't converge, it falls back to
+  [`fix_post_generation_pi`](../ai_workflows/fix_post_generation_pi.py),
+  which removes failing tests and writes an intervention report. Returns
+  `RUN_STATUS_SUCCESS`, `RUN_STATUS_FAILURE`, or
+  `SUCCESS_WITH_INTERVENTION_STATUS` and populates
+  `self.post_generation_intervention`.
+- **Iteration finalization**: `_finalize_successful_iteration` runs
+  `generateMetadata` (with `--agentAllowedPackages=fromJar`),
+  `_run_test_with_retry`, then delegates to
+  [`library_finalization.run_library_finalization`](../utility_scripts/library_finalization.py)
+  before committing the iteration. Returns
+  `(status, checkpoint_commit_hash)`.
+- **Library finalization** (shared utility): in order,
+  `./gradlew splitTestOnlyMetadata`, `checkMetadataFiles` with
+  allowed-packages auto-repair, `run_style_fix_and_checks`, and
+  `./gradlew generateLibraryStats`. Any failure aborts the iteration.
+- **Allowed-packages auto-repair**:
+  `_run_check_metadata_files_with_allowed_packages_fix` (used by
+  `library_finalization`) runs `checkMetadataFiles` and, on `TypeReached:`
+  errors, appends missing packages to the library's `index.json` (up to
+  3 attempts).
+
+All concrete strategies expect `library` (coordinates),
+`reachability_repo_path`, and a starting `checkpoint_commit_hash`.
+
+## 3. Concrete Strategies
+
+### 3.1 `basic_iterative`
+
+[`basic_iterative_strategy.py`](../ai_workflows/workflow_strategies/basic_iterative_strategy.py)
+
+- **Required prompts**: `initial`, `after-successful-iteration`,
+  `after-failed-iteration`.
+- **Required params**: `max-test-iterations`, `max-failed-generations`,
+  `max-successful-generations`.
+- **Loop**: outer counters track failed and successful generations. The inner
+  test loop (`max-test-iterations` per generation) tries to either reach
+  `nativeTest` or pass tests. On a non-`nativeTest` failure the agent receives
+  the test output via `after-failed-iteration`; on success the iteration is
+  finalized, committed, the checkpoint advances, and the agent context is
+  cleared. Repeated failures reset the working tree to the checkpoint and
+  increment the failed counter.
+- **Stops**: when `max-failed-generations` or `max-successful-generations` is
+  reached.
+- **Returns**: `(status, global_iterations, unittest_number)`.
+
+### 3.2 `dynamic_access_iterative`
+
+[`dynamic_access_iterative_strategy.py`](../ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py)
+
+- **Required prompts**: `dynamic-access-iteration`.
+- **Required params**: `max-iterations` (per uncovered class),
+  `max-class-test-iterations`.
+- **Loop**: parses `dynamic-access-coverage.json`; iterates over classes with
+  uncovered call sites. For each class it renders the iteration prompt with
+  uncovered call-site lists and the coverage delta, runs the inner test loop,
+  regenerates the report on success, and advances the checkpoint when
+  coverage increases (even partially). A class is "exhausted" after
+  `max-iterations` without progress.
+- **Composition**: when no DA report exists or it has zero DA calls, falls
+  back to `basic_iterative` via
+  `load_strategy_by_name("basic_iterative_pi_gpt-5.4")`.
+- **Returns**: `(status, global_iterations, 1)`.
+
+### 3.3 `optimistic_dynamic_access`
+
+[`optimistic_dynamic_access_strategy.py`](../ai_workflows/workflow_strategies/optimistic_dynamic_access_strategy.py)
+
+- **Required prompts**: `optimistic-dynamic-access-iteration`.
+- **Required params**: `max-optimistic-iterations`, `max-test-iterations`.
+- **Loop**: each outer iteration shows the agent the *full* DA report (all
+  uncovered call sites) in a single prompt, then runs the inner test loop. On
+  success the report is regenerated and the iteration is committed. Stops
+  early when every call site is covered.
+- **Composition**: same DA-missing fallback to `basic_iterative` as above.
+- **Returns**: `(status, prompt_iterations, successful_iterations)`.
+
+### 3.4 `increase_dynamic_access_coverage` (composite)
+
+[`increase_dynamic_access_coverage_strategy.py`](../ai_workflows/workflow_strategies/increase_dynamic_access_coverage_strategy.py)
+
+- **Required prompts / params**: none directly — both are delegated to the
+  primary workflow.
+- **Behaviour**: instantiates a primary strategy (named via
+  `primary-workflow` in the strategy config — e.g. `javac_iterative`,
+  `java_run_iterative`, or `optimistic_dynamic_access`) and runs it. If the
+  primary succeeds, runs `dynamic_access_iterative`'s per-class coverage
+  phase to lift coverage further. If the primary fails, returns its result
+  unchanged. Iteration counts are merged.
+- **Intervention**: inherits the primary's `post_generation_intervention` if
+  it set one.
+
+### 3.5 `javac_iterative` / `java_run_iterative`
+
+[`java_fix_iterative_strategy.py`](../ai_workflows/workflow_strategies/java_fix_iterative_strategy.py)
+
+- Two registrations of the same base — `javac_iterative` (compile-fix mode)
+  and `java_run_iterative` (JVM-runtime-fix mode). They differ only in
+  prompt context and log prefix.
+- **Required prompts**: `initial`. **Required params**: `max-test-iterations`.
+- **Loop**: runs an initial Gradle test, ships the captured error to the
+  agent via the `initial` prompt, then loops (up to `max-test-iterations`):
+  re-run the test; if `nativeTest` is reached or the build passes, return
+  success; otherwise feed the failure output back to the agent and retry. No
+  internal checkpointing — these strategies operate on PRs that already have
+  a baseline. The agent context is cleared at the end.
+- **Returns**: `(status, global_iterations)`.
+- **Inputs**: expects `updated_library` (the new coordinates) and
+  `reachability_repo_path`.
+
+## 4. Predefined Strategies
+
+[`predefined_strategies.json`](../strategies/predefined_strategies.json)
+binds each workflow strategy to an agent, a model, prompt template paths, and
+parameter values. The `--strategy-name` passed to an entry script names one
+of these bundles. Examples grouped by underlying workflow strategy:
+
+| Workflow strategy | Predefined strategy entries |
+| --- | --- |
+| `basic_iterative` | `basic_iterative_pi_gpt-5.4`, `codex_iterative_codex_gpt-5.4` |
+| `dynamic_access_iterative` | `dynamic_access_main_sources_*`, `dynamic_access_test_sources_*`, `dynamic_access_documentation_sources_*`, `dynamic_access_main_sources_with_tests_*`, `dynamic_access_main_sources_with_documentation_*`, `dynamic_access_main_sources_with_tests_and_documentation_*`, `dynamic_access_test_sources_with_documentation_*` (each with `pi`/`codex` agent and a model suffix) |
+| `optimistic_dynamic_access` | (selected internally as the primary in composite entries) |
+| `increase_dynamic_access_coverage` | `javac_iterative_with_coverage_sources_pi_gpt-5.4`, `javac_iterative_with_coverage_sources_pi_gpt-5.5`, `java_run_iterative_with_coverage_sources_pi_gpt-5.5`, `optimistic_dynamic_access_iterative_pi_gpt-5.4` |
+| `javac_iterative` | `javac_iterative_sources_pi_gpt-5.4` |
+| `java_run_iterative` | `java_run_iterative_sources_pi_gpt-5.4` |
+
+Naming convention: `<workflow>_<source-context>_<agent>_<model>`. The
+`source-context` segment selects which JARs (main / tests / documentation /
+combinations) `source_context` materializes for the agent.
+
+## 5. Adding a New Strategy
+
+1. Subclass `WorkflowStrategy` under
+   [`ai_workflows/workflow_strategies/`](../ai_workflows/workflow_strategies/).
+2. Decorate the class with `@WorkflowStrategy.register("name")` and declare
+   `REQUIRED_PROMPTS` / `REQUIRED_PARAMS`.
+3. Implement `run(agent, **kwargs)`. Reuse `_run_test_with_retry`,
+   `_finalize_successful_iteration`, and
+   `_run_check_metadata_files_with_allowed_packages_fix` rather than
+   reimplementing build/commit logic.
+4. Add prompt templates under [`prompt_templates/`](../prompt_templates/).
+5. Add one or more entries to
+   [`strategies/predefined_strategies.json`](../strategies/predefined_strategies.json)
+   that bind the new workflow name to an agent, model, prompts, and
+   parameters.

--- a/forge/docs/workflow-strategies.md
+++ b/forge/docs/workflow-strategies.md
@@ -308,7 +308,7 @@ Runs the native-image metadata-tracing loop specified in
 the result to Codex. Sequence:
 
 1. Invoke the reusable trace driver
-   ([`utility_scripts/native_metadata_exploration.py`](../utility_scripts/native_metadata_exploration.py))
+   (`utility_scripts/native_metadata_exploration.py`)
    with the failing library's coordinate. The driver iterates
    `nativeTraceImage` → `runNativeTraceImage` → optional
    `mergeNativeTraceMetadata` until convergence, build failure, or the

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -10,6 +10,7 @@ plugins {
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import org.graalvm.internal.tck.CheckDocLinksTask
 import org.graalvm.internal.tck.ContributionTask
 import org.graalvm.internal.tck.DockerTask
 import org.graalvm.internal.tck.MetadataFilesCheckerTask
@@ -341,6 +342,12 @@ tasks.register("generateReadmeBadgeSummary", GenerateReadmeBadgeSummaryTask.clas
 tasks.register("validateLibraryStats", ValidateLibraryStatsTask.class) { task ->
     task.setDescription("Validates exploded stats/*.json files against the committed JSON schema")
     task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+}
+
+tasks.register("checkDocLinks", CheckDocLinksTask.class) { task ->
+    task.setDescription("Verifies that every repo-local link in Markdown documentation resolves")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.getRepoRoot().set(tck.repoRoot)
 }
 
 tasks.register("analyzeExternalLibraryDynamicAccess", AnalyzeExternalLibraryDynamicAccessTask.class) { task ->

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/CheckDocLinksTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/CheckDocLinksTask.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Verifies that every repo-local link in Markdown documentation resolves to
+ * an existing path inside the repository.
+ *
+ * <p>Walks the repository for {@code .md} files (excluding generated/build/test
+ * scratch directories), parses inline {@code [text](target)} and reference-style
+ * {@code [label]: target} links, and fails the build if any link points to a
+ * missing repository path. External URLs ({@code http://}, {@code https://},
+ * {@code mailto:}, etc.) are intentionally skipped — only repository-local
+ * targets are checked.
+ */
+public abstract class CheckDocLinksTask extends DefaultTask {
+
+    private static final Set<String> EXCLUDED_DIRECTORIES = new HashSet<>(Arrays.asList(
+            ".git", ".gradle", ".idea", ".venv", "build", "node_modules",
+            "metadata", "tests", "local_repositories", "native-build-tools"
+    ));
+
+    private static final List<String> EXTERNAL_PROTOCOLS = Arrays.asList(
+            "http://", "https://", "mailto:", "ftp://", "ftps://",
+            "ssh://", "git://", "tel:"
+    );
+
+    private static final Pattern INLINE_LINK = Pattern.compile(
+            "!?" +                                  // optional image marker
+            "\\[" +
+            "(?:\\\\.|[^\\[\\]\\\\])*" +            // link text
+            "]\\(\\s*" +
+            "(?<target>(?:\\\\.|[^\\s)\\\\])+)" +   // link target
+            "(?:\\s+\"[^\"]*\")?" +                 // optional title
+            "(?:\\s+'[^']*')?" +
+            "\\s*\\)"
+    );
+
+    private static final Pattern REFERENCE_LINK = Pattern.compile(
+            "(?m)^\\s{0,3}\\[(?:\\\\.|[^\\[\\]\\\\])+]:\\s+(?<target>\\S+)"
+    );
+
+    private static final Pattern CODE_FENCE = Pattern.compile("^\\s*(```|~~~)");
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract DirectoryProperty getRepoRoot();
+
+    @TaskAction
+    public void check() throws IOException {
+        Path repoRoot = getRepoRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
+        List<String> errors = new ArrayList<>();
+        List<Path> markdownFiles = collectMarkdownFiles(repoRoot);
+        for (Path markdownFile : markdownFiles) {
+            String content = stripCodeFences(Files.readString(markdownFile));
+            checkLinksInContent(repoRoot, markdownFile, content, INLINE_LINK, errors);
+            checkLinksInContent(repoRoot, markdownFile, content, REFERENCE_LINK, errors);
+        }
+        if (!errors.isEmpty()) {
+            StringBuilder message = new StringBuilder("Broken repo-local Markdown links found:\n");
+            for (String error : errors) {
+                message.append("  ").append(error).append('\n');
+            }
+            message.append("\nTotal broken links: ").append(errors.size());
+            throw new GradleException(message.toString());
+        }
+        getLogger().lifecycle("All repo-local Markdown links resolve.");
+    }
+
+    private List<Path> collectMarkdownFiles(Path repoRoot) throws IOException {
+        List<Path> files = new ArrayList<>();
+        Files.walkFileTree(repoRoot, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                if (!dir.equals(repoRoot) && EXCLUDED_DIRECTORIES.contains(dir.getFileName().toString())) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (file.getFileName().toString().endsWith(".md")) {
+                    files.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        files.sort(Path::compareTo);
+        return files;
+    }
+
+    private static String stripCodeFences(String content) {
+        StringBuilder out = new StringBuilder(content.length());
+        boolean inFence = false;
+        for (String line : content.split("\\R", -1)) {
+            if (CODE_FENCE.matcher(line).find()) {
+                inFence = !inFence;
+                out.append('\n');
+                continue;
+            }
+            out.append(inFence ? "" : line).append('\n');
+        }
+        return out.toString();
+    }
+
+    private void checkLinksInContent(
+            Path repoRoot, Path markdownFile, String content, Pattern pattern, List<String> errors
+    ) {
+        Matcher matcher = pattern.matcher(content);
+        while (matcher.find()) {
+            String target = matcher.group("target").trim();
+            if (target.startsWith("<") && target.endsWith(">")) {
+                target = target.substring(1, target.length() - 1);
+            }
+            if (target.isEmpty() || isExternal(target) || target.startsWith("#")) {
+                continue;
+            }
+            String pathPart = target;
+            int hash = pathPart.indexOf('#');
+            if (hash >= 0) {
+                pathPart = pathPart.substring(0, hash);
+            }
+            if (pathPart.isEmpty()) {
+                continue;
+            }
+            Path resolved;
+            if (pathPart.startsWith("/")) {
+                resolved = repoRoot.resolve(pathPart.substring(1)).normalize();
+            } else {
+                resolved = markdownFile.getParent().resolve(pathPart).normalize();
+            }
+            if (!Files.exists(resolved)) {
+                int line = lineNumberOf(content, matcher.start());
+                errors.add(String.format(
+                        "%s:%d: target not found: %s -> %s",
+                        repoRoot.relativize(markdownFile),
+                        line,
+                        target,
+                        repoRoot.relativize(resolved)
+                ));
+            }
+        }
+    }
+
+    private static boolean isExternal(String target) {
+        String lower = target.toLowerCase();
+        for (String prefix : EXTERNAL_PROTOCOLS) {
+            if (lower.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int lineNumberOf(String content, int offset) {
+        int line = 1;
+        for (int i = 0; i < offset && i < content.length(); i++) {
+            if (content.charAt(i) == '\n') {
+                line++;
+            }
+        }
+        return line;
+    }
+}


### PR DESCRIPTION
Fixes #3592

## Summary
- split Forge documentation into architecture, functional-spec, and workflow-focused documents
- fix repo-local Markdown links affected by the documentation restructure
- add `checkDocLinks` as a Gradle verification task and wire it into `check` and CI

## Testing
- `./gradlew checkDocLinks --console=plain`