### PR TITLE
[GenAI] Test fix for net.razorvine:serpent:1.30 using gpt-5.5

### DIFF
--- a/metadata/net.razorvine/serpent/1.30/reachability-metadata.json
+++ b/metadata/net.razorvine/serpent/1.30/reachability-metadata.json
@@ -1,0 +1,80 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "java.net.URI",
+      "methods" : [
+        {
+          "name" : "getAuthority",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getFragment",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getHost",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPath",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPort",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getQuery",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawAuthority",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawFragment",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawPath",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawQuery",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawSchemeSpecificPart",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRawUserInfo",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getScheme",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSchemeSpecificPart",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUserInfo",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isAbsolute",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isOpaque",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/net.razorvine/serpent/index.json
+++ b/metadata/net.razorvine/serpent/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.30",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/razorvine/serpent/1.30/serpent-1.30-sources.jar",
+    "repository-url" : "https://github.com/irmen/Serpent",
+    "test-code-url" : "https://github.com/irmen/Serpent/tree/serpent-1.30/java/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/razorvine/serpent/1.30/serpent-1.30-javadoc.jar",
+    "description" : "Serpent serializes Java object trees into Python ast.literal_eval-compatible literal expressions and parses those expressions back into Java objects. It provides a safer, more expressive alternative to JSON for exchanging structured data between Java and Python systems.",
     "tested-versions" : [
       "1.30"
     ],

--- a/metadata/net.razorvine/serpent/index.json
+++ b/metadata/net.razorvine/serpent/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.30",
+    "tested-versions" : [
+      "1.30"
+    ],
+    "allowed-packages" : [
+      "net.razorvine.serpent"
+    ]
+  },
+  {
     "metadata-version" : "1.23",
     "source-code-url" : "https://repo1.maven.org/maven2/net/razorvine/serpent/1.23/serpent-1.23-sources.jar",
     "repository-url" : "https://github.com/irmen/Serpent",

--- a/stats/net.razorvine/serpent/1.30/execution-metrics.json
+++ b/stats/net.razorvine/serpent/1.30/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T10:06:42.784309Z",
+    "library": "net.razorvine:serpent:1.30",
+    "starting_commit": "b6da9e5319fd5a5a79e0ee1022bc069cb69b61a7",
+    "ending_commit": "52d3c80fcf34b6b9d6760a27d946db27406f2614",
+    "previous_library": "net.razorvine:serpent:1.23",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.30",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 20,
+            "totalCalls": 20
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 20,
+        "totalCalls": 20
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 910,
+          "missed": 3790,
+          "ratio": 0.193617,
+          "total": 4700
+        },
+        "line": {
+          "covered": 196,
+          "missed": 875,
+          "ratio": 0.183007,
+          "total": 1071
+        },
+        "method": {
+          "covered": 19,
+          "missed": 153,
+          "ratio": 0.110465,
+          "total": 172
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.23",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 20,
+            "totalCalls": 20
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 20,
+        "totalCalls": 20
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 931,
+          "missed": 3788,
+          "ratio": 0.197288,
+          "total": 4719
+        },
+        "line": {
+          "covered": 202,
+          "missed": 878,
+          "ratio": 0.187037,
+          "total": 1080
+        },
+        "method": {
+          "covered": 19,
+          "missed": 152,
+          "ratio": 0.111111,
+          "total": 171
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 86277,
+      "cached_input_tokens_used": 407040,
+      "output_tokens_used": 3519,
+      "iterations": 2,
+      "cost_usd": 0.3091,
+      "tested_library_loc": 196,
+      "metadata_entries": 18,
+      "previous_library_metadata_entries": 18,
+      "code_coverage_percent": 18.3,
+      "previous_library_coverage_percent": 18.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyFloat.java",
+      "metadata_file": "metadata/net.razorvine/serpent/1.30/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.razorvine/serpent/1.30/stats.json
+++ b/stats/net.razorvine/serpent/1.30/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.30",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 20,
+          "totalCalls" : 20
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 20,
+      "totalCalls" : 20
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 910,
+        "missed" : 3790,
+        "ratio" : 0.193617,
+        "total" : 4700
+      },
+      "line" : {
+        "covered" : 196,
+        "missed" : 875,
+        "ratio" : 0.183007,
+        "total" : 1071
+      },
+      "method" : {
+        "covered" : 19,
+        "missed" : 153,
+        "ratio" : 0.110465,
+        "total" : 172
+      }
+    }
+  } ]
+}

