### PR TITLE
Fix execution metrics updates for pre-release promotion

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.graalvm.internal.tck.stats.LibraryStatsModels;
 import org.graalvm.internal.tck.stats.LibraryStatsSupport;
@@ -244,28 +246,107 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
         String group = metadataBaseDir.getParent().getFileName().toString();
         Path repositoryRoot = metadataBaseDir.getParent().getParent().getParent();
         Path statsRoot = repositoryRoot.resolve("stats");
+        Path oldStatsDir = statsRoot.resolve(group).resolve(artifact).resolve(oldVersion);
+        Path newStatsDir = statsRoot.resolve(group).resolve(artifact).resolve(newVersion);
+
         Path oldStatsFile = LibraryStatsSupport.repositoryStatsFile(statsRoot, group, artifact, oldVersion);
-        if (!Files.exists(oldStatsFile)) return;
+        if (Files.exists(oldStatsFile)) {
+            LibraryStatsModels.MetadataVersionStats metadataVersionStats = LibraryStatsSupport.loadMetadataVersionStats(oldStatsFile);
+            LibraryStatsModels.MetadataVersionStats updatedStats = new LibraryStatsModels.MetadataVersionStats(
+                    metadataVersionStats.versions().stream()
+                            .map(versionStats -> oldVersion.equals(versionStats.version())
+                                    ? new LibraryStatsModels.VersionStats(newVersion, versionStats.dynamicAccess(), versionStats.libraryCoverage())
+                                    : versionStats)
+                            .toList()
+            );
 
-        LibraryStatsModels.MetadataVersionStats metadataVersionStats = LibraryStatsSupport.loadMetadataVersionStats(oldStatsFile);
-        LibraryStatsModels.MetadataVersionStats updatedStats = new LibraryStatsModels.MetadataVersionStats(
-                metadataVersionStats.versions().stream()
-                        .map(versionStats -> oldVersion.equals(versionStats.version())
-                                ? new LibraryStatsModels.VersionStats(newVersion, versionStats.dynamicAccess(), versionStats.libraryCoverage())
-                                : versionStats)
-                        .toList()
-        );
+            Path newStatsFile = LibraryStatsSupport.repositoryStatsFile(statsRoot, group, artifact, newVersion);
+            LibraryStatsSupport.writeMetadataVersionStats(newStatsFile, updatedStats);
+            if (!oldStatsFile.equals(newStatsFile)) {
+                Files.deleteIfExists(oldStatsFile);
+            }
+        }
+        updateExecutionMetrics(oldStatsDir, newStatsDir, group, artifact, oldVersion, newVersion);
 
