### PR TITLE
[GenAI] Add support for org.crac:crac:1.5.0 using gpt-5.5

### DIFF
--- a/metadata/org.crac/crac/1.5.0/reachability-metadata.json
+++ b/metadata/org.crac/crac/1.5.0/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$ResourceWrapper"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "equals",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.crac/crac/index.json
+++ b/metadata/org.crac/crac/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.5.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/crac/crac/1.5.0/crac-1.5.0-sources.jar",
+    "repository-url" : "https://github.com/CRaC/org.crac",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/crac/crac/1.5.0/crac-1.5.0-javadoc.jar",
+    "description" : "org.crac provides a compatibility wrapper for the OpenJDK CRaC API so applications can compile and run across JDKs with jdk.crac, javax.crac, or no CRaC implementation. At runtime it detects an available CRaC implementation and delegates to it, otherwise it uses a dummy implementation that lets applications run while checkpoint requests fail.",
+    "tested-versions" : [
+      "1.5.0"
+    ],
+    "allowed-packages" : [
+      "org.crac"
+    ]
+  }
+]

--- a/stats/org.crac/crac/1.5.0/execution-metrics.json
+++ b/stats/org.crac/crac/1.5.0/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T23:34:57.724392Z",
+    "library": "org.crac:crac:1.5.0",
+    "starting_commit": "cec6cebec31537e33bef7277578cd8950632c2c0",
+    "ending_commit": "d6e4e45a596ff7efa93ba53fd916772eb344b171",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 17,
+            "totalCalls": 17
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 17,
+        "totalCalls": 17
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 283,
+          "missed": 219,
+          "ratio": 0.563745,
+          "total": 502
+        },
+        "line": {
+          "covered": 69,
+          "missed": 65,
+          "ratio": 0.514925,
+          "total": 134
+        },
+        "method": {
+          "covered": 19,
+          "missed": 15,
+          "ratio": 0.558824,
+          "total": 34
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 108006,
+      "cached_input_tokens_used": 1278976,
+      "output_tokens_used": 23261,
+      "iterations": 3,
+      "cost_usd": 1.3373,
+      "generated_loc": 241,
+      "tested_library_loc": 69,
+      "metadata_entries": 2,
+      "test_only_metadata_entries": 12,
+      "code_coverage_percent": 51.49
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CRaCImplTest.java",
+      "metadata_file": "metadata/org.crac/crac/1.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.crac/crac/1.5.0/stats.json
+++ b/stats/org.crac/crac/1.5.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 17,
+          "totalCalls" : 17
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 17,
+      "totalCalls" : 17
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 283,
+        "missed" : 219,
+        "ratio" : 0.563745,
+        "total" : 502
+      },
+      "line" : {
+        "covered" : 69,
+        "missed" : 65,
+        "ratio" : 0.514925,
+        "total" : 134
+      },
+      "method" : {
+        "covered" : 19,
+        "missed" : 15,
+        "ratio" : 0.558824,
+        "total" : 34
+      }
+    }
+  } ]
+}

--- a/tests/src/org.crac/crac/1.5.0/.gitignore
+++ b/tests/src/org.crac/crac/1.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.crac/crac/1.5.0/build.gradle
+++ b/tests/src/org.crac/crac/1.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.crac:crac:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/gradle.properties
+++ b/tests/src/org.crac/crac/1.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.crac:crac:1.5.0
+library.version = 1.5.0
+metadata.dir = org.crac/crac/1.5.0/

