### PR TITLE
[GenAI] Add support for com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.1 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.dataformat.yaml.YAMLParser"
+      },
+      "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.dataformat.yaml.YAMLParser"
+      },
+      "type": "java.sql.Timestamp"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/index.json
+++ b/metadata/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.18.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.18.1/jackson-dataformat-yaml-2.18.1-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-dataformats-text",
+    "test-code-url" : "https://github.com/FasterXML/jackson-dataformats-text/tree/jackson-dataformats-text-2.18.1/yaml/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.18.1/jackson-dataformat-yaml-2.18.1-javadoc.jar",
+    "description" : "Jackson Dataformat YAML provides Jackson-backed reading and writing of YAML data through the standard streaming and data-binding APIs. It integrates SnakeYAML as the underlying YAML parser and generator so Java applications can serialize and deserialize YAML alongside other Jackson data formats.",
+    "tested-versions" : [
+      "2.18.1"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.dataformat.yaml"
+    ]
+  }
+]

--- a/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T14:54:06.676161Z",
+    "library": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.1",
+    "starting_commit": "3f2006c02c6f3e7401d3cc29dc2eed2cfc378056",
+    "ending_commit": "fb5228638213d61251073332ab57a3c688c1d514",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.18.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2702,
+          "missed": 3895,
+          "ratio": 0.40958,
+          "total": 6597
+        },
+        "line": {
+          "covered": 640,
+          "missed": 850,
+          "ratio": 0.42953,
+          "total": 1490
+        },
+        "method": {
+          "covered": 127,
+          "missed": 167,
+          "ratio": 0.431973,
+          "total": 294
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 138680,
+      "cached_input_tokens_used": 1062400,
+      "output_tokens_used": 17473,
+      "iterations": 3,
+      "cost_usd": 1.0554,
+      "generated_loc": 363,
+      "tested_library_loc": 640,
+      "metadata_entries": 2,
+      "code_coverage_percent": 42.95
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/stats.json
+++ b/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.18.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2702,
+        "missed" : 3895,
+        "ratio" : 0.40958,
+        "total" : 6597
+      },
+      "line" : {
+        "covered" : 640,
+        "missed" : 850,
+        "ratio" : 0.42953,
+        "total" : 1490
+      },
+      "method" : {
+        "covered" : 127,
+        "missed" : 167,
+        "ratio" : 0.431973,
+        "total" : 294
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/.gitignore
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/build.gradle
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.1
+library.version = 2.18.1
+metadata.dir = com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.dataformat.jackson-dataformat-yaml_tests'

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
@@ -290,4 +290,60 @@ public class Jackson_dataformat_yamlTest {
             assertThat(allDocuments.get(1).path("priority").asInt()).isEqualTo(2);
         }
     }
+
+    @Test
+    void generatorAndParserSupportNativeYamlObjectIds() throws Exception {
+        YAMLFactory factory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.USE_NATIVE_OBJECT_ID)
+                .build();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (JsonGenerator generator = factory.createGenerator(output)) {
+            generator.writeStartObject();
+            generator.writeFieldName("base");
+            generator.writeObjectId("shared-settings");
+            generator.writeStartObject();
+            generator.writeStringField("host", "localhost");
+            generator.writeNumberField("port", 8080);
+            generator.writeEndObject();
+            generator.writeFieldName("alias");
+            generator.writeObjectRef("shared-settings");
+            generator.writeEndObject();
+        }
+
+        byte[] serialized = output.toByteArray();
+        String yaml = output.toString(StandardCharsets.UTF_8);
+
+        assertThat(yaml)
+                .contains("base: &shared-settings")
+                .contains("alias: *shared-settings");
+
+        try (YAMLParser parser = (YAMLParser) factory.createParser(serialized)) {
+            assertThat(parser.canReadObjectId()).isTrue();
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("base");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
+            assertThat(parser.getObjectId()).isEqualTo("shared-settings");
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("host");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("localhost");
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("port");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_NUMBER_INT);
+            assertThat(parser.getIntValue()).isEqualTo(8080);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_OBJECT);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("alias");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("shared-settings");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_OBJECT);
+            assertThat(parser.nextToken()).isNull();
+        }
+    }
 }

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
@@ -6,11 +6,288 @@
  */
 package com_fasterxml_jackson_dataformat.jackson_dataformat_yaml;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import org.junit.jupiter.api.Test;
 
