### PR TITLE
Add Forge graphify and new benchmark strategies

### DIFF
--- a/forge/DEVELOPING.md
+++ b/forge/DEVELOPING.md
@@ -23,6 +23,7 @@ Forge is located inside `graalvm-reachability-metadata/forge`. The parent checko
   - Either export GRAALVM_HOME and JAVA_HOME, or pass explicit paths to scripts.
   - JAVA_HOME should point to a GraalVM distribution; if omitted, the scripts fall back to GRAALVM_HOME or the current environment.
 - Python 3 and the tooling required by the agent strategy you plan to run.
+- Strategies with `"graphify-context": true` require graphify to be installed for the selected agent backend. Install docs: https://github.com/safishamsi/graphify#install
 - Set `PYTHONPATH` so cross-package imports work (run from the `forge/` directory):
   ```bash
   export PYTHONPATH=$PWD

--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -285,6 +285,13 @@ def init_agent(
     )
 
 
+def _build_benchmark_metrics_entry(run_metrics: dict) -> dict:
+    """Return a benchmark metrics entry without workflow artifact paths."""
+    benchmark_entry = dict(run_metrics)
+    benchmark_entry.pop("artifacts", None)
+    return benchmark_entry
+
+
 def write_add_new_library_support_metrics(run_metrics, metrics_json, is_benchmark_mode, package, artifact,
                                           library_version, metrics_repo_root=None):
     """Write or update add_new_library_support metrics depending on the execution mode."""
@@ -303,24 +310,9 @@ def write_add_new_library_support_metrics(run_metrics, metrics_json, is_benchmar
         library_id = f"{package}:{artifact}:{library_version}"
 
         updated = False
-        for item in metrics_array:
+        for index, item in enumerate(metrics_array):
             if item.get("library") == library_id:
-                metrics_block = run_metrics.get("metrics")
-                item["status"] = run_metrics.get("status")
-                item["input_tokens_used"] = metrics_block.get("input_tokens_used")
-                if "cached_input_tokens_used" in metrics_block:
-                    item["cached_input_tokens_used"] = metrics_block.get("cached_input_tokens_used")
-                if run_metrics.get("starting_commit") is not None:
-                    item["starting_commit"] = run_metrics.get("starting_commit")
-                if run_metrics.get("ending_commit") is not None:
-                    item["ending_commit"] = run_metrics.get("ending_commit")
-                item["output_tokens_used"] = metrics_block.get("output_tokens_used")
-                item["iterations"] = metrics_block.get("iterations")
-                item["cost_usd"] = metrics_block.get("cost_usd")
-                item["generated_loc"] = metrics_block.get("generated_loc")
-                item["tested_library_loc"] = metrics_block.get("tested_library_loc")
-                item["code_coverage_percent"] = metrics_block.get("code_coverage_percent")
-                item["metadata_entries"] = metrics_block.get("metadata_entries")
+                metrics_array[index] = _build_benchmark_metrics_entry(run_metrics)
                 updated = True
                 break
 
@@ -460,6 +452,16 @@ def main(argv=None):
         model_name=model_name,
     )
 
+    # Requires the graphify skill to be installed for the selected agent backend.
+    # Install docs: https://github.com/safishamsi/graphify#install
+    if strategy.get("parameters", {}).get("graphify-context"):
+        graphify_dirs = [
+            os.path.join(a.local_dir, "extracted")
+            for a in prepared_source_context.artifacts
+            if a.available and a.local_dir and os.path.isdir(os.path.join(a.local_dir, "extracted"))
+        ]
+        agent.graphify(graphify_dirs)
+
     workflow_status, global_iterations, unittest_number = strategy_obj.run(
         agent=agent,
         checkpoint_commit_hash=checkpoint_commit_hash,
@@ -489,12 +491,18 @@ def main(argv=None):
 
     if workflow_status == RUN_STATUS_SUCCESS:
         if is_benchmark_mode:
-            log_stage("generate-metadata", f"Benchmark mode: running generateMetadata only for {library}")
+            log_stage("generate-metadata", f"Benchmark mode: running generateMetadata and generateLibraryStats for {library}")
             if not strategy_obj._run_gradle_command([
                 "./gradlew",
                 "generateMetadata",
                 f"-Pcoordinates={library}",
                 "--agentAllowedPackages=fromJar",
+            ]):
+                workflow_status = RUN_STATUS_FAILURE
+            elif not strategy_obj._run_gradle_command([
+                "./gradlew",
+                "generateLibraryStats",
+                f"-Pcoordinates={library}",
             ]):
                 workflow_status = RUN_STATUS_FAILURE
             elif not strategy_obj._commit_library_iteration():

--- a/forge/ai_workflows/agents/agent.py
+++ b/forge/ai_workflows/agents/agent.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import tempfile
 
+from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import display_log_path, resolve_task_log_dir
 
 
@@ -130,3 +131,15 @@ class Agent(ABC):
     @abstractmethod
     def run_test_command(self, test_cmd: str) -> str:
         """Execute a shell test command via the agent and return its combined stdout/stderr."""
+
+    def graphify(self, source_dirs: list[str]) -> str:
+        """Send graphify prompts to the agent session to build a merged knowledge graph context."""
+        if not source_dirs:
+            return ""
+        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        result = self.send_prompt(f"/graphify {source_dirs[0]} --include-local")
+        for extra_dir in source_dirs[1:]:
+            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            result = self.send_prompt(f"/graphify {extra_dir} --update")
+        log_stage("graphify", "Knowledge graph context initialized")
+        return result

--- a/forge/ai_workflows/agents/codex_agent.py
+++ b/forge/ai_workflows/agents/codex_agent.py
@@ -22,7 +22,7 @@ class CodexAgent(Agent):
             self,
             model_name: str,
             working_dir: str,
-            timeout: int = 600,
+            timeout: int = 1200,
             task_type: str = "session",
             library: str | None = None,
             **_,
@@ -63,6 +63,20 @@ class CodexAgent(Agent):
     @property
     def thread_id(self) -> str | None:
         return self._thread_id
+
+    def graphify(self, source_dirs: list[str]) -> str:
+        """Send $graphify to the Codex session to build a merged knowledge graph context."""
+        from utility_scripts.stage_logger import log_stage
+        from utility_scripts.task_logs import display_log_path
+        if not source_dirs:
+            return ""
+        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        result = self.send_prompt(f"$graphify {source_dirs[0]}")
+        for extra_dir in source_dirs[1:]:
+            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            result = self.send_prompt(f"$graphify {extra_dir} --update")
+        log_stage("graphify", "Knowledge graph context initialized")
+        return result
 
     def send_prompt(self, prompt: str) -> str:
         self._print_session_log_once("Codex", self._session_log_path)

--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -64,6 +64,20 @@ class PiAgent(Agent):
     def cached_input_tokens_used(self) -> int:
         return self._cached_input_tokens_used
 
+    def graphify(self, source_dirs: list[str]) -> str:
+        """Send /skill:graphify to the Pi session to build a merged knowledge graph context."""
+        from utility_scripts.stage_logger import log_stage
+        from utility_scripts.task_logs import display_log_path
+        if not source_dirs:
+            return ""
+        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        result = self.send_prompt(f"/skill:graphify {source_dirs[0]}")
+        for extra_dir in source_dirs[1:]:
+            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            result = self.send_prompt(f"/skill:graphify {extra_dir} --update")
+        log_stage("graphify", "Knowledge graph context initialized")
+        return result
+
     def send_prompt(self, prompt: str) -> str:
         original_session_path = self._session_path
         try:

--- a/forge/benchmarks/benchmark_suite.json
+++ b/forge/benchmarks/benchmark_suite.json
@@ -1,10 +1,266 @@
 [
-    {
-      "name": "Genesis",
-      "description": "Workflow using the `dynamic_access_main_sources_pi_gpt-5.4` strategy for three selected libraries. Initial tests for these libraries are human written.",
-      "libraries": [
-        "ch.qos.logback:logback-core:1.1.3"
-      ],
-      "strategy": "dynamic_access_main_sources_pi_gpt-5.4"
-    }
+  {
+    "name": "genesis_basic_pi_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `basic_iterative_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "basic_iterative_pi_gpt-5.4"
+  },
+  {
+    "name": "genesis_basic_pi_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `basic_iterative_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "basic_iterative_pi_gpt-5.5"
+  },
+  {
+    "name": "genesis_basic_codex_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `basic_iterative_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "basic_iterative_codex_gpt-5.4"
+  },
+  {
+    "name": "genesis_basic_codex_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `basic_iterative_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "basic_iterative_codex_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_pi_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_main_sources_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_main_sources_pi_gpt-5.4"
+  },
+  {
+    "name": "genesis_da_pi_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_main_sources_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_main_sources_pi_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_codex_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_main_sources_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_main_sources_codex_gpt-5.4"
+  },
+  {
+    "name": "genesis_da_docs_codex_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_documentation_sources_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_documentation_sources_codex_gpt-5.4"
+  },
+  {
+    "name": "genesis_da_codex_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_main_sources_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_main_sources_codex_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_docs_codex_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_documentation_sources_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_documentation_sources_codex_gpt-5.5"
+  },
+  {
+    "name": "genesis_optimistic_pi_gpt-5.3",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `optimistic_dynamic_access_iterative_pi_gpt-5.3` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_pi_gpt-5.3"
+  },
+  {
+    "name": "genesis_optimistic_pi_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `optimistic_dynamic_access_iterative_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_pi_gpt-5.4"
+  },
+  {
+    "name": "genesis_optimistic_pi_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `optimistic_dynamic_access_iterative_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_pi_gpt-5.5"
+  },
+  {
+    "name": "genesis_optimistic_codex_gpt-5.4",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `optimistic_dynamic_access_iterative_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_codex_gpt-5.4"
+  },
+  {
+    "name": "genesis_optimistic_codex_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `optimistic_dynamic_access_iterative_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_codex_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_bulk_pi_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_bulk_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_bulk_pi_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_graphify_bulk_pi_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_graphify_bulk_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_graphify_bulk_pi_gpt-5.5"
+  },
+  {
+    "name": "genesis_da_graphify_bulk_codex_gpt-5.5",
+    "description": "Benchmark for `ch.qos.logback:logback-core:1.1.3` using the `dynamic_access_graphify_bulk_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "ch.qos.logback:logback-core:1.1.3"
+    ],
+    "strategy": "dynamic_access_graphify_bulk_codex_gpt-5.5"
+  },
+  {
+    "name": "nexus_basic_pi_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `basic_iterative_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "basic_iterative_pi_gpt-5.4"
+  },
+  {
+    "name": "nexus_basic_pi_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `basic_iterative_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "basic_iterative_pi_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_pi_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_main_sources_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_main_sources_pi_gpt-5.4"
+  },
+  {
+    "name": "nexus_da_pi_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_main_sources_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_main_sources_pi_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_codex_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_main_sources_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_main_sources_codex_gpt-5.4"
+  },
+  {
+    "name": "nexus_da_docs_codex_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_documentation_sources_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_documentation_sources_codex_gpt-5.4"
+  },
+  {
+    "name": "nexus_da_codex_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_main_sources_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_main_sources_codex_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_docs_codex_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_documentation_sources_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_documentation_sources_codex_gpt-5.5"
+  },
+  {
+    "name": "nexus_optimistic_pi_gpt-5.3",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `optimistic_dynamic_access_iterative_pi_gpt-5.3` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_pi_gpt-5.3"
+  },
+  {
+    "name": "nexus_optimistic_pi_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `optimistic_dynamic_access_iterative_pi_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_pi_gpt-5.4"
+  },
+  {
+    "name": "nexus_optimistic_codex_gpt-5.4",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `optimistic_dynamic_access_iterative_codex_gpt-5.4` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "optimistic_dynamic_access_iterative_codex_gpt-5.4"
+  },
+  {
+    "name": "nexus_da_bulk_pi_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_bulk_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_bulk_pi_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_bulk_codex_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_bulk_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_bulk_codex_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_graphify_bulk_pi_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_graphify_bulk_pi_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_graphify_bulk_pi_gpt-5.5"
+  },
+  {
+    "name": "nexus_da_graphify_bulk_codex_gpt-5.5",
+    "description": "Benchmark for `com.h2database:h2:2.1.210` using the `dynamic_access_graphify_bulk_codex_gpt-5.5` strategy.",
+    "libraries": [
+      "com.h2database:h2:2.1.210"
+    ],
+    "strategy": "dynamic_access_graphify_bulk_codex_gpt-5.5"
+  }
 ]

