### PR TITLE
Pass validation lane reproduction command to Codex

### DIFF
--- a/forge/ai_workflows/fix_metadata_codex.py
+++ b/forge/ai_workflows/fix_metadata_codex.py
@@ -12,13 +12,19 @@ CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1200
 
 
-def run_codex_metadata_fix(reachability_metadata_path: str, coordinates: str) -> tuple[int, str, bool]:
+def run_codex_metadata_fix(
+        reachability_metadata_path: str,
+        coordinates: str,
+        reproduction_command: str | None = None,
+) -> tuple[int, str, bool]:
     """Run Codex to update metadata entries for the target library.
 
     Requires the ``fix-missing-reachability-metadata`` skill. The skill definition lives at:
     https://github.com/oracle/graalvm-reachability-metadata/blob/master/skills/fix-missing-reachability-metadata/SKILL.md
     """
     prompt = f"Fix the metadata entries for {coordinates}"
+    if reproduction_command:
+        prompt += f"\n\nReproduce the failure with:\n{reproduction_command}"
     cmd = [
         "codex", "exec",
         "--dangerously-bypass-approvals-and-sandbox",

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -165,6 +165,7 @@ class WorkflowStrategy(ABC):
         def run_lane(
                 stage_name: str,
                 command_runner: Callable[[], str],
+                reproduction_command: str,
         ) -> str:
             log_stage("post-generation-test", f"Running {stage_name} for {library}")
             test_output = command_runner()
@@ -173,7 +174,11 @@ class WorkflowStrategy(ABC):
                 return RUN_STATUS_SUCCESS
 
             log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
-            codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(repo_path, library)
+            codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
+                repo_path,
+                library,
+                reproduction_command=reproduction_command,
+            )
             recovery_test_output = test_output
             if not codex_timed_out and codex_rc == 0:
                 recovery_test_output = command_runner()
@@ -215,6 +220,7 @@ class WorkflowStrategy(ABC):
         regular_status = run_lane(
             "current-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd),
+            test_cmd,
         )
         if regular_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE
@@ -226,6 +232,7 @@ class WorkflowStrategy(ABC):
         future_defaults_status = run_lane(
             "future-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd, future_defaults_env),
+            f"GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all {test_cmd}",
         )
         if future_defaults_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE
@@ -239,6 +246,7 @@ class WorkflowStrategy(ABC):
         graalvm_25_status = run_lane(
             "current-defaults GRAALVM_25_0 test",
             lambda: self._run_command_with_env(test_cmd, graalvm_25_env),
+            f"GRAALVM_HOME=$GRAALVM_HOME_25_0 JAVA_HOME=$GRAALVM_HOME_25_0 {test_cmd}",
         )
         if graalvm_25_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE


### PR DESCRIPTION
### Summary

Closes #3919.

Codex metadata fix currently receives only the target coordinates. After the validation flow added multiple test lanes, Codex can be invoked after a failure in the regular, future-defaults, or GraalVM 25.0 lane, but it is not told how to reproduce that specific lane.

This PR adds optional reproduction guidance to `run_codex_metadata_fix()` and passes the failed lane's command from `_run_test_with_retry()`.

### Details

- Keeps existing callers unchanged by making the reproduction command optional.
- Regular lane passes `./gradlew test -Pcoordinates=<library>`.
- Future-defaults lane passes `GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all ./gradlew test -Pcoordinates=<library>`.
- GraalVM 25.0 lane passes the command with `GRAALVM_HOME` and `JAVA_HOME` set from `GRAALVM_HOME_25_0`.