### PR TITLE
[Automation] Generated metadata for org.slf4j:jcl-over-slf4j:1.5.7

### DIFF
--- a/metadata/org.slf4j/jcl-over-slf4j/1.5.7/reachability-metadata.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/1.5.7/reachability-metadata.json
@@ -1,0 +1,60 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SimpleLog"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLocationAwareLog"
+      },
+      "type": "org.apache.commons.logging.impl.SLF4JLocationAwareLog"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "type": "org.apache.commons.logging.impl.SLF4JLogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "type": "org.slf4j.LoggerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "type": "org.slf4j.helpers.MarkerIgnoringBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "type": "org.slf4j.impl.JDK14LoggerAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "type": "org.slf4j.impl.JDK14LoggerFactory"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.slf4j/jcl-over-slf4j/index.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.5.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.7/jcl-over-slf4j-1.5.7-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_1.5.7_FINAL/jcl-over-slf4j/src/test/java",
+    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_1.5.7_FINAL/slf4j-site/src/site/pages/legacy.html",
+    "description" : "jcl-over-slf4j provides a drop-in implementation of the Jakarta Commons Logging 1.1.1 API that routes logging calls through SLF4J. It lets applications or dependencies that still call JCL use the SLF4J-selected backend without keeping the original Commons Logging runtime on the classpath.",
+    "test-version" : "1.5.6",
+    "tested-versions" : [
+      "1.5.7"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.logging"
+    ]
+  },
+  {
     "metadata-version" : "1.5.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/stats/org.slf4j/jcl-over-slf4j/1.5.7/stats.json
+++ b/stats/org.slf4j/jcl-over-slf4j/1.5.7/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.5.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 683,
+        "missed" : 585,
+        "ratio" : 0.538644,
+        "total" : 1268
+      },
+      "line" : {
+        "covered" : 172,
+        "missed" : 149,
+        "ratio" : 0.535826,
+        "total" : 321
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 73,
+        "ratio" : 0.401639,
+        "total" : 122
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3555

This PR provides new metadata needed for the org.slf4j:jcl-over-slf4j:1.5.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.slf4j:jcl-over-slf4j:1.5.6`): 7
- Metadata entries (new `org.slf4j:jcl-over-slf4j:1.5.7`): 9
- Library coverage (previous): 54.29%
- Library coverage (new): 53.58%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:jcl-over-slf4j:1.5.6: 7/7 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.5.7: 7/7 covered calls (100.00%)

**Reflection:**
- org.slf4j:jcl-over-slf4j:1.5.6: 5/5 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.5.7: 5/5 covered calls (100.00%)

**Resources:**
- org.slf4j:jcl-over-slf4j:1.5.6: 2/2 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.5.7: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:jcl-over-slf4j:1.5.6: 679/1241 (54.71%)
- org.slf4j:jcl-over-slf4j:1.5.7: 683/1268 (53.86%)

**Line:**
- org.slf4j:jcl-over-slf4j:1.5.6: 171/315 (54.29%)
- org.slf4j:jcl-over-slf4j:1.5.7: 172/321 (53.58%)

**Method:**
- org.slf4j:jcl-over-slf4j:1.5.6: 49/120 (40.83%)
- org.slf4j:jcl-over-slf4j:1.5.7: 49/122 (40.16%)