--- a/forge/pyproject.toml
+++ b/forge/pyproject.toml
@@ -6,6 +6,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "pylint",
     "jsonschema",
+    "graphifyy",
 ]
 
 [project.scripts]

--- a/forge/schemas/benchmark_run_metrics_schema.json
+++ b/forge/schemas/benchmark_run_metrics_schema.json
@@ -2,6 +2,359 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Benchmark Run Metrics Schema",
   "description": "JSON Schema for benchmark-level metrics produced by Metadata Forge benchmarking.",
+  "$defs": {
+    "dynamicAccessEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coveredCalls",
+        "totalCalls",
+        "coverageRatio"
+      ],
+      "properties": {
+        "coveredCalls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalCalls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "coverageRatio": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "libraryCoverageEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "covered",
+            "total",
+            "ratio"
+          ],
+          "properties": {
+            "covered": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "missed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "ratio": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        },
+        {
+          "type": "string",
+          "const": "N/A"
+        }
+      ]
+    },
+    "statsSnapshot": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dynamicAccess": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "coveredCalls",
+            "totalCalls",
+            "coverageRatio",
+            "breakdown"
+          ],
+          "properties": {
+            "coveredCalls": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "totalCalls": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "coverageRatio": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "breakdown": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/dynamicAccessEntry"
+              }
+            }
+          }
+        },
+        "libraryCoverage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "instruction": {
+              "$ref": "#/$defs/libraryCoverageEntry"
+            },
+            "line": {
+              "$ref": "#/$defs/libraryCoverageEntry"
+            },
+            "method": {
+              "$ref": "#/$defs/libraryCoverageEntry"
+            }
+          }
+        }
+      }
+    },
+    "metricsBlock": {
+      "type": "object",
+      "description": "Collected run metrics.",
+      "additionalProperties": false,
+      "required": [
+        "input_tokens_used",
+        "output_tokens_used",
+        "iterations",
+        "cost_usd",
+        "tested_library_loc",
+        "code_coverage_percent",
+        "metadata_entries"
+      ],
+      "properties": {
+        "input_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cached_input_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "iterations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "generated_loc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tested_library_loc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "metadata_entries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "code_coverage_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "artifactsBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "test_file",
+        "metadata_file"
+      ],
+      "properties": {
+        "test_file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "metadata_file": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "runMetricsEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timestamp",
+        "library",
+        "strategy_name",
+        "status",
+        "metrics"
+      ],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "library": {
+          "type": "string",
+          "pattern": "^[^:]+:[^:]+:[^:]+$"
+        },
+        "starting_commit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ending_commit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "strategy_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "agent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure",
+            "success_with_intervention"
+          ]
+        },
+        "post_generation_intervention": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "stage",
+            "intervention_file",
+            "analysis_markdown"
+          ],
+          "properties": {
+            "stage": {
+              "type": "string",
+              "minLength": 1
+            },
+            "intervention_file": {
+              "type": "string",
+              "minLength": 1
+            },
+            "analysis_markdown": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "stats": {
+          "$ref": "#/$defs/statsSnapshot"
+        },
+        "metrics": {
+          "$ref": "#/$defs/metricsBlock"
+        },
+        "artifacts": {
+          "$ref": "#/$defs/artifactsBlock"
+        }
+      }
+    },
+    "legacyBenchmarkEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "library",
+        "status",
+        "input_tokens_used",
+        "output_tokens_used",
+        "iterations",
+        "cost_usd",
+        "generated_loc",
+        "tested_library_loc",
+        "code_coverage_percent",
+        "metadata_entries",
+        "original_metadata_entry_count"
+      ],
+      "properties": {
+        "library": {
+          "type": "string",
+          "pattern": "^[^:]+:[^:]+:[^:]+$"
+        },
+        "starting_commit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ending_commit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure",
+            "success_with_intervention"
+          ]
+        },
+        "input_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cached_input_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "iterations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "generated_loc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tested_library_loc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "code_coverage_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "metadata_entries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "original_metadata_entry_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
   "type": "array",
   "items": {
     "type": "object",
@@ -26,98 +379,14 @@
         "type": "array",
         "description": "Per-library metrics collected during this benchmark run.",
         "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "library",
-            "status",
-            "input_tokens_used",
-            "output_tokens_used",
-            "iterations",
-            "cost_usd",
-            "generated_loc",
-            "tested_library_loc",
-            "code_coverage_percent",
-            "metadata_entries",
-            "original_metadata_entry_count"
-          ],
-          "properties": {
-            "library": {
-              "type": "string",
-              "pattern": "^[^:]+:[^:]+:[^:]+$",
-              "description": "Dependency coordinate in the form group:artifact:version."
+          "oneOf": [
+            {
+              "$ref": "#/$defs/runMetricsEntry"
             },
-            "starting_commit": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Git commit hash at the start of the generation workflow for this library."
-            },
-            "ending_commit": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Git commit hash at the end of the generation workflow for this library."
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "success_with_intervention"
-              ],
-              "description": "Outcome of the workflow run for this library."
-            },
-            "input_tokens_used": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Total LLM input tokens consumed for this library."
-            },
-            "cached_input_tokens_used": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Subset of input tokens served from cache when reported by the agent."
-            },
-            "output_tokens_used": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Total LLM output tokens consumed for this library."
-            },
-            "iterations": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of iterations performed by the strategy for this library."
-            },
-            "cost_usd": {
-              "type": "number",
-              "minimum": 0,
-              "description": "Estimated cost in USD for this library run."
-            },
-            "generated_loc": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Lines of code generated by the agent for this library."
-            },
-            "tested_library_loc": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Lines of code covered within the target library during this benchmark."
-            },
-            "code_coverage_percent": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 100,
-              "description": "Code coverage percentage (0–100) for this library."
-            },
-            "metadata_entries": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of metadata entries produced for this library during the run."
-            },
-            "original_metadata_entry_count": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of metadata entries that existed for this library before the benchmark run."
+            {
+              "$ref": "#/$defs/legacyBenchmarkEntry"
             }