--- a/tests/src/net.razorvine/serpent/1.30/.gitignore
+++ b/tests/src/net.razorvine/serpent/1.30/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.razorvine/serpent/1.30/build.gradle
+++ b/tests/src/net.razorvine/serpent/1.30/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.razorvine:serpent:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/gradle.properties
+++ b/tests/src/net.razorvine/serpent/1.30/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.razorvine:serpent:1.30
+library.version = 1.30
+metadata.dir = net.razorvine/serpent/1.30/

--- a/tests/src/net.razorvine/serpent/1.30/settings.gradle
+++ b/tests/src/net.razorvine/serpent/1.30/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.razorvine.serpent_tests'

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyByteArray.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyByteArray.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyByteArray {
+    private final byte[] bytes;
+
+    public PyByteArray(byte[] bytes) {
+        this.bytes = bytes.clone();
+    }
+
+    public PyString __str__() {
+        return new PyString(bytes);
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyBytes.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyBytes.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public class PyBytes {
+    private final byte[] bytes;
+
+    public PyBytes(byte[] bytes) {
+        this.bytes = bytes.clone();
+    }
+
+    public byte[] toBytes() {
+        return bytes.clone();
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyComplex.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyComplex.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyComplex {
+    private final PyFloat real;
+    private final PyFloat imaginary;
+
+    public PyComplex(double real, double imaginary) {
+        this.real = new PyFloat(real);
+        this.imaginary = new PyFloat(imaginary);
+    }
+
+    public PyFloat getReal() {
+        return real;
+    }
+
+    public PyFloat getImag() {
+        return imaginary;
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyFloat.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyFloat.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyFloat {
+    private final Double value;
+
+    public PyFloat(double value) {
+        this.value = value;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyMemoryView.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyMemoryView.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyMemoryView {
+    private final byte[] bytes;
+
+    public PyMemoryView(byte[] bytes) {
+        this.bytes = bytes.clone();
+    }
+
+    public PyBytes tobytes() {
+        return new PyBytes(bytes);
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyString.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyString.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyString extends PyBytes {
+    public PyString(byte[] bytes) {
+        super(bytes);
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyTuple.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/PyTuple.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+public final class PyTuple {
+    private final Object[] values;
+
+    public PyTuple(Object... values) {
+        this.values = values;
+    }
+
+    public Object[] toArray() {
+        return values;
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.python.core;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import net.razorvine.serpent.Serializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializerTest {
+    @Test
+    public void serializesKnownJythonObjectsThroughPublicSerializerApi() {
+        Serializer serializer = new Serializer();
+        List<Object> values = Arrays.asList(
+                new PyTuple("alpha", 7, true),
+                new PyComplex(3.5, -2.25),
+                new PyByteArray(new byte[] {'h', 'e', 'l', 'l', 'o' }),
+                new PyMemoryView(new byte[] {'w', 'o', 'r', 'l', 'd' }));
+
+        String body = serializeBody(serializer, values);
+
+        assertThat(body)
+                .startsWith("[('alpha',7,True),(3.5-2.25j),")
+                .contains("'data':'aGVsbG8='")
+                .contains("'data':'d29ybGQ='")
+                .contains("'encoding':'base64'");
+    }
+
+    @Test
+    public void serializesSerializablePropertiesThroughPublicGetters() throws Exception {
+        Serializer serializer = new Serializer(false, true, true);
+        URI uri = new URI("https://example.com:8443/docs?q=serpent#section");
+
+        String body = serializeBody(serializer, uri);
+
+        assertThat(body)
+                .contains("'__class__':'java.net.URI'")
+                .contains("'scheme':'https'")
+                .contains("'host':'example.com'")
+                .contains("'path':'/docs'")
+                .contains("'query':'q=serpent'")
+                .contains("'port':8443")
+                .contains("'absolute':True")
+                .contains("'opaque':False");
+    }
+
+    private static String serializeBody(Serializer serializer, Object value) {
+        String serialized = new String(serializer.serialize(value), StandardCharsets.UTF_8);
+        int firstLineEnd = serialized.indexOf('\n');
+        return serialized.substring(firstLineEnd + 1);
+    }
+}

--- a/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
@@ -38,7 +38,7 @@ public class SerializerTest {
 
     @Test
     public void serializesSerializablePropertiesThroughPublicGetters() throws Exception {
-        Serializer serializer = new Serializer(false, true, true);
+        Serializer serializer = new Serializer(false, true);
         URI uri = new URI("https://example.com:8443/docs?q=serpent#section");
 
         String body = serializeBody(serializer, uri);

--- a/tests/src/net.razorvine/serpent/1.30/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.razorvine/serpent/1.30/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,86 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyByteArray",
+      "methods" : [
+        {
+          "name" : "__str__",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyBytes",
+      "methods" : [
+        {
+          "name" : "toBytes",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyComplex",
+      "methods" : [
+        {
+          "name" : "getImag",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getReal",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyFloat",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyMemoryView",
+      "methods" : [
+        {
+          "name" : "tobytes",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyString"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.razorvine.serpent.Serializer"
+      },
+      "type" : "org.python.core.PyTuple",
+      "methods" : [
+        {
+          "name" : "toArray",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/net.razorvine/serpent/1.30/user-code-filter.json
+++ b/tests/src/net.razorvine/serpent/1.30/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "net.razorvine.serpent.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3547

This PR provides test fixes and new metadata for net.razorvine:serpent:1.30, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 86277
- Cached input tokens: 407040
- Output tokens: 3519
- Entries found: 18
- Iterations: 2
- Library coverage percentage: 18.3
- Previous library version metadata entries: 18
- Previous library version coverage percentage: 18.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.razorvine:serpent:1.23: 20/20 covered calls (100.00%)
- net.razorvine:serpent:1.30: 20/20 covered calls (100.00%)

**Reflection:**
- net.razorvine:serpent:1.23: 20/20 covered calls (100.00%)
- net.razorvine:serpent:1.30: 20/20 covered calls (100.00%)

#### Library coverage

**Instruction:**
- net.razorvine:serpent:1.23: 931/4719 (19.73%)
- net.razorvine:serpent:1.30: 910/4700 (19.36%)

**Line:**
- net.razorvine:serpent:1.23: 202/1080 (18.70%)
- net.razorvine:serpent:1.30: 196/1071 (18.30%)

**Method:**
- net.razorvine:serpent:1.23: 19/171 (11.11%)
- net.razorvine:serpent:1.30: 19/172 (11.05%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/net.razorvine/serpent/1.23/src/test/java/org/python/core/SerializerTest.java 2/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
index 3a28b6cfc5..65f161ab67 100644
--- 1/tests/src/net.razorvine/serpent/1.23/src/test/java/org/python/core/SerializerTest.java
+++ 2/tests/src/net.razorvine/serpent/1.30/src/test/java/org/python/core/SerializerTest.java
@@ -38,7 +38,7 @@ public class SerializerTest {
 
     @Test
     public void serializesSerializablePropertiesThroughPublicGetters() throws Exception {
-        Serializer serializer = new Serializer(false, true, true);
+        Serializer serializer = new Serializer(false, true);
         URI uri = new URI("https://example.com:8443/docs?q=serpent#section");
 
         String body = serializeBody(serializer, uri);

```
