### PR TITLE
[GenAI] Test fix for org.apache.directory.api:api-i18n:2.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.directory.api/api-i18n/2.0.0/reachability-metadata.json
+++ b/metadata/org.apache.directory.api/api-i18n/2.0.0/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.directory.api.i18n.I18n"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.directory.api.i18n.I18n"
+      },
+      "glob": "org/apache/directory/api/i18n/errors.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.directory.api.i18n.I18n"
+      },
+      "glob": "org/apache/directory/api/i18n/messages.properties"
+    },
+    {
+      "bundle": "org/apache/directory/api/i18n/errors"
+    },
+    {
+      "bundle": "org/apache/directory/api/i18n/messages"
+    }
+  ]
+}

--- a/metadata/org.apache.directory.api/api-i18n/index.json
+++ b/metadata/org.apache.directory.api/api-i18n/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-i18n/2.0.0/api-i18n-2.0.0-sources.jar",
+    "repository-url" : "https://github.com/apache/directory-ldap-api",
+    "test-code-url" : "https://github.com/apache/directory-ldap-api/blob/2.0.0/integ-osgi/src/test/java/org/apache/directory/api/osgi/ApiI18nOsgiTest.java",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-i18n/2.0.0/api-i18n-2.0.0-javadoc.jar",
+    "description" : "Apache Directory LDAP API I18n provides the internationalized message and error-code resources used by the Apache Directory LDAP API modules. It exposes the I18n enum and resource bundles that format localized diagnostics for LDAP, ASN1, DSML, and related Directory API components.",
     "tested-versions" : [
       "2.0.0"
     ],

