### PR TITLE
[GenAI] Add support for io.dropwizard.metrics:metrics-json:4.2.0 using gpt-5.5

### DIFF
--- a/metadata/io.dropwizard.metrics/metrics-json/4.2.0/reachability-metadata.json
+++ b/metadata/io.dropwizard.metrics/metrics-json/4.2.0/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.json.HealthCheckModule"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.json.MetricsModule"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.json.MetricsModule$TimerSerializer"
+      },
+      "type": "double[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.codahale.metrics.json.HealthCheckModule$HealthCheckResultSerializer"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    }
+  ]
+}

--- a/metadata/io.dropwizard.metrics/metrics-json/index.json
+++ b/metadata/io.dropwizard.metrics/metrics-json/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-json/4.2.0/metrics-json-4.2.0-sources.jar",
+    "repository-url" : "https://github.com/dropwizard/metrics/",
+    "test-code-url" : "https://github.com/dropwizard/metrics/tree/v4.2.0/metrics-json/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-json/4.2.0/metrics-json-4.2.0-javadoc.jar",
+    "description" : "Metrics JSON provides Jackson integration for Dropwizard Metrics. It serializes metric registries, gauges, counters, histograms, meters, timers, and health-check results into JSON-friendly structures.",
+    "tested-versions" : [
+      "4.2.0"
+    ],
+    "allowed-packages" : [
+      "com.codahale.metrics.json"
+    ]
+  }
+]

--- a/stats/io.dropwizard.metrics/metrics-json/4.2.0/execution-metrics.json
+++ b/stats/io.dropwizard.metrics/metrics-json/4.2.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T14:58:24.743196Z",
+    "library": "io.dropwizard.metrics:metrics-json:4.2.0",
+    "starting_commit": "57a9bf94fedf98fca2ab031a7d3d75e8be71f193",
+    "ending_commit": "b0db4f8d87602727dfc0798f90456ffd95725492",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 689,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 689
+        },
+        "line": {
+          "covered": 144,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 144
+        },
+        "method": {
+          "covered": 26,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 26
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 141396,
+      "cached_input_tokens_used": 886272,
+      "output_tokens_used": 16552,
+      "iterations": 3,
+      "cost_usd": 0.9397,
+      "generated_loc": 219,
+      "tested_library_loc": 144,
+      "metadata_entries": 4,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java",
+      "metadata_file": "metadata/io.dropwizard.metrics/metrics-json/4.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.dropwizard.metrics/metrics-json/4.2.0/stats.json
+++ b/stats/io.dropwizard.metrics/metrics-json/4.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 689,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 689
+      },
+      "line" : {
+        "covered" : 144,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 144
+      },
+      "method" : {
+        "covered" : 26,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 26
+      }
+    }
+  } ]
+}

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/.gitignore
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/build.gradle
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "io.dropwizard.metrics:metrics-json:$libraryVersion"
+    testImplementation "io.dropwizard.metrics:metrics-healthchecks:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/build.gradle
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.dropwizard.metrics:metrics-json:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/gradle.properties
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.dropwizard.metrics:metrics-json:4.2.0
+library.version = 4.2.0
+metadata.dir = io.dropwizard.metrics/metrics-json/4.2.0/

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/settings.gradle
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.dropwizard.metrics.metrics-json_tests'

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
@@ -20,6 +20,8 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingWindowReservoir;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.json.HealthCheckModule;
 import com.codahale.metrics.json.MetricsModule;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -153,7 +155,46 @@ public class Metrics_jsonTest {
         assertThat(timerJson.get("duration_units").asText()).isEqualTo("nanoseconds");
     }
 
