### PR TITLE
[GenAI] Test fix for com.thoughtworks.paranamer:paranamer:2.8.1 using gpt-5.5

### DIFF
--- a/metadata/com.thoughtworks.paranamer/paranamer/2.8.1/reachability-metadata.json
+++ b/metadata/com.thoughtworks.paranamer/paranamer/2.8.1/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.BytecodeReadingParanamer"
+      },
+      "glob" : "com/thoughtworks/paranamer/com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest$$Lambda/0x000000001a1aaf70.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.BytecodeReadingParanamer"
+      },
+      "glob" : "com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest$$Lambda/0x000000001a1aaf70.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.BytecodeReadingParanamer"
+      },
+      "glob" : "com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest$ParameterNameFixture.class"
+    }
+  ]
+}

--- a/metadata/com.thoughtworks.paranamer/paranamer/index.json
+++ b/metadata/com.thoughtworks.paranamer/paranamer/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.8.1",
+    "tested-versions" : [
+      "2.8.1"
+    ],
+    "allowed-packages" : [
+      "com.thoughtworks.paranamer"
+    ]
+  },
+  {
     "metadata-version" : "2.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.3/paranamer-2.3-sources.jar",
     "repository-url" : "https://github.com/paul-hammant/paranamer",

--- a/stats/com.thoughtworks.paranamer/paranamer/2.8.1/execution-metrics.json
+++ b/stats/com.thoughtworks.paranamer/paranamer/2.8.1/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-04-30": {
+    "timestamp": "2026-04-30T10:30:47.273106Z",
+    "library": "com.thoughtworks.paranamer:paranamer:2.8.1",
+    "starting_commit": "1626b6ef655b01240f286c0968a4aa20bb54126d",
+    "ending_commit": "33e912f810332174772183da4e4aeb4fdca7a89d",
+    "previous_library": "com.thoughtworks.paranamer:paranamer:2.3",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.8.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1318,
+          "missed": 1241,
+          "ratio": 0.515045,
+          "total": 2559
+        },
+        "line": {
+          "covered": 317,
+          "missed": 316,
+          "ratio": 0.50079,
+          "total": 633
+        },
+        "method": {
+          "covered": 41,
+          "missed": 53,
+          "ratio": 0.43617,
+          "total": 94
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1282,
+          "missed": 1613,
+          "ratio": 0.442832,
+          "total": 2895
+        },
+        "line": {
+          "covered": 307,
+          "missed": 394,
+          "ratio": 0.437946,
+          "total": 701
+        },
+        "method": {
+          "covered": 38,
+          "missed": 38,
+          "ratio": 0.5,
+          "total": 76
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 97053,
+      "cached_input_tokens_used": 1026048,
+      "output_tokens_used": 11903,
+      "iterations": 2,
+      "cost_usd": 0.8701,
+      "tested_library_loc": 317,
+      "metadata_entries": 3,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 50.08,
+      "previous_library_coverage_percent": 43.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest.java",
+      "metadata_file": "metadata/com.thoughtworks.paranamer/paranamer/2.8.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.thoughtworks.paranamer/paranamer/2.8.1/stats.json
+++ b/stats/com.thoughtworks.paranamer/paranamer/2.8.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.8.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1318,
+        "missed" : 1241,
+        "ratio" : 0.515045,
+        "total" : 2559
+      },
+      "line" : {
+        "covered" : 317,
+        "missed" : 316,
+        "ratio" : 0.50079,
+        "total" : 633
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 53,
+        "ratio" : 0.43617,
+        "total" : 94
+      }
+    }
+  } ]
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/.gitignore
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/build.gradle
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.thoughtworks.paranamer:paranamer:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/gradle.properties
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.thoughtworks.paranamer:paranamer:2.8.1
+library.version = 2.8.1
+metadata.dir = com.thoughtworks.paranamer/paranamer/2.8.1/

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/settings.gradle
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.thoughtworks.paranamer.paranamer_tests'

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest.java
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/BytecodeReadingParanamerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_paranamer.paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.paranamer.BytecodeReadingParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class BytecodeReadingParanamerTest {
+    @Test
+    void readsParameterNamesFromAvailableClassResource() throws Exception {
+        BytecodeReadingParanamer paranamer = new BytecodeReadingParanamer();
+        Method method = ParameterNameFixture.class.getDeclaredMethod("format", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method, false);
+
+        assertThat(parameterNames).satisfiesAnyOf(
+                names -> assertThat(names).containsExactly("message", "repeatCount"),
+                names -> assertThat(names).isEmpty());
+    }
+
+    @Test
+    void returnsEmptyNamesWhenGeneratedClassHasNoBytecodeResource() throws Exception {
+        BytecodeReadingParanamer paranamer = new BytecodeReadingParanamer();
+        ParameterizedOperation operation = value -> value.length();
+        Method method = operation.getClass().getDeclaredMethod("apply", String.class);
+        assertThat(method.getDeclaringClass()).isSameAs(operation.getClass());
+
+        String[] parameterNames = paranamer.lookupParameterNames(method, false);
+
+        assertThat(parameterNames).isEmpty();
+    }
+
+    private interface ParameterizedOperation {
+        int apply(String value);
+    }
+
+    private static final class ParameterNameFixture {
+        String format(String message, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(message);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_paranamer.paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.paranamer.DefaultParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class DefaultParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        DefaultParanamer paranamer = new DefaultParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
@@ -9,32 +9,21 @@ package com_thoughtworks_paranamer.paranamer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.thoughtworks.paranamer.DefaultParanamer;
-import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.Test;
 
 public class DefaultParanamerTest {
     @Test
-    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+    void readsParameterNamesFromReflectionMetadata() throws Exception {
         DefaultParanamer paranamer = new DefaultParanamer();
-        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+        Constructor<ConstructorParameterFixture> constructor = ConstructorParameterFixture.class.getDeclaredConstructor(
+                String.class, int.class);
 
-        String[] parameterNames = paranamer.lookupParameterNames(method);
+        String[] parameterNames = paranamer.lookupParameterNames(constructor);
 
         assertThat(parameterNames).containsExactly("text", "repeatCount");
     }
 
-    public static final class MethodParameterFixture {
-        public static final String __PARANAMER_DATA = """
-                v1.0
-                combine java.lang.String,int text,repeatCount
-                """;
-
-        public String combine(String text, int repeatCount) {
-            StringBuilder result = new StringBuilder();
-            for (int index = 0; index < repeatCount; index++) {
-                result.append(text);
-            }
-            return result.toString();
-        }
+    public record ConstructorParameterFixture(String text, int repeatCount) {
     }
 }

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/LegacyParanamerTest.java
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/LegacyParanamerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_paranamer.paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.paranamer.LegacyParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class LegacyParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        LegacyParanamer paranamer = new LegacyParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.DefaultParanamer"
+      },
+      "type" : "com_thoughtworks_paranamer.paranamer.DefaultParanamerTest$MethodParameterFixture",
+      "fields" : [
+        {
+          "name" : "__PARANAMER_DATA"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,10 +4,14 @@
       "condition" : {
         "typeReached" : "com.thoughtworks.paranamer.DefaultParanamer"
       },
-      "type" : "com_thoughtworks_paranamer.paranamer.DefaultParanamerTest$MethodParameterFixture",
-      "fields" : [
+      "type" : "com_thoughtworks_paranamer.paranamer.DefaultParanamerTest$ConstructorParameterFixture",
+      "methods" : [
         {
-          "name" : "__PARANAMER_DATA"
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
         }
       ]
     },

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -10,6 +10,26 @@
           "name" : "__PARANAMER_DATA"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.LegacyParanamer"
+      },
+      "type" : "com_thoughtworks_paranamer.paranamer.LegacyParanamerTest$MethodParameterFixture",
+      "fields" : [
+        {
+          "name" : "__PARANAMER_DATA"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "combine",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -34,6 +34,17 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.thoughtworks.paranamer.LegacyParanamer"
+      },
+      "type" : "com_thoughtworks_paranamer.paranamer.LegacyParanamerTest$MethodParameterFixture",
+      "fields" : [
+        {
+          "name" : "__PARANAMER_DATA"
+        }
+      ]
     }
   ]
 }

--- a/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/user-code-filter.json
+++ b/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.thoughtworks.paranamer.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3536

This PR provides test fixes and new metadata for com.thoughtworks.paranamer:paranamer:2.8.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 97053
- Cached input tokens: 1026048
- Output tokens: 11903
- Entries found: 3
- Iterations: 2
- Library coverage percentage: 50.08
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 43.79

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.thoughtworks.paranamer:paranamer:2.3: 4/4 covered calls (100.00%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 4/4 covered calls (100.00%)

**Reflection:**
- com.thoughtworks.paranamer:paranamer:2.3: 2/2 covered calls (100.00%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 2/2 covered calls (100.00%)

**Resources:**
- com.thoughtworks.paranamer:paranamer:2.3: 2/2 covered calls (100.00%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.thoughtworks.paranamer:paranamer:2.3: 1282/2895 (44.28%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 1318/2559 (51.50%)

**Line:**
- com.thoughtworks.paranamer:paranamer:2.3: 307/701 (43.79%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 317/633 (50.08%)

**Method:**
- com.thoughtworks.paranamer:paranamer:2.3: 38/76 (50.00%)
- com.thoughtworks.paranamer:paranamer:2.8.1: 41/94 (43.62%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.thoughtworks.paranamer/paranamer/2.3/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java 2/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
index d58a5be367..9e6fe4d328 100644
--- 1/tests/src/com.thoughtworks.paranamer/paranamer/2.3/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
+++ 2/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/DefaultParanamerTest.java
@@ -9,32 +9,21 @@ package com_thoughtworks_paranamer.paranamer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.thoughtworks.paranamer.DefaultParanamer;
-import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.Test;
 
 public class DefaultParanamerTest {
     @Test
-    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+    void readsParameterNamesFromReflectionMetadata() throws Exception {
         DefaultParanamer paranamer = new DefaultParanamer();
-        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+        Constructor<ConstructorParameterFixture> constructor = ConstructorParameterFixture.class.getDeclaredConstructor(
+                String.class, int.class);
 
-        String[] parameterNames = paranamer.lookupParameterNames(method);
+        String[] parameterNames = paranamer.lookupParameterNames(constructor);
 
         assertThat(parameterNames).containsExactly("text", "repeatCount");
     }
 
-    public static final class MethodParameterFixture {
-        public static final String __PARANAMER_DATA = """
-                v1.0
-                combine java.lang.String,int text,repeatCount
-                """;
-
-        public String combine(String text, int repeatCount) {
-            StringBuilder result = new StringBuilder();
-            for (int index = 0; index < repeatCount; index++) {
-                result.append(text);
-            }
-            return result.toString();
-        }
+    public record ConstructorParameterFixture(String text, int repeatCount) {
     }
 }
diff --git 1/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/LegacyParanamerTest.java 2/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/LegacyParanamerTest.java
new file mode 100644
index 0000000000..657fcc6f14
--- /dev/null
+++ 2/tests/src/com.thoughtworks.paranamer/paranamer/2.8.1/src/test/java/com_thoughtworks_paranamer/paranamer/LegacyParanamerTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_paranamer.paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.paranamer.LegacyParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class LegacyParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        LegacyParanamer paranamer = new LegacyParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

```