-        Path newStatsFile = LibraryStatsSupport.repositoryStatsFile(statsRoot, group, artifact, newVersion);
-        LibraryStatsSupport.writeMetadataVersionStats(newStatsFile, updatedStats);
-        if (!oldStatsFile.equals(newStatsFile)) {
-            Files.deleteIfExists(oldStatsFile);
+        if (!oldStatsDir.equals(newStatsDir)) {
             try {
-                Files.deleteIfExists(oldStatsFile.getParent());
+                Files.deleteIfExists(oldStatsDir);
             } catch (DirectoryNotEmptyException ignored) {
                 // Keep the old directory when other stats artifacts still exist in it.
             }
         }
+    }
+
+    /**
+     * Updates committed Forge execution metrics when the metadata-version directory is promoted.
+     */
+    private void updateExecutionMetrics(Path oldStatsDir, Path newStatsDir, String group, String artifact, String oldVersion, String newVersion) throws IOException {
+        Path oldMetricsFile = oldStatsDir.resolve("execution-metrics.json");
+        if (!Files.exists(oldMetricsFile)) return;
+
+        ObjectMapper objectMapper = new ObjectMapper()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ObjectNode executionMetrics = (ObjectNode) objectMapper.readTree(oldMetricsFile.toFile());
+        executionMetrics.properties().forEach(entry -> updateRunMetrics(entry.getValue(), group, artifact, oldVersion, newVersion));
+
+        Files.createDirectories(newStatsDir);
+        Path newMetricsFile = newStatsDir.resolve("execution-metrics.json");
+        writeJsonWithTrailingNewline(objectMapper, newMetricsFile, executionMetrics);
+        if (!oldMetricsFile.equals(newMetricsFile)) {
+            Files.deleteIfExists(oldMetricsFile);
+        }
+    }
+
+    private void updateRunMetrics(JsonNode runMetrics, String group, String artifact, String oldVersion, String newVersion) {
+        if (!(runMetrics instanceof ObjectNode objectNode)) return;
+
+        updateCoordinateField(objectNode, "library", group, artifact, oldVersion, newVersion);
+        updateCoordinateField(objectNode, "previous_library", group, artifact, oldVersion, newVersion);
+        updateStatsVersion(objectNode.get("stats"), oldVersion, newVersion);
+        updateStatsVersion(objectNode.get("previous_library_stats"), oldVersion, newVersion);
+        updateArtifactPaths(objectNode.get("artifacts"), oldVersion, newVersion);
+    }
+
+    private void updateCoordinateField(ObjectNode runMetrics, String fieldName, String group, String artifact, String oldVersion, String newVersion) {
+        JsonNode coordinateNode = runMetrics.get(fieldName);
+        if (coordinateNode == null || !coordinateNode.isTextual()) return;
+
+        String oldCoordinate = group + ":" + artifact + ":" + oldVersion;
+        if (oldCoordinate.equals(coordinateNode.asText())) {
+            runMetrics.put(fieldName, group + ":" + artifact + ":" + newVersion);
+        }
+    }
+
+    private void updateStatsVersion(JsonNode stats, String oldVersion, String newVersion) {
+        if (!(stats instanceof ObjectNode statsObject)) return;
+
+        JsonNode versionNode = statsObject.get("version");
+        if (versionNode != null && versionNode.isTextual() && oldVersion.equals(versionNode.asText())) {
+            statsObject.put("version", newVersion);
+        }
+    }
+
+    private void updateArtifactPaths(JsonNode artifacts, String oldVersion, String newVersion) {
+        if (!(artifacts instanceof ObjectNode artifactsObject)) return;
+
+        artifactsObject.properties().forEach(entry -> {
+            JsonNode value = entry.getValue();
+            if (value != null && value.isTextual()) {
+                artifactsObject.put(entry.getKey(), value.asText().replace("/" + oldVersion + "/", "/" + newVersion + "/"));
+            }
+        });
+    }
+
+    private void writeJsonWithTrailingNewline(ObjectMapper objectMapper, Path path, JsonNode jsonNode) throws IOException {
+        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+        prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+
+        String json = objectMapper.writer(prettyPrinter).writeValueAsString(jsonNode);
+        if (!json.endsWith("\n")) {
+            json = json + System.lineSeparator();
+        }
+        Files.writeString(path, json, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     /**

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
@@ -7,6 +7,7 @@
 package org.graalvm.internal.tck;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graalvm.internal.tck.stats.LibraryStatsSupport;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -69,6 +70,28 @@ class TestedVersionUpdaterTaskTests {
                 """,
                 StandardCharsets.UTF_8
         );
+        Files.writeString(
+                tempDir.resolve("stats/com.example/demo/1.0.0-RC1/execution-metrics.json"),
+                """
+                {
+                  "add_new_library_support:2026-04-30": {
+                    "library": "com.example:demo:1.0.0-RC1",
+                    "previous_library": "com.example:demo:1.0.0-RC1",
+                    "stats": {
+                      "version": "1.0.0-RC1"
+                    },
+                    "previous_library_stats": {
+                      "version": "1.0.0-RC1"
+                    },
+                    "artifacts": {
+                      "test_file": "tests/src/com.example/demo/1.0.0-RC1/src/test/java/com/example/DemoTest.java",
+                      "metadata_file": "metadata/com.example/demo/1.0.0-RC1/reachability-metadata.json"
+                    }
+                  }
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
 
         TestTestedVersionUpdaterTask task = createTask();
         task.setCoordinates(group + ":" + artifact + ":" + newVersion);
@@ -94,6 +117,19 @@ class TestedVersionUpdaterTaskTests {
         assertThat(LibraryStatsSupport.loadMetadataVersionStats(newStatsFile).versions())
                 .extracting(version -> version.version())
                 .containsExactly("1.0.0");
+
+        Path newMetricsFile = tempDir.resolve("stats/com.example/demo/1.0.0/execution-metrics.json");
+        assertThat(newMetricsFile).exists();
+        assertThat(tempDir.resolve("stats/com.example/demo/1.0.0-RC1/execution-metrics.json")).doesNotExist();
+        JsonNode runMetrics = OBJECT_MAPPER.readTree(newMetricsFile.toFile()).get("add_new_library_support:2026-04-30");
+        assertThat(runMetrics.get("library").asText()).isEqualTo("com.example:demo:1.0.0");
+        assertThat(runMetrics.get("previous_library").asText()).isEqualTo("com.example:demo:1.0.0");
+        assertThat(runMetrics.get("stats").get("version").asText()).isEqualTo("1.0.0");
+        assertThat(runMetrics.get("previous_library_stats").get("version").asText()).isEqualTo("1.0.0");
+        assertThat(runMetrics.get("artifacts").get("test_file").asText())
+                .isEqualTo("tests/src/com.example/demo/1.0.0/src/test/java/com/example/DemoTest.java");
+        assertThat(runMetrics.get("artifacts").get("metadata_file").asText())
+                .isEqualTo("metadata/com.example/demo/1.0.0/reachability-metadata.json");
 
         List<Map<String, Object>> indexEntries = OBJECT_MAPPER.readValue(
                 tempDir.resolve("metadata/com.example/demo/index.json").toFile(),


### PR DESCRIPTION
Fixes #3568.

## Problem

`addTestedVersion` already has special handling for the case where a pre-release metadata version is replaced by the corresponding full release. That path removes matching pre-release tested versions, renames the metadata and test directories, updates `gradle.properties`, updates dependent `test-version` references, and rewrites the promoted entry in `stats.json`.

The missing piece was committed Forge execution metrics. If the old stats directory also contained `execution-metrics.json`, the task left that file behind under the old pre-release version and kept its internal fields pointing at the old coordinate. A later `validateLibraryStats` run then fails because `metadata/**/index.json` no longer lists the pre-release in `tested-versions`, but the execution metrics still refer to it.

PR #3559 exposed this with `org.apache.directory.api:api-i18n`, where `1.0.0-M20` was promoted to `1.0.0` for metadata/tests/stats, while `stats/org.apache.directory.api/api-i18n/1.0.0-M20/execution-metrics.json` still recorded `org.apache.directory.api:api-i18n:1.0.0-M20`.

## Fix

The pre-release promotion path now also handles `execution-metrics.json`:

- moves the metrics file from the old stats directory to the promoted stats directory;
- rewrites `library` and `previous_library` coordinates when they match the promoted artifact/version;
- rewrites `stats.version` and `previous_library_stats.version` from the old pre-release to the full release;
- rewrites versioned artifact paths so they point at the promoted metadata/test directories;
- still keeps the old stats directory if unrelated files remain in it.

This keeps metadata, tests, stats, and Forge execution metrics in sync when `addTestedVersion` promotes a pre-release metadata version.

## Testing

- `./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.TestedVersionUpdaterTaskTests --stacktrace`
- `./gradlew validateLibraryStats --stacktrace`

I also checked current `master` for existing stale execution metrics and did not find existing broken cases.