+    @Test
+    void healthCheckModuleSerializesResultStatusDetailsAndNestedErrors() throws Exception {
+        HealthCheckModule module = new HealthCheckModule();
+        ObjectMapper mapper = mapperWith(module);
+        IllegalStateException cause = new IllegalStateException("connection refused");
+        IllegalArgumentException error = new IllegalArgumentException("database unavailable", cause);
+        HealthCheck.Result result = HealthCheck.Result.builder()
+                .unhealthy(error)
+                .withMessage("readiness check failed")
+                .withDetail("service", "orders")
+                .withDetail("attempt", 3)
+                .build();
+
+        JsonNode json = toJson(mapper, result);
+
+        assertThat(module.getModuleName()).isEqualTo("healthchecks");
+        assertThat(module.version().getGroupId()).isEqualTo("io.dropwizard.metrics");
+        assertThat(module.version().getArtifactId()).isEqualTo("metrics-json");
+
+        assertThat(json.get("healthy").asBoolean()).isFalse();
+        assertThat(json.get("message").asText()).isEqualTo("readiness check failed");
+        assertThat(json.get("service").asText()).isEqualTo("orders");
+        assertThat(json.get("attempt").asInt()).isEqualTo(3);
+        assertThat(json.get("duration").asLong()).isGreaterThanOrEqualTo(0L);
+        assertThat(json.get("timestamp").asText()).isNotBlank();
+        assertThat(json.at("/error/type").asText()).isEqualTo("java.lang.IllegalArgumentException");
+        assertThat(json.at("/error/message").asText()).isEqualTo("database unavailable");
+        assertThat(json.at("/error/stack").isArray()).isTrue();
+        assertThat(json.at("/error/stack").size()).isGreaterThan(0);
+        assertThat(json.at("/error/cause/type").asText()).isEqualTo("java.lang.IllegalStateException");
+        assertThat(json.at("/error/cause/message").asText()).isEqualTo("connection refused");
+    }
+
     private static ObjectMapper mapperWith(MetricsModule module) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(module);
+        return mapper;
+    }
+
+    private static ObjectMapper mapperWith(HealthCheckModule module) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(module);
         return mapper;

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.Clock;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -128,6 +129,22 @@ public class Metrics_jsonTest {
     }
 
     @Test
