### PR TITLE
[GenAI] Add support for org.apache.commons:commons-fileupload2-core:2.0.0-M2 using gpt-5.5

### DIFF
--- a/metadata/org.apache.commons/commons-fileupload2-core/2.0.0-M2/reachability-metadata.json
+++ b/metadata/org.apache.commons/commons-fileupload2-core/2.0.0-M2/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.fileupload2.core.DiskFileItem"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.commons/commons-fileupload2-core/index.json
+++ b/metadata/org.apache.commons/commons-fileupload2-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.0-M2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-fileupload2-core/2.0.0-M2/commons-fileupload2-core-2.0.0-M2-sources.jar",
+    "repository-url" : "https://github.com/apache/commons-fileupload",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-fileupload2-core/2.0.0-M2/commons-fileupload2-core-2.0.0-M2-test-sources.jar",
+    "documentation-url" : "https://github.com/apache/commons-fileupload/blob/rel/commons-fileupload-2.0.0-M2/src/site/xdoc/index.xml",
+    "description" : "Apache Commons FileUpload Core provides the core API and implementation for parsing multipart file upload requests in Java applications. It supports streamed or disk-backed processing of uploaded form fields and file items for web frameworks and server integrations.",
+    "tested-versions" : [
+      "2.0.0-M2"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.fileupload2.core"
+    ]
+  }
+]