-          }
+          ]
         }
       }
     }
@@ -129,20 +398,29 @@
         "timestamp": "2026-02-20T16:00:00Z",
         "metrics": [
           {
+            "timestamp": "2026-02-20T16:05:00Z",
             "library": "com.hazelcast:hazelcast:5.5.0",
             "starting_commit": "6d9a591c",
             "ending_commit": "7f2c13aa",
+            "strategy_name": "dynamic_access_main_sources_pi_gpt-5.4",
+            "agent": "pi",
+            "model": "oca/gpt-5.4",
             "status": "success",
-            "input_tokens_used": 78628,
-            "cached_input_tokens_used": 52412,
-            "output_tokens_used": 19305,
-            "iterations": 7,
-            "cost_usd": 0.3682,
-            "generated_loc": 319,
-            "tested_library_loc": 13397,
-            "code_coverage_percent": 10.9,
-            "metadata_entries": 975,
-            "original_metadata_entry_count": 1325
+            "metrics": {
+              "input_tokens_used": 78628,
+              "cached_input_tokens_used": 52412,
+              "output_tokens_used": 19305,
+              "iterations": 7,
+              "cost_usd": 0.3682,
+              "generated_loc": 319,
+              "tested_library_loc": 13397,
+              "code_coverage_percent": 10.9,
+              "metadata_entries": 975
+            },
+            "artifacts": {
+              "test_file": "tests/src/com.hazelcast/hazelcast/5.5.0/src/test/java/com_hazelcast/hazelcast/HazelcastTest.java",
+              "metadata_file": "metadata/com.hazelcast/hazelcast/5.5.0/reachability-metadata.json"
+            }
           }
         ]
       }