--- a/metadata/org.apache.directory.api/api-i18n/index.json
+++ b/metadata/org.apache.directory.api/api-i18n/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0",
+    "tested-versions" : [
+      "2.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.directory.api.i18n"
+    ]
+  },
+  {
     "metadata-version" : "1.0.0-M20",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-i18n/1.0.0-M20/api-i18n-1.0.0-M20-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/directory/shared/",

--- a/stats/org.apache.directory.api/api-i18n/2.0.0/execution-metrics.json
+++ b/stats/org.apache.directory.api/api-i18n/2.0.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T09:55:54.863343Z",
+    "library": "org.apache.directory.api:api-i18n:2.0.0",
+    "starting_commit": "b5361721e11628812ac8534412333df08ab36eb3",
+    "ending_commit": "34c3bdb1dff827652b83b49e35844ef5f4abb2cf",
+    "previous_library": "org.apache.directory.api:api-i18n:1.0.0-M20",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 14213,
+          "missed": 155,
+          "ratio": 0.989212,
+          "total": 14368
+        },
+        "line": {
+          "covered": 1302,
+          "missed": 32,
+          "ratio": 0.976012,
+          "total": 1334
+        },
+        "method": {
+          "covered": 6,
+          "missed": 1,
+          "ratio": 0.857143,
+          "total": 7
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.0-M20",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7885,
+          "missed": 106,
+          "ratio": 0.986735,
+          "total": 7991
+        },
+        "line": {
+          "covered": 723,
+          "missed": 19,
+          "ratio": 0.974394,
+          "total": 742
+        },
+        "method": {
+          "covered": 5,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 5
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 119862,
+      "cached_input_tokens_used": 516096,
+      "output_tokens_used": 3613,
+      "iterations": 2,
+      "cost_usd": 0.3664,
+      "tested_library_loc": 1302,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 9,
+      "code_coverage_percent": 97.6,
+      "previous_library_coverage_percent": 97.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java",
+      "metadata_file": "metadata/org.apache.directory.api/api-i18n/2.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.directory.api/api-i18n/2.0.0/stats.json
+++ b/stats/org.apache.directory.api/api-i18n/2.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 14213,
+        "missed" : 155,
+        "ratio" : 0.989212,
+        "total" : 14368
+      },
+      "line" : {
+        "covered" : 1302,
+        "missed" : 32,
+        "ratio" : 0.976012,
+        "total" : 1334
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 1,
+        "ratio" : 0.857143,
+        "total" : 7
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/.gitignore
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/build.gradle
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.directory.api:api-i18n:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/gradle.properties
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.directory.api:api-i18n:2.0.0
+library.version = 2.0.0
+metadata.dir = org.apache.directory.api/api-i18n/2.0.0/

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/settings.gradle
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.directory.api.api-i18n_tests'

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_directory_api.api_i18n;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.directory.api.i18n.I18n;
+import org.junit.jupiter.api.Test;
+
+public class I18nTest {
+    @Test
+    void formatsKnownErrorMessagesFromTheResourceBundle() {
+        String message = I18n.err(I18n.ERR_00001_BAD_TRANSITION_FROM_STATE, "START", "0x30");
+
+        assertThat(message)
+                .startsWith("ERR_00001_BAD_TRANSITION_FROM_STATE ")
+                .contains("Bad transition from state START, tag 0x30");
+    }
+
+    @Test
+    void formatsMessagePatternsAfterLoadingMessageResourceBundle() {
+        String message = I18n.msg("Directory API {0} message", "i18n");
+
+        assertThat(message).isEqualTo("Directory API i18n message");
+    }
+}

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 public class I18nTest {
     @Test
     void formatsKnownErrorMessagesFromTheResourceBundle() {
-        String message = I18n.err(I18n.ERR_00001_BAD_TRANSITION_FROM_STATE, "START", "0x30");
+        String message = I18n.err(I18n.ERR_01200_BAD_TRANSITION_FROM_STATE, "START", "0x30");
 
         assertThat(message)
-                .startsWith("ERR_00001_BAD_TRANSITION_FROM_STATE ")
+                .startsWith("ERR_01200_BAD_TRANSITION_FROM_STATE ")
                 .contains("Bad transition from state START, tag 0x30");
     }
 

--- a/tests/src/org.apache.directory.api/api-i18n/2.0.0/user-code-filter.json
+++ b/tests/src/org.apache.directory.api/api-i18n/2.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.api.i18n.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3549

This PR provides test fixes and new metadata for org.apache.directory.api:api-i18n:2.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 119862
- Cached input tokens: 516096
- Output tokens: 3613
- Entries found: 5
- Iterations: 2
- Library coverage percentage: 97.6
- Previous library version metadata entries: 9
- Previous library version coverage percentage: 97.44

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.directory.api:api-i18n:1.0.0-M20: 2/2 covered calls (100.00%)
- org.apache.directory.api:api-i18n:2.0.0: 2/2 covered calls (100.00%)

**Resources:**
- org.apache.directory.api:api-i18n:1.0.0-M20: 2/2 covered calls (100.00%)
- org.apache.directory.api:api-i18n:2.0.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.directory.api:api-i18n:1.0.0-M20: 7885/7991 (98.67%)
- org.apache.directory.api:api-i18n:2.0.0: 14213/14368 (98.92%)

**Line:**
- org.apache.directory.api:api-i18n:1.0.0-M20: 723/742 (97.44%)
- org.apache.directory.api:api-i18n:2.0.0: 1302/1334 (97.60%)

**Method:**
- org.apache.directory.api:api-i18n:1.0.0-M20: 5/5 (100.00%)
- org.apache.directory.api:api-i18n:2.0.0: 6/7 (85.71%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.directory.api/api-i18n/1.0.0-M20/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java 2/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
index dd574cc2d5..7591036694 100644
--- 1/tests/src/org.apache.directory.api/api-i18n/1.0.0-M20/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
+++ 2/tests/src/org.apache.directory.api/api-i18n/2.0.0/src/test/java/org_apache_directory_api/api_i18n/I18nTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 public class I18nTest {
     @Test
     void formatsKnownErrorMessagesFromTheResourceBundle() {
-        String message = I18n.err(I18n.ERR_00001_BAD_TRANSITION_FROM_STATE, "START", "0x30");
+        String message = I18n.err(I18n.ERR_01200_BAD_TRANSITION_FROM_STATE, "START", "0x30");
 
         assertThat(message)
-                .startsWith("ERR_00001_BAD_TRANSITION_FROM_STATE ")
+                .startsWith("ERR_01200_BAD_TRANSITION_FROM_STATE ")
                 .contains("Bad transition from state START, tag 0x30");
     }
 

```
