### PR TITLE
[GenAI] Add support for org.xmlunit:xmlunit-placeholders:2.10.2 using gpt-5.5

### DIFF
--- a/metadata/org.xmlunit/xmlunit-placeholders/2.10.2/reachability-metadata.json
+++ b/metadata/org.xmlunit/xmlunit-placeholders/2.10.2/reachability-metadata.json
@@ -1,0 +1,36 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.xmlunit.placeholder.PlaceholderDifferenceEvaluator"
+      },
+      "type": "org.xmlunit.placeholder.IgnorePlaceholderHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.xmlunit.placeholder.PlaceholderDifferenceEvaluator"
+      },
+      "type": "org.xmlunit.placeholder.IsDateTimePlaceholderHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.xmlunit.placeholder.PlaceholderDifferenceEvaluator"
+      },
+      "type": "org.xmlunit.placeholder.IsNumberPlaceholderHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.xmlunit.placeholder.PlaceholderDifferenceEvaluator"
+      },
+      "type": "org.xmlunit.placeholder.MatchesRegexPlaceholderHandler"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.xmlunit.placeholder.PlaceholderDifferenceEvaluator"
+      },
+      "glob": "META-INF/services/org.xmlunit.placeholder.PlaceholderHandler"
+    }
+  ]
+}

--- a/metadata/org.xmlunit/xmlunit-placeholders/index.json
+++ b/metadata/org.xmlunit/xmlunit-placeholders/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.10.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/xmlunit/xmlunit-placeholders/2.10.2/xmlunit-placeholders-2.10.2-sources.jar",
+    "repository-url" : "https://github.com/xmlunit/xmlunit",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/xmlunit/xmlunit-placeholders/2.10.2/xmlunit-placeholders-2.10.2-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/xmlunit/xmlunit-placeholders/2.10.2/xmlunit-placeholders-2.10.2-javadoc.jar",
+    "description" : "XMLUnit Placeholders adds an experimental placeholder DSL to XMLUnit comparisons, letting control XML use tokens such as ${xmlunit.ignore}, ${xmlunit.isNumber}, ${xmlunit.matchesRegex}, and ${xmlunit.isDateTime} in element text or attribute values. The module integrates this behavior through placeholder difference evaluators and helper methods for DiffBuilder or CompareMatcher so tests can tolerate dynamic XML values while still comparing document structure.",
+    "tested-versions" : [
+      "2.10.2"
+    ],
+    "allowed-packages" : [
+      "org.xmlunit.placeholder"
+    ]
+  }
+]

--- a/stats/org.xmlunit/xmlunit-placeholders/2.10.2/execution-metrics.json
+++ b/stats/org.xmlunit/xmlunit-placeholders/2.10.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T11:51:33.514075Z",
+    "library": "org.xmlunit:xmlunit-placeholders:2.10.2",
+    "starting_commit": "2d254735312ed0825b607a5f96921e632bf31424",
+    "ending_commit": "69b32d603425e5e02f6d705235a83df09eba0038",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.10.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 822,
+          "missed": 22,
+          "ratio": 0.973934,
+          "total": 844
+        },
+        "line": {
+          "covered": 161,
+          "missed": 9,
+          "ratio": 0.947059,
+          "total": 170
+        },
+        "method": {
+          "covered": 39,
+          "missed": 1,
+          "ratio": 0.975,
+          "total": 40
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 203605,
+      "cached_input_tokens_used": 1268736,
+      "output_tokens_used": 14728,
+      "iterations": 4,
+      "cost_usd": 1.0762,
+      "generated_loc": 282,
+      "tested_library_loc": 161,
+      "metadata_entries": 5,
+      "code_coverage_percent": 94.71
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java",
+      "metadata_file": "metadata/org.xmlunit/xmlunit-placeholders/2.10.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.xmlunit/xmlunit-placeholders/2.10.2/stats.json
+++ b/stats/org.xmlunit/xmlunit-placeholders/2.10.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.10.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 822,
+        "missed" : 22,
+        "ratio" : 0.973934,
+        "total" : 844
+      },
+      "line" : {
+        "covered" : 161,
+        "missed" : 9,
+        "ratio" : 0.947059,
+        "total" : 170
+      },
+      "method" : {
+        "covered" : 39,
+        "missed" : 1,
+        "ratio" : 0.975,
+        "total" : 40
+      }
+    }
+  } ]
+}

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/.gitignore
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/build.gradle
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.xmlunit:xmlunit-placeholders:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/gradle.properties
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.xmlunit:xmlunit-placeholders:2.10.2
+library.version = 2.10.2
+metadata.dir = org.xmlunit/xmlunit-placeholders/2.10.2/

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/settings.gradle
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.xmlunit.xmlunit-placeholders_tests'

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
@@ -125,6 +125,24 @@ public class Xmlunit_placeholdersTest {
     }
 
     @Test