--- a/forge/schemas/strategy_schema.json
+++ b/forge/schemas/strategy_schema.json
@@ -77,6 +77,9 @@
                   "type": "string",
                   "minLength": 1
                 }
+              },
+              {
+                "type": "boolean"
               }
             ]
           }

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -470,5 +470,257 @@
       ]
     },
     "mcps": []
+  },
+  {
+    "name": "basic_iterative_codex_gpt-5.4",
+    "description": "Basic iterative add-new-library workflow for the Codex agent.",
+    "agent": "codex",
+    "workflow": "basic_iterative",
+    "model": "gpt-5.4",
+    "prompts": {
+      "initial": "prompt_templates/initial/basic_initial.md",
+      "after-successful-iteration": "prompt_templates/after-successful-iteration/codex_after_success.md",
+      "after-failed-iteration": "prompt_templates/after-failed-iteration/basic_after_fail.md"
+    },
+    "parameters": {
+      "max-test-iterations": 5,
+      "max-failed-generations": 2,
+      "max-successful-generations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "basic_iterative_codex_gpt-5.5",
+    "description": "Basic iterative add-new-library workflow for the Codex agent using gpt-5.5.",
+    "agent": "codex",
+    "workflow": "basic_iterative",
+    "model": "gpt-5.5",
+    "prompts": {
+      "initial": "prompt_templates/initial/basic_initial.md",
+      "after-successful-iteration": "prompt_templates/after-successful-iteration/codex_after_success.md",
+      "after-failed-iteration": "prompt_templates/after-failed-iteration/basic_after_fail.md"
+    },
+    "parameters": {
+      "max-test-iterations": 5,
+      "max-failed-generations": 2,
+      "max-successful-generations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_bulk_pi_gpt-5.5",
+    "description": "Pi bulk dynamic-access strategy. Unlike the regular dynamic-access strategy, which iterates through uncovered classes and refines coverage class by class, this strategy gives the agent the full dynamic-access report in one prompt and asks it to cover the missing accesses in a single broad pass.",
+    "agent": "pi",
+    "workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_bulk_codex_gpt-5.5",
+    "description": "Codex bulk dynamic-access strategy. Unlike the regular dynamic-access strategy, which iterates through uncovered classes and refines coverage class by class, this strategy gives the agent the full dynamic-access report in one prompt and asks it to cover the missing accesses in a single broad pass.",
+    "agent": "codex",
+    "workflow": "optimistic_dynamic_access",
+    "model": "gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_graphify_bulk_pi_gpt-5.5",
+    "description": "Pi graphify-assisted bulk dynamic-access strategy. It first builds graphify context from downloaded source artifacts, then gives the agent the full dynamic-access report in one broad pass. Unlike the regular dynamic-access strategy, it does not run the class-by-class refinement loop.",
+    "agent": "pi",
+    "workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-test-iterations": 3,
+      "graphify-context": true,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_graphify_bulk_codex_gpt-5.5",
+    "description": "Codex graphify-assisted bulk dynamic-access strategy. It first builds graphify context from downloaded source artifacts, then gives the agent the full dynamic-access report in one broad pass. Unlike the regular dynamic-access strategy, it does not run the class-by-class refinement loop.",
+    "agent": "codex",
+    "workflow": "optimistic_dynamic_access",
+    "model": "gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-test-iterations": 3,
+      "graphify-context": true,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "optimistic_dynamic_access_iterative_pi_gpt-5.3",
+    "description": "Composite strategy: optimistic bulk DA coverage, then per-class DA refinement.",
+    "agent": "pi",
+    "workflow": "increase_dynamic_access_coverage",
+    "primary-workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.3-codex",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 2,
+      "max-test-iterations": 3,
+      "max-class-test-iterations": 2,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "optimistic_dynamic_access_iterative_pi_gpt-5.5",
+    "description": "Composite strategy: optimistic bulk DA coverage, then per-class DA refinement using gpt-5.5.",
+    "agent": "pi",
+    "workflow": "increase_dynamic_access_coverage",
+    "primary-workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 2,
+      "max-test-iterations": 3,
+      "max-class-test-iterations": 2,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "optimistic_dynamic_access_iterative_codex_gpt-5.4",
+    "description": "Composite Codex strategy: optimistic bulk DA coverage, then per-class DA refinement.",
+    "agent": "codex",
+    "workflow": "increase_dynamic_access_coverage",
+    "primary-workflow": "optimistic_dynamic_access",
+    "model": "gpt-5.4",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 2,
+      "max-test-iterations": 3,
+      "max-class-test-iterations": 2,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "optimistic_dynamic_access_iterative_codex_gpt-5.5",
+    "description": "Composite Codex strategy: optimistic bulk DA coverage, then per-class DA refinement using gpt-5.5.",
+    "agent": "codex",
+    "workflow": "increase_dynamic_access_coverage",
+    "primary-workflow": "optimistic_dynamic_access",
+    "model": "gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 2,
+      "max-test-iterations": 3,
+      "max-class-test-iterations": 2,
+      "source-context-types": [
+        "main"
+      ],
+      "max-optimistic-iterations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "basic_iterative_pi_gpt-5.5",
+    "description": "Same configuration as basic_iterative, but uses gpt-5.5 instead.",
+    "agent": "pi",
+    "workflow": "basic_iterative",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "initial": "prompt_templates/initial/basic_initial.md",
+      "after-successful-iteration": "prompt_templates/after-successful-iteration/basic_after_success.md",
+      "after-failed-iteration": "prompt_templates/after-failed-iteration/basic_after_fail.md"
+    },
+    "parameters": {
+      "max-test-iterations": 5,
+      "max-failed-generations": 2,
+      "max-successful-generations": 3
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_main_sources_codex_gpt-5.5",
+    "description": "Dynamic-access-guided Codex workflow using downloaded main library sources as read-only context. Uses gpt-5.5.",
+    "agent": "codex",
+    "workflow": "dynamic_access_iterative",
+    "model": "gpt-5.5",
+    "prompts": {
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 3,
+      "max-class-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": []
+  },
+  {
+    "name": "dynamic_access_documentation_sources_codex_gpt-5.5",
+    "description": "Dynamic-access-guided Codex workflow using downloaded documentation artifacts as read-only context. Uses gpt-5.5.",
+    "agent": "codex",
+    "workflow": "dynamic_access_iterative",
+    "model": "gpt-5.5",
+    "prompts": {
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 3,
+      "max-class-test-iterations": 3,
+      "source-context-types": [
+        "documentation"
+      ]
+    },
+    "mcps": []
   }
 ]


### PR DESCRIPTION
## What changed
This updates the in-repo Forge benchmark setup so we can compare the same libraries across basic generation, regular dynamic-access refinement, bulk dynamic-access, and graphify-assisted bulk dynamic-access strategies.

### Notable details
- `graphify-context` now runs before the workflow when a strategy opts in.
- Bulk dynamic-access strategies give the agent the full dynamic-access report in one broad pass, unlike the regular DA strategy which refines uncovered classes iteratively.
- Benchmark metrics can now keep nested run metrics and stats snapshots, while still accepting existing flat benchmark entries.
- Introduced multiple benchmarks in the suite.

Closes #3894