--- a/tests/src/org.crac/crac/1.5.0/settings.gradle
+++ b/tests/src/org.crac/crac/1.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.crac.crac_tests'

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/CheckpointException.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/CheckpointException.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax.crac;
+
+public class CheckpointException extends Exception {
+    private static final long serialVersionUID = 1L;
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Context.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Context.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax.crac;
+
+public interface Context<R extends Resource> {
+    void register(R resource);
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Core.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Core.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax.crac;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class Core {
+    private static final GlobalContext GLOBAL_CONTEXT = new GlobalContext();
+    private static int checkpointRestoreCount;
+
+    private Core() {
+    }
+
+    public static Context<Resource> getGlobalContext() {
+        return GLOBAL_CONTEXT;
+    }
+
+    public static void checkpointRestore() throws CheckpointException, RestoreException {
+        checkpointRestoreCount++;
+    }
+
+    public static int registeredResourceCount() {
+        return GLOBAL_CONTEXT.registeredResourceCount();
+    }
+
+    public static int checkpointRestoreCount() {
+        return checkpointRestoreCount;
+    }
+
+    public static void clear() {
+        GLOBAL_CONTEXT.clear();
+        checkpointRestoreCount = 0;
+    }
+
+    private static final class GlobalContext implements Context<Resource> {
+        private final List<Resource> resources = new ArrayList<>();
+
+        @Override
+        public void register(Resource resource) {
+            resources.add(Objects.requireNonNull(resource));
+        }
+
+        private int registeredResourceCount() {
+            return resources.size();
+        }
+
+        private void clear() {
+            resources.clear();
+        }
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Core.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Core.java
@@ -33,6 +33,10 @@ public final class Core {
         return checkpointRestoreCount;
     }
 
+    public static boolean firstRegisteredResourceEquals(Object candidate) {
+        return GLOBAL_CONTEXT.firstRegisteredResourceEquals(candidate);
+    }
+
     public static void clear() {
         GLOBAL_CONTEXT.clear();
         checkpointRestoreCount = 0;
@@ -48,6 +52,10 @@ public final class Core {
 
         private int registeredResourceCount() {
             return resources.size();
+        }
+
+        private boolean firstRegisteredResourceEquals(Object candidate) {
+            return !resources.isEmpty() && resources.get(0).equals(candidate);
         }
 
         private void clear() {

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Resource.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/Resource.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax.crac;
+
+public interface Resource {
+    void beforeCheckpoint(Context<? extends Resource> context) throws Exception;
+
+    void afterRestore(Context<? extends Resource> context) throws Exception;
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/RestoreException.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/javax/crac/RestoreException.java
@@ -4,13 +4,8 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package org_crac.crac;
+package javax.crac;
 
-import org.junit.jupiter.api.Test;
-
-class CracTest {
-    @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
-    }
+public class RestoreException extends Exception {
+    private static final long serialVersionUID = 1L;
 }

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CRaCImplTest.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CRaCImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_crac.crac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.PlatformManagedObject;
+import java.lang.reflect.Constructor;
+
+import javax.management.ObjectName;
+
+import org.crac.management.CRaCMXBean;
+import org.junit.jupiter.api.Test;
+
+public class CRaCImplTest {
+    @Test
+    void delegatesRestoreMetricsToPlatformBean() throws Exception {
+        ObjectName objectName = new ObjectName("org.crac.test:type=CRaC");
+        CRaCMXBean bean = newCRaCMXBean(new RecordingPlatformBean(123L, 456L, objectName));
+
+        assertThat(bean.getUptimeSinceRestore()).isEqualTo(123L);
+        assertThat(bean.getRestoreTime()).isEqualTo(456L);
+        assertThat(bean.getObjectName()).isEqualTo(objectName);
+    }
+
+    @Test
+    void reportsUnavailableMetricsWhenPlatformBeanThrows() throws Exception {
+        CRaCMXBean bean = newCRaCMXBean(new FailingPlatformBean());
+
+        assertThat(bean.getUptimeSinceRestore()).isEqualTo(-1L);
+        assertThat(bean.getRestoreTime()).isEqualTo(-1L);
+    }
+
+    private static CRaCMXBean newCRaCMXBean(PlatformCRaCMXBean platformBean) throws Exception {
+        Class<?> implementationClass = Class.forName("org.crac.management.CRaCImpl");
+        Constructor<?> constructor = implementationClass.getDeclaredConstructor(Class.class, PlatformManagedObject.class);
+        constructor.setAccessible(true);
+        return (CRaCMXBean) constructor.newInstance(PlatformCRaCMXBean.class, platformBean);
+    }
+
+    public interface PlatformCRaCMXBean extends PlatformManagedObject {
+        long getUptimeSinceRestore();
+
+        long getRestoreTime();
+    }
+
+    public static final class RecordingPlatformBean implements PlatformCRaCMXBean {
+        private final long uptimeSinceRestore;
+        private final long restoreTime;
+        private final ObjectName objectName;
+
+        RecordingPlatformBean(long uptimeSinceRestore, long restoreTime, ObjectName objectName) {
+            this.uptimeSinceRestore = uptimeSinceRestore;
+            this.restoreTime = restoreTime;
+            this.objectName = objectName;
+        }
+
+        @Override
+        public long getUptimeSinceRestore() {
+            return uptimeSinceRestore;
+        }
+
+        @Override
+        public long getRestoreTime() {
+            return restoreTime;
+        }
+
+        @Override
+        public ObjectName getObjectName() {
+            return objectName;
+        }
+    }
+
+    public static final class FailingPlatformBean implements PlatformCRaCMXBean {
+        @Override
+        public long getUptimeSinceRestore() {
+            throw new IllegalStateException("uptime unavailable");
+        }
+
+        @Override
+        public long getRestoreTime() {
+            throw new IllegalStateException("restore time unavailable");
+        }
+
+        @Override
+        public ObjectName getObjectName() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CoreInnerCompatTest.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CoreInnerCompatTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_crac.crac;
+
+import static javax.crac.Core.checkpointRestoreCount;
+import static javax.crac.Core.clear;
+import static javax.crac.Core.registeredResourceCount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CoreInnerCompatTest {
+    @BeforeEach
+    void clearCompatState() {
+        clear();
+    }
+
+    @Test
+    void registerAndCheckpointRestoreDelegateToCompatibilityApi() throws Exception {
+        Core.getGlobalContext().register(new RecordingResource());
+
+        assertThat(registeredResourceCount()).isEqualTo(1);
+
+        Core.checkpointRestore();
+
+        assertThat(checkpointRestoreCount()).isEqualTo(1);
+    }
+
+    private static final class RecordingResource implements Resource {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+            throw new AssertionError("Unexpected checkpoint callback");
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            throw new AssertionError("Unexpected restore callback");
+        }
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CoreInnerResourceWrapperTest.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CoreInnerResourceWrapperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_crac.crac;
+
+import static javax.crac.Core.clear;
+import static javax.crac.Core.firstRegisteredResourceEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CoreInnerResourceWrapperTest {
+    @BeforeEach
+    void clearCompatState() {
+        clear();
+    }
+
+    @Test
+    void objectMethodCallsAreDelegatedToWrappedResource() {
+        Resource resource = new PassiveResource();
+
+        Core.getGlobalContext().register(resource);
+
+        assertThat(firstRegisteredResourceEquals(resource)).isTrue();
+    }
+
+    private static final class PassiveResource implements Resource {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+        }
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CracTest.java
+++ b/tests/src/org.crac/crac/1.5.0/src/test/java/org_crac/crac/CracTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_crac.crac;
+
+import org.junit.jupiter.api.Test;
+
+class CracTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.crac/crac/1.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.crac/crac/1.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,78 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : "javax.crac.CheckpointException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : "javax.crac.Context",
+      "methods" : [
+        {
+          "name" : "register",
+          "parameterTypes" : [
+            "javax.crac.Resource"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : "javax.crac.Core",
+      "methods" : [
+        {
+          "name" : "checkpointRestore",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getGlobalContext",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : "javax.crac.Resource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : "javax.crac.RestoreException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.management.CRaCImpl"
+      },
+      "type" : "org_crac.crac.CRaCImplTest$PlatformCRaCMXBean",
+      "methods" : [
+        {
+          "name" : "getRestoreTime",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUptimeSinceRestore",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.crac.Core$Compat"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.crac.Resource"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/org.crac/crac/1.5.0/user-code-filter.json
+++ b/tests/src/org.crac/crac/1.5.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.crac.**"
+      "includeClasses" : "org.crac.**"
     }
   ]
 }

--- a/tests/src/org.crac/crac/1.5.0/user-code-filter.json
+++ b/tests/src/org.crac/crac/1.5.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.crac.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3731

This PR introduces tests and metadata for org.crac:crac:1.5.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 108006
- Cached input tokens: 1278976
- Output tokens: 23261
- Metadata entries: 2
- Test-only metadata entries: 12
- Iterations: 3
- Library coverage percentage: 51.49
- Generated lines of code: 241
- Tested library lines of code: 69

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3721cf138689bc7a5e27699773806f01b4c4a1f8`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 17/17 covered calls (100.00%)
- Reflection: 17/17 covered calls (100.00%)

Library coverage:
- Instruction: 283/502 (56.37%)
- Line: 69/134 (51.49%)
- Method: 19/34 (55.88%)