--- a/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M2/execution-metrics.json
+++ b/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T18:33:39.871811Z",
+    "library": "org.apache.commons:commons-fileupload2-core:2.0.0-M2",
+    "starting_commit": "231d5b93143356aae55a67b92556d3b069bfa362",
+    "ending_commit": "3ca2c8260ce9599b87207b8960e7fa75d412de12",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-M2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3065,
+          "missed": 1002,
+          "ratio": 0.753627,
+          "total": 4067
+        },
+        "line": {
+          "covered": 722,
+          "missed": 242,
+          "ratio": 0.748963,
+          "total": 964
+        },
+        "method": {
+          "covered": 163,
+          "missed": 37,
+          "ratio": 0.815,
+          "total": 200
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 256288,
+      "cached_input_tokens_used": 1479168,
+      "output_tokens_used": 18089,
+      "iterations": 3,
+      "cost_usd": 1.2823,
+      "generated_loc": 397,
+      "tested_library_loc": 722,
+      "metadata_entries": 2,
+      "code_coverage_percent": 74.9
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java",
+      "metadata_file": "metadata/org.apache.commons/commons-fileupload2-core/2.0.0-M2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M2/stats.json
+++ b/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0-M2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3065,
+        "missed" : 1002,
+        "ratio" : 0.753627,
+        "total" : 4067
+      },
+      "line" : {
+        "covered" : 722,
+        "missed" : 242,
+        "ratio" : 0.748963,
+        "total" : 964
+      },
+      "method" : {
+        "covered" : 163,
+        "missed" : 37,
+        "ratio" : 0.815,
+        "total" : 200
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/.gitignore
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.commons:commons-fileupload2-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/gradle.properties
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.commons:commons-fileupload2-core:2.0.0-M2
+library.version = 2.0.0-M2
+metadata.dir = org.apache.commons/commons-fileupload2-core/2.0.0-M2/

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/settings.gradle
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.commons.commons-fileupload2-core_tests'

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -100,6 +100,27 @@ public class Commons_fileupload2_coreTest {
     }
 
     @Test
+    void decodesRfc2231EncodedDispositionParameters() throws Exception {
+        String boundary = "encoded-parameters";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name*=UTF-8''caf%C3%A9; filename*=UTF-8''r%C3%A9sum%C3%A9.txt",
+                        "Content-Type: text/plain; charset=UTF-8",
+                        "",
+                        "contents"));
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+
+        List<DiskFileItem> items = upload.parseRequest(request(boundary, body));
+
+        assertThat(items).singleElement().satisfies(item -> {
+            assertThat(item.getFieldName()).isEqualTo("café");
+            assertThat(item.isFormField()).isFalse();
+            assertThat(item.getName()).isEqualTo("résumé.txt");
+            assertThat(item.getContentType()).isEqualTo("text/plain; charset=UTF-8");
+            assertThat(item.getString()).isEqualTo("contents");
+        });
+    }
+
+    @Test
     void groupsRepeatedFormFieldsInParameterMap() throws Exception {
         String boundary = "grouped";
         byte[] body = multipart(boundary,

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_fileupload2_core;
+
+import org.junit.jupiter.api.Test;
+
+class Commons_fileupload2_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -6,11 +6,397 @@
  */
 package org_apache_commons.commons_fileupload2_core;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Commons_fileupload2_coreTest {
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.fileupload2.core.AbstractFileUpload;
+import org.apache.commons.fileupload2.core.DiskFileItem;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.core.FileItemFactory.AbstractFileItemBuilder;
+import org.apache.commons.fileupload2.core.FileItemHeaders;
+import org.apache.commons.fileupload2.core.FileItemInput;
+import org.apache.commons.fileupload2.core.FileItemInputIterator;
+import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadContentTypeException;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadSizeException;
+import org.apache.commons.fileupload2.core.MultipartInput;
+import org.apache.commons.fileupload2.core.ParameterParser;
+import org.apache.commons.fileupload2.core.RequestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Commons_fileupload2_coreTest {
+    private static final String CRLF = "\r\n";
+
+    @TempDir
+    Path tempDir;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void parsesMultipartRequestIntoDiskFileItemsWithHeadersAndProgress() throws Exception {
+        String boundary = "AaB03x";
+        String text = "Résumé café";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"description\"",
+                        "Content-Type: text/plain; charset=UTF-8",
+                        "X-Custom: first",
+                        "X-Custom: second",
+                        "",
+                        text),
+                part("Content-Disposition: form-data; name=\"upload\"; filename=\"notes.txt\"",
+                        "Content-Type: text/plain",
+                        "",
+                        "alpha\nbeta"));
+        Upload upload = newUpload(8);
+        AtomicLong lastBytesRead = new AtomicLong();
+        AtomicInteger lastItem = new AtomicInteger();
+        upload.setProgressListener((bytesRead, contentLength, items) -> {
+            lastBytesRead.set(bytesRead);
+            lastItem.set(items);
+        });
+
+        List<DiskFileItem> items = upload.parseRequest(request(boundary, body));
+
+        assertThat(items).hasSize(2);
+        DiskFileItem description = items.get(0);
+        assertThat(description.getFieldName()).isEqualTo("description");
+        assertThat(description.isFormField()).isTrue();
+        assertThat(description.getName()).isNull();
+        assertThat(description.getContentType()).isEqualTo("text/plain; charset=UTF-8");
+        assertThat(description.getCharset()).isEqualTo(StandardCharsets.UTF_8);
+        assertThat(description.getString()).isEqualTo(text);
+        assertThat(description.getHeaders().getHeader("x-custom")).isEqualTo("first");
+        assertThat(iteratorToList(description.getHeaders().getHeaders("X-Custom"))).containsExactly("first", "second");
+
+        DiskFileItem uploadItem = items.get(1);
+        assertThat(uploadItem.getFieldName()).isEqualTo("upload");
+        assertThat(uploadItem.isFormField()).isFalse();
+        assertThat(uploadItem.getName()).isEqualTo("notes.txt");
+        assertThat(uploadItem.getContentType()).isEqualTo("text/plain");
+        assertThat(uploadItem.getString(StandardCharsets.US_ASCII)).isEqualTo("alpha\nbeta");
+        assertThat(uploadItem.isInMemory()).isFalse();
+        assertThat(uploadItem.getPath()).isNotNull();
+        assertThat(Files.exists(uploadItem.getPath())).isTrue();
+        assertThat(lastBytesRead.get()).isGreaterThan(0);
+        assertThat(lastItem.get()).isEqualTo(2);
+    }
+
+    @Test
+    void groupsRepeatedFormFieldsInParameterMap() throws Exception {
+        String boundary = "grouped";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"tag\"", "", "red"),
+                part("Content-Disposition: form-data; name=\"tag\"", "", "blue"),
+                part("Content-Disposition: form-data; name=\"single\"", "", "value"));
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+
+        Map<String, List<DiskFileItem>> parameterMap = upload.parseParameterMap(request(boundary, body));
+
+        assertThat(parameterMap).containsOnlyKeys("tag", "single");
+        assertThat(parameterMap.get("tag")).extracting(item -> item.getString()).containsExactly("red", "blue");
+        assertThat(parameterMap.get("single")).singleElement().extracting(item -> item.getString()).isEqualTo("value");
+    }
+
+    @Test
+    void streamsNestedMultipartMixedFileItemsWithSharedFieldName() throws Exception {
+        String boundary = "outer";
+        String nestedBoundary = "inner";
+        String nestedBody = "--" + nestedBoundary + CRLF
+                + "Content-Disposition: attachment; filename=\"first.txt\"" + CRLF
+                + "Content-Type: text/plain" + CRLF
+                + CRLF
+                + "first" + CRLF
+                + "--" + nestedBoundary + CRLF
+                + "Content-Disposition: attachment; filename=\"second.txt\"" + CRLF
+                + "Content-Type: text/plain" + CRLF
+                + CRLF
+                + "second" + CRLF
+                + "--" + nestedBoundary + "--";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"files\"",
+                        "Content-Type: multipart/mixed; boundary=" + nestedBoundary,
+                        "",
+                        nestedBody));
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+
+        FileItemInputIterator iterator = upload.getItemIterator(request(boundary, body));
+
+        assertThat(iterator.hasNext()).isTrue();
+        FileItemInput first = iterator.next();
+        assertThat(first.getFieldName()).isEqualTo("files");
+        assertThat(first.isFormField()).isFalse();
+        assertThat(first.getName()).isEqualTo("first.txt");
+        assertThat(readUtf8(first.getInputStream())).isEqualTo("first");
+        assertThat(iterator.hasNext()).isTrue();
+        FileItemInput second = iterator.next();
+        assertThat(second.getFieldName()).isEqualTo("files");
+        assertThat(second.isFormField()).isFalse();
+        assertThat(second.getName()).isEqualTo("second.txt");
+        assertThat(readUtf8(second.getInputStream())).isEqualTo("second");
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
+    void enforcesRequestFileAndItemCountLimits() throws Exception {
+        String boundary = "limits";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"first\"", "", "1"),
+                part("Content-Disposition: form-data; name=\"second\"", "", "2"));
+        Upload requestLimitedUpload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+        requestLimitedUpload.setSizeMax(body.length - 1L);
+        assertThatExceptionOfType(FileUploadSizeException.class)
+                .isThrownBy(() -> requestLimitedUpload.parseRequest(request(boundary, body)))
+                .satisfies(exception -> {
+                    assertThat(exception.getPermitted()).isEqualTo(body.length - 1L);
+                    assertThat(exception.getActualSize()).isEqualTo(body.length);
+                });
+
+        Upload fileLimitedUpload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+        fileLimitedUpload.setFileSizeMax(3);
+        byte[] largeBody = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"payload\"; filename=\"payload.txt\"",
+                        "Content-Length: 4",
+                        "",
+                        "data"));
+        assertThatExceptionOfType(FileUploadByteCountLimitException.class)
+                .isThrownBy(() -> fileLimitedUpload.parseRequest(request(boundary, largeBody)))
+                .satisfies(exception -> {
+                    assertThat(exception.getFieldName()).isEqualTo("payload");
+                    assertThat(exception.getFileName()).isEqualTo("payload.txt");
+                    assertThat(exception.getPermitted()).isEqualTo(3);
+                    assertThat(exception.getActualSize()).isEqualTo(4);
+                });
+
+        Upload countLimitedUpload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+        countLimitedUpload.setFileCountMax(1);
+        assertThatExceptionOfType(FileUploadFileCountLimitException.class)
+                .isThrownBy(() -> countLimitedUpload.parseRequest(request(boundary, body)))
+                .satisfies(exception -> {
+                    assertThat(exception.getPermitted()).isEqualTo(1);
+                    assertThat(exception.getActualSize()).isEqualTo(1);
+                });
+    }
+
+    @Test
+    void rejectsNonMultipartAndMultipartWithoutBoundary() {
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+
+        assertThatExceptionOfType(FileUploadContentTypeException.class)
+                .isThrownBy(() -> upload.getItemIterator(new MemoryRequestContext("text/plain", new byte[0], StandardCharsets.UTF_8)))
+                .satisfies(exception -> assertThat(exception.getContentType()).isEqualTo("text/plain"));
+        assertThatThrownBy(() -> upload.getItemIterator(new MemoryRequestContext("multipart/form-data", new byte[0], StandardCharsets.UTF_8)))
+                .isInstanceOf(FileUploadException.class)
+                .hasMessageContaining("no multipart boundary");
+    }
+
+    @Test
+    void diskFileItemBuilderStoresSmallItemsInMemoryAndLargeItemsOnDisk() throws Exception {
+        FileItemHeaders headers = AbstractFileItemBuilder.newFileItemHeaders();
+        headers.addHeader("Content-Language", "en");
+        DiskFileItem inMemory = DiskFileItem.builder()
+                .setPath(tempDir)
+                .setBufferSize(64)
+                .setFieldName("comment")
+                .setFileName("comment.txt")
+                .setContentType("text/plain; charset=UTF-8")
+                .setFormField(true)
+                .setFileItemHeaders(headers)
+                .get();
+        try (OutputStream outputStream = inMemory.getOutputStream()) {
+            outputStream.write("hello".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertThat(inMemory.isInMemory()).isTrue();
+        assertThat(inMemory.getPath()).isNull();
+        assertThat(inMemory.get()).containsExactly("hello".getBytes(StandardCharsets.UTF_8));
+        assertThat(inMemory.getString()).isEqualTo("hello");
+        assertThat(inMemory.getHeaders().getHeader("content-language")).isEqualTo("en");
+        inMemory.setFieldName("renamed").setFormField(false);
+        assertThat(inMemory.getFieldName()).isEqualTo("renamed");
+        assertThat(inMemory.isFormField()).isFalse();
+        Path copied = tempDir.resolve("copied.txt");
+        inMemory.write(copied);
+        assertThat(Files.readString(copied)).isEqualTo("hello");
+
+        DiskFileItem onDisk = DiskFileItem.builder()
+                .setPath(tempDir)
+                .setBufferSize(4)
+                .setFieldName("upload")
+                .setFileName("large.txt")
+                .setContentType("application/octet-stream")
+                .get();
+        try (OutputStream outputStream = onDisk.getOutputStream()) {
+            outputStream.write("0123456789".getBytes(StandardCharsets.US_ASCII));
+        }
+        Path tempFile = onDisk.getPath();
+        assertThat(onDisk.isInMemory()).isFalse();
+        assertThat(tempFile).isNotNull();
+        assertThat(Files.exists(tempFile)).isTrue();
+        assertThat(onDisk.getSize()).isEqualTo(10);
+        assertThat(readUtf8(onDisk.getInputStream())).isEqualTo("0123456789");
+        Path moved = tempDir.resolve("moved.bin");
+        onDisk.write(moved);
+        assertThat(Files.readString(moved, StandardCharsets.US_ASCII)).isEqualTo("0123456789");
+        assertThat(onDisk.getSize()).isEqualTo(10);
+        assertThat(Files.exists(tempFile)).isFalse();
+    }
+
+    @Test
+    void validatesFileNamesAndParsesHeaderParameters() {
+        assertThat(DiskFileItem.checkFileName("safe-name.txt")).isEqualTo("safe-name.txt");
+        assertThatExceptionOfType(InvalidPathException.class)
+                .isThrownBy(() -> DiskFileItem.checkFileName("bad\0name.txt"))
+                .satisfies(exception -> {
+                    assertThat(exception.getInput()).isEqualTo("bad\0name.txt");
+                    assertThat(exception.getIndex()).isEqualTo(3);
+                    assertThat(exception.getReason()).contains("bad\\0name.txt");
+                });
+
+        ParameterParser parser = new ParameterParser();
+        parser.setLowerCaseNames(true);
+        Map<String, String> parameters = parser.parse("form-data; name=\"file\"; filename=\"a;b.txt\"; charset=UTF-8", ';');
+        assertThat(parameters).containsEntry("name", "file");
+        assertThat(parameters).containsEntry("filename", "a;b.txt");
+        assertThat(parameters).containsEntry("charset", "UTF-8");
+
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+        assertThat(upload.getBoundary("multipart/form-data; boundary=\"abc123\"")).containsExactly("abc123".getBytes(StandardCharsets.ISO_8859_1));
+        FileItemHeaders headers = upload.getParsedHeaders("Content-Disposition: form-data; name=\"field\"; filename=\"demo.txt\"" + CRLF
+                + "X-Long: first" + CRLF
+                + "\tcontinued" + CRLF
+                + CRLF);
+        assertThat(upload.getFieldName(headers)).isEqualTo("field");
+        assertThat(upload.getFileName(headers)).isEqualTo("demo.txt");
+        assertThat(headers.getHeader("x-long")).isEqualTo("first continued");
+        assertThat(iteratorToList(headers.getHeaderNames())).containsExactly("content-disposition", "x-long");
+        assertThat(AbstractFileUpload.isMultipartContent(request("abc", new byte[0]))).isTrue();
+        assertThat(AbstractFileUpload.isMultipartContent(new MemoryRequestContext(null, new byte[0], StandardCharsets.UTF_8))).isFalse();
+    }
+
+    @Test
+    void multipartInputReadsBodiesAndDiscardsUnneededParts() throws Exception {
+        String boundary = "raw";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"keep\"", "", "kept"),
+                part("Content-Disposition: form-data; name=\"drop\"", "", "discarded"));
+        MultipartInput input = MultipartInput.builder()
+                .setInputStream(new ByteArrayInputStream(body))
+                .setBoundary(boundary.getBytes(StandardCharsets.ISO_8859_1))
+                .get();
+
+        assertThat(input.skipPreamble()).isTrue();
+        assertThat(input.readHeaders()).contains("name=\"keep\"");
+        assertThat(readUtf8(input.newInputStream())).isEqualTo("kept");
+        assertThat(input.readBoundary()).isTrue();
+        assertThat(input.readHeaders()).contains("name=\"drop\"");
+        assertThat(input.discardBodyData()).isEqualTo("discarded".length());
+        assertThat(input.readBoundary()).isFalse();
+    }
+
+    private Upload newUpload(final int threshold) {
+        DiskFileItemFactory factory = DiskFileItemFactory.builder()
+                .setPath(tempDir)
+                .setBufferSize(threshold)
+                .setCharset(StandardCharsets.ISO_8859_1)
+                .get();
+        Upload upload = new Upload();
+        upload.setFileItemFactory(factory);
+        return upload;
+    }
+
+    private static MemoryRequestContext request(final String boundary, final byte[] body) {
+        return new MemoryRequestContext("multipart/form-data; boundary=" + boundary, body, StandardCharsets.UTF_8);
+    }
+
+    private static byte[] multipart(final String boundary, final String... parts) {
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            builder.append("--").append(boundary).append(CRLF).append(part).append(CRLF);
+        }
+        builder.append("--").append(boundary).append("--").append(CRLF);
+        return builder.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String part(final String... lines) {
+        return String.join(CRLF, lines);
+    }
+
+    private static String readUtf8(final InputStream inputStream) throws IOException {
+        try (InputStream stream = inputStream) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static List<String> iteratorToList(final Iterator<String> iterator) {
+        List<String> values = new ArrayList<>();
+        iterator.forEachRemaining(values::add);
+        return values;
+    }
+
+    private static final class Upload extends AbstractFileUpload<MemoryRequestContext, DiskFileItem, DiskFileItemFactory> {
+        @Override
+        public FileItemInputIterator getItemIterator(final MemoryRequestContext request) throws FileUploadException, IOException {
+            return super.getItemIterator((RequestContext) request);
+        }
+
+        @Override
+        public Map<String, List<DiskFileItem>> parseParameterMap(final MemoryRequestContext request) throws FileUploadException {
+            return super.parseParameterMap((RequestContext) request);
+        }
+
+        @Override
+        public List<DiskFileItem> parseRequest(final MemoryRequestContext request) throws FileUploadException {
+            return super.parseRequest((RequestContext) request);
+        }
+    }
+
+    private static final class MemoryRequestContext implements RequestContext {
+        private final String contentType;
+        private final byte[] body;
+        private final Charset charset;
+
+        private MemoryRequestContext(final String contentType, final byte[] body, final Charset charset) {
+            this.contentType = contentType;
+            this.body = body.clone();
+            this.charset = charset;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return charset.name();
+        }
+
+        @Override
+        public long getContentLength() {
+            return body.length;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(body);
+        }
     }
 }

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -53,7 +53,7 @@ public class Commons_fileupload2_coreTest {
     @Test
     void parsesMultipartRequestIntoDiskFileItemsWithHeadersAndProgress() throws Exception {
         String boundary = "AaB03x";
-        String text = "Résumé café";
+        String text = "R\u00e9sum\u00e9 caf\u00e9";
         byte[] body = multipart(boundary,
                 part("Content-Disposition: form-data; name=\"description\"",
                         "Content-Type: text/plain; charset=UTF-8",
@@ -112,9 +112,9 @@ public class Commons_fileupload2_coreTest {
         List<DiskFileItem> items = upload.parseRequest(request(boundary, body));
 
         assertThat(items).singleElement().satisfies(item -> {
-            assertThat(item.getFieldName()).isEqualTo("café");
+            assertThat(item.getFieldName()).isEqualTo("caf\u00e9");
             assertThat(item.isFormField()).isFalse();
-            assertThat(item.getName()).isEqualTo("résumé.txt");
+            assertThat(item.getName()).isEqualTo("r\u00e9sum\u00e9.txt");
             assertThat(item.getContentType()).isEqualTo("text/plain; charset=UTF-8");
             assertThat(item.getString()).isEqualTo("contents");
         });

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -155,6 +155,29 @@ public class Commons_fileupload2_coreTest {
     }
 
     @Test
+    void streamingIteratorSkipsUnreadPartWhenAdvanced() throws Exception {
+        String boundary = "skip-unread";
+        byte[] body = multipart(boundary,
+                part("Content-Disposition: form-data; name=\"first\"", "", "unread payload"),
+                part("Content-Disposition: form-data; name=\"second\"", "", "read payload"));
+        Upload upload = newUpload(DiskFileItemFactory.DEFAULT_THRESHOLD);
+
+        FileItemInputIterator iterator = upload.getItemIterator(request(boundary, body));
+
+        assertThat(iterator.hasNext()).isTrue();
+        FileItemInput first = iterator.next();
+        assertThat(first.getFieldName()).isEqualTo("first");
+        assertThat(iterator.hasNext()).isTrue();
+        FileItemInput second = iterator.next();
+        assertThat(second.getFieldName()).isEqualTo("second");
+        assertThat(readUtf8(second.getInputStream())).isEqualTo("read payload");
+        assertThatExceptionOfType(FileItemInput.ItemSkippedException.class)
+                .isThrownBy(() -> first.getInputStream())
+                .withMessageContaining("getInputStream()");
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
     void enforcesRequestFileAndItemCountLimits() throws Exception {
         String boundary = "limits";
         byte[] body = multipart(boundary,

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.commons.fileupload2.core.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.commons.fileupload2.core.**"
+      "includeClasses" : "org.apache.commons.fileupload2.core.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3789

This PR introduces tests and metadata for org.apache.commons:commons-fileupload2-core:2.0.0-M2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 256288
- Cached input tokens: 1479168
- Output tokens: 18089
- Entries: 2
- Iterations: 3
- Library coverage percentage: 74.9
- Generated lines of code: 397
- Tested library lines of code: 722

### Metadata Forge

- Forge monitored branch: `mm/test-all-graal-versions`
- Forge branch: `mm/test-all-graal-versions`
- Forge commit hash: `bd80a18f356c51ea7089f1f3985748831c92387c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3065/4067 (75.36%)
- Line: 722/964 (74.90%)
- Method: 163/200 (81.50%)