-class Jackson_dataformat_yamlTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jackson_dataformat_yamlTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void readTreeParsesNestedYamlDocumentsAndScalarTypes() throws Exception {
+        YAMLMapper mapper = new YAMLMapper();
+
+        String yaml = """
+                # Application configuration expressed with common YAML structures.
+                service:
+                  name: billing-api
+                  active: true
+                  retries: 3
+                  timeout: 2.5
+                  endpoints:
+                    - /health
+                    - /metrics
+                  headers: {Accept: application/json, Cache-Control: no-cache}
+                description: |
+                  first line
+                  second line
+                folded: >
+                  alpha
+                  beta
+                emptyValue: null
+                """;
+
+        JsonNode root = mapper.readTree(yaml);
+        JsonNode service = root.path("service");
+
+        assertThat(service.path("name").asText()).isEqualTo("billing-api");
+        assertThat(service.path("active").asBoolean()).isTrue();
+        assertThat(service.path("retries").asInt()).isEqualTo(3);
+        assertThat(service.path("timeout").asDouble()).isEqualTo(2.5d);
+        assertThat(service.path("endpoints")).hasSize(2);
+        assertThat(service.path("endpoints").get(0).asText()).isEqualTo("/health");
+        assertThat(service.path("endpoints").get(1).asText()).isEqualTo("/metrics");
+        assertThat(service.path("headers").path("Accept").asText()).isEqualTo("application/json");
+        assertThat(service.path("headers").path("Cache-Control").asText()).isEqualTo("no-cache");
+        assertThat(root.path("description").asText()).isEqualTo("first line\nsecond line\n");
+        assertThat(root.path("folded").asText()).isEqualTo("alpha beta\n");
+        assertThat(root.path("emptyValue").isNull()).isTrue();
+    }
+
+    @Test
+    void writeValueRoundTripsOrderedMapsListsAndScalars() throws Exception {
+        YAMLMapper mapper = YAMLMapper.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .build();
+
+        Map<String, Object> limits = new LinkedHashMap<>();
+        limits.put("cpu", "500m");
+        limits.put("memory", "256Mi");
+
+        Map<String, Object> container = new LinkedHashMap<>();
+        container.put("image", "example/app:1.0");
+        container.put("ports", List.of(8080, 8443));
+        container.put("limits", limits);
+
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("name", "demo");
+        document.put("enabled", true);
+        document.put("replicas", 2);
+        document.put("ratio", 0.75d);
+        document.put("container", container);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        mapper.writeValue(output, document);
+
+        byte[] serialized = output.toByteArray();
+        String yaml = output.toString(StandardCharsets.UTF_8);
+        JsonNode tree = mapper.readTree(serialized);
+        Map<String, Object> roundTripped = mapper.readValue(
+                serialized, new TypeReference<LinkedHashMap<String, Object>>() { });
+
+        assertThat(yaml).doesNotStartWith("---");
+        assertThat(yaml)
+                .contains("name: \"demo\"")
+                .contains("enabled: true")
+                .contains("replicas: 2")
+                .contains("container:")
+                .contains("ports:")
+                .contains("- 8080")
+                .contains("cpu: \"500m\"");
+        assertThat(tree.path("container").path("limits").path("memory").asText()).isEqualTo("256Mi");
+        assertThat(tree.path("container").path("ports").get(1).asInt()).isEqualTo(8443);
+        assertThat(roundTripped).containsEntry("name", "demo");
+        assertThat(roundTripped).containsEntry("enabled", true);
+        assertThat(((Number) roundTripped.get("replicas")).intValue()).isEqualTo(2);
+        assertThat(((Number) roundTripped.get("ratio")).doubleValue()).isEqualTo(0.75d);
+    }
+
+    @Test
+    void streamingParserExposesExpectedJsonTokenSequenceAndValues() throws Exception {
+        YAMLFactory factory = new YAMLFactory();
+        String yaml = """
+                name: telemetry
+                active: true
+                threshold: 0.75
+                retries: 4
+                labels:
+                  - core
+                  - native
+                nothing: null
+                """;
+
+        try (JsonParser parser = factory.createParser(yaml)) {
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("name");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("telemetry");
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("active");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_TRUE);
+            assertThat(parser.getBooleanValue()).isTrue();
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("threshold");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_NUMBER_FLOAT);
+            assertThat(parser.getDoubleValue()).isEqualTo(0.75d);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("retries");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_NUMBER_INT);
+            assertThat(parser.getIntValue()).isEqualTo(4);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("labels");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_ARRAY);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("core");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("native");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_ARRAY);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("nothing");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_NULL);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_OBJECT);
+            assertThat(parser.nextToken()).isNull();
+        }
+    }
+
+    @Test
+    void streamingGeneratorWritesNestedObjectsArraysAndBinaryValues() throws Exception {
+        YAMLFactory factory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .build();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (JsonGenerator generator = factory.createGenerator(output)) {
+            generator.writeStartObject();
+            generator.writeStringField("kind", "Secret");
+            generator.writeFieldName("data");
+            generator.writeStartObject();
+            generator.writeBinaryField("token", "native-yaml".getBytes(StandardCharsets.UTF_8));
+            generator.writeEndObject();
+            generator.writeFieldName("hosts");
+            generator.writeStartArray();
+            generator.writeString("api.example.test");
+            generator.writeString("metrics.example.test");
+            generator.writeEndArray();
+            generator.writeEndObject();
+        }
+
+        byte[] serialized = output.toByteArray();
+        String yaml = output.toString(StandardCharsets.UTF_8);
+        JsonNode tree = new YAMLMapper().readTree(serialized);
+
+        assertThat(yaml).doesNotStartWith("---");
+        assertThat(yaml)
+                .contains("kind: Secret")
+                .contains("data:")
+                .contains("token:")
+                .contains("hosts:")
+                .contains("- api.example.test")
+                .contains("- metrics.example.test");
+        assertThat(tree.path("kind").asText()).isEqualTo("Secret");
+        byte[] expectedToken = "native-yaml".getBytes(StandardCharsets.UTF_8);
+        assertThat(tree.path("data").path("token").binaryValue()).isEqualTo(expectedToken);
+        assertThat(tree.path("hosts")).hasSize(2);
+    }
+
+    @Test
+    void parserFeatureCanKeepBooleanLikeWordsAsStrings() throws Exception {
+        YAMLFactory factory = YAMLFactory.builder()
+                .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS)
+                .build();
+        YAMLMapper mapper = YAMLMapper.builder(factory).build();
+
+        String yaml = """
+                switches:
+                  power: on
+                  archived: off
+                  answer: yes
+                  rejected: no
+                regularBoolean: true
+                """;
+
+        JsonNode root = mapper.readTree(yaml);
+        JsonNode switches = root.path("switches");
+
+        assertThat(switches.path("power").isTextual()).isTrue();
+        assertThat(switches.path("power").asText()).isEqualTo("on");
+        assertThat(switches.path("archived").asText()).isEqualTo("off");
+        assertThat(switches.path("answer").asText()).isEqualTo("yes");
+        assertThat(switches.path("rejected").asText()).isEqualTo("no");
+        assertThat(root.path("regularBoolean").isBoolean()).isTrue();
+        assertThat(root.path("regularBoolean").asBoolean()).isTrue();
+    }
+
+    @Test
+    void generatorFeaturesControlLiteralBlocksQuotingAndDocumentMarker() throws Exception {
+        YAMLFactory factory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE)
+                .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
+                .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS)
+                .build();
+        YAMLMapper mapper = YAMLMapper.builder(factory).build();
+        ObjectNode document = mapper.createObjectNode();
+        document.put("numericText", "007");
+        document.put("booleanLikeText", "on");
+        document.put("description", "line one\nline two\n");
+        document.putArray("tags").add("yaml").add("jackson");
+
+        String yaml = mapper.writeValueAsString(document);
+        JsonNode roundTripped = mapper.readTree(yaml);
+
+        assertThat(yaml).doesNotStartWith("---");
+        assertThat(yaml).contains("description: |");
+        assertThat(roundTripped.path("numericText").asText()).isEqualTo("007");
+        assertThat(roundTripped.path("booleanLikeText").asText()).isEqualTo("on");
+        assertThat(roundTripped.path("description").asText()).isEqualTo("line one\nline two\n");
+        assertThat(roundTripped.path("tags").get(0).asText()).isEqualTo("yaml");
+        assertThat(roundTripped.path("tags").get(1).asText()).isEqualTo("jackson");
+    }
+
+    @Test
+    void mappingIteratorReadsMultipleYamlDocumentsFromOneStream() throws Exception {
+        YAMLMapper mapper = new YAMLMapper();
+        String yaml = """
+                ---
+                name: first
+                priority: 1
+                ---
+                name: second
+                priority: 2
+                """;
+
+        try (MappingIterator<JsonNode> documents = mapper.readerFor(JsonNode.class).readValues(yaml)) {
+            List<JsonNode> allDocuments = documents.readAll();
+
+            assertThat(allDocuments).hasSize(2);
+            assertThat(allDocuments.get(0).path("name").asText()).isEqualTo("first");
+            assertThat(allDocuments.get(0).path("priority").asInt()).isEqualTo(1);
+            assertThat(allDocuments.get(1).path("name").asText()).isEqualTo("second");
+            assertThat(allDocuments.get(1).path("priority").asInt()).isEqualTo(2);
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_dataformat.jackson_dataformat_yaml;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_dataformat_yamlTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/src/test/java/com_fasterxml_jackson_dataformat/jackson_dataformat_yaml/Jackson_dataformat_yamlTest.java
@@ -292,6 +292,73 @@ public class Jackson_dataformat_yamlTest {
     }
 
     @Test
+    void generatorAndParserSupportNativeYamlTypeIds() throws Exception {
+        YAMLFactory factory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)
+                .build();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (JsonGenerator generator = factory.createGenerator(output)) {
+            generator.writeStartObject();
+            generator.writeFieldName("resource");
+            generator.writeTypeId("service");
+            generator.writeStartObject();
+            generator.writeStringField("name", "catalog");
+            generator.writeNumberField("replicas", 3);
+            generator.writeEndObject();
+            generator.writeFieldName("labels");
+            generator.writeTypeId("tag-list");
+            generator.writeStartArray();
+            generator.writeString("public");
+            generator.writeString("stable");
+            generator.writeEndArray();
+            generator.writeEndObject();
+        }
+
+        byte[] serialized = output.toByteArray();
+        String yaml = output.toString(StandardCharsets.UTF_8);
+
+        assertThat(yaml)
+                .contains("resource: !<service>")
+                .contains("labels: !<tag-list>")
+                .contains("- \"public\"")
+                .contains("- \"stable\"");
+
+        try (YAMLParser parser = (YAMLParser) factory.createParser(serialized)) {
+            assertThat(parser.canReadTypeId()).isTrue();
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("resource");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
+            assertThat(parser.getTypeId()).isEqualTo("service");
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("name");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("catalog");
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("replicas");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_NUMBER_INT);
+            assertThat(parser.getIntValue()).isEqualTo(3);
+
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_OBJECT);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.FIELD_NAME);
+            assertThat(parser.currentName()).isEqualTo("labels");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.START_ARRAY);
+            assertThat(parser.getTypeId()).isEqualTo("tag-list");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("public");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.VALUE_STRING);
+            assertThat(parser.getText()).isEqualTo("stable");
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_ARRAY);
+            assertThat(parser.nextToken()).isEqualTo(JsonToken.END_OBJECT);
+            assertThat(parser.nextToken()).isNull();
+        }
+    }
+
+    @Test
     void generatorAndParserSupportNativeYamlObjectIds() throws Exception {
         YAMLFactory factory = YAMLFactory.builder()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.fasterxml.jackson.dataformat.yaml.**"
+      "includeClasses" : "com.fasterxml.jackson.dataformat.yaml.**"
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.fasterxml.jackson.dataformat.yaml.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2469

This PR introduces tests and metadata for com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 138680
- Cached input tokens: 1062400
- Output tokens: 17473
- Entries: 2
- Iterations: 3
- Library coverage percentage: 42.95
- Generated lines of code: 363
- Tested library lines of code: 640

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `60823661b7840463506f36a43ea4456146609dfd`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2702/6597 (40.96%)
- Line: 640/1490 (42.95%)
- Method: 127/294 (43.20%)