+    void meterRatesAreConvertedToTheConfiguredRateUnit() throws Exception {
+        ManualClock clock = new ManualClock();
+        Meter meter = new Meter(clock);
+        ObjectMapper mapper = mapperWith(new MetricsModule(TimeUnit.MINUTES, TimeUnit.MILLISECONDS, true));
+
+        meter.mark(4);
+        clock.add(1, TimeUnit.SECONDS);
+
+        JsonNode json = toJson(mapper, meter);
+
+        assertThat(json.get("count").asLong()).isEqualTo(4L);
+        assertThat(json.get("mean_rate").asDouble()).isEqualTo(240.0d);
+        assertThat(json.get("units").asText()).isEqualTo("events/minute");
+    }
+
+    @Test
     void sampleArraysCanBeSuppressedWithoutRemovingDistributionStatistics() throws Exception {
         ObjectMapper mapper = mapperWith(new MetricsModule(TimeUnit.SECONDS, TimeUnit.NANOSECONDS, false));
         Histogram histogram = new Histogram(new SlidingWindowReservoir(10));
@@ -186,6 +203,19 @@ public class Metrics_jsonTest {
         assertThat(json.at("/error/stack").size()).isGreaterThan(0);
         assertThat(json.at("/error/cause/type").asText()).isEqualTo("java.lang.IllegalStateException");
         assertThat(json.at("/error/cause/message").asText()).isEqualTo("connection refused");
+    }
+
+    private static final class ManualClock extends Clock {
+        private long tick;
+
+        @Override
+        public long getTick() {
+            return tick;
+        }
+
+        private void add(long duration, TimeUnit unit) {
+            tick += unit.toNanos(duration);
+        }
     }
 
     private static ObjectMapper mapperWith(MetricsModule module) {

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_dropwizard_metrics.metrics_json;
+
+import org.junit.jupiter.api.Test;
+
+class Metrics_jsonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/src/test/java/io_dropwizard_metrics/metrics_json/Metrics_jsonTest.java
@@ -6,11 +6,185 @@
  */
 package io_dropwizard_metrics.metrics_json;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingWindowReservoir;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-class Metrics_jsonTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Metrics_jsonTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void moduleExposesIdentityAndSerializesIndividualMetricTypes() throws Exception {
+        MetricsModule module = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true);
+        ObjectMapper mapper = mapperWith(module);
+
+        Counter counter = new Counter();
+        counter.inc(7);
+
+        Gauge<Integer> gauge = () -> 42;
+        Gauge<Integer> failingGauge = () -> {
+            throw new IllegalStateException("sensor unavailable");
+        };
+
+        Histogram histogram = new Histogram(new SlidingWindowReservoir(10));
+        histogram.update(10);
+        histogram.update(20);
+        histogram.update(30);
+
+        Meter meter = new Meter();
+        meter.mark(3);
+
+        Timer timer = new Timer(new SlidingWindowReservoir(10));
+        timer.update(1500, TimeUnit.MICROSECONDS);
+        timer.update(2, TimeUnit.MILLISECONDS);
+
+        JsonNode counterJson = toJson(mapper, counter);
+        JsonNode gaugeJson = toJson(mapper, gauge);
+        JsonNode failingGaugeJson = toJson(mapper, failingGauge);
+        JsonNode histogramJson = toJson(mapper, histogram);
+        JsonNode meterJson = toJson(mapper, meter);
+        JsonNode timerJson = toJson(mapper, timer);
+
+        assertThat(module.getModuleName()).isEqualTo("metrics");
+        assertThat(module.version().getGroupId()).isEqualTo("io.dropwizard.metrics");
+        assertThat(module.version().getArtifactId()).isEqualTo("metrics-json");
+        assertThat(module.version().isUnknownVersion()).isFalse();
+
+        assertThat(counterJson.get("count").asLong()).isEqualTo(7L);
+        assertThat(gaugeJson.get("value").asInt()).isEqualTo(42);
+        assertThat(failingGaugeJson.get("error").asText())
+                .isEqualTo("java.lang.IllegalStateException: sensor unavailable");
+
+        assertThat(histogramJson.get("count").asLong()).isEqualTo(3L);
+        assertThat(histogramJson.get("min").asLong()).isEqualTo(10L);
+        assertThat(histogramJson.get("max").asLong()).isEqualTo(30L);
+        assertThat(longValues(histogramJson.get("values"))).containsExactly(10L, 20L, 30L);
+        assertThat(histogramJson.get("p50").asDouble()).isEqualTo(20.0d);
+        assertThat(histogramJson.get("stddev").asDouble()).isGreaterThan(0.0d);
+
+        assertThat(meterJson.get("count").asLong()).isEqualTo(3L);
+        assertThat(meterJson.get("units").asText()).isEqualTo("events/second");
+        assertThat(meterJson.has("mean_rate")).isTrue();
+        assertThat(meterJson.has("m1_rate")).isTrue();
+        assertThat(meterJson.has("m5_rate")).isTrue();
+        assertThat(meterJson.has("m15_rate")).isTrue();
+
+        assertThat(timerJson.get("count").asLong()).isEqualTo(2L);
+        assertThat(timerJson.get("min").asDouble()).isEqualTo(1.5d);
+        assertThat(timerJson.get("max").asDouble()).isEqualTo(2.0d);
+        assertThat(doubleValues(timerJson.get("values"))).containsExactly(1.5d, 2.0d);
+        assertThat(timerJson.get("duration_units").asText()).isEqualTo("milliseconds");
+        assertThat(timerJson.get("rate_units").asText()).isEqualTo("calls/second");
+    }
+
+    @Test
+    void registrySerializerGroupsMetricsAndAppliesTheConfiguredFilter() throws Exception {
+        MetricFilter apiOnlyFilter = (String name, Metric metric) -> name.startsWith("api.");
+        ObjectMapper mapper = mapperWith(new MetricsModule(TimeUnit.SECONDS, TimeUnit.MICROSECONDS, true,
+                apiOnlyFilter));
+        MetricRegistry registry = new MetricRegistry();
+
+        registry.register("api.queue.depth", (Gauge<Integer>) () -> 5);
+        registry.counter("api.requests").inc(11);
+        registry.histogram("api.payload.bytes").update(512);
+        registry.meter("api.throughput").mark(2);
+        registry.timer("api.latency").update(750, TimeUnit.MICROSECONDS);
+        registry.counter("internal.requests").inc(99);
+        registry.register("internal.queue.depth", (Gauge<Integer>) () -> 100);
+
+        JsonNode root = toJson(mapper, registry);
+
+        assertThat(root.get("version").asText()).isEqualTo("4.0.0");
+        assertThat(fieldNames(root.get("gauges"))).containsExactly("api.queue.depth");
+        assertThat(fieldNames(root.get("counters"))).containsExactly("api.requests");
+        assertThat(fieldNames(root.get("histograms"))).containsExactly("api.payload.bytes");
+        assertThat(fieldNames(root.get("meters"))).containsExactly("api.throughput");
+        assertThat(fieldNames(root.get("timers"))).containsExactly("api.latency");
+
+        assertThat(root.at("/gauges/api.queue.depth/value").asInt()).isEqualTo(5);
+        assertThat(root.at("/counters/api.requests/count").asLong()).isEqualTo(11L);
+        assertThat(root.at("/histograms/api.payload.bytes/count").asLong()).isEqualTo(1L);
+        assertThat(root.at("/meters/api.throughput/count").asLong()).isEqualTo(2L);
+        assertThat(root.at("/timers/api.latency/count").asLong()).isEqualTo(1L);
+        assertThat(root.at("/timers/api.latency/min").asDouble()).isEqualTo(750.0d);
+        assertThat(root.at("/timers/api.latency/duration_units").asText()).isEqualTo("microseconds");
+    }
+
+    @Test
+    void sampleArraysCanBeSuppressedWithoutRemovingDistributionStatistics() throws Exception {
+        ObjectMapper mapper = mapperWith(new MetricsModule(TimeUnit.SECONDS, TimeUnit.NANOSECONDS, false));
+        Histogram histogram = new Histogram(new SlidingWindowReservoir(10));
+        Timer timer = new Timer(new SlidingWindowReservoir(10));
+
+        histogram.update(4);
+        histogram.update(8);
+        timer.update(12, TimeUnit.NANOSECONDS);
+        timer.update(16, TimeUnit.NANOSECONDS);
+
+        JsonNode histogramJson = toJson(mapper, histogram);
+        JsonNode timerJson = toJson(mapper, timer);
+
+        assertThat(histogramJson.has("values")).isFalse();
+        assertThat(histogramJson.get("count").asLong()).isEqualTo(2L);
+        assertThat(histogramJson.get("min").asLong()).isEqualTo(4L);
+        assertThat(histogramJson.get("max").asLong()).isEqualTo(8L);
+        assertThat(histogramJson.get("p50").asDouble()).isEqualTo(6.0d);
+
+        assertThat(timerJson.has("values")).isFalse();
+        assertThat(timerJson.get("count").asLong()).isEqualTo(2L);
+        assertThat(timerJson.get("min").asDouble()).isEqualTo(12.0d);
+        assertThat(timerJson.get("max").asDouble()).isEqualTo(16.0d);
+        assertThat(timerJson.get("p50").asDouble()).isEqualTo(14.0d);
+        assertThat(timerJson.get("duration_units").asText()).isEqualTo("nanoseconds");
+    }
+
+    private static ObjectMapper mapperWith(MetricsModule module) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(module);
+        return mapper;
+    }
+
+    private static JsonNode toJson(ObjectMapper mapper, Object value) throws Exception {
+        return mapper.readTree(mapper.writeValueAsString(value));
+    }
+
+    private static List<String> fieldNames(JsonNode node) {
+        List<String> names = new ArrayList<>();
+        Iterator<String> iterator = node.fieldNames();
+        while (iterator.hasNext()) {
+            names.add(iterator.next());
+        }
+        return names;
+    }
+
+    private static List<Long> longValues(JsonNode node) {
+        List<Long> values = new ArrayList<>();
+        for (JsonNode value : node) {
+            values.add(value.asLong());
+        }
+        return values;
+    }
+
+    private static List<Double> doubleValues(JsonNode node) {
+        List<Double> values = new ArrayList<>();
+        for (JsonNode value : node) {
+            values.add(value.asDouble());
+        }
+        return values;
     }
 }

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/user-code-filter.json
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.codahale.metrics.json.**"
+    }
+  ]
+}

--- a/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/user-code-filter.json
+++ b/tests/src/io.dropwizard.metrics/metrics-json/4.2.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.codahale.metrics.json.**"
+      "includeClasses" : "com.codahale.metrics.json.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3060

This PR introduces tests and metadata for io.dropwizard.metrics:metrics-json:4.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 141396
- Cached input tokens: 886272
- Output tokens: 16552
- Entries: 4
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 219
- Tested library lines of code: 144

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `60823661b7840463506f36a43ea4456146609dfd`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 689/689 (100.00%)
- Line: 144/144 (100.00%)
- Method: 26/26 (100.00%)
