### PR TITLE
Do not require graphifyy for Forge install

### DIFF
--- a/forge/pyproject.toml
+++ b/forge/pyproject.toml
@@ -6,7 +6,6 @@ license = {file = "LICENSE"}
 dependencies = [
     "pylint",
     "jsonschema",
-    "graphifyy",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What changed
Removes `graphifyy` from the hard dependencies in `forge/pyproject.toml`.

Forge does not import `graphifyy` directly. Graphify-backed strategies call graphify through the selected agent session, and the prerequisite is documented for those opt-in strategies. Keeping it as a hard dependency makes plain `pip install -e .` fail when `graphifyy` is not available from the configured package index.

## Validation
- `python3 -m py_compile forge/ai_workflows/add_new_library_support.py forge/ai_workflows/agents/agent.py forge/ai_workflows/agents/codex_agent.py forge/ai_workflows/agents/pi_agent.py forge/benchmarks/benchmark_runner.py`
- `PYTHONPATH=. python3 utility_scripts/schema_validator.py strategy strategies/predefined_strategies.json`
- `PYTHONPATH=. python3 utility_scripts/schema_validator.py benchmark_suite benchmarks/benchmark_suite.json`

Closes #3903