### PR TITLE
[GenAI] Test fix for com.jamesmurty.utils:java-xmlbuilder:0.6 using gpt-5.5

### DIFF
--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/0.6/reachability-metadata.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/0.6/reachability-metadata.json
@@ -1,0 +1,85 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "type": "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "glob": "META-INF/services/java.nio.charset.spi.CharsetProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.transform.TransformerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.xpath.XPathFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/Encodings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.XMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities_en_US.properties"
+    },
+    {
+      "bundle": "com.sun.org.apache.xml.internal.serializer.XMLEntities"
+    }
+  ]
+}

--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
@@ -2,12 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "0.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/0.6/java-xmlbuilder-0.6-sources.jar",
+    "repository-url" : "https://github.com/jmurty/java-xmlbuilder",
+    "test-code-url" : "https://github.com/jmurty/java-xmlbuilder/tree/v0.6/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/0.6/java-xmlbuilder-0.6-javadoc.jar",
+    "description" : "java-xmlbuilder is a Java utility for constructing XML documents with a fluent, chainable builder API instead of manual string concatenation or verbose JAXP DOM code. It builds on standard JAXP and DOM APIs so callers can serialize the result, parse existing XML, query with XPath, or access the underlying W3C document for further manipulation.",
     "tested-versions" : [
       "0.6"
     ],
     "allowed-packages" : [
-      "com.jamesmurty.utils",
-      "net.iharder.base64"
+      "com.jamesmurty.utils"
     ]
   },
   {

--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.6",
+    "tested-versions" : [
+      "0.6"
+    ],
+    "allowed-packages" : [
+      "com.jamesmurty.utils",
+      "net.iharder.base64"
+    ]
+  },
+  {
     "metadata-version" : "0.4",
     "source-code-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/0.4/java-xmlbuilder-0.4-sources.jar",
     "repository-url" : "https://github.com/jmurty/java-xmlbuilder",

--- a/stats/com.jamesmurty.utils/java-xmlbuilder/0.6/execution-metrics.json
+++ b/stats/com.jamesmurty.utils/java-xmlbuilder/0.6/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "fix_javac_fail:2026-04-30": {
+    "timestamp": "2026-04-30T10:43:10.685328Z",
+    "library": "com.jamesmurty.utils:java-xmlbuilder:0.6",
+    "starting_commit": "fa8f04a3698a1e67e9da73ccb8a73f6f99443aac",
+    "ending_commit": "e242cbe7718a606585ddfb0a46b2a3d85e59da27",
+    "previous_library": "com.jamesmurty.utils:java-xmlbuilder:0.4",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 452,
+          "missed": 452,
+          "ratio": 0.5,
+          "total": 904
+        },
+        "line": {
+          "covered": 115,
+          "missed": 83,
+          "ratio": 0.580808,
+          "total": 198
+        },
+        "method": {
+          "covered": 33,
+          "missed": 32,
+          "ratio": 0.507692,
+          "total": 65
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3045,
+          "missed": 1642,
+          "ratio": 0.649669,
+          "total": 4687
+        },
+        "line": {
+          "covered": 148,
+          "missed": 359,
+          "ratio": 0.291913,
+          "total": 507
+        },
+        "method": {
+          "covered": 16,
+          "missed": 56,
+          "ratio": 0.222222,
+          "total": 72
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 47787,
+      "cached_input_tokens_used": 350720,
+      "output_tokens_used": 5090,
+      "iterations": 1,
+      "cost_usd": 0.3281,
+      "tested_library_loc": 115,
+      "metadata_entries": 17,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 58.08,
+      "previous_library_coverage_percent": 29.19
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java",
+      "metadata_file": "metadata/com.jamesmurty.utils/java-xmlbuilder/0.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.jamesmurty.utils/java-xmlbuilder/0.6/stats.json
+++ b/stats/com.jamesmurty.utils/java-xmlbuilder/0.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 452,
+        "missed" : 452,
+        "ratio" : 0.5,
+        "total" : 904
+      },
+      "line" : {
+        "covered" : 115,
+        "missed" : 83,
+        "ratio" : 0.580808,
+        "total" : 198
+      },
+      "method" : {
+        "covered" : 33,
+        "missed" : 32,
+        "ratio" : 0.507692,
+        "total" : 65
+      }
+    }
+  } ]
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/.gitignore
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/build.gradle
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.jamesmurty.utils:java-xmlbuilder:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/gradle.properties
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.jamesmurty.utils:java-xmlbuilder:0.6
+library.version = 0.6
+metadata.dir = com.jamesmurty.utils/java-xmlbuilder/0.6/

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/settings.gradle
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.jamesmurty.utils.java-xmlbuilder_tests'

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_jamesmurty_utils.java_xmlbuilder;
+
+import net.iharder.base64.Base64;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Base64Test {
+    @Test
+    void encodedSerializableObjectCanBeDecoded() {
+        String original = "XML builder Base64 serialization payload";
+
+        String encodedObject = Base64.encodeObject(original, Base64.DONT_BREAK_LINES);
+        Object decodedObject = Base64.decodeToObject(encodedObject);
+
+        assertThat(encodedObject).isNotBlank();
+        assertThat(decodedObject).isEqualTo(original);
+    }
+
+    @Test
+    void gzipEncodedSerializableObjectCanBeDecoded() {
+        String original = "Compressible Base64 serialization payload for XML builder";
+
+        String encodedObject = Base64.encodeObject(original, Base64.GZIP | Base64.DONT_BREAK_LINES);
+        Object decodedObject = Base64.decodeToObject(encodedObject);
+
+        assertThat(encodedObject).isNotBlank();
+        assertThat(decodedObject).isEqualTo(original);
+    }
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -6,31 +6,47 @@
  */
 package com_jamesmurty_utils.java_xmlbuilder;
 
-import net.iharder.base64.Base64;
+import com.jamesmurty.utils.XMLBuilder;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+import java.util.Properties;
+
+import javax.xml.transform.OutputKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Base64Test {
     @Test
-    void encodedSerializableObjectCanBeDecoded() {
-        String original = "XML builder Base64 serialization payload";
+    void xmlDocumentCanBeBuiltSerializedParsedAndQueried() throws Exception {
+        XMLBuilder builder = XMLBuilder.create("catalog")
+                .namespace("bk", "https://example.com/book")
+                .e("bk:book")
+                .a("id", "java-xmlbuilder")
+                .e("title")
+                .t("Reachability Metadata")
+                .up()
+                .e("description")
+                .data("<native-image ready>")
+                .up()
+                .up()
+                .e("count")
+                .t("1");
+        Properties outputProperties = new Properties();
+        outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 
-        String encodedObject = Base64.encodeObject(original, Base64.DONT_BREAK_LINES);
-        Object decodedObject = Base64.decodeToObject(encodedObject);
+        String xml = builder.asString(outputProperties);
+        XMLBuilder parsed = XMLBuilder.parse(new InputSource(new StringReader(xml)));
+        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", parsed.buildDocumentNamespaceContext());
+        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", parsed.buildDocumentNamespaceContext());
+        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", parsed.buildDocumentNamespaceContext());
+        XMLBuilder count = parsed.xpathFind("/catalog/count");
 
-        assertThat(encodedObject).isNotBlank();
-        assertThat(decodedObject).isEqualTo(original);
-    }
-
-    @Test
-    void gzipEncodedSerializableObjectCanBeDecoded() {
-        String original = "Compressible Base64 serialization payload for XML builder";
-
-        String encodedObject = Base64.encodeObject(original, Base64.GZIP | Base64.DONT_BREAK_LINES);
-        Object decodedObject = Base64.decodeToObject(encodedObject);
-
-        assertThat(encodedObject).isNotBlank();
-        assertThat(decodedObject).isEqualTo(original);
+        assertThat(xml).contains("xmlns:bk=\"https://example.com/book\"");
+        assertThat(book.getElement().getAttribute("id")).isEqualTo("java-xmlbuilder");
+        assertThat(title.getElement().getTextContent()).isEqualTo("Reachability Metadata");
+        assertThat(description.getElement().getTextContent()).isEqualTo("<native-image ready>");
+        assertThat(count.getElement().getTextContent()).isEqualTo("1");
     }
 }

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.jamesmurty.utils.**"
+    },
+    {
+      "includeClasses" : "net.iharder.base64.**"
+    }
+  ]
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
@@ -5,9 +5,6 @@
     },
     {
       "includeClasses" : "com.jamesmurty.utils.**"
-    },
-    {
-      "includeClasses" : "net.iharder.base64.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3535

This PR provides test fixes and new metadata for com.jamesmurty.utils:java-xmlbuilder:0.6, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 47787
- Cached input tokens: 350720
- Output tokens: 5090
- Entries found: 17
- Iterations: 1
- Library coverage percentage: 58.08
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 29.19

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22880046959560927ca299df755112db0c0177fd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.jamesmurty.utils:java-xmlbuilder:0.4: 2/2 covered calls (100.00%)
- com.jamesmurty.utils:java-xmlbuilder:0.6: 0/0 covered calls (100.00%)

**Reflection:**
- com.jamesmurty.utils:java-xmlbuilder:0.4: 2/2 covered calls (100.00%)
- com.jamesmurty.utils:java-xmlbuilder:0.6: N/A

#### Library coverage

**Instruction:**
- com.jamesmurty.utils:java-xmlbuilder:0.4: 3045/4687 (64.97%)
- com.jamesmurty.utils:java-xmlbuilder:0.6: 452/904 (50.00%)

**Line:**
- com.jamesmurty.utils:java-xmlbuilder:0.4: 148/507 (29.19%)
- com.jamesmurty.utils:java-xmlbuilder:0.6: 115/198 (58.08%)

**Method:**
- com.jamesmurty.utils:java-xmlbuilder:0.4: 16/72 (22.22%)
- com.jamesmurty.utils:java-xmlbuilder:0.6: 33/65 (50.77%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.4/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
index 81d471eba4..86b1360d06 100644
--- 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.4/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -6,31 +6,47 @@
  */
 package com_jamesmurty_utils.java_xmlbuilder;
 
-import net.iharder.base64.Base64;
+import com.jamesmurty.utils.XMLBuilder;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.io.StringReader;
+import java.util.Properties;
 
-public class Base64Test {
-    @Test
-    void encodedSerializableObjectCanBeDecoded() {
-        String original = "XML builder Base64 serialization payload";
+import javax.xml.transform.OutputKeys;
 
-        String encodedObject = Base64.encodeObject(original, Base64.DONT_BREAK_LINES);
-        Object decodedObject = Base64.decodeToObject(encodedObject);
-
-        assertThat(encodedObject).isNotBlank();
-        assertThat(decodedObject).isEqualTo(original);
-    }
+import static org.assertj.core.api.Assertions.assertThat;
 
+public class Base64Test {
     @Test
-    void gzipEncodedSerializableObjectCanBeDecoded() {
-        String original = "Compressible Base64 serialization payload for XML builder";
-
-        String encodedObject = Base64.encodeObject(original, Base64.GZIP | Base64.DONT_BREAK_LINES);
-        Object decodedObject = Base64.decodeToObject(encodedObject);
-
-        assertThat(encodedObject).isNotBlank();
-        assertThat(decodedObject).isEqualTo(original);
+    void xmlDocumentCanBeBuiltSerializedParsedAndQueried() throws Exception {
+        XMLBuilder builder = XMLBuilder.create("catalog")
+                .namespace("bk", "https://example.com/book")
+                .e("bk:book")
+                .a("id", "java-xmlbuilder")
+                .e("title")
+                .t("Reachability Metadata")
+                .up()
+                .e("description")
+                .data("<native-image ready>")
+                .up()
+                .up()
+                .e("count")
+                .t("1");
+        Properties outputProperties = new Properties();
+        outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+
+        String xml = builder.asString(outputProperties);
+        XMLBuilder parsed = XMLBuilder.parse(new InputSource(new StringReader(xml)));
+        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", parsed.buildDocumentNamespaceContext());
+        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", parsed.buildDocumentNamespaceContext());
+        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", parsed.buildDocumentNamespaceContext());
+        XMLBuilder count = parsed.xpathFind("/catalog/count");
+
+        assertThat(xml).contains("xmlns:bk=\"https://example.com/book\"");
+        assertThat(book.getElement().getAttribute("id")).isEqualTo("java-xmlbuilder");
+        assertThat(title.getElement().getTextContent()).isEqualTo("Reachability Metadata");
+        assertThat(description.getElement().getTextContent()).isEqualTo("<native-image ready>");
+        assertThat(count.getElement().getTextContent()).isEqualTo("1");
     }
 }
diff --git 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.4/user-code-filter.json 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
index 4571eb6f7e..045fa106ff 100644
--- 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.4/user-code-filter.json
+++ 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/user-code-filter.json
@@ -5,9 +5,6 @@
     },
     {
       "includeClasses" : "com.jamesmurty.utils.**"
-    },
-    {
-      "includeClasses" : "net.iharder.base64.**"
     }
   ]
 }

```
