### PR TITLE
[GenAI] Test fix for org.apache.xbean:xbean-asm9-shaded:4.22 using gpt-5.5

### DIFF
--- a/metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type" : "java.util.Set"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.ClassReader"
+      },
+      "glob" : "org/apache/xbean/asm9/ClassReader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.Constants"
+      },
+      "glob" : "org_apache_xbean/xbean_asm9_shaded/ConstantsExperimentalClassVisitor.class"
+    }
+  ]
+}

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.22",
+    "tested-versions" : [
+      "4.22"
+    ],
+    "allowed-packages" : [
+      "org.apache.xbean.asm9"
+    ]
+  },
+  {
     "metadata-version" : "4.20",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.20/xbean-asm9-shaded-4.20-sources.jar",
     "repository-url" : "https://github.com/apache/geronimo-xbean",

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.22",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.22/xbean-asm9-shaded-4.22-sources.jar",
+    "repository-url" : "https://github.com/apache/geronimo-xbean",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/apache/geronimo-xbean/blob/xbean-4.22/README.adoc",
+    "description" : "Apache XBean xbean-asm9-shaded repackages and shades ASM 9 classes under the org.apache.xbean.asm9 namespace. It provides an isolated bytecode manipulation dependency for XBean and consumers that need ASM without package conflicts.",
     "tested-versions" : [
       "4.22"
     ],

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.22/execution-metrics.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.22/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T10:05:22.465944Z",
+    "library": "org.apache.xbean:xbean-asm9-shaded:4.22",
+    "starting_commit": "c5a122002d7f6a31a6ddef208f028b69d563591a",
+    "ending_commit": "02e1373d45bc2734ccb52214e30e1ec14377b712",
+    "previous_library": "org.apache.xbean:xbean-asm9-shaded:4.20",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.22",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.75,
+        "coveredCalls": 3,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1880,
+          "missed": 39245,
+          "ratio": 0.045714,
+          "total": 41125
+        },
+        "line": {
+          "covered": 445,
+          "missed": 9258,
+          "ratio": 0.045862,
+          "total": 9703
+        },
+        "method": {
+          "covered": 75,
+          "missed": 1275,
+          "ratio": 0.055556,
+          "total": 1350
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.20",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.833333,
+        "coveredCalls": 5,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1237,
+          "missed": 44456,
+          "ratio": 0.027072,
+          "total": 45693
+        },
+        "line": {
+          "covered": 287,
+          "missed": 10485,
+          "ratio": 0.026643,
+          "total": 10772
+        },
+        "method": {
+          "covered": 61,
+          "missed": 1403,
+          "ratio": 0.041667,
+          "total": 1464
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 197657,
+      "cached_input_tokens_used": 2268672,
+      "output_tokens_used": 23532,
+      "iterations": 5,
+      "cost_usd": 1.8403,
+      "tested_library_loc": 445,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 11,
+      "code_coverage_percent": 4.59,
+      "previous_library_coverage_percent": 2.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java",
+      "metadata_file": "metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.22/stats.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.22/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.22",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 0.5,
+          "coveredCalls" : 1,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 0.75,
+      "coveredCalls" : 3,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1880,
+        "missed" : 39245,
+        "ratio" : 0.045714,
+        "total" : 41125
+      },
+      "line" : {
+        "covered" : 445,
+        "missed" : 9258,
+        "ratio" : 0.045862,
+        "total" : 9703
+      },
+      "method" : {
+        "covered" : 75,
+        "missed" : 1275,
+        "ratio" : 0.055556,
+        "total" : 1350
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/.gitignore
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/build.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.xbean:xbean-asm9-shaded:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/gradle.properties
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.xbean:xbean-asm9-shaded:4.22
+library.version = 4.22
+metadata.dir = org.apache.xbean/xbean-asm9-shaded/4.22/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/settings.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.xbean.xbean-asm9-shaded_tests'

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.io.IOException;
+
+import org.apache.xbean.asm9.ClassReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReaderTest {
+    @Test
+    void readsClassBytesFromTheSystemClassLoader() throws IOException {
+        ClassReader classReader = new ClassReader(ClassReader.class.getName());
+
+        assertThat(classReader.getClassName()).isEqualTo("org/apache/xbean/asm9/ClassReader");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -9,11 +9,22 @@ package org_apache_xbean.xbean_asm9_shaded;
 import java.io.IOException;
 
 import org.apache.xbean.asm9.ClassReader;
+import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Opcodes;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassReaderTest {
+    @Test
+    void readsGeneratedClassBytes() {
+        ClassReader classReader = new ClassReader(createClassBytes());
+
+        assertThat(classReader.getClassName()).isEqualTo("sample/Generated");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+
     @Test
     void readsClassBytesFromTheSystemClassLoader() throws IOException {
         ClassReader classReader = new ClassReader(ClassReader.class.getName());
@@ -21,5 +32,21 @@ public class ClassReaderTest {
         assertThat(classReader.getClassName()).isEqualTo("org/apache/xbean/asm9/ClassReader");
         assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
         assertThat(classReader.getInterfaces()).isEmpty();
+    }
+
+    @Test
+    void readsApplicationClassBytesFromTheSystemClassLoader() throws IOException {
+        ClassReader classReader = new ClassReader(ClassReaderTest.class.getName());
+
+        assertThat(classReader.getClassName()).isEqualTo("org_apache_xbean/xbean_asm9_shaded/ClassReaderTest");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+
+    private static byte[] createClassBytes() {
+        ClassWriter classWriter = new ClassWriter(0);
+        classWriter.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Generated", null, "java/lang/Object", null);
+        classWriter.visitEnd();
+        return classWriter.toByteArray();
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -34,15 +34,6 @@ public class ClassReaderTest {
         assertThat(classReader.getInterfaces()).isEmpty();
     }
 
-    @Test
-    void readsApplicationClassBytesFromTheSystemClassLoader() throws IOException {
-        ClassReader classReader = new ClassReader(ClassReaderTest.class.getName());
-
-        assertThat(classReader.getClassName()).isEqualTo("org_apache_xbean/xbean_asm9_shaded/ClassReaderTest");
-        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
-        assertThat(classReader.getInterfaces()).isEmpty();
-    }
-
     private static byte[] createClassBytes() {
         ClassWriter classWriter = new ClassWriter(0);
         classWriter.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Generated", null, "java/lang/Object", null);

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import org.apache.xbean.asm9.ClassWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassWriterTest {
+    @Test
+    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+
+        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+    }
+
+    @Test
+    void returnsObjectWhenEitherLoadedTypeIsAnInterface() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/List", "java/util/Set");
+
+        assertThat(commonSuperClass).isEqualTo("java/lang/Object");
+    }
+
+    private static final class TestableClassWriter extends ClassWriter {
+        private TestableClassWriter() {
+            super(0);
+        }
+
+        private String commonSuperClass(String firstType, String secondType) {
+            return super.getCommonSuperClass(firstType, secondType);
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
@@ -7,18 +7,21 @@
 package org_apache_xbean.xbean_asm9_shaded;
 
 import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassWriterTest {
     @Test
-    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+    void returnsSharedAbstractSuperclassForConcreteTypes() {
         TestableClassWriter classWriter = new TestableClassWriter();
 
-        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+        String commonSuperClass = classWriter.commonSuperClass(
+                Type.getInternalName(FirstChild.class),
+                Type.getInternalName(SecondChild.class));
 
-        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+        assertThat(commonSuperClass).isEqualTo(Type.getInternalName(Parent.class));
     }
 
     @Test
@@ -28,6 +31,15 @@ public class ClassWriterTest {
         String commonSuperClass = classWriter.commonSuperClass("java/util/List", "java/util/Set");
 
         assertThat(commonSuperClass).isEqualTo("java/lang/Object");
+    }
+
+    private abstract static class Parent {
+    }
+
+    private static final class FirstChild extends Parent {
+    }
+
+    private static final class SecondChild extends Parent {
     }
 
     private static final class TestableClassWriter extends ClassWriter {

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class ConstantsTest {
+    @Test
+    void experimentalApiChecksTheCallerClassBytecodeResource() {
+        assertThatIllegalStateException()
+                .isThrownBy(() -> createExperimentalClassNode());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ClassNode createExperimentalClassNode() {
+        return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -16,13 +16,13 @@ public class ConstantsTest {
     @Test
     void experimentalApiChecksExternalVisitorBytecodeResource() {
         assertThatIllegalStateException()
-                .isThrownBy(ExperimentalClassVisitor::new);
+                .isThrownBy(ConstantsExperimentalClassVisitor::new);
     }
+}
 
-    private static final class ExperimentalClassVisitor extends ClassVisitor {
-        @SuppressWarnings("deprecation")
-        private ExperimentalClassVisitor() {
-            super(Opcodes.ASM10_EXPERIMENTAL);
-        }
+final class ConstantsExperimentalClassVisitor extends ClassVisitor {
+    @SuppressWarnings("deprecation")
+    ConstantsExperimentalClassVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -6,21 +6,23 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
+import org.apache.xbean.asm9.ClassVisitor;
 import org.apache.xbean.asm9.Opcodes;
-import org.apache.xbean.asm9.tree.ClassNode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
     @Test
-    void experimentalApiChecksTheCallerClassBytecodeResource() {
+    void experimentalApiChecksExternalVisitorBytecodeResource() {
         assertThatIllegalStateException()
-                .isThrownBy(() -> createExperimentalClassNode());
+                .isThrownBy(ExperimentalClassVisitor::new);
     }
 
-    @SuppressWarnings("deprecation")
-    private static ClassNode createExperimentalClassNode() {
-        return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    private static final class ExperimentalClassVisitor extends ClassVisitor {
+        @SuppressWarnings("deprecation")
+        private ExperimentalClassVisitor() {
+            super(Opcodes.ASM10_EXPERIMENTAL);
+        }
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import org.apache.xbean.asm9.Type;
+import org.apache.xbean.asm9.tree.analysis.BasicValue;
+import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleVerifierTest {
+    @Test
+    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
+        SimpleVerifier verifier = new SimpleVerifier();
+        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
+        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
+
+        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
+
+        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+    }
+
+    @Test
+    void recognizesAssignableArrayValues() {
+        SimpleVerifier verifier = new SimpleVerifier();
+        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
+        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+
+        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+
+        assertThat(mergedValue).isEqualTo(objectArrayValue);
+        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -6,38 +6,45 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.LinkedList;
-
-import org.apache.xbean.asm9.Type;
-import org.apache.xbean.asm9.tree.analysis.BasicValue;
-import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.commons.AnalyzerAdapter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleVerifierTest {
     @Test
-    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
-        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
+    void initializesLocalsFromMethodDescriptor() {
+        AnalyzerAdapter analyzer = new AnalyzerAdapter(
+                "example/Owner",
+                Opcodes.ACC_PUBLIC,
+                "collect",
+                "(ILjava/lang/String;[Ljava/lang/Object;)V",
+                null);
 
-        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
-
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+        assertThat(analyzer.locals)
+                .containsExactly("example/Owner", Opcodes.INTEGER, "java/lang/String", "[Ljava/lang/Object;");
+        assertThat(analyzer.stack).isEmpty();
     }
 
     @Test
-    void recognizesAssignableArrayValues() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
-        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+    void tracksObjectArrayLoadsAndStores() {
+        AnalyzerAdapter analyzer = new AnalyzerAdapter(
+                "example/Owner",
+                Opcodes.ACC_PUBLIC,
+                "readElement",
+                "([Ljava/lang/String;)Ljava/lang/String;",
+                null);
 
-        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+        analyzer.visitVarInsn(Opcodes.ALOAD, 1);
+        analyzer.visitInsn(Opcodes.ICONST_0);
+        analyzer.visitInsn(Opcodes.AALOAD);
 
-        assertThat(mergedValue).isEqualTo(objectArrayValue);
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+        assertThat(analyzer.stack).containsExactly("java/lang/String");
+
+        analyzer.visitVarInsn(Opcodes.ASTORE, 2);
+
+        assertThat(analyzer.stack).isEmpty();
+        assertThat(analyzer.locals).containsExactly("example/Owner", "[Ljava/lang/String;", "java/lang/String");
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type" : "org_apache_xbean.xbean_asm9_shaded.ClassWriterTest$FirstChild"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type" : "org_apache_xbean.xbean_asm9_shaded.ClassWriterTest$SecondChild"
+    }
+  ]
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/user-code-filter.json
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.xbean.asm9.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3552

This PR provides test fixes and new metadata for org.apache.xbean:xbean-asm9-shaded:4.22, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 197657
- Cached input tokens: 2268672
- Output tokens: 23532
- Entries found: 4
- Iterations: 5
- Library coverage percentage: 4.59
- Previous library version metadata entries: 11
- Previous library version coverage percentage: 2.66

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.xbean:xbean-asm9-shaded:4.20: 5/6 covered calls (83.33%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 3/4 covered calls (75.00%)

**Reflection:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 4/4 covered calls (100.00%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 2/2 covered calls (100.00%)

**Resources:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 1/2 covered calls (50.00%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 1/2 covered calls (50.00%)

#### Library coverage

**Instruction:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 1237/45693 (2.71%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 1880/41125 (4.57%)

**Line:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 287/10772 (2.66%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 445/9703 (4.59%)

**Method:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 61/1464 (4.17%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 75/1350 (5.56%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
index 3406904b93..ecfc6ab522 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -9,11 +9,22 @@ package org_apache_xbean.xbean_asm9_shaded;
 import java.io.IOException;
 
 import org.apache.xbean.asm9.ClassReader;
+import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Opcodes;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassReaderTest {
+    @Test
+    void readsGeneratedClassBytes() {
+        ClassReader classReader = new ClassReader(createClassBytes());
+
+        assertThat(classReader.getClassName()).isEqualTo("sample/Generated");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+
     @Test
     void readsClassBytesFromTheSystemClassLoader() throws IOException {
         ClassReader classReader = new ClassReader(ClassReader.class.getName());
@@ -22,4 +33,11 @@ public class ClassReaderTest {
         assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
         assertThat(classReader.getInterfaces()).isEmpty();
     }
+
+    private static byte[] createClassBytes() {
+        ClassWriter classWriter = new ClassWriter(0);
+        classWriter.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Generated", null, "java/lang/Object", null);
+        classWriter.visitEnd();
+        return classWriter.toByteArray();
+    }
 }
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
index 0a2396a55e..10e1b86755 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
@@ -7,18 +7,21 @@
 package org_apache_xbean.xbean_asm9_shaded;
 
 import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassWriterTest {
     @Test
-    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+    void returnsSharedAbstractSuperclassForConcreteTypes() {
         TestableClassWriter classWriter = new TestableClassWriter();
 
-        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+        String commonSuperClass = classWriter.commonSuperClass(
+                Type.getInternalName(FirstChild.class),
+                Type.getInternalName(SecondChild.class));
 
-        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+        assertThat(commonSuperClass).isEqualTo(Type.getInternalName(Parent.class));
     }
 
     @Test
@@ -30,6 +33,15 @@ public class ClassWriterTest {
         assertThat(commonSuperClass).isEqualTo("java/lang/Object");
     }
 
+    private abstract static class Parent {
+    }
+
+    private static final class FirstChild extends Parent {
+    }
+
+    private static final class SecondChild extends Parent {
+    }
+
     private static final class TestableClassWriter extends ClassWriter {
         private TestableClassWriter() {
             super(0);
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
index 48d7212d03..80672ebff4 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -6,21 +6,23 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
+import org.apache.xbean.asm9.ClassVisitor;
 import org.apache.xbean.asm9.Opcodes;
-import org.apache.xbean.asm9.tree.ClassNode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
     @Test
-    void experimentalApiChecksTheCallerClassBytecodeResource() {
+    void experimentalApiChecksExternalVisitorBytecodeResource() {
         assertThatIllegalStateException()
-                .isThrownBy(() -> createExperimentalClassNode());
+                .isThrownBy(ConstantsExperimentalClassVisitor::new);
     }
+}
 
+final class ConstantsExperimentalClassVisitor extends ClassVisitor {
     @SuppressWarnings("deprecation")
-    private static ClassNode createExperimentalClassNode() {
-        return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    ConstantsExperimentalClassVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
     }
 }
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
index 0b51b23a35..fd5d1cfa8f 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -6,38 +6,45 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.LinkedList;
-
-import org.apache.xbean.asm9.Type;
-import org.apache.xbean.asm9.tree.analysis.BasicValue;
-import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.commons.AnalyzerAdapter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleVerifierTest {
     @Test
-    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
-        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
-
-        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
-
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+    void initializesLocalsFromMethodDescriptor() {
+        AnalyzerAdapter analyzer = new AnalyzerAdapter(
+                "example/Owner",
+                Opcodes.ACC_PUBLIC,
+                "collect",
+                "(ILjava/lang/String;[Ljava/lang/Object;)V",
+                null);
+
+        assertThat(analyzer.locals)
+                .containsExactly("example/Owner", Opcodes.INTEGER, "java/lang/String", "[Ljava/lang/Object;");
+        assertThat(analyzer.stack).isEmpty();
     }
 
     @Test
-    void recognizesAssignableArrayValues() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
-        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+    void tracksObjectArrayLoadsAndStores() {
+        AnalyzerAdapter analyzer = new AnalyzerAdapter(
+                "example/Owner",
+                Opcodes.ACC_PUBLIC,
+                "readElement",
+                "([Ljava/lang/String;)Ljava/lang/String;",
+                null);
+
+        analyzer.visitVarInsn(Opcodes.ALOAD, 1);
+        analyzer.visitInsn(Opcodes.ICONST_0);
+        analyzer.visitInsn(Opcodes.AALOAD);
+
+        assertThat(analyzer.stack).containsExactly("java/lang/String");
 
-        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+        analyzer.visitVarInsn(Opcodes.ASTORE, 2);
 
-        assertThat(mergedValue).isEqualTo(objectArrayValue);
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+        assertThat(analyzer.stack).isEmpty();
+        assertThat(analyzer.locals).containsExactly("example/Owner", "[Ljava/lang/String;", "java/lang/String");
     }
 }

```
