### PR TITLE
[Automation] Generated metadata for org.apache.velocity:velocity-engine-core:2.4

### DIFF
--- a/metadata/org.apache.velocity/velocity-engine-core/2.4/reachability-metadata.json
+++ b/metadata/org.apache.velocity/velocity-engine-core/2.4/reachability-metadata.json
@@ -1,0 +1,733 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.SetPropertyExecutor"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassFieldMap"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.SetPropertyExecutor"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassFieldMap"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassFieldMap"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.MethodMap"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl$VelMethodImpl"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.SetPropertyExecutor"
+      },
+      "type" : "java.util.Date",
+      "methods" : [
+        {
+          "name" : "setTime",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "java.util.Dictionary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "java.util.Dictionary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "java.util.Hashtable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "java.util.Hashtable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.DuckType"
+      },
+      "type" : "java.util.Optional",
+      "methods" : [
+        {
+          "name" : "isEmpty",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.VelocityContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.AbstractContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.GetExecutor"
+      },
+      "type" : "org.apache.velocity.context.Context",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.Context",
+      "methods" : [
+        {
+          "name" : "getKeys",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.InternalContextBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.InternalEventContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.InternalHousekeepingContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.DeprecationAwareExtProperties"
+      },
+      "type" : "org.apache.velocity.runtime.DeprecatedRuntimeConstants",
+      "fields" : [
+        {
+          "name" : "OLD_CHECK_EMPTY_OBJECTS"
+        },
+        {
+          "name" : "OLD_CONTEXT_AUTOREFERENCE_KEY"
+        },
+        {
+          "name" : "OLD_CONVERSION_HANDLER_CLASS"
+        },
+        {
+          "name" : "OLD_CUSTOM_DIRECTIVES"
+        },
+        {
+          "name" : "OLD_DEFINE_DIRECTIVE_MAXDEPTH"
+        },
+        {
+          "name" : "OLD_DS_RESOURCE_LOADER_DATASOURCE"
+        },
+        {
+          "name" : "OLD_DS_RESOURCE_LOADER_KEY_COLUMN"
+        },
+        {
+          "name" : "OLD_DS_RESOURCE_LOADER_TEMPLATE_COLUMN"
+        },
+        {
+          "name" : "OLD_DS_RESOURCE_LOADER_TIMESTAMP_COLUMN"
+        },
+        {
+          "name" : "OLD_ERRORMSG_END"
+        },
+        {
+          "name" : "OLD_ERRORMSG_START"
+        },
+        {
+          "name" : "OLD_EVENTHANDLER_INCLUDE"
+        },
+        {
+          "name" : "OLD_EVENTHANDLER_INVALIDREFERENCES"
+        },
+        {
+          "name" : "OLD_EVENTHANDLER_METHODEXCEPTION"
+        },
+        {
+          "name" : "OLD_EVENTHANDLER_REFERENCEINSERTION"
+        },
+        {
+          "name" : "OLD_FILE_RESOURCE_LOADER_CACHE"
+        },
+        {
+          "name" : "OLD_FILE_RESOURCE_LOADER_PATH"
+        },
+        {
+          "name" : "OLD_INPUT_ENCODING"
+        },
+        {
+          "name" : "OLD_INTERPOLATE_STRINGLITERALS"
+        },
+        {
+          "name" : "OLD_MAX_NUMBER_LOOPS"
+        },
+        {
+          "name" : "OLD_PARSE_DIRECTIVE_MAXDEPTH"
+        },
+        {
+          "name" : "OLD_RESOURCE_LOADERS"
+        },
+        {
+          "name" : "OLD_RESOURCE_LOADER_CHECK_INTERVAL"
+        },
+        {
+          "name" : "OLD_RESOURCE_MANAGER_DEFAULTCACHE_SIZE"
+        },
+        {
+          "name" : "OLD_RESOURCE_MANAGER_LOGWHENFOUND"
+        },
+        {
+          "name" : "OLD_RUNTIME_LOG_REFERENCE_LOG_INVALID"
+        },
+        {
+          "name" : "OLD_RUNTIME_REFERENCES_STRICT"
+        },
+        {
+          "name" : "OLD_RUNTIME_REFERENCES_STRICT_ESCAPE"
+        },
+        {
+          "name" : "OLD_SKIP_INVALID_ITERATOR"
+        },
+        {
+          "name" : "OLD_SPACE_GOBBLING"
+        },
+        {
+          "name" : "OLD_STRICT_MATH"
+        },
+        {
+          "name" : "OLD_UBERSPECT_CLASSNAME"
+        },
+        {
+          "name" : "OLD_VM_BODY_REFERENCE"
+        },
+        {
+          "name" : "OLD_VM_ENABLE_BC_MODE"
+        },
+        {
+          "name" : "OLD_VM_LIBRARY"
+        },
+        {
+          "name" : "OLD_VM_LIBRARY_DEFAULT"
+        },
+        {
+          "name" : "OLD_VM_MAX_DEPTH"
+        },
+        {
+          "name" : "OLD_VM_PERM_ALLOW_INLINE"
+        },
+        {
+          "name" : "OLD_VM_PERM_ALLOW_INLINE_REPLACE_GLOBAL"
+        },
+        {
+          "name" : "OLD_VM_PERM_INLINE_LOCAL"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.ParserPoolImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.DeprecationAwareExtProperties"
+      },
+      "type" : "org.apache.velocity.runtime.RuntimeConstants",
+      "fields" : [
+        {
+          "name" : "CHECK_EMPTY_OBJECTS"
+        },
+        {
+          "name" : "CONTEXT_AUTOREFERENCE_KEY"
+        },
+        {
+          "name" : "CONVERSION_HANDLER_CLASS"
+        },
+        {
+          "name" : "CUSTOM_DIRECTIVES"
+        },
+        {
+          "name" : "DEFINE_DIRECTIVE_MAXDEPTH"
+        },
+        {
+          "name" : "DS_RESOURCE_LOADER_DATASOURCE"
+        },
+        {
+          "name" : "DS_RESOURCE_LOADER_KEY_COLUMN"
+        },
+        {
+          "name" : "DS_RESOURCE_LOADER_TEMPLATE_COLUMN"
+        },
+        {
+          "name" : "DS_RESOURCE_LOADER_TIMESTAMP_COLUMN"
+        },
+        {
+          "name" : "ERRORMSG_END"
+        },
+        {
+          "name" : "ERRORMSG_START"
+        },
+        {
+          "name" : "EVENTHANDLER_INCLUDE"
+        },
+        {
+          "name" : "EVENTHANDLER_INVALIDREFERENCES"
+        },
+        {
+          "name" : "EVENTHANDLER_METHODEXCEPTION"
+        },
+        {
+          "name" : "EVENTHANDLER_REFERENCEINSERTION"
+        },
+        {
+          "name" : "FILE_RESOURCE_LOADER_CACHE"
+        },
+        {
+          "name" : "FILE_RESOURCE_LOADER_PATH"
+        },
+        {
+          "name" : "INPUT_ENCODING"
+        },
+        {
+          "name" : "INTERPOLATE_STRINGLITERALS"
+        },
+        {
+          "name" : "MAX_NUMBER_LOOPS"
+        },
+        {
+          "name" : "PARSE_DIRECTIVE_MAXDEPTH"
+        },
+        {
+          "name" : "RESOURCE_LOADERS"
+        },
+        {
+          "name" : "RESOURCE_LOADER_CHECK_INTERVAL"
+        },
+        {
+          "name" : "RESOURCE_MANAGER_DEFAULTCACHE_SIZE"
+        },
+        {
+          "name" : "RESOURCE_MANAGER_LOGWHENFOUND"
+        },
+        {
+          "name" : "RUNTIME_LOG_REFERENCE_LOG_INVALID"
+        },
+        {
+          "name" : "RUNTIME_REFERENCES_STRICT"
+        },
+        {
+          "name" : "RUNTIME_REFERENCES_STRICT_ESCAPE"
+        },
+        {
+          "name" : "SKIP_INVALID_ITERATOR"
+        },
+        {
+          "name" : "SPACE_GOBBLING"
+        },
+        {
+          "name" : "STRICT_MATH"
+        },
+        {
+          "name" : "UBERSPECT_CLASSNAME"
+        },
+        {
+          "name" : "VM_BODY_REFERENCE"
+        },
+        {
+          "name" : "VM_ENABLE_BC_MODE"
+        },
+        {
+          "name" : "VM_LIBRARY"
+        },
+        {
+          "name" : "VM_LIBRARY_DEFAULT"
+        },
+        {
+          "name" : "VM_MAX_DEPTH"
+        },
+        {
+          "name" : "VM_PERM_ALLOW_INLINE"
+        },
+        {
+          "name" : "VM_PERM_ALLOW_INLINE_REPLACE_GLOBAL"
+        },
+        {
+          "name" : "VM_PERM_INLINE_LOCAL"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Break",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Define",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Evaluate",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.ASTDirective"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Include",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Macro",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Parse",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Stop",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.parser.StandardParser",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.velocity.runtime.RuntimeServices"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.StandardParser"
+      },
+      "type" : "org.apache.velocity.runtime.parser.StandardParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.resource.ResourceManagerImpl"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceCacheImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceManagerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.resource.loader.ResourceLoaderFactory"
+      },
+      "type" : "org.apache.velocity.runtime.resource.loader.FileResourceLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PutExecutor"
+      },
+      "type" : "org.apache.velocity.util.DeprecationAwareExtProperties",
+      "methods" : [
+        {
+          "name" : "put",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "org.apache.velocity.util.DeprecationAwareExtProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "org.apache.velocity.util.ExtProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "org.apache.velocity.util.introspection.TypeConversionHandlerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.util.introspection.UberspectImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.ClassUtils"
+      },
+      "type" : "org.apache.velocity.app.VelocityEngine",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.app.VelocityEngine"
+      },
+      "type" : "org.apache.velocity.util.introspection.UberspectPublicFields",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/directive.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/velocity.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.velocity/velocity-engine-core/index.json
+++ b/metadata/org.apache.velocity/velocity-engine-core/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.4",
+    "test-version" : "2.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.4/velocity-engine-core-2.4-sources.jar",
+    "repository-url" : "https://github.com/apache/velocity-engine",
+    "test-code-url" : "https://github.com/apache/velocity-engine/tree/2.4/velocity-engine-core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.4/velocity-engine-core-2.4-javadoc.jar",
+    "description" : "Apache Velocity Engine Core is the runtime for Apache Velocity, a Java template engine that merges templates with context data to produce text output. It provides the parser, template rendering engine, resource loading, introspection, and macro support used to embed Velocity templating in JVM applications.",
+    "tested-versions" : [
+      "2.4"
+    ],
+    "allowed-packages" : [
+      "org.apache.velocity"
+    ]
+  },
+  {
     "metadata-version" : "2.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3-sources.jar",
     "repository-url" : "https://github.com/apache/velocity-engine",

--- a/stats/org.apache.velocity/velocity-engine-core/2.4/stats.json
+++ b/stats/org.apache.velocity/velocity-engine-core/2.4/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.942857,
+          "coveredCalls" : 33,
+          "totalCalls" : 35
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.95,
+      "coveredCalls" : 38,
+      "totalCalls" : 40
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18743,
+        "missed" : 56447,
+        "ratio" : 0.249275,
+        "total" : 75190
+      },
+      "line" : {
+        "covered" : 3730,
+        "missed" : 12201,
+        "ratio" : 0.234135,
+        "total" : 15931
+      },
+      "method" : {
+        "covered" : 610,
+        "missed" : 1571,
+        "ratio" : 0.279688,
+        "total" : 2181
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3551

This PR provides new metadata needed for the org.apache.velocity:velocity-engine-core:2.4, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.velocity:velocity-engine-core:2.3`): 148
- Metadata entries (new `org.apache.velocity:velocity-engine-core:2.4`): 159
- Library coverage (previous): 23.08%
- Library coverage (new): 23.41%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.velocity:velocity-engine-core:2.3: 36/36 covered calls (100.00%)
- org.apache.velocity:velocity-engine-core:2.4: 38/40 covered calls (95.00%)

**Reflection:**
- org.apache.velocity:velocity-engine-core:2.3: 31/31 covered calls (100.00%)
- org.apache.velocity:velocity-engine-core:2.4: 33/35 covered calls (94.29%)

**Resources:**
- org.apache.velocity:velocity-engine-core:2.3: 5/5 covered calls (100.00%)
- org.apache.velocity:velocity-engine-core:2.4: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.velocity:velocity-engine-core:2.3: 18854/76226 (24.73%)
- org.apache.velocity:velocity-engine-core:2.4: 18743/75190 (24.93%)

**Line:**
- org.apache.velocity:velocity-engine-core:2.3: 3745/16228 (23.08%)
- org.apache.velocity:velocity-engine-core:2.4: 3730/15931 (23.41%)

**Method:**
- org.apache.velocity:velocity-engine-core:2.3: 615/2179 (28.22%)
- org.apache.velocity:velocity-engine-core:2.4: 610/2181 (27.97%)