+    void dateTimePlaceholdersAcceptExplicitDateFormatArguments() {
+        String control = """
+                <audit>
+                    <timestamp>${xmlunit.isDateTime(dd/MM/yyyy HH:mm:ss)}</timestamp>
+                </audit>
+                """;
+        String test = """
+                <audit>
+                    <timestamp>30/04/2026 14:35:21</timestamp>
+                </audit>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
     void customPlaceholderDelimitersAllowNonDefaultMarkerSyntax() {
         String control = """
                 <metrics>

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_xmlunit.xmlunit_placeholders;
+
+import org.junit.jupiter.api.Test;
+
+class Xmlunit_placeholdersTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
@@ -92,6 +92,39 @@ public class Xmlunit_placeholdersTest {
     }
 
     @Test
+    void placeholdersMatchXsiTypeLocalPartsWhenNamespaceUriIsUnchanged() {
+        String control = """
+                <document xmlns:doc="urn:document-types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="doc:${xmlunit.matchesRegex([A-Z][A-Za-z]+Document)}"/>
+                """;
+        String test = """
+                <document xmlns:doc="urn:document-types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="doc:InvoiceDocument"/>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void placeholdersInXsiTypeDoNotMaskNamespaceUriDifferences() {
+        String control = """
+                <document xmlns:doc="urn:expected-document-types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="doc:${xmlunit.ignore}"/>
+                """;
+        String test = """
+                <document xmlns:doc="urn:actual-document-types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="doc:InvoiceDocument"/>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertTrue(diff.hasDifferences());
+        assertTrue(diff.fullDescription().contains("urn:actual-document-types"), diff::fullDescription);
+    }
+
+    @Test
     void customPlaceholderDelimitersAllowNonDefaultMarkerSyntax() {
         String control = """
                 <metrics>

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/src/test/java/org_xmlunit/xmlunit_placeholders/Xmlunit_placeholdersTest.java
@@ -6,11 +6,273 @@
  */
 package org_xmlunit.xmlunit_placeholders;
 
-import org.junit.jupiter.api.Test;
+import java.util.regex.Pattern;
 
-class Xmlunit_placeholdersTest {
+import org.junit.jupiter.api.Test;
+import org.xmlunit.XMLUnitException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.placeholder.IgnorePlaceholderHandler;
+import org.xmlunit.placeholder.IsDateTimePlaceholderHandler;
+import org.xmlunit.placeholder.IsNumberPlaceholderHandler;
+import org.xmlunit.placeholder.MatchesRegexPlaceholderHandler;
+import org.xmlunit.placeholder.PlaceholderDifferenceEvaluator;
+import org.xmlunit.placeholder.PlaceholderSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Xmlunit_placeholdersTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultPlaceholderSupportMatchesTextAttributesNumbersDatesRegexesAndIgnoredValues() {
+        String control = """
+                <order id="${xmlunit.matchesRegex(^ORD-[0-9]{4}$)}" revision="${xmlunit.isNumber}">
+                    <createdAt>${xmlunit.isDateTime}</createdAt>
+                    <checksum>${xmlunit.ignore}</checksum>
+                    <total>${xmlunit.isNumber}</total>
+                    <customerCode>${xmlunit.matchesRegex(^[A-Z]{3}-[0-9]{2}$)}</customerCode>
+                </order>
+                """;
+        String test = """
+                <order id="ORD-2026" revision="7">
+                    <createdAt>2026-04-30T10:15:30+02:00</createdAt>
+                    <checksum>runtime-specific-value</checksum>
+                    <total>-1234.50e+2</total>
+                    <customerCode>ABC-42</customerCode>
+                </order>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void placeholdersCanRepresentMissingTextAndMissingAttributes() {
+        String control = """
+                <profile id="42" volatileToken="${xmlunit.ignore}">
+                    <displayName>${xmlunit.ignore}</displayName>
+                    <score>${xmlunit.isNumber}</score>
+                </profile>
+                """;
+        String test = """
+                <profile id="42">
+                    <displayName/>
+                    <score>98.75</score>
+                </profile>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void placeholderEvaluatorHandlesTextCdataNodeTypeMismatch() {
+        String control = """
+                <job>
+                    <payload><![CDATA[${xmlunit.matchesRegex(^JOB-[0-9]+$)}]]></payload>
+                </job>
+                """;
+        String test = """
+                <job>
+                    <payload>JOB-2048</payload>
+                </job>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void customPlaceholderDelimitersAllowNonDefaultMarkerSyntax() {
+        String control = """
+                <metrics>
+                    <count>[[xmlunit.isNumber]]</count>
+                    <lastSeen>[[xmlunit.isDateTime]]</lastSeen>
+                    <opaque>[[xmlunit.ignore]]</opaque>
+                </metrics>
+                """;
+        String test = """
+                <metrics>
+                    <count>12345</count>
+                    <lastSeen>2026-04-30</lastSeen>
+                    <opaque>anything supplied by the application</opaque>
+                </metrics>
+                """;
+
+        DiffBuilder diffBuilder = DiffBuilder.compare(control).withTest(test).ignoreWhitespace().checkForIdentical();
+        Diff diff = PlaceholderSupport.withPlaceholderSupportUsingDelimiters(
+                diffBuilder,
+                Pattern.quote("[["),
+                Pattern.quote("]]"))
+                .build();
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void customArgumentDelimitersAndSeparatorAreAppliedToRegexPlaceholders() {
+        String control = """
+                <events>
+                    <event code="[[xmlunit.matchesRegex::^[A-Z]{2}[0-9]{3}$::]]">[[xmlunit.ignore]]</event>
+                </events>
+                """;
+        String test = """
+                <events>
+                    <event code="AB123">created</event>
+                </events>
+                """;
+
+        DiffBuilder diffBuilder = DiffBuilder.compare(control).withTest(test).ignoreWhitespace().checkForIdentical();
+        Diff diff = PlaceholderSupport.withPlaceholderSupportUsingDelimiters(
+                diffBuilder,
+                Pattern.quote("[["),
+                Pattern.quote("]]"),
+                Pattern.quote("::"),
+                Pattern.quote("::"),
+                Pattern.quote(";;"))
+                .build();
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void placeholderSupportCanBeChainedAfterDomainSpecificDifferenceEvaluator() {
+        String control = """
+                <task id="${xmlunit.matchesRegex(^TASK-[0-9]+$)}" status="pending">
+                    <assignee>${xmlunit.ignore}</assignee>
+                </task>
+                """;
+        String test = """
+                <task id="TASK-77" status="PENDING">
+                    <assignee>Ada Lovelace</assignee>
+                </task>
+                """;
+
+        DiffBuilder diffBuilder = DiffBuilder.compare(control).withTest(test).ignoreWhitespace().checkForSimilar();
+        Diff diff = PlaceholderSupport.withPlaceholderSupportChainedAfter(diffBuilder, this::caseInsensitiveStatus)
+                .build();
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    @Test
+    void nonMatchingPlaceholderLeavesADifferenceInTheDiffResult() {
+        String control = """
+                <invoice>
+                    <amount>${xmlunit.isNumber}</amount>
+                    <reference>${xmlunit.matchesRegex(^INV-[0-9]+$)}</reference>
+                </invoice>
+                """;
+        String test = """
+                <invoice>
+                    <amount>not-a-number</amount>
+                    <reference>INV-100</reference>
+                </invoice>
+                """;
+
+        Diff diff = buildDefaultDiff(control, test);
+
+        assertTrue(diff.hasDifferences());
+        assertTrue(diff.fullDescription().contains("not-a-number"), diff::fullDescription);
+    }
+
+    @Test
+    void placeholdersMustOccupyTheEntireTextOrAttributeValue() {
+        String control = """
+                <message>prefix ${xmlunit.ignore}</message>
+                """;
+        String test = """
+                <message>prefix generated-value</message>
+                """;
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> buildDefaultDiff(control, test));
+
+        assertTrue(exceptionChainContains(exception, "exclusively occupy"), exception::toString);
+    }
+
+    @Test
+    void directHandlersExposeTheirKeywordsAndComparisonSemantics() {
+        IgnorePlaceholderHandler ignoreHandler = new IgnorePlaceholderHandler();
+        IsNumberPlaceholderHandler numberHandler = new IsNumberPlaceholderHandler();
+        IsDateTimePlaceholderHandler dateTimeHandler = new IsDateTimePlaceholderHandler();
+        MatchesRegexPlaceholderHandler regexHandler = new MatchesRegexPlaceholderHandler();
+
+        assertEquals("ignore", ignoreHandler.getKeyword());
+        assertEquals(ComparisonResult.EQUAL, ignoreHandler.evaluate("any value"));
+        assertEquals("isNumber", numberHandler.getKeyword());
+        assertEquals(ComparisonResult.EQUAL, numberHandler.evaluate(" -3.5e+8 "));
+        assertEquals(ComparisonResult.DIFFERENT, numberHandler.evaluate("12 apples"));
+        assertEquals("isDateTime", dateTimeHandler.getKeyword());
+        assertEquals(ComparisonResult.EQUAL, dateTimeHandler.evaluate("30/04/2026", "dd/MM/yyyy"));
+        assertEquals(ComparisonResult.DIFFERENT, dateTimeHandler.evaluate("not a date", "dd/MM/yyyy"));
+        assertEquals("matchesRegex", regexHandler.getKeyword());
+        assertEquals(ComparisonResult.EQUAL, regexHandler.evaluate("ticket-2048", "ticket-[0-9]+"));
+        assertEquals(ComparisonResult.DIFFERENT, regexHandler.evaluate("ticket-open", "ticket-[0-9]+"));
+    }
+
+    @Test
+    void regexHandlerReportsInvalidPatternsAsXmlUnitExceptions() {
+        MatchesRegexPlaceholderHandler regexHandler = new MatchesRegexPlaceholderHandler();
+
+        XMLUnitException exception = assertThrows(XMLUnitException.class, () -> regexHandler.evaluate("value", "["));
+
+        assertNotNull(exception.getCause());
+    }
+
+    @Test
+    void differenceEvaluatorConstructorsUseDefaultDelimitersForBlankArguments() {
+        String control = """
+                <sample code="${xmlunit.isNumber}">${xmlunit.ignore}</sample>
+                """;
+        String test = """
+                <sample code="123">generated text</sample>
+                """;
+
+        Diff diff = DiffBuilder.compare(control)
+                .withTest(test)
+                .ignoreWhitespace()
+                .checkForIdentical()
+                .withDifferenceEvaluator(new PlaceholderDifferenceEvaluator(" ", ""))
+                .build();
+
+        assertFalse(diff.hasDifferences(), diff::fullDescription);
+    }
+
+    private Diff buildDefaultDiff(String control, String test) {
+        DiffBuilder diffBuilder = DiffBuilder.compare(control).withTest(test).ignoreWhitespace().checkForIdentical();
+        return PlaceholderSupport.withPlaceholderSupport(diffBuilder).build();
+    }
+
+    private boolean exceptionChainContains(Throwable throwable, String text) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains(text)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private ComparisonResult caseInsensitiveStatus(Comparison comparison, ComparisonResult outcome) {
+        if (comparison.getType() != ComparisonType.ATTR_VALUE) {
+            return outcome;
+        }
+        Object controlValue = comparison.getControlDetails().getValue();
+        Object testValue = comparison.getTestDetails().getValue();
+        if ("pending".equals(controlValue) && "PENDING".equals(testValue)) {
+            return ComparisonResult.SIMILAR;
+        }
+        return outcome;
     }
 }

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/user-code-filter.json
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.xmlunit.placeholder.**"
+      "includeClasses" : "org.xmlunit.placeholder.**"
     }
   ]
 }

--- a/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/user-code-filter.json
+++ b/tests/src/org.xmlunit/xmlunit-placeholders/2.10.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.xmlunit.placeholder.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2780

This PR introduces tests and metadata for org.xmlunit:xmlunit-placeholders:2.10.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 203605
- Cached input tokens: 1268736
- Output tokens: 14728
- Entries: 5
- Iterations: 4
- Library coverage percentage: 94.71
- Generated lines of code: 282
- Tested library lines of code: 161

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `09ad55b2d1377afc8cb5d8b3ad7d37bcb60d2a3b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 822/844 (97.39%)
- Line: 161/170 (94.71%)
- Method: 39/40 (97.50%)
