### PR TITLE
Run test finalization for all GraalVM versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,6 @@
 ## One command for complete infrastructure testing
 ./gradlew testAllInfra -Pparallelism=4 --stacktrace
 
-## Future-defaults testing
-- Do not run `future-defaults-all` by default on regular released GraalVM/JDK versions.
-- Run the future-defaults lane only when explicitly validating against an early-access or latest GraalVM build, including versions named `ea`, `dev`, or `latest`.
-
 ## Code Style
 - Always try to reuse existing code.
 - Be assertive in code.
@@ -48,7 +44,6 @@
   - ./gradlew pullAllowedDockerImages -Pcoordinates=group:artifact:version
   - ./gradlew checkMetadataFiles -Pcoordinates=group:artifact:version
   - ./gradlew test -Pcoordinates=group:artifact:version
-  - If using an early-access/latest GraalVM build, also run: GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=group:artifact:version
 - Sharded example (1/64):
   - ./gradlew pullAllowedDockerImages -Pcoordinates=1/64
   - ./gradlew checkMetadataFiles -Pcoordinates=1/64

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 import re
 import subprocess
 import sys
+from typing import Callable
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from ai_workflows.fix_post_generation_pi import (
@@ -134,6 +135,19 @@ class WorkflowStrategy(ABC):
         result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         return result.stdout
 
+    def _run_command_with_env(self, cmd: str, env: dict[str, str] | None = None) -> str:
+        """Execute a shell command with optional environment overrides."""
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            cwd=getattr(self, "reachability_repo_path", None),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        return result.stdout
+
     @staticmethod
     def _get_first_failed_task(output: str):
         """Extract the first Gradle task name that failed from build output, or None."""
@@ -145,47 +159,93 @@ class WorkflowStrategy(ABC):
         """Run Gradle tests for a library and classify post-generation failures."""
         self.post_generation_intervention = None
         test_cmd = f"./gradlew test -Pcoordinates={library}"
-        test_output = self._run_command(test_cmd)
-        if self._get_first_failed_task(test_output) is None:
-            return RUN_STATUS_SUCCESS
-
-        log_stage("metadata-fix", f"Running metadata fix workflow for {self.library}")
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
-        codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(repo_path, library)
-        recovery_test_output = test_output
-        if not codex_timed_out and codex_rc == 0:
-            recovery_test_output = self._run_command(test_cmd)
-            if self._get_first_failed_task(recovery_test_output) is None:
+        final_status = RUN_STATUS_SUCCESS
+
+        def run_lane(
+                stage_name: str,
+                command_runner: Callable[[], str],
+        ) -> str:
+            log_stage("post-generation-test", f"Running {stage_name} for {library}")
+            test_output = command_runner()
+            if self._get_first_failed_task(test_output) is None:
+                log_stage("post-generation-test", f"{stage_name} passed for {library}")
                 return RUN_STATUS_SUCCESS
-        log_stage("post-generation-fix", f"Running pi post generation fix for {self.library}")
-        pi_rc, intervention_path, pi_timed_out = run_pi_post_generation_fix(
-            reachability_metadata_path=repo_path,
-            coordinates=library,
-            codex_log_path=codex_log_path,
-            test_output=recovery_test_output,
-            model_name=self.model_name,
-            timeout_seconds=self._parameter_int("post-generation-timeout-seconds", DEFAULT_PI_TIMEOUT_SECONDS),
-            max_test_output_chars=self._parameter_int(
-                "post-generation-test-output-chars",
-                DEFAULT_MAX_TEST_OUTPUT_CHARS,
-            ),
+
+            log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
+            codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(repo_path, library)
+            recovery_test_output = test_output
+            if not codex_timed_out and codex_rc == 0:
+                recovery_test_output = command_runner()
+                if self._get_first_failed_task(recovery_test_output) is None:
+                    log_stage("post-generation-test", f"{stage_name} passed for {library} after metadata fix")
+                    return RUN_STATUS_SUCCESS
+
+            log_stage("post-generation-fix", f"Running pi post generation fix for {library} after {stage_name} failure")
+            pi_rc, intervention_path, pi_timed_out = run_pi_post_generation_fix(
+                reachability_metadata_path=repo_path,
+                coordinates=library,
+                codex_log_path=codex_log_path,
+                test_output=recovery_test_output,
+                model_name=self.model_name,
+                timeout_seconds=self._parameter_int("post-generation-timeout-seconds", DEFAULT_PI_TIMEOUT_SECONDS),
+                max_test_output_chars=self._parameter_int(
+                    "post-generation-test-output-chars",
+                    DEFAULT_MAX_TEST_OUTPUT_CHARS,
+                ),
+            )
+            if pi_timed_out or pi_rc != 0:
+                return RUN_STATUS_FAILURE
+
+            rerun_output = command_runner()
+            if self._get_first_failed_task(rerun_output) is not None:
+                return RUN_STATUS_FAILURE
+
+            with open(intervention_path, "r", encoding="utf-8") as intervention_file:
+                intervention_markdown = intervention_file.read().strip()
+
+            if self.post_generation_intervention is None:
+                self.post_generation_intervention = {
+                    "stage": POST_GENERATION_STAGE_METADATA_FIX_FAILED,
+                    "intervention_file": os.path.relpath(intervention_path, repo_path),
+                    "analysis_markdown": intervention_markdown,
+                }
+            return SUCCESS_WITH_INTERVENTION_STATUS
+
+        regular_status = run_lane(
+            "current-defaults latest GRAALVM test",
+            lambda: self._run_command_with_env(test_cmd),
         )
-        if pi_timed_out or pi_rc != 0:
+        if regular_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE
+        if regular_status == SUCCESS_WITH_INTERVENTION_STATUS:
+            final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
-        rerun_output = self._run_command(test_cmd)
-        if self._get_first_failed_task(rerun_output) is not None:
+        future_defaults_env = dict(os.environ)
+        future_defaults_env["GVM_TCK_NATIVE_IMAGE_MODE"] = "future-defaults-all"
+        future_defaults_status = run_lane(
+            "future-defaults latest GRAALVM test",
+            lambda: self._run_command_with_env(test_cmd, future_defaults_env),
+        )
+        if future_defaults_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE
+        if future_defaults_status == SUCCESS_WITH_INTERVENTION_STATUS:
+            final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
-        with open(intervention_path, "r", encoding="utf-8") as intervention_file:
-            intervention_markdown = intervention_file.read().strip()
+        graalvm_25_home = os.environ["GRAALVM_HOME_25_0"]
+        graalvm_25_env = dict(os.environ)
+        graalvm_25_env["GRAALVM_HOME"] = graalvm_25_home
+        graalvm_25_env["JAVA_HOME"] = graalvm_25_home
+        graalvm_25_status = run_lane(
+            "current-defaults GRAALVM_25_0 test",
+            lambda: self._run_command_with_env(test_cmd, graalvm_25_env),
+        )
+        if graalvm_25_status == RUN_STATUS_FAILURE:
+            return RUN_STATUS_FAILURE
+        if graalvm_25_status == SUCCESS_WITH_INTERVENTION_STATUS:
+            final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
-        self.post_generation_intervention = {
-            "stage": POST_GENERATION_STAGE_METADATA_FIX_FAILED,
-            "intervention_file": os.path.relpath(intervention_path, repo_path),
-            "analysis_markdown": intervention_markdown,
-        }
-        return SUCCESS_WITH_INTERVENTION_STATUS
+        return final_status
 
     def _run_gradle_command_with_output(self, command: list[str]) -> subprocess.CompletedProcess[str]:
         """Run a Gradle command in the reachability repo and capture combined output."""

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -80,7 +80,7 @@ from utility_scripts.task_logs import (
     resolve_logs_root,
     sanitize_library_log_segment,
 )
-from utility_scripts.workflow_setup import require_graalvm_home_env, run_metadata_fix_until_tests_pass
+from utility_scripts.workflow_setup import require_graalvm_home_env
 
 try:
     import fcntl
@@ -2313,25 +2313,6 @@ def invoke_pipeline(
         if rc != 0:
             print(
                 f"\nERROR: add_new_library_support workflow failed for issue #{issue_number} (exit {rc})",
-                file=sys.stderr,
-            )
-            return False
-        graalvm_25_home = require_graalvm_home_env(POST_GENERATION_GRAALVM_ENV_VAR)
-        log_stage(
-            "post-generation-validation",
-            f"Running validation for issue #{issue_number} with {POST_GENERATION_GRAALVM_ENV_VAR}",
-        )
-        if not run_metadata_fix_until_tests_pass(
-            repo_path=claimed_issue.worktree_path,
-            library=claimed_issue.issue_coordinates,
-            graalvm_home=graalvm_25_home,
-            graalvm_env_var_name=POST_GENERATION_GRAALVM_ENV_VAR,
-        ):
-            if is_user_interrupt_requested():
-                raise KeyboardInterrupt
-            print(
-                f"ERROR: Post-generation validation failed for issue #{issue_number} with "
-                f"{POST_GENERATION_GRAALVM_ENV_VAR}.",
                 file=sys.stderr,
             )
             return False

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -895,14 +895,12 @@ class InterruptHandlingTests(unittest.TestCase):
         claimed_issue = _claimed_issue()
 
         with patch.object(forge_metadata, "run_add_new_library_support_workflow", return_value=130), \
-                patch.object(forge_metadata, "require_graalvm_home_env") as require_graalvm_home, \
-                patch.object(forge_metadata, "run_metadata_fix_until_tests_pass") as validate_metadata:
+                patch.object(forge_metadata, "require_graalvm_home_env") as require_graalvm_home:
             with self.assertRaises(KeyboardInterrupt):
                 forge_metadata.invoke_pipeline(claimed_issue, None, False)
 
         self.assertTrue(forge_metadata.is_user_interrupt_requested())
         require_graalvm_home.assert_not_called()
-        validate_metadata.assert_not_called()
 
     def test_interrupted_failed_workflow_skips_human_intervention_handling(self) -> None:
         claimed_issue = _claimed_issue()


### PR DESCRIPTION
### Summary

Closes #3917.

This PR moves the extra post-generation validation into `_run_test_with_retry()` so workflows using that path run the same validation sequence before finalization continues.

### Flow

The validation flow now runs these lanes in order:

1. Regular test: `./gradlew test -Pcoordinates=<library>`.
2. Future-defaults test: the same command with `GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all`.
3. GraalVM 25.0 test: the same command with `GRAALVM_HOME` and `JAVA_HOME` set from `GRAALVM_HOME_25_0`.

For each lane, failure recovery follows the same pattern:

1. Run Codex metadata fix.
2. Rerun the failed lane.
3. If it still fails, run Pi post-generation intervention.
4. Rerun the failed lane again.
5. If it still fails, return workflow failure.

If Pi intervention succeeds, the workflow returns `success_with_intervention`. The first recorded intervention remains sticky and is not overwritten by later lanes.

### Details

- Removed the old Forge-only post-generation GraalVM 25.0 validation from `forge_metadata.py` to avoid running that lane twice.
- Kept `GRAALVM_HOME_25_0` validation centralized in Forge startup checks.
- Removed the manual future-defaults instruction from `AGENTS.md`, because the workflow now runs that lane automatically.

### Verification

- `python3 -m py_compile ai_workflows/workflow_strategies/workflow_strategy.py forge_metadata.py tests/test_forge_metadata.py`
- `python3 -m unittest tests.test_forge_metadata.InterruptHandlingTests.test_interrupt_return_code_from_workflow_raises_keyboard_interrupt`
