### PR TITLE
[GenAI] Test fix for org.junit.platform:junit-platform-commons:1.11.0 using gpt-5.5

### DIFF
--- a/metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json
@@ -1,0 +1,93 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceClassScanner"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "java.util.UUID"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "java.util.UUID[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ClasspathScanner"
+      },
+      "glob" : "org_junit_platform/junit_platform_commons"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ClassLoaderUtils"
+      },
+      "glob" : "org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest$LocationSubject.class"
+    }
+  ]
+}

--- a/metadata/org.junit.platform/junit-platform-commons/index.json
+++ b/metadata/org.junit.platform/junit-platform-commons/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.11.0",
+    "tested-versions" : [
+      "1.11.0"
+    ],
+    "allowed-packages" : [
+      "org.junit.platform.commons"
+    ]
+  },
+  {
     "metadata-version" : "1.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit5",

--- a/metadata/org.junit.platform/junit-platform-commons/index.json
+++ b/metadata/org.junit.platform/junit-platform-commons/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.11.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.11.0/junit-platform-commons-1.11.0-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit-framework",
+    "test-code-url" : "https://github.com/junit-team/junit-framework/tree/r5.11.0/platform-tests/src/test/java/org/junit/platform/commons",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.11.0/junit-platform-commons-1.11.0-javadoc.jar",
+    "description" : "JUnit Platform Commons provides shared utility APIs and support classes used by JUnit 5, including reflection, annotation lookup, classpath scanning, logging, and precondition checks. It supports the JUnit Platform's test discovery and execution infrastructure but is not itself a test engine.",
     "tested-versions" : [
       "1.11.0"
     ],

--- a/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T10:04:43.598298Z",
+    "library": "org.junit.platform:junit-platform-commons:1.11.0",
+    "starting_commit": "752ac2ec76f33c6d1ce9b7447de2ae276d1c29d9",
+    "ending_commit": "c5f7e301e25f0fb4dac0857d0dc927d3e1e15ae2",
+    "previous_library": "org.junit.platform:junit-platform-commons:1.8.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.11.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 28,
+        "totalCalls": 28
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3050,
+          "missed": 4980,
+          "ratio": 0.379826,
+          "total": 8030
+        },
+        "line": {
+          "covered": 647,
+          "missed": 1009,
+          "ratio": 0.3907,
+          "total": 1656
+        },
+        "method": {
+          "covered": 204,
+          "missed": 384,
+          "ratio": 0.346939,
+          "total": 588
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.8.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 26,
+            "totalCalls": 26
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 28,
+        "totalCalls": 28
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2763,
+          "missed": 3435,
+          "ratio": 0.445789,
+          "total": 6198
+        },
+        "line": {
+          "covered": 582,
+          "missed": 703,
+          "ratio": 0.452918,
+          "total": 1285
+        },
+        "method": {
+          "covered": 184,
+          "missed": 261,
+          "ratio": 0.413483,
+          "total": 445
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 218728,
+      "cached_input_tokens_used": 1976320,
+      "output_tokens_used": 22427,
+      "iterations": 5,
+      "cost_usd": 1.661,
+      "tested_library_loc": 647,
+      "metadata_entries": 19,
+      "previous_library_metadata_entries": 25,
+      "code_coverage_percent": 39.07,
+      "previous_library_coverage_percent": 45.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java",
+      "metadata_file": "metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.junit.platform/junit-platform-commons/1.11.0/stats.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.11.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.11.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 28,
+      "totalCalls" : 28
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3050,
+        "missed" : 4980,
+        "ratio" : 0.379826,
+        "total" : 8030
+      },
+      "line" : {
+        "covered" : 647,
+        "missed" : 1009,
+        "ratio" : 0.3907,
+        "total" : 1656
+      },
+      "method" : {
+        "covered" : 204,
+        "missed" : 384,
+        "ratio" : 0.346939,
+        "total" : 588
+      }
+    }
+  } ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/.gitignore
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.platform:junit-platform-commons:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs("-H:+AllowJRTFileSystem")
+            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
+            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/gradle.properties
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.platform:junit-platform-commons:1.11.0
+library.version = 1.11.0
+metadata.dir = org.junit.platform/junit-platform-commons/1.11.0/

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/settings.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.platform.junit-platform-commons_tests'

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/AnnotationUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/AnnotationUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnotationUtilsTest {
+
+    @Test
+    void findsPublicFieldsAnnotatedWithMetaAnnotation() {
+        List<Field> fields = AnnotationSupport.findPublicAnnotatedFields(AnnotatedFieldSubject.class,
+                CharSequence.class, DomainField.class);
+
+        assertThat(fields).extracting(Field::getName).containsExactly("publicText");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+    public @interface DomainField {
+    }
+
+    @DomainField
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface ImportantDomainField {
+    }
+
+    public static class AnnotatedFieldSubject {
+
+        @ImportantDomainField
+        public String publicText = "matched";
+
+        @ImportantDomainField
+        public Integer wrongType = 42;
+
+        public String unannotatedText = "ignored";
+
+        @ImportantDomainField
+        private String privateText = "ignored";
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.net.URL;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassLoaderUtilsTest {
+
+    @Test
+    void getsLocationForClassLoadedByApplicationClassLoader() {
+        LocationSubject subject = new LocationSubject();
+
+        Optional<URL> location = ClassLoaderUtils.getLocation(subject);
+
+        assertThat(location).isNotNull();
+        location.ifPresent(url -> assertThat(url.toExternalForm()).isNotBlank());
+    }
+
+    public static class LocationSubject {
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClasspathScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClasspathScannerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClasspathScannerTest {
+
+    @Test
+    void scansPackageResourcesUsingDefaultClassLoader() {
+        String packageName = ClasspathScannerTest.class.getPackageName();
+        String scannerTestName = ClasspathScannerTest.class.getName();
+
+        List<Class<?>> classes = ReflectionSupport.findAllClassesInPackage(packageName,
+                candidate -> candidate == ClasspathScannerTest.class, name -> name.equals(scannerTestName));
+
+        assertThat(classes).doesNotHaveDuplicates();
+        assertThat(classes).allSatisfy(candidate -> assertThat(candidate).isSameAs(ClasspathScannerTest.class));
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+public class ModuleUtilsInnerModuleReferenceResourceScannerTest {
+
+    @Test
+    void attemptsToLoadModuleResourcesBeforeApplyingCallerFilter() {
+        assertThatNullPointerException().isThrownBy(
+                () -> ModuleUtils.findAllResourcesInModule("java.base", resource -> false));
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
@@ -6,16 +6,21 @@
  */
 package org_junit_platform.junit_platform_commons;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.Resource;
 import org.junit.platform.commons.util.ModuleUtils;
 
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ModuleUtilsInnerModuleReferenceResourceScannerTest {
 
     @Test
-    void attemptsToLoadModuleResourcesBeforeApplyingCallerFilter() {
-        assertThatNullPointerException().isThrownBy(
-                () -> ModuleUtils.findAllResourcesInModule("java.base", resource -> false));
+    void loadsResourcesDiscoveredInNamedModule() {
+        List<Resource> resources = ModuleUtils.findAllResourcesInModule("java.base",
+                resource -> resource.getName().equals("java/lang/uniName.dat"));
+
+        assertThat(resources).extracting(Resource::getName).contains("java/lang/uniName.dat");
     }
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceScannerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ClassFilter;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilsInnerModuleReferenceScannerTest {
+
+    @Test
+    void scansNamedModuleAndLoadsMatchingClass() {
+        ClassFilter classFilter = ClassFilter.of(name -> name.equals(String.class.getName()),
+                candidate -> candidate == String.class);
+
+        List<Class<?>> classes = ModuleUtils.findAllClassesInModule("java.base", classFilter);
+
+        assertThat(classes).containsExactly(String.class);
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+
+    @Test
+    void createsInstanceFromMatchingDeclaredConstructor() {
+        InstantiatedSubject subject = ReflectionUtils.newInstance(InstantiatedSubject.class, "created");
+
+        assertThat(subject.getValue()).isEqualTo("created");
+    }
+
+    @Test
+    void findsDeclaredConstructorsMatchingPredicate() {
+        List<Constructor<?>> constructors = ReflectionUtils.findConstructors(ConstructorSubject.class,
+                constructor -> constructor.getParameterCount() == 1);
+
+        assertThat(constructors).hasSize(1);
+        assertThat(constructors.get(0).getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void readsPrivateFieldValueByName() throws Exception {
+        FieldSubject subject = new FieldSubject("field-value");
+
+        Object value = ReflectionUtils.tryToReadFieldValue(FieldSubject.class, "value", subject).get();
+
+        assertThat(value).isEqualTo("field-value");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void resolvesOutermostInstanceFromInnerClass() {
+        OuterSubject outer = new OuterSubject("outer-value");
+        OuterSubject.InnerSubject inner = outer.new InnerSubject();
+
+        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
+
+        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
+    }
+
+    @Test
+    void findsFieldsDeclaredByImplementedInterfaces() {
+        List<Field> fields = ReflectionUtils.findFields(InterfaceFieldSubject.class,
+                field -> field.getName().equals("INTERFACE_FIELD"), HierarchyTraversalMode.TOP_DOWN);
+
+        assertThat(fields).extracting(Field::getName).containsExactly("INTERFACE_FIELD");
+    }
+
+    @Test
+    void getsPublicMethodByNameAndParameterTypes() throws Exception {
+        Method method = ReflectionUtils.tryToGetMethod(MethodSubject.class, "echo", String.class).get();
+
+        assertThat(method.getName()).isEqualTo("echo");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void findsMethodsDeclaredByInterfaces() {
+        Optional<Method> method = ReflectionUtils.findMethod(InterfaceMethodSubject.class, "interfaceMethod");
+
+        assertThat(method).hasValueSatisfying(value -> assertThat(value.getName()).isEqualTo("interfaceMethod"));
+    }
+
+    @Test
+    void loadsObjectArrayTypesBySourceName() throws Exception {
+        Class<?> arrayType = ReflectionUtils.tryToLoadClass("java.util.UUID[][]").get();
+
+        assertThat(arrayType).isEqualTo(UUID[][].class);
+    }
+
+    public static class InstantiatedSubject {
+
+        private final String value;
+
+        public InstantiatedSubject(String value) {
+            this.value = value;
+        }
+
+        String getValue() {
+            return value;
+        }
+    }
+
+    public static class ConstructorSubject {
+
+        public ConstructorSubject() {
+        }
+
+        public ConstructorSubject(String value) {
+        }
+    }
+
+    public static class FieldSubject {
+
+        private final String value;
+
+        FieldSubject(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class OuterSubject {
+
+        private final String value;
+
+        OuterSubject(String value) {
+            this.value = value;
+        }
+
+        public class InnerSubject {
+
+            String getOuterValue() {
+                return value;
+            }
+        }
+    }
+
+    public interface InterfaceFields {
+
+        String INTERFACE_FIELD = "interface-field";
+    }
+
+    public static class InterfaceFieldSubject implements InterfaceFields {
+    }
+
+    public static class MethodSubject {
+
+        public String echo(String value) {
+            return value;
+        }
+    }
+
+    public interface InterfaceMethodSubject {
+
+        void interfaceMethod();
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -82,7 +82,7 @@ public class ReflectionUtilsTest {
     }
 
     @Test
-    void resolvesPublicImplementationMethodToInterfaceMethod() {
+    void resolvesPublicImplementationMethodToInterfaceMethod() throws Exception {
         Method implementationMethod = ReflectionUtils.tryToGetMethod(InterfaceImplementationSubject.class,
                 "implementedContractMethod", String.class).get();
 

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -46,15 +46,16 @@ public class ReflectionUtilsTest {
         assertThat(value).isEqualTo("field-value");
     }
 
-    @SuppressWarnings("deprecation")
     @Test
-    void resolvesOutermostInstanceFromInnerClass() {
+    void invokesMethodOnInnerClassInstance() throws Exception {
         OuterSubject outer = new OuterSubject("outer-value");
         OuterSubject.InnerSubject inner = outer.new InnerSubject();
+        Method method = inner.getClass().getDeclaredMethod("getOuterValue");
 
-        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
+        Object outerValue = ReflectionUtils.invokeMethod(method, inner);
 
-        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
+        assertThat(ReflectionUtils.isInnerClass(inner.getClass())).isTrue();
+        assertThat(outerValue).isEqualTo("outer-value");
     }
 
     @Test

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -82,6 +82,19 @@ public class ReflectionUtilsTest {
     }
 
     @Test
+    void resolvesPublicImplementationMethodToInterfaceMethod() {
+        Method implementationMethod = ReflectionUtils.tryToGetMethod(InterfaceImplementationSubject.class,
+                "implementedContractMethod", String.class).get();
+
+        Method interfaceMethod = ReflectionUtils.getInterfaceMethodIfPossible(implementationMethod,
+                InterfaceImplementationSubject.class);
+
+        assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(MethodContract.class);
+        assertThat(interfaceMethod.getName()).isEqualTo("implementedContractMethod");
+        assertThat(interfaceMethod.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
     void loadsObjectArrayTypesBySourceName() throws Exception {
         Class<?> arrayType = ReflectionUtils.tryToLoadClass("java.util.UUID[][]").get();
 
@@ -153,5 +166,18 @@ public class ReflectionUtilsTest {
     public interface InterfaceMethodSubject {
 
         void interfaceMethod();
+    }
+
+    public interface MethodContract {
+
+        String implementedContractMethod(String value);
+    }
+
+    public static class InterfaceImplementationSubject implements MethodContract {
+
+        @Override
+        public String implementedContractMethod(String value) {
+            return value;
+        }
     }
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/RuntimeUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/RuntimeUtilsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.RuntimeUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class RuntimeUtilsTest {
+
+    @Test
+    void determinesDebugModeWithoutThrowing() {
+        assertThatCode(() -> {
+            RuntimeUtils.isDebugMode();
+        }).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,272 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest",
+      "methods" : [
+        {
+          "name" : "findsPublicFieldsAnnotatedWithMetaAnnotation",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest$AnnotatedFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest$AnnotatedFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest",
+      "methods" : [
+        {
+          "name" : "getsLocationForClassLoadedByApplicationClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest$LocationSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest",
+      "methods" : [
+        {
+          "name" : "scansPackageResourcesUsingDefaultClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x000000001b11a120"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest",
+      "methods" : [
+        {
+          "name" : "scansNamedModuleAndLoadsMatchingClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest",
+      "methods" : [
+        {
+          "name" : "createsInstanceFromMatchingDeclaredConstructor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsDeclaredConstructorsMatchingPredicate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsFieldsDeclaredByImplementedInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsMethodsDeclaredByInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getsPublicMethodByNameAndParameterTypes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "loadsObjectArrayTypesBySourceName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "readsPrivateFieldValueByName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "resolvesOutermostInstanceFromInnerClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$ConstructorSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$FieldSubject",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InstantiatedSubject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceFields"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceMethodSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$MethodSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$OuterSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$OuterSubject$InnerSubject",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest",
+      "methods" : [
+        {
+          "name" : "determinesDebugModeWithoutThrowing",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -139,7 +139,7 @@
       "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest",
       "methods" : [
         {
-          "name" : "attemptsToLoadModuleResourcesBeforeApplyingCallerFilter",
+          "name" : "loadsResourcesDiscoveredInNamedModule",
           "parameterTypes" : [ ]
         }
       ]
@@ -291,6 +291,98 @@
           "parameterTypes" : [ ]
         }
       ]
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "glob" : "java/lang/uniName.dat"
+    },
+    {
+      "glob" : "java/time/chrono/hijrah-config-Hijrah-umalqura_islamic-umalqura.properties"
+    },
+    {
+      "glob" : "java/util/currency.data"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt72b/nfc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt72b/nfkc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt72b/ubidi.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt72b/uprops.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt73b/nfc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt73b/nfkc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt73b/ubidi.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt73b/uprops.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt74b/nfc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt74b/nfkc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt74b/ubidi.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt74b/uprops.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt75b/nfc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt75b/nfkc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt75b/ubidi.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt75b/uprops.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/ubidi.icu"
+    },
+    {
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "glob" : "jdk/internal/vm/options"
+    },
+    {
+      "glob" : "sun/net/idn/uidna.spp"
+    },
+    {
+      "glob" : "sun/net/www/content-types.properties"
+    },
+    {
+      "glob" : "sun/text/resources/LineBreakIteratorData"
+    },
+    {
+      "glob" : "sun/text/resources/SentenceBreakIteratorData"
+    },
+    {
+      "glob" : "sun/text/resources/WordBreakIteratorData"
     }
   ]
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -124,6 +124,30 @@
       "condition" : {
         "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
       },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest",
+      "methods" : [
+        {
+          "name" : "attemptsToLoadModuleResourcesBeforeApplyingCallerFilter",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
       "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
     },
     {

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -291,6 +291,72 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x000000003211bc80"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceImplementationSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$MethodContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$OuterSubject$InnerSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest"
     }
   ],
   "resources" : [
@@ -382,6 +448,181 @@
       "glob" : "sun/text/resources/SentenceBreakIteratorData"
     },
     {
+      "glob" : "sun/text/resources/WordBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "java/lang/uniName.dat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "java/time/chrono/hijrah-config-Hijrah-umalqura_islamic-umalqura.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "java/util/currency.data"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/ubidi.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "jdk/internal/vm/options"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/net/idn/uidna.spp"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/net/www/content-types.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/text/resources/LineBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/text/resources/SentenceBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/text/resources/WordBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/uniName.dat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "java/time/chrono/hijrah-config-Hijrah-umalqura_islamic-umalqura.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/currency.data"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/ubidi.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/vm/options"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "sun/net/idn/uidna.spp"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "sun/net/www/content-types.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "sun/text/resources/LineBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "sun/text/resources/SentenceBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
       "glob" : "sun/text/resources/WordBreakIteratorData"
     }
   ]

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/lang/uniName.dat
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/lang/uniName.dat
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/time/chrono/hijrah-config-Hijrah-umalqura_islamic-umalqura.properties
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/time/chrono/hijrah-config-Hijrah-umalqura_islamic-umalqura.properties
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/util/currency.data
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/java/util/currency.data
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/nfc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/nfc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/nfkc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/nfkc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/ubidi.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/ubidi.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/uprops.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt72b/uprops.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/nfc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/nfc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/nfkc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/nfkc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/ubidi.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/ubidi.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/uprops.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt73b/uprops.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/nfc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/nfc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/ubidi.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/ubidi.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/uprops.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt74b/uprops.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/nfc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/nfc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/nfkc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/nfkc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/ubidi.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/ubidi.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/uprops.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt75b/uprops.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/nfc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/nfc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/nfkc.nrm
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/nfkc.nrm
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/ubidi.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/ubidi.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/uprops.icu
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/icu/impl/data/icudt76b/uprops.icu
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/vm/options
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/jdk/internal/vm/options
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/net/idn/uidna.spp
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/net/idn/uidna.spp
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/net/www/content-types.properties
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/net/www/content-types.properties
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/LineBreakIteratorData
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/LineBreakIteratorData
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/SentenceBreakIteratorData
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/SentenceBreakIteratorData
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/WordBreakIteratorData
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/sun/text/resources/WordBreakIteratorData
@@ -1,0 +1,1 @@
+test resource for ModuleUtils resource scanning

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.junit.platform.commons.**"
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.junit.platform.commons.**"
+      "includeClasses" : "org.junit.platform.commons.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3554

This PR provides test fixes and new metadata for org.junit.platform:junit-platform-commons:1.11.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 218728
- Cached input tokens: 1976320
- Output tokens: 22427
- Entries found: 19
- Iterations: 5
- Library coverage percentage: 39.07
- Previous library version metadata entries: 25
- Previous library version coverage percentage: 45.29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.junit.platform:junit-platform-commons:1.8.2: 28/28 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 28/28 covered calls (100.00%)

**Reflection:**
- org.junit.platform:junit-platform-commons:1.8.2: 26/26 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 25/25 covered calls (100.00%)

**Resources:**
- org.junit.platform:junit-platform-commons:1.8.2: 2/2 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.junit.platform:junit-platform-commons:1.8.2: 2763/6198 (44.58%)
- org.junit.platform:junit-platform-commons:1.11.0: 3050/8030 (37.98%)

**Line:**
- org.junit.platform:junit-platform-commons:1.8.2: 582/1285 (45.29%)
- org.junit.platform:junit-platform-commons:1.11.0: 647/1656 (39.07%)

**Method:**
- org.junit.platform:junit-platform-commons:1.8.2: 184/445 (41.35%)
- org.junit.platform:junit-platform-commons:1.11.0: 204/588 (34.69%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
new file mode 100644
index 0000000000..6b978cf306
--- /dev/null
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.Resource;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilsInnerModuleReferenceResourceScannerTest {
+
+    @Test
+    void loadsResourcesDiscoveredInNamedModule() {
+        List<Resource> resources = ModuleUtils.findAllResourcesInModule("java.base",
+                resource -> resource.getName().equals("java/lang/uniName.dat"));
+
+        assertThat(resources).extracting(Resource::getName).contains("java/lang/uniName.dat");
+    }
+}
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
index dc620b48e6..ad76b681df 100644
--- 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -46,15 +46,16 @@ public class ReflectionUtilsTest {
         assertThat(value).isEqualTo("field-value");
     }
 
-    @SuppressWarnings("deprecation")
     @Test
-    void resolvesOutermostInstanceFromInnerClass() {
+    void invokesMethodOnInnerClassInstance() throws Exception {
         OuterSubject outer = new OuterSubject("outer-value");
         OuterSubject.InnerSubject inner = outer.new InnerSubject();
+        Method method = inner.getClass().getDeclaredMethod("getOuterValue");
 
-        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
+        Object outerValue = ReflectionUtils.invokeMethod(method, inner);
 
-        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
+        assertThat(ReflectionUtils.isInnerClass(inner.getClass())).isTrue();
+        assertThat(outerValue).isEqualTo("outer-value");
     }
 
     @Test
@@ -80,6 +81,19 @@ public class ReflectionUtilsTest {
         assertThat(method).hasValueSatisfying(value -> assertThat(value.getName()).isEqualTo("interfaceMethod"));
     }
 
+    @Test
+    void resolvesPublicImplementationMethodToInterfaceMethod() throws Exception {
+        Method implementationMethod = ReflectionUtils.tryToGetMethod(InterfaceImplementationSubject.class,
+                "implementedContractMethod", String.class).get();
+
+        Method interfaceMethod = ReflectionUtils.getInterfaceMethodIfPossible(implementationMethod,
+                InterfaceImplementationSubject.class);
+
+        assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(MethodContract.class);
+        assertThat(interfaceMethod.getName()).isEqualTo("implementedContractMethod");
+        assertThat(interfaceMethod.getParameterTypes()).containsExactly(String.class);
+    }
+
     @Test
     void loadsObjectArrayTypesBySourceName() throws Exception {
         Class<?> arrayType = ReflectionUtils.tryToLoadClass("java.util.UUID[][]").get();
@@ -153,4 +167,17 @@ public class ReflectionUtilsTest {
 
         void interfaceMethod();
     }
+
+    public interface MethodContract {
+
+        String implementedContractMethod(String value);
+    }
+
+    public static class InterfaceImplementationSubject implements MethodContract {
+
+        @Override
+        public String implementedContractMethod(String value) {
+            return value;
+        }
+    }
 }
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/user-code-filter.json 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
index ee16e006c9..3c368c3d39 100644
--- 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/user-code-filter.json
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.junit.platform.commons.**"
+      "includeClasses" : "org.junit.platform.commons.**"
     }
   ]
 }

```
