### PR TITLE
Track test-only metadata entry counts

### DIFF
--- a/forge/DEVELOPING.md
+++ b/forge/DEVELOPING.md
@@ -308,7 +308,7 @@ Workflow-local logs are grouped by library first as `logs/<group>:<artifact>:<ve
   ```bash
     python3 utility_scripts/schema_validator.py <schema_name> <file_path>`)
   ```
-  - `run_metrics_output` validates run metrics output files using `../stats/schemas/run_metrics_output_schema.json`:
+  - `run_metrics_output` validates run metrics output files using `../stats/schemas/run-metrics-output-schema-v1.0.1.json`:
     ```bash
     python3 utility_scripts/schema_validator.py run_metrics_output output/results.json
     ```

--- a/forge/docs/ai-workflow-testing.md
+++ b/forge/docs/ai-workflow-testing.md
@@ -108,6 +108,7 @@ Inspect at least these fields:
 - `metrics.tested_library_loc`
 - `metrics.code_coverage_percent`
 - `metrics.metadata_entries`
+- `metrics.test_only_metadata_entries` when test-only metadata exists
 - `artifacts.test_file`
 - `artifacts.metadata_file`
 

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -115,10 +115,20 @@ def create_pull_request(
     cached_input_tokens_used = int(metrics.get("cached_input_tokens_used", 0) or 0)
     output_tokens_used = int(metrics.get("output_tokens_used", 0))
     entries_found = int(metrics.get("metadata_entries", 0))
+    test_only_metadata_entries = int(metrics.get("test_only_metadata_entries", 0) or 0)
     iterations = int(metrics.get("iterations", 0))
     code_coverage_percent = metrics.get("code_coverage_percent", 0)
     previous_library_metadata_entries = int(metrics.get("previous_library_metadata_entries", 0))
+    previous_library_test_only_metadata_entries = int(metrics.get("previous_library_test_only_metadata_entries", 0) or 0)
     previous_library_coverage_percent = metrics.get("previous_library_coverage_percent", 0)
+    test_only_metadata_entries_line = ""
+    if test_only_metadata_entries > 0:
+        test_only_metadata_entries_line = f"- Test-only metadata entries: {test_only_metadata_entries}\n"
+    previous_test_only_metadata_entries_line = ""
+    if previous_library_test_only_metadata_entries > 0:
+        previous_test_only_metadata_entries_line = (
+            f"- Previous library version test-only metadata entries: {previous_library_test_only_metadata_entries}\n"
+        )
 
     diff_text = generate_diff_text(group, artifact, old_version, new_version, repo_path)
     stats_section = format_stats_diff(repo_path, old_coordinates, new_coordinates)
@@ -136,10 +146,12 @@ Summary:
 - Input tokens: {input_tokens_used}
 - Cached input tokens: {cached_input_tokens_used}
 - Output tokens: {output_tokens_used}
-- Entries found: {entries_found}
+- Metadata entries: {entries_found}
+{test_only_metadata_entries_line}\
 - Iterations: {iterations}
 - Library coverage percentage: {code_coverage_percent}
 - Previous library version metadata entries: {previous_library_metadata_entries}
+{previous_test_only_metadata_entries_line}\
 - Previous library version coverage percentage: {previous_library_coverage_percent}
 
 {format_forge_revision_section()}

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -185,10 +185,20 @@ def create_pull_request(
     cached_input_tokens_used = int(metrics.get("cached_input_tokens_used", 0) or 0)
     output_tokens_used = int(metrics.get("output_tokens_used", 0))
     entries_found = int(metrics.get("metadata_entries", 0))
+    test_only_metadata_entries = int(metrics.get("test_only_metadata_entries", 0) or 0)
     iterations = int(metrics.get("iterations", 0))
     code_coverage_percent = metrics.get("code_coverage_percent", 0)
     previous_library_metadata_entries = int(metrics.get("previous_library_metadata_entries", 0))
+    previous_library_test_only_metadata_entries = int(metrics.get("previous_library_test_only_metadata_entries", 0) or 0)
     previous_library_coverage_percent = metrics.get("previous_library_coverage_percent", 0)
+    test_only_metadata_entries_line = ""
+    if test_only_metadata_entries > 0:
+        test_only_metadata_entries_line = f"- Test-only metadata entries: {test_only_metadata_entries}\n"
+    previous_test_only_metadata_entries_line = ""
+    if previous_library_test_only_metadata_entries > 0:
+        previous_test_only_metadata_entries_line = (
+            f"- Previous library version test-only metadata entries: {previous_library_test_only_metadata_entries}\n"
+        )
 
     diff_text = generate_diff_text(group, artifact, old_version, new_version, repo_path)
     stats_section = format_stats_diff(repo_path, old_coordinates, new_coordinates)
@@ -207,10 +217,12 @@ Summary:
 - Input tokens: {input_tokens_used}
 - Cached input tokens: {cached_input_tokens_used}
 - Output tokens: {output_tokens_used}
-- Entries found: {entries_found}
+- Metadata entries: {entries_found}
+{test_only_metadata_entries_line}\
 - Iterations: {iterations}
 - Library coverage percentage: {code_coverage_percent}
 - Previous library version metadata entries: {previous_library_metadata_entries}
+{previous_test_only_metadata_entries_line}\
 - Previous library version coverage percentage: {previous_library_coverage_percent}
 
 {format_forge_revision_section()}

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -59,10 +59,14 @@ def build_pull_request_body(
     output_tokens_used = metrics.get("output_tokens_used", 0)
     cached_input_tokens_used = metrics.get("cached_input_tokens_used", 0)
     entries_found = metrics.get("metadata_entries", 0)
+    test_only_metadata_entries = int(metrics.get("test_only_metadata_entries", 0) or 0)
     iterations = metrics.get("iterations", 0)
     code_coverage_percent = metrics.get("code_coverage_percent", 0)
     generated_loc = metrics.get("generated_loc", 0)
     tested_library_loc = metrics.get("tested_library_loc", 0)
+    test_only_metadata_entries_line = ""
+    if test_only_metadata_entries > 0:
+        test_only_metadata_entries_line = f"- Test-only metadata entries: {test_only_metadata_entries}\n"
 
     body = f"""
 ## What does this PR do?
@@ -78,7 +82,8 @@ Summary:
 - Input tokens: {input_tokens_used}
 - Cached input tokens: {cached_input_tokens_used}
 - Output tokens: {output_tokens_used}
-- Entries: {entries_found}
+- Metadata entries: {entries_found}
+{test_only_metadata_entries_line}\
 - Iterations: {iterations}
 - Library coverage percentage: {code_coverage_percent}
 - Generated lines of code: {generated_loc}

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -22,6 +22,7 @@ from git_scripts.common_git import (
 )
 from utility_scripts.metrics_writer import (
     count_metadata_entries,
+    count_test_only_metadata_entries,
     collect_version_coverage_metrics,
 )
 from utility_scripts.library_stats import stats_artifact_dir
@@ -100,15 +101,28 @@ def create_pull_request(
 
     new_entries = count_metadata_entries(repo_path, group, artifact, new_version)
     previous_entries = count_metadata_entries(repo_path, group, artifact, old_version)
+    new_test_entries = count_test_only_metadata_entries(repo_path, group, artifact, new_version)
+    previous_test_entries = count_test_only_metadata_entries(repo_path, group, artifact, old_version)
     previous_coverage, _ = collect_version_coverage_metrics(repo_path, group, artifact, old_version)
     new_coverage, _ = collect_version_coverage_metrics(repo_path, group, artifact, new_version)
 
     stats_section = format_stats_diff(repo_path, old_coordinates, new_coordinates)
 
+    previous_test_entries_line = ""
+    if previous_test_entries > 0:
+        previous_test_entries_line = (
+            f"- Test-only metadata entries (previous `{old_coordinates}`): {previous_test_entries}\n"
+        )
+    new_test_entries_line = ""
+    if new_test_entries > 0:
+        new_test_entries_line = f"- Test-only metadata entries (new `{new_coordinates}`): {new_test_entries}\n"
+
     metrics_section = (
         f"\n\n"
         f"- Metadata entries (previous `{old_coordinates}`): {previous_entries}\n"
+        f"{previous_test_entries_line}"
         f"- Metadata entries (new `{new_coordinates}`): {new_entries}\n"
+        f"{new_test_entries_line}"
         f"- Library coverage (previous): {previous_coverage:.2f}%\n"
         f"- Library coverage (new): {new_coverage:.2f}%"
     )

--- a/forge/schemas/benchmark_run_metrics_schema.json
+++ b/forge/schemas/benchmark_run_metrics_schema.json
@@ -168,6 +168,10 @@
           "type": "integer",
           "minimum": 0
         },
+        "test_only_metadata_entries": {
+          "type": "integer",
+          "minimum": 1
+        },
         "code_coverage_percent": {
           "type": "number",
           "minimum": 0,
@@ -347,6 +351,10 @@
         "metadata_entries": {
           "type": "integer",
           "minimum": 0
+        },
+        "test_only_metadata_entries": {
+          "type": "integer",
+          "minimum": 1
         },
         "original_metadata_entry_count": {
           "type": "integer",

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -13,6 +13,7 @@ from ai_workflows.add_new_library_support import (
     write_add_new_library_support_metrics,
 )
 from ai_workflows.java_fail_workflow import JAVAC_CONFIG, resolve_fix_metrics_json, write_fix_metrics
+from utility_scripts.metrics_writer import count_test_only_metadata_entries, create_run_metrics_output_json
 
 
 def _minimal_run_metrics(library: str = "org.example:demo:1.0.0") -> dict:
@@ -53,7 +54,130 @@ def _public_execution_metrics(run_metrics: dict) -> dict:
     return run_metrics
 
 
+class DummyAgent:
+    total_tokens_sent = 1
+    total_tokens_received = 2
+    cached_input_tokens_used = 0
+
+
 class MetricsPathTests(unittest.TestCase):
+    def test_count_test_only_metadata_entries_counts_direct_native_image_reachability_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(test_metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "reflection": [
+                            {
+                                "condition": {"typeReached": "org.example.Demo"},
+                                "type": "org.example.TestFixture",
+                                "methods": [{"name": "create"}, {"name": "read"}],
+                            }
+                        ]
+                    },
+                    file,
+                )
+
+            self.assertEqual(count_test_only_metadata_entries(temp_dir, "org.example", "demo", "1.0.0"), 3)
+
+    def test_create_run_metrics_includes_test_only_metadata_entries_only_when_positive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tests_root = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "java",
+            )
+            metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo", "1.0.0")
+            metadata_index_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            stats_dir = os.path.join(temp_dir, "stats", "org.example", "demo", "1.0.0")
+            test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(tests_root)
+            os.makedirs(metadata_dir)
+            os.makedirs(stats_dir)
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(tests_root, "DemoTest.java"), "w", encoding="utf-8") as file:
+                file.write("class DemoTest {}\n")
+            with open(os.path.join(metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump({"reflection": [{"type": "org.example.Demo"}]}, file)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "tested-versions": ["1.0.0"],
+                        }
+                    ],
+                    file,
+                )
+            with open(os.path.join(test_metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump({"reflection": [{"type": "org.example.TestFixture"}]}, file)
+            with open(os.path.join(stats_dir, "stats.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "versions": [
+                            {
+                                "version": "1.0.0",
+                                "libraryCoverage": {
+                                    "line": {
+                                        "covered": 1,
+                                        "missed": 0,
+                                        "total": 1,
+                                        "ratio": 1.0,
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                    file,
+                )
+
+            run_metrics = create_run_metrics_output_json(
+                repo_path=temp_dir,
+                package="org.example",
+                artifact="demo",
+                library_version="1.0.0",
+                agent=DummyAgent(),
+                model_name="oca/gpt-5.4",
+                global_iterations=1,
+                tests_root=tests_root,
+                strategy_name="basic_iterative_pi_gpt-5.4",
+                status="success",
+            )
+
+            self.assertEqual(run_metrics["metrics"]["metadata_entries"], 1)
+            self.assertEqual(run_metrics["metrics"]["test_only_metadata_entries"], 1)
+
     def test_in_repo_add_new_library_support_metrics_resolves_to_stats_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             reachability_repo = os.path.join(temp_dir, "graalvm-reachability-metadata")

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -234,6 +234,30 @@ def count_metadata_entries(repo_path: str, package: str, artifact: str, library_
     return total
 
 
+def count_test_only_metadata_entries(repo_path: str, package: str, artifact: str, library_version: str) -> int:
+    """Count test-only reachability metadata entries for a library version."""
+    test_version = _resolve_test_version_dir(repo_path, package, artifact, library_version)
+    reach_json = os.path.join(
+        repo_path,
+        "tests",
+        "src",
+        package,
+        artifact,
+        test_version,
+        "src",
+        "test",
+        "resources",
+        "META-INF",
+        "native-image",
+        "reachability-metadata.json",
+    )
+    if not os.path.isfile(reach_json):
+        return 0
+
+    counts = reachability_metadata_count.count_reachability_file(reach_json)
+    return int(counts.get("total", 0))
+
+
 def _get_repo_root() -> str:
     # repo root is two directories up from this file
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -325,13 +349,18 @@ def collect_and_print_metrics(
 
     # Calculating generated metadata entries
     total_entries = count_metadata_entries(repo_path, package, artifact, library_version)
+    test_only_metadata_entries = count_test_only_metadata_entries(repo_path, package, artifact, library_version)
 
     cached_tokens_suffix = ""
     if cached_input_tokens_used is not None:
         cached_tokens_suffix = f" Cached Input Tokens: {cached_input_tokens_used}"
 
+    test_metadata_suffix = ""
+    if test_only_metadata_entries > 0:
+        test_metadata_suffix = f" Test-Only Metadata Entries: {test_only_metadata_entries}"
+
     print(
-        f"Iterations: {global_iterations}  Input Tokens: {input_tokens_used}{cached_tokens_suffix} Output Tokens: {output_tokens_used} Total Entries: {total_entries} Coverage: {coverage_percent:.2f}% Generated LOC: {generated_loc} Cost: {total_cost_usd:.4f} Library lines covered: {lines_covered}")
+        f"Iterations: {global_iterations}  Input Tokens: {input_tokens_used}{cached_tokens_suffix} Output Tokens: {output_tokens_used} Metadata Entries: {total_entries}{test_metadata_suffix} Coverage: {coverage_percent:.2f}% Generated LOC: {generated_loc} Cost: {total_cost_usd:.4f} Library lines covered: {lines_covered}")
 
     metrics = {
         "coverage_percent": coverage_percent,
@@ -345,6 +374,8 @@ def collect_and_print_metrics(
         "total_entries": total_entries,
         "cost_usd": total_cost_usd,
     }
+    if test_only_metadata_entries > 0:
+        metrics["test_only_metadata_entries"] = test_only_metadata_entries
     if cached_input_tokens_used is not None:
         metrics["cached_input_tokens_used"] = cached_input_tokens_used
     return metrics
@@ -365,12 +396,14 @@ def build_run_metrics_dict(
         total_entries: int,
         test_file: str,
         metadata_file: str,
+        test_only_metadata_entries: int = 0,
         generated_loc: int | None = None,
         cached_input_tokens_used: int | None = None,
         starting_commit: str | None = None,
         ending_commit: str | None = None,
         previous_library: str | None = None,
         previous_library_metadata_entries: int | None = None,
+        previous_library_test_only_metadata_entries: int | None = None,
         previous_library_coverage_percent: float | None = None,
         agent_name: str | None = None,
         model_name: str | None = None,
@@ -391,8 +424,12 @@ def build_run_metrics_dict(
         metrics["generated_loc"] = generated_loc
     metrics["tested_library_loc"] = lines_covered
     metrics["metadata_entries"] = total_entries
+    if test_only_metadata_entries > 0:
+        metrics["test_only_metadata_entries"] = test_only_metadata_entries
     if previous_library_metadata_entries is not None:
         metrics["previous_library_metadata_entries"] = previous_library_metadata_entries
+    if previous_library_test_only_metadata_entries is not None and previous_library_test_only_metadata_entries > 0:
+        metrics["previous_library_test_only_metadata_entries"] = previous_library_test_only_metadata_entries
     metrics["code_coverage_percent"] = round(coverage_percent, 2)
     if previous_library_coverage_percent is not None:
         metrics["previous_library_coverage_percent"] = round(previous_library_coverage_percent, 2)
@@ -512,6 +549,7 @@ def create_run_metrics_output_json(
         lines_covered=metrics.get("lines_covered", 0),
         coverage_percent=metrics.get("coverage_percent", 0.0),
         total_entries=metrics.get("total_entries", 0),
+        test_only_metadata_entries=metrics.get("test_only_metadata_entries", 0),
         test_file=test_file,
         metadata_file=metadata_file,
         stats=stats,
@@ -546,6 +584,7 @@ def create_javac_fix_run_metrics_output_json(
         library_version=previous_library_version,
     )
     previous_entries = count_metadata_entries(repo_path, package, artifact, previous_library_version)
+    previous_test_entries = count_test_only_metadata_entries(repo_path, package, artifact, previous_library_version)
     agent_name = resolve_agent(strategy_name)
     stats = load_library_stats_snapshot(repo_path, package, artifact, new_library_version)
     previous_stats = load_library_stats_snapshot(repo_path, package, artifact, previous_library_version)
@@ -568,10 +607,12 @@ def create_javac_fix_run_metrics_output_json(
         lines_covered=metrics.get("lines_covered", 0),
         coverage_percent=metrics.get("coverage_percent", 0.0),
         total_entries=metrics.get("total_entries", 0),
+        test_only_metadata_entries=metrics.get("test_only_metadata_entries", 0),
         test_file=test_file,
         metadata_file=metadata_file,
         previous_library=f"{package}:{artifact}:{previous_library_version}",
         previous_library_metadata_entries=previous_entries,
+        previous_library_test_only_metadata_entries=previous_test_entries,
         previous_library_coverage_percent=previous_coverage_percent,
         stats=stats,
         previous_library_stats=previous_stats,

--- a/forge/utility_scripts/schema_validator.py
+++ b/forge/utility_scripts/schema_validator.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 from jsonschema import Draft202012Validator, FormatChecker
 
 SCHEMA_NAME_MAP = {
-    "run_metrics_output": "run_metrics_output_schema.json",
+    "run_metrics_output": "run-metrics-output-schema-v1.0.1.json",
     "benchmark_run_metrics": "benchmark_run_metrics_schema.json",
     "benchmark_suite": "benchmark_suite_schema.json",
     "strategy": "strategy_schema.json",
@@ -60,7 +60,7 @@ def validate_json_file(file_path: str, schema_name: str):
 
 
 def validate_run_metrics(file_path: str):
-    """Validate against `stats/schemas/run_metrics_output_schema.json`."""
+    """Validate against `stats/schemas/run-metrics-output-schema-v1.0.1.json`."""
     validate_json_file(file_path, "run_metrics_output")
 
 

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -18,7 +18,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Do not accept changes that remove meaningful test coverage just to make `java` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
-- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. When the PR reports both library metadata entries and test-only metadata entries, sum them for that version's total. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer small, targeted review comments. This label is for JVM runtime repair work, not a full redesign of historical tests.
 
@@ -60,7 +60,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Metadata entries`, legacy `Entries` or `Entries found`, `Test-only metadata entries`, `Metadata entries (new ...)`, `Test-only metadata entries (new ...)`, `Previous library version metadata entries`, and `Previous library version test-only metadata entries`.
+   - Treat each version's total as library metadata entries plus test-only metadata entries when both are reported.
    - Do not manually count entries from metadata files.
    - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
    - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -18,7 +18,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Do not accept changes that remove meaningful test coverage just to make `javac` pass.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
-- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. When the PR reports both library metadata entries and test-only metadata entries, sum them for that version's total. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer small, targeted review comments. This label is for repair work, not a full redesign of historical tests.
 
@@ -58,7 +58,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Metadata entries`, legacy `Entries` or `Entries found`, `Test-only metadata entries`, `Metadata entries (new ...)`, `Test-only metadata entries (new ...)`, `Previous library version metadata entries`, and `Previous library version test-only metadata entries`.
+   - Treat each version's total as library metadata entries plus test-only metadata entries when both are reported.
    - Do not manually count entries from metadata files.
    - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
    - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -18,7 +18,7 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
 - Do not accept fixes that hide the failing native path by skipping assertions, skipping native-image runtime execution, or weakening the test until the failure disappears.
 - Treat dynamic-access coverage preservation as the main quality gate. The new version should not report lower dynamic-access coverage than the previously tested version unless the PR gives a concrete, credible reason.
 - For numeric gates, compare the reported evidence as-is. Do not inspect generation filters, agent configuration, or metadata contents to second-guess why dynamic-access or metadata-count numbers are what they are.
-- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
+- Compare total metadata entry counts between the previous metadata version and the new metadata version only as a severe-drop guardrail, using the counts reported in the PR description. When the PR reports both library metadata entries and test-only metadata entries, sum them for that version's total. Report metadata entry count issues only when the PR-reported new total metadata entry count has fewer than 25% as many entries as the PR-reported original count.
 - Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 - Prefer concrete evidence from native run output, generated metadata, stats, and CI over style objections.
 
@@ -60,7 +60,8 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If stats are missing or stale, ask for `generateLibraryStats` or the relevant CI stats job before approving.
 
 5. Compare metadata entry counts.
-   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Entries found` and `Previous library version metadata entries`.
+   - Compare total metadata entry counts for the previous metadata version and the new metadata version from the PR description, matching summary fields such as `Metadata entries`, legacy `Entries` or `Entries found`, `Test-only metadata entries`, `Metadata entries (new ...)`, `Test-only metadata entries (new ...)`, `Previous library version metadata entries`, and `Previous library version test-only metadata entries`.
+   - Treat each version's total as library metadata entries plus test-only metadata entries when both are reported.
    - Do not manually count entries from metadata files.
    - Do not use metadata file contents to argue that passing reported entry counts are incomplete.
    - Do not require an exact match. Differences are normal when upstream APIs move, generated metadata is cleaned up, or dynamic-access totals change.

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -21,7 +21,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 - Require at least 50% reported dynamic-access coverage when there are dynamic-access calls to cover. Use the exploded stats files under `stats/<group>/<artifact>/<metadata-version>/stats.json` when available, and block the PR when dynamic-access coverage is below 50% or the PR provides no credible dynamic-access coverage evidence for non-zero dynamic-access calls.
 - Treat dynamic-access coverage counts as a minimum gate, not complete metadata evidence. They can miss metadata required through downstream libraries, so do not use high coverage alone to prove that the submitted metadata is complete or necessary.
 - Treat `0/0` dynamic-access coverage as a valid no-calls case, not as failed coverage. Do not reject a PR only because the exploded stats report `0/0` dynamic-access calls while the PR adds metadata; those stats can miss metadata required through downstream libraries.
-- Do not explicitly read or review individual metadata entries. Use the metadata entry count reported in the PR description for the metadata/dynamic-access mismatch check; do not manually count entries from metadata files. Only request investigation when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count.
+- Do not explicitly read or review individual metadata entries. Use the metadata entry count reported in the PR description for the metadata/dynamic-access mismatch check; do not manually count entries from metadata files. When the PR reports both library metadata entries and test-only metadata entries, use their sum as the PR-reported metadata entry count. Only request investigation when the covered dynamic-access call count is at least 75% higher than that PR-reported total.
 - Accept only `reachability-metadata.json` files as metadata files. Reject legacy native-image metadata config files such as `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, or `predefined-classes-config.json`.
 
 ## Workflow
@@ -53,7 +53,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
 4. Review the metadata files only for presence and scope.
    - Confirm the expected metadata files exist for the single target coordinate.
    - Do not read, list, or reason from individual entries inside `reachability-metadata.json`.
-   - For metadata/dynamic-access mismatch checks, use only the metadata entry count reported in the PR description, such as `Entries` or `Entries found`; do not manually count metadata entries from files.
+   - For metadata/dynamic-access mismatch checks, use only the metadata entry count reported in the PR description, such as `Metadata entries`, or legacy fields such as `Entries` and `Entries found` in older PRs; add `Test-only metadata entries` when the PR reports it; do not manually count metadata entries from files.
    - Treat `reachability-metadata.json` containing `{}` as acceptable when the rest of the PR is coherent and validation passes.
    - Do not use the exploded stats files under `stats/<group>/<artifact>/<metadata-version>/stats.json` alone to argue that the submitted metadata is unnecessary.
 
@@ -63,7 +63,7 @@ Treat the following as hard review rules unless the PR provides a strong reason 
    - If the PR reports zero dynamic-access calls and `reachability-metadata.json` is `{}`, that is acceptable as long as the test is library-specific and the scope is otherwise correct.
    - If the PR reports zero dynamic-access calls while adding metadata, do not reject it on that basis alone; dynamic-access stats can miss metadata required through downstream libraries.
    - If the stats report less than 50% coverage for non-zero dynamic-access calls, or no usable coverage signal for claimed dynamic-access behavior, ask for stronger tests or refreshed coverage evidence.
-   - Ask for metadata/coverage mismatch investigation only when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count.
+   - Ask for metadata/coverage mismatch investigation only when the covered dynamic-access call count is at least 75% higher than the PR-reported metadata entry count, where the reported count is `Metadata entries` plus `Test-only metadata entries` when both are present. For older PRs, use legacy `Entries` or `Entries found` as the metadata entry count.
    - If the PR description does not report a usable metadata entry count, do not infer one from metadata files; ask for refreshed PR summary evidence when that count is needed for the mismatch check.
    - Prefer concrete test quality issues over speculation about whether specific metadata entries are needed.
 
@@ -98,7 +98,7 @@ Match the concise review style already used in this repository:
 - For multiple-library PRs: say that `library-new-request` PRs must push only one library and ask for the unrelated library additions to be removed.
 - For insufficient dynamic-access coverage: say that new-library PRs need at least 50% dynamic-access coverage when there are dynamic-access calls to cover, and ask for stronger tests or refreshed coverage evidence.
 - For unsupported coverage claims: ask for refreshed coverage evidence when the PR makes concrete coverage claims that are not supported by the diff.
-- For metadata/dynamic-access entry mismatch: ask for investigation only when covered dynamic-access calls are at least 75% higher than the PR-reported metadata entry count. Do not manually count or argue from metadata contents.
+- For metadata/dynamic-access entry mismatch: ask for investigation only when covered dynamic-access calls are at least 75% higher than the PR-reported metadata entry count, summing library and test-only metadata entries when both are reported. Do not manually count or argue from metadata contents.
 - For legacy metadata files: say that metadata must use `reachability-metadata.json` and ask for old config files such as `reflect-config.json` or `resource-config.json` to be replaced.
 
 Keep comments short, factual, and blocking. Focus on the concrete defect, not a long explanation.

--- a/stats/ch.qos.logback/logback-core/1.1.3/execution-metrics.json
+++ b/stats/ch.qos.logback/logback-core/1.1.3/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 798,
       "tested_library_loc": 817,
       "metadata_entries": 32,
+      "test_only_metadata_entries": 30,
       "code_coverage_percent": 10.41
     },
     "artifacts": {

--- a/stats/ch.qos.logback/logback-core/1.2.12/execution-metrics.json
+++ b/stats/ch.qos.logback/logback-core/1.2.12/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 710,
       "tested_library_loc": 3613,
       "metadata_entries": 13,
+      "test_only_metadata_entries": 20,
       "code_coverage_percent": 8.99
     },
     "artifacts": {

--- a/stats/com.fasterxml.jackson.core/jackson-core/2.1.3/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.core/jackson-core/2.1.3/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 30,
       "tested_library_loc": 330,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 0.77
     },
     "artifacts": {

--- a/stats/com.fasterxml.jackson.core/jackson-core/2.6.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.core/jackson-core/2.6.0/execution-metrics.json
@@ -92,6 +92,7 @@
       "cost_usd": 0.753,
       "tested_library_loc": 46,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 3,
       "previous_library_metadata_entries": 0,
       "code_coverage_percent": 0.41,
       "previous_library_coverage_percent": 0.77

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.13.4/execution-metrics.json
@@ -46,6 +46,7 @@
       "generated_loc": 459,
       "tested_library_loc": 0,
       "metadata_entries": 18,
+      "test_only_metadata_entries": 27,
       "code_coverage_percent": 34.08
     },
     "artifacts": {

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/execution-metrics.json
@@ -75,6 +75,7 @@
       "cost_usd": 4.6565,
       "tested_library_loc": 0,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 47,
       "previous_library_metadata_entries": 18,
       "code_coverage_percent": 36.81,
       "previous_library_coverage_percent": 34.08

--- a/stats/com.fasterxml/classmate/1.5.1/execution-metrics.json
+++ b/stats/com.fasterxml/classmate/1.5.1/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 94,
       "tested_library_loc": 1680,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 25.13
     },
     "artifacts": {
@@ -112,6 +113,7 @@
       "generated_loc": 85,
       "tested_library_loc": 1645,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 24.61
     },
     "artifacts": {

--- a/stats/com.mchange/mchange-commons-java/0.2.15/execution-metrics.json
+++ b/stats/com.mchange/mchange-commons-java/0.2.15/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 2008,
       "tested_library_loc": 9558,
       "metadata_entries": 220,
+      "test_only_metadata_entries": 104,
       "code_coverage_percent": 14.85
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 1682,
       "tested_library_loc": 1753,
       "metadata_entries": 451,
+      "test_only_metadata_entries": 104,
       "code_coverage_percent": 13.63
     },
     "artifacts": {

--- a/stats/com.rabbitmq/amqp-client/5.12.0/execution-metrics.json
+++ b/stats/com.rabbitmq/amqp-client/5.12.0/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 297,
       "tested_library_loc": 723,
       "metadata_entries": 47,
+      "test_only_metadata_entries": 11,
       "code_coverage_percent": 6.33
     },
     "artifacts": {

--- a/stats/com.sun.activation/jakarta.activation/2.0.0/execution-metrics.json
+++ b/stats/com.sun.activation/jakarta.activation/2.0.0/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 150,
       "tested_library_loc": 1759,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 5,
       "code_coverage_percent": 21.88
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 159,
       "tested_library_loc": 349,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 5,
       "code_coverage_percent": 21.84
     },
     "artifacts": {

--- a/stats/com.thoughtworks.paranamer/paranamer/2.3/execution-metrics.json
+++ b/stats/com.thoughtworks.paranamer/paranamer/2.3/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 76,
       "tested_library_loc": 307,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 43.79
     },
     "artifacts": {

--- a/stats/com.thoughtworks.paranamer/paranamer/2.8.1/execution-metrics.json
+++ b/stats/com.thoughtworks.paranamer/paranamer/2.8.1/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 0.8701,
       "tested_library_loc": 317,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 7,
       "previous_library_metadata_entries": 3,
       "code_coverage_percent": 50.08,
       "previous_library_coverage_percent": 43.79

--- a/stats/com.zaxxer/HikariCP-java7/2.4.13/execution-metrics.json
+++ b/stats/com.zaxxer/HikariCP-java7/2.4.13/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 779,
       "tested_library_loc": 694,
       "metadata_entries": 55,
+      "test_only_metadata_entries": 20,
       "code_coverage_percent": 35.32
     },
     "artifacts": {

--- a/stats/com.zaxxer/HikariCP/4.0.3/execution-metrics.json
+++ b/stats/com.zaxxer/HikariCP/4.0.3/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 857,
       "tested_library_loc": 761,
       "metadata_entries": 16,
+      "test_only_metadata_entries": 3,
       "code_coverage_percent": 30.75
     },
     "artifacts": {

--- a/stats/commons-io/commons-io/2.11.0/execution-metrics.json
+++ b/stats/commons-io/commons-io/2.11.0/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 212,
       "tested_library_loc": 505,
       "metadata_entries": 9,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 1.45
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 229,
       "tested_library_loc": 156,
       "metadata_entries": 8,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 2.24
     },
     "artifacts": {

--- a/stats/commons-io/commons-io/2.17.0/execution-metrics.json
+++ b/stats/commons-io/commons-io/2.17.0/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 8.5972,
       "tested_library_loc": 260,
       "metadata_entries": 8,
+      "test_only_metadata_entries": 14,
       "previous_library_metadata_entries": 8,
       "code_coverage_percent": 3.11,
       "previous_library_coverage_percent": 2.24

--- a/stats/dom4j/dom4j/1.6.1/execution-metrics.json
+++ b/stats/dom4j/dom4j/1.6.1/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 429,
       "tested_library_loc": 988,
       "metadata_entries": 60,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 10.67
     },
     "artifacts": {

--- a/stats/io.jsonwebtoken/jjwt-api/0.11.5/execution-metrics.json
+++ b/stats/io.jsonwebtoken/jjwt-api/0.11.5/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 102,
       "tested_library_loc": 56,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 7,
       "code_coverage_percent": 4.08
     },
     "artifacts": {

--- a/stats/io.jsonwebtoken/jjwt-api/0.12.3/execution-metrics.json
+++ b/stats/io.jsonwebtoken/jjwt-api/0.12.3/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 228,
       "tested_library_loc": 506,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 9,
       "code_coverage_percent": 5.84
     },
     "artifacts": {

--- a/stats/io.opencensus/opencensus-api/0.31.1/execution-metrics.json
+++ b/stats/io.opencensus/opencensus-api/0.31.1/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 36,
       "tested_library_loc": 1,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 0.03
     },
     "artifacts": {

--- a/stats/jakarta.persistence/jakarta.persistence-api/3.0.0/execution-metrics.json
+++ b/stats/jakarta.persistence/jakarta.persistence-api/3.0.0/execution-metrics.json
@@ -46,6 +46,7 @@
       "generated_loc": 14,
       "tested_library_loc": 0,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 0.0
     },
     "artifacts": {

--- a/stats/jakarta.persistence/jakarta.persistence-api/3.2.0/execution-metrics.json
+++ b/stats/jakarta.persistence/jakarta.persistence-api/3.2.0/execution-metrics.json
@@ -75,6 +75,7 @@
       "cost_usd": 0.4471,
       "tested_library_loc": 162,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 1,
       "previous_library_metadata_entries": 4,
       "code_coverage_percent": 33.54,
       "previous_library_coverage_percent": 44.17

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0/execution-metrics.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 459,
       "tested_library_loc": 239,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 18,
       "code_coverage_percent": 13.54
     },
     "artifacts": {

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/execution-metrics.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 3.2724,
       "tested_library_loc": 196,
       "metadata_entries": 17,
+      "test_only_metadata_entries": 32,
       "previous_library_metadata_entries": 3,
       "code_coverage_percent": 11.63,
       "previous_library_coverage_percent": 13.54

--- a/stats/javax.activation/javax.activation-api/1.2.0/execution-metrics.json
+++ b/stats/javax.activation/javax.activation-api/1.2.0/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 254,
       "tested_library_loc": 229,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 21.09
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 323,
       "tested_library_loc": 195,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 17.96
     },
     "artifacts": {

--- a/stats/javax.el/javax.el-api/3.0.0/execution-metrics.json
+++ b/stats/javax.el/javax.el-api/3.0.0/execution-metrics.json
@@ -15,6 +15,7 @@
       "generated_loc": 526,
       "tested_library_loc": 1830,
       "metadata_entries": 37,
+      "test_only_metadata_entries": 23,
       "code_coverage_percent": 31.35
     },
     "artifacts": {

--- a/stats/javax.persistence/javax.persistence-api/2.2/execution-metrics.json
+++ b/stats/javax.persistence/javax.persistence-api/2.2/execution-metrics.json
@@ -46,6 +46,7 @@
       "generated_loc": 14,
       "tested_library_loc": 0,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 0.0
     },
     "artifacts": {

--- a/stats/javax.servlet.jsp/jsp-api/2.1/execution-metrics.json
+++ b/stats/javax.servlet.jsp/jsp-api/2.1/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 95,
       "tested_library_loc": 77,
       "metadata_entries": 4,
+      "test_only_metadata_entries": 24,
       "code_coverage_percent": 5.45
     },
     "artifacts": {

--- a/stats/javax.servlet/javax.servlet-api/3.1.0/execution-metrics.json
+++ b/stats/javax.servlet/javax.servlet-api/3.1.0/execution-metrics.json
@@ -17,6 +17,7 @@
       "generated_loc": 0,
       "tested_library_loc": 0,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 0.0
     },
     "artifacts": {

--- a/stats/javax.validation/validation-api/1.0.0.GA/execution-metrics.json
+++ b/stats/javax.validation/validation-api/1.0.0.GA/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 230,
       "tested_library_loc": 59,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 35.33
     },
     "artifacts": {

--- a/stats/javax.validation/validation-api/1.1.0.Final/execution-metrics.json
+++ b/stats/javax.validation/validation-api/1.1.0.Final/execution-metrics.json
@@ -86,6 +86,7 @@
       "cost_usd": 0.3201,
       "tested_library_loc": 41,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 4,
       "previous_library_metadata_entries": 0,
       "code_coverage_percent": 24.7,
       "previous_library_coverage_percent": 35.33

--- a/stats/javax.validation/validation-api/2.0.0.Final/execution-metrics.json
+++ b/stats/javax.validation/validation-api/2.0.0.Final/execution-metrics.json
@@ -81,6 +81,7 @@
       "cost_usd": 0.4664,
       "tested_library_loc": 58,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 6,
       "previous_library_metadata_entries": 3,
       "code_coverage_percent": 27.23,
       "previous_library_coverage_percent": 24.7

--- a/stats/javax.xml.bind/jaxb-api/2.3.1/execution-metrics.json
+++ b/stats/javax.xml.bind/jaxb-api/2.3.1/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 588,
       "tested_library_loc": 207,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 23,
       "code_coverage_percent": 12.16
     },
     "artifacts": {

--- a/stats/jline/jline/2.14.6/execution-metrics.json
+++ b/stats/jline/jline/2.14.6/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 450,
       "tested_library_loc": 1317,
       "metadata_entries": 15,
+      "test_only_metadata_entries": 12,
       "code_coverage_percent": 24.86
     },
     "artifacts": {

--- a/stats/net.razorvine/pyrolite/4.30/execution-metrics.json
+++ b/stats/net.razorvine/pyrolite/4.30/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 294,
       "tested_library_loc": 743,
       "metadata_entries": 8,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 26.69
     },
     "artifacts": {

--- a/stats/net.razorvine/serpent/1.23/execution-metrics.json
+++ b/stats/net.razorvine/serpent/1.23/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 164,
       "tested_library_loc": 202,
       "metadata_entries": 18,
+      "test_only_metadata_entries": 14,
       "code_coverage_percent": 18.7
     },
     "artifacts": {

--- a/stats/net.razorvine/serpent/1.30/execution-metrics.json
+++ b/stats/net.razorvine/serpent/1.30/execution-metrics.json
@@ -87,6 +87,7 @@
       "cost_usd": 0.3091,
       "tested_library_loc": 196,
       "metadata_entries": 18,
+      "test_only_metadata_entries": 14,
       "previous_library_metadata_entries": 18,
       "code_coverage_percent": 18.3,
       "previous_library_coverage_percent": 18.7

--- a/stats/org.apache.commons/commons-collections4/4.4/execution-metrics.json
+++ b/stats/org.apache.commons/commons-collections4/4.4/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 3060,
       "tested_library_loc": 2853,
       "metadata_entries": 175,
+      "test_only_metadata_entries": 17,
       "code_coverage_percent": 21.76
     },
     "artifacts": {

--- a/stats/org.apache.commons/commons-lang3/3.11/execution-metrics.json
+++ b/stats/org.apache.commons/commons-lang3/3.11/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 1186,
       "tested_library_loc": 7198,
       "metadata_entries": 44,
+      "test_only_metadata_entries": 76,
       "code_coverage_percent": 9.04
     },
     "artifacts": {
@@ -112,6 +113,7 @@
       "generated_loc": 1029,
       "tested_library_loc": 1387,
       "metadata_entries": 41,
+      "test_only_metadata_entries": 76,
       "code_coverage_percent": 8.73
     },
     "artifacts": {

--- a/stats/org.apache.kafka/kafka-streams/3.6.0/execution-metrics.json
+++ b/stats/org.apache.kafka/kafka-streams/3.6.0/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 6.1027,
       "tested_library_loc": 8571,
       "metadata_entries": 147,
+      "test_only_metadata_entries": 2,
       "previous_library_metadata_entries": 44,
       "code_coverage_percent": 7.63,
       "previous_library_coverage_percent": 6.26

--- a/stats/org.apache.openejb/javaee-api/5.0-2/execution-metrics.json
+++ b/stats/org.apache.openejb/javaee-api/5.0-2/execution-metrics.json
@@ -40,6 +40,7 @@
       "generated_loc": 868,
       "tested_library_loc": 1297,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 12,
       "code_coverage_percent": 12.65
     },
     "artifacts": {

--- a/stats/org.apache.tomcat.embed/tomcat-embed-el/9.0.83/execution-metrics.json
+++ b/stats/org.apache.tomcat.embed/tomcat-embed-el/9.0.83/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 626,
       "tested_library_loc": 2233,
       "metadata_entries": 44,
+      "test_only_metadata_entries": 53,
       "code_coverage_percent": 28.9
     },
     "artifacts": {

--- a/stats/org.apache.tomcat/tomcat-juli/11.0.0/execution-metrics.json
+++ b/stats/org.apache.tomcat/tomcat-juli/11.0.0/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 1.303,
       "tested_library_loc": 291,
       "metadata_entries": 1,
+      "test_only_metadata_entries": 9,
       "previous_library_metadata_entries": 0,
       "code_coverage_percent": 32.51,
       "previous_library_coverage_percent": 30.34

--- a/stats/org.apache.velocity/velocity-engine-core/2.3/execution-metrics.json
+++ b/stats/org.apache.velocity/velocity-engine-core/2.3/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 448,
       "tested_library_loc": 3745,
       "metadata_entries": 148,
+      "test_only_metadata_entries": 14,
       "code_coverage_percent": 23.08
     },
     "artifacts": {

--- a/stats/org.awaitility/awaitility/4.2.1/execution-metrics.json
+++ b/stats/org.awaitility/awaitility/4.2.1/execution-metrics.json
@@ -87,6 +87,7 @@
       "cost_usd": 0.3708,
       "tested_library_loc": 482,
       "metadata_entries": 15,
+      "test_only_metadata_entries": 14,
       "previous_library_metadata_entries": 15,
       "code_coverage_percent": 38.56,
       "previous_library_coverage_percent": 38.32

--- a/stats/org.codehaus.woodstox/stax2-api/4.2.2/execution-metrics.json
+++ b/stats/org.codehaus.woodstox/stax2-api/4.2.2/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 111,
       "tested_library_loc": 225,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 3,
       "code_coverage_percent": 0.93
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 112,
       "tested_library_loc": 45,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 3,
       "code_coverage_percent": 0.93
     },
     "artifacts": {

--- a/stats/org.fusesource.hawtbuf/hawtbuf/1.11/execution-metrics.json
+++ b/stats/org.fusesource.hawtbuf/hawtbuf/1.11/execution-metrics.json
@@ -51,6 +51,7 @@
       "generated_loc": 183,
       "tested_library_loc": 1710,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 29.35
     },
     "artifacts": {

--- a/stats/org.glassfish.jaxb/txw2/2.3.1/execution-metrics.json
+++ b/stats/org.glassfish.jaxb/txw2/2.3.1/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 64,
       "tested_library_loc": 595,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 38.44
     },
     "artifacts": {

--- a/stats/org.hamcrest/hamcrest-core/1.3/execution-metrics.json
+++ b/stats/org.hamcrest/hamcrest-core/1.3/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 92,
       "tested_library_loc": 85,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 4,
       "code_coverage_percent": 15.45
     },
     "artifacts": {

--- a/stats/org.hamcrest/hamcrest-library/1.3/execution-metrics.json
+++ b/stats/org.hamcrest/hamcrest-library/1.3/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 75,
       "tested_library_loc": 65,
       "metadata_entries": 6,
+      "test_only_metadata_entries": 16,
       "code_coverage_percent": 11.27
     },
     "artifacts": {

--- a/stats/org.immutables/value/2.8.2/execution-metrics.json
+++ b/stats/org.immutables/value/2.8.2/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 640,
       "tested_library_loc": 8076,
       "metadata_entries": 107,
+      "test_only_metadata_entries": 13,
       "code_coverage_percent": 2.68
     },
     "artifacts": {
@@ -122,6 +123,7 @@
       "generated_loc": 938,
       "tested_library_loc": 1553,
       "metadata_entries": 67,
+      "test_only_metadata_entries": 13,
       "code_coverage_percent": 2.59
     },
     "artifacts": {

--- a/stats/org.jboss.classfilewriter/jboss-classfilewriter/1.2.4.Final/execution-metrics.json
+++ b/stats/org.jboss.classfilewriter/jboss-classfilewriter/1.2.4.Final/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 360,
       "tested_library_loc": 971,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 11,
       "code_coverage_percent": 30.25
     },
     "artifacts": {
@@ -112,6 +113,7 @@
       "generated_loc": 776,
       "tested_library_loc": 1115,
       "metadata_entries": 7,
+      "test_only_metadata_entries": 11,
       "code_coverage_percent": 34.74
     },
     "artifacts": {

--- a/stats/org.jboss.jdeparser/jdeparser/2.0.2.Final/execution-metrics.json
+++ b/stats/org.jboss.jdeparser/jdeparser/2.0.2.Final/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 24,
       "tested_library_loc": 263,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 7.16
     },
     "artifacts": {

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/execution-metrics.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.2.0.GA/execution-metrics.json
@@ -15,6 +15,7 @@
       "generated_loc": 652,
       "tested_library_loc": 4336,
       "metadata_entries": 60,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 24.87
     },
     "artifacts": {
@@ -80,6 +81,7 @@
       "generated_loc": 718,
       "tested_library_loc": 4561,
       "metadata_entries": 25,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 26.16
     },
     "artifacts": {
@@ -145,6 +147,7 @@
       "generated_loc": 704,
       "tested_library_loc": 903,
       "metadata_entries": 16,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 26.04
     },
     "artifacts": {

--- a/stats/org.jboss.resteasy/resteasy-client/6.2.12.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-client/6.2.12.Final/execution-metrics.json
@@ -12,6 +12,7 @@
       "generated_loc": 220,
       "tested_library_loc": 3310,
       "metadata_entries": 193,
+      "test_only_metadata_entries": 12,
       "code_coverage_percent": 17.04
     },
     "artifacts": {
@@ -77,6 +78,7 @@
       "generated_loc": 355,
       "tested_library_loc": 3739,
       "metadata_entries": 191,
+      "test_only_metadata_entries": 12,
       "code_coverage_percent": 19.25
     },
     "artifacts": {

--- a/stats/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/execution-metrics.json
+++ b/stats/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 132,
       "tested_library_loc": 298,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 14,
       "code_coverage_percent": 14.91
     },
     "artifacts": {

--- a/stats/org.jline/jline-console/3.22.0/execution-metrics.json
+++ b/stats/org.jline/jline-console/3.22.0/execution-metrics.json
@@ -81,6 +81,7 @@
       "cost_usd": 0.9669,
       "tested_library_loc": 745,
       "metadata_entries": 5,
+      "test_only_metadata_entries": 1,
       "previous_library_metadata_entries": 4,
       "code_coverage_percent": 17.75,
       "previous_library_coverage_percent": 16.38

--- a/stats/org.jline/jline-console/3.28.0/execution-metrics.json
+++ b/stats/org.jline/jline-console/3.28.0/execution-metrics.json
@@ -87,6 +87,7 @@
       "cost_usd": 0.1501,
       "tested_library_loc": 760,
       "metadata_entries": 5,
+      "test_only_metadata_entries": 1,
       "previous_library_metadata_entries": 5,
       "code_coverage_percent": 17.69,
       "previous_library_coverage_percent": 17.75

--- a/stats/org.junit.platform/junit-platform-commons/1.8.2/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.8.2/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 238,
       "tested_library_loc": 582,
       "metadata_entries": 25,
+      "test_only_metadata_entries": 47,
       "code_coverage_percent": 45.29
     },
     "artifacts": {

--- a/stats/org.mortbay.jetty/servlet-api/2.5-20081211/execution-metrics.json
+++ b/stats/org.mortbay.jetty/servlet-api/2.5-20081211/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 446,
       "tested_library_loc": 174,
       "metadata_entries": 12,
+      "test_only_metadata_entries": 1,
       "code_coverage_percent": 28.57
     },
     "artifacts": {

--- a/stats/org.objenesis/objenesis/3.2/execution-metrics.json
+++ b/stats/org.objenesis/objenesis/3.2/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 1472,
       "tested_library_loc": 201,
       "metadata_entries": 3,
+      "test_only_metadata_entries": 6,
       "code_coverage_percent": 42.23
     },
     "artifacts": {

--- a/stats/org.osgi/org.osgi.compendium/5.0.0/execution-metrics.json
+++ b/stats/org.osgi/org.osgi.compendium/5.0.0/execution-metrics.json
@@ -15,6 +15,7 @@
       "generated_loc": 1094,
       "tested_library_loc": 1212,
       "metadata_entries": 33,
+      "test_only_metadata_entries": 24,
       "code_coverage_percent": 6.51
     },
     "artifacts": {

--- a/stats/org.slf4j/slf4j-api/1.7.36/execution-metrics.json
+++ b/stats/org.slf4j/slf4j-api/1.7.36/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 160,
       "tested_library_loc": 133,
       "metadata_entries": 5,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 13.03
     },
     "artifacts": {

--- a/stats/org.thymeleaf/thymeleaf/3.1.4.RELEASE/execution-metrics.json
+++ b/stats/org.thymeleaf/thymeleaf/3.1.4.RELEASE/execution-metrics.json
@@ -97,6 +97,7 @@
       "cost_usd": 3.6228,
       "tested_library_loc": 5888,
       "metadata_entries": 43,
+      "test_only_metadata_entries": 77,
       "previous_library_metadata_entries": 122,
       "code_coverage_percent": 26.56,
       "previous_library_coverage_percent": 23.26

--- a/stats/org.w3c.css/sac/1.3/execution-metrics.json
+++ b/stats/org.w3c.css/sac/1.3/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 99,
       "tested_library_loc": 5,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 5.75
     },
     "artifacts": {

--- a/stats/org.yaml/snakeyaml/1.32/execution-metrics.json
+++ b/stats/org.yaml/snakeyaml/1.32/execution-metrics.json
@@ -52,6 +52,7 @@
       "generated_loc": 719,
       "tested_library_loc": 1990,
       "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
       "code_coverage_percent": 31.55
     },
     "artifacts": {

--- a/stats/schemas/run-metrics-output-schema-v1.0.1.json
+++ b/stats/schemas/run-metrics-output-schema-v1.0.1.json
@@ -306,12 +306,22 @@
             "metadata_entries": {
               "type": "integer",
               "minimum": 0,
-              "description": "Number of metadata entries produced."
+              "description": "Number of library metadata entries produced."
+            },
+            "test_only_metadata_entries": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of test-only metadata entries produced when test metadata exists."
             },
             "previous_library_metadata_entries": {
               "type": "integer",
               "minimum": 0,
-              "description": "Metadata entry count for the previous library version."
+              "description": "Library metadata entry count for the previous library version."
+            },
+            "previous_library_test_only_metadata_entries": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Test-only metadata entry count for the previous library version when test metadata exists."
             },
             "previous_library_coverage_percent": {
               "type": "number",

--- a/stats/xpp3/xpp3/1.1.4c/execution-metrics.json
+++ b/stats/xpp3/xpp3/1.1.4c/execution-metrics.json
@@ -57,6 +57,7 @@
       "generated_loc": 276,
       "tested_library_loc": 885,
       "metadata_entries": 12,
+      "test_only_metadata_entries": 12,
       "code_coverage_percent": 20.17
     },
     "artifacts": {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
@@ -76,7 +76,7 @@ public final class LibraryStatsSchemaValidator {
         JsonSchema runMetricsSchema;
         try {
             schema = JSON_SCHEMA_FACTORY.getSchema(schemaFile.toUri());
-            runMetricsSchema = JSON_SCHEMA_FACTORY.getSchema(statsRoot.resolve("schemas").resolve("run_metrics_output_schema.json").toUri());
+            runMetricsSchema = JSON_SCHEMA_FACTORY.getSchema(statsRoot.resolve("schemas").resolve("run-metrics-output-schema-v1.0.1.json").toUri());
         } catch (Exception e) {
             throw new GradleException("Failed to load library stats schema from " + schemaFile, e);
         }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateLibraryStatsTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateLibraryStatsTaskTests.java
@@ -658,9 +658,9 @@ class ValidateLibraryStatsTaskTests {
                 StandardCharsets.UTF_8
         );
         Files.writeString(
-                tempDir.resolve("stats/schemas/run_metrics_output_schema.json"),
+                tempDir.resolve("stats/schemas/run-metrics-output-schema-v1.0.1.json"),
                 Files.readString(
-                        locateRepoFile("stats/schemas/run_metrics_output_schema.json"),
+                        locateRepoFile("stats/schemas/run-metrics-output-schema-v1.0.1.json"),
                         StandardCharsets.UTF_8
                 ),
                 StandardCharsets.UTF_8


### PR DESCRIPTION
## Summary

Fixes #3594

This PR makes Forge distinguish library metadata entries from test-only metadata entries in generated run metrics and PR descriptions.

- Add optional `test_only_metadata_entries` and `previous_library_test_only_metadata_entries` metrics.
- Print `Metadata entries` and optional `Test-only metadata entries` in generated PR descriptions.
- Update review skills to sum library and test-only metadata counts, while remaining compatible with legacy `Entries` and `Entries found` PR bodies.
- Backfill existing execution metrics that already have test-only metadata.
- Rename the run metrics schema to `run-metrics-output-schema-v1.0.1.json` and update schema references.

## Verification

- `PYTHONPATH=$PWD python3 -m unittest tests.test_metrics_paths`
- `PYTHONPATH=$PWD python3 -m compileall -q utility_scripts ai_workflows git_scripts tests/test_metrics_paths.py`
- Validated all `331` `stats/**/execution-metrics.json` files with `run_metrics_output`
- Validated benchmark schema examples
- `git diff --check`