### PR TITLE
[GenAI] Add support for io.lettuce:lettuce-core:6.1.10.RELEASE using gpt-5.5

### DIFF
--- a/metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json
+++ b/metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json
@@ -1,0 +1,367 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.jfr.JfrEventRecorder"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.LettuceClassUtils"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectEvent"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.jfr.JfrEventRecorder"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionEventSupport"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.LettuceClassUtils"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectedEvent"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.AddressResolverGroupProvider"
+      },
+      "type": "io.netty.resolver.dns$DnsAddressResolverGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.AddressResolverGroupProvider"
+      },
+      "type": "io.netty.resolver.dns.DnsAddressResolverGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.HashedWheelTimer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.ResourceLeakDetector$DefaultResourceLeak"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultEventLoopGroupProvider"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultEventLoopGroupProvider"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.jfr.EventRecorderHolder"
+      },
+      "type": "jdk.jfr.Event"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.HdrHistogram$Histogram"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.HdrHistogram.Histogram"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.LatencyUtils$PauseDetector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.LatencyUtils.PauseDetector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.DirectProcessor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.FluxCreate$BaseSink"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.FluxCreate$SerializedSink"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.util.concurrent.MpscLinkedQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.util.concurrent.MpscLinkedQueue$LinkedQueueNode"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandArgs$KeyArgument"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandArgs$ValueArgument"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.codec.StringCodec"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.connection.JfrConnectEvent"
+      },
+      "module": "jdk.jfr",
+      "glob": "jdk/jfr/internal/types/metadata.bin"
+    }
+  ]
+}

--- a/metadata/io.lettuce/lettuce-core/index.json
+++ b/metadata/io.lettuce/lettuce-core/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.1.10.RELEASE",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/lettuce/lettuce-core/6.1.10.RELEASE/lettuce-core-6.1.10.RELEASE-sources.jar",
+    "repository-url" : "https://github.com/redis/lettuce",
+    "test-code-url" : "https://github.com/redis/lettuce/tree/6.1.10.RELEASE/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/lettuce/lettuce-core/6.1.10.RELEASE/lettuce-core-6.1.10.RELEASE-docs.zip",
+    "description" : "Lettuce is a scalable, thread-safe Redis client for Java applications with synchronous, asynchronous, and reactive APIs. It supports advanced Redis features including Sentinel, Cluster, pipelining, auto-reconnect, codecs, native transports, and multiple command interface styles.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "1.4"
+    },
+    "tested-versions" : [
+      "6.1.10.RELEASE"
+    ],
+    "allowed-packages" : [
+      "io.lettuce.core"
+    ]
+  }
+]

--- a/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/execution-metrics.json
+++ b/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/execution-metrics.json
@@ -1,0 +1,50 @@
+{
+  "add_new_library_support:2026-04-30": {
+    "timestamp": "2026-04-30T23:44:42.757059Z",
+    "library": "io.lettuce:lettuce-core:6.1.10.RELEASE",
+    "starting_commit": "6ad37d18f6f1654d73add8b942decd608facc9b5",
+    "ending_commit": "f925a592508cbbc494d7fbaf636b28fab941af36",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.1.10.RELEASE",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 12175,
+          "missed": 108156,
+          "ratio": 0.101179,
+          "total": 120331
+        },
+        "line": {
+          "covered": 1956,
+          "missed": 21091,
+          "ratio": 0.08487,
+          "total": 23047
+        },
+        "method": {
+          "covered": 606,
+          "missed": 7715,
+          "ratio": 0.072828,
+          "total": 8321
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 337225,
+      "cached_input_tokens_used": 4174336,
+      "output_tokens_used": 33104,
+      "iterations": 7,
+      "cost_usd": 3.0803,
+      "generated_loc": 470,
+      "tested_library_loc": 1956,
+      "metadata_entries": 65,
+      "code_coverage_percent": 8.49
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java",
+      "metadata_file": "metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/stats.json
+++ b/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "6.1.10.RELEASE",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 12175,
+        "missed" : 108156,
+        "ratio" : 0.101179,
+        "total" : 120331
+      },
+      "line" : {
+        "covered" : 1956,
+        "missed" : 21091,
+        "ratio" : 0.08487,
+        "total" : 23047
+      },
+      "method" : {
+        "covered" : 606,
+        "missed" : 7715,
+        "ratio" : 0.072828,
+        "total" : 8321
+      }
+    }
+  } ]
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/.gitignore
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/build.gradle
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.lettuce:lettuce-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/gradle.properties
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.lettuce:lettuce-core:6.1.10.RELEASE
+library.version = 6.1.10.RELEASE
+metadata.dir = io.lettuce/lettuce-core/6.1.10.RELEASE/

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/settings.gradle
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.lettuce.lettuce-core_tests'

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_lettuce.lettuce_core;
+
+import org.junit.jupiter.api.Test;
+
+class Lettuce_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -6,11 +6,427 @@
  */
 package io_lettuce.lettuce_core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.lettuce.core.BitFieldArgs;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.CompositeArgument;
+import io.lettuce.core.GeoArgs;
+import io.lettuce.core.GeoCoordinates;
+import io.lettuce.core.GeoValue;
+import io.lettuce.core.GeoWithin;
+import io.lettuce.core.KeyValue;
+import io.lettuce.core.Limit;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.ScanArgs;
+import io.lettuce.core.ScoredValue;
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.SortArgs;
+import io.lettuce.core.SslOptions;
+import io.lettuce.core.SslVerifyMode;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.Value;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
+import io.lettuce.core.cluster.SlotHash;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+import io.lettuce.core.cluster.models.slots.ClusterSlotRange;
+import io.lettuce.core.cluster.models.slots.ClusterSlotsParser;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.models.role.RedisInstance;
+import io.lettuce.core.models.stream.PendingMessage;
+import io.lettuce.core.output.IntegerOutput;
+import io.lettuce.core.output.StatusOutput;
+import io.lettuce.core.output.ValueOutput;
+import io.lettuce.core.protocol.Command;
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.ProtocolVersion;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.ssl.SslProvider;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
-class Lettuce_coreTest {
+public class Lettuce_coreTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void parsesBuildsAndCopiesRedisUris() {
+        RedisURI standaloneUri = RedisURI.builder()
+                .withHost("cache.example.test")
+                .withPort(6380)
+                .withDatabase(5)
+                .withClientName("lettuce-native")
+                .withAuthentication("default", "s3cr3t")
+                .withTimeout(Duration.ofMillis(250))
+                .build();
+
+        assertThat(standaloneUri.getHost()).isEqualTo("cache.example.test");
+        assertThat(standaloneUri.getPort()).isEqualTo(6380);
+        assertThat(standaloneUri.getDatabase()).isEqualTo(5);
+        assertThat(standaloneUri.getClientName()).isEqualTo("lettuce-native");
+        assertThat(standaloneUri.getUsername()).isEqualTo("default");
+        assertThat(standaloneUri.getPassword()).containsExactly('s', '3', 'c', 'r', '3', 't');
+        assertThat(standaloneUri.getTimeout()).isEqualTo(Duration.ofMillis(250));
+
+        RedisURI tlsUri = RedisURI.builder(standaloneUri)
+                .withHost("secure.example.test")
+                .withPort(6381)
+                .withSsl(true)
+                .withStartTls(true)
+                .withVerifyPeer(SslVerifyMode.CA)
+                .build();
+
+        assertThat(tlsUri.isSsl()).isTrue();
+        assertThat(tlsUri.isStartTls()).isTrue();
+        assertThat(tlsUri.getVerifyMode()).isEqualTo(SslVerifyMode.CA);
+        assertThat(tlsUri.toURI().getScheme()).isEqualTo("redis+tls");
+
+        RedisURI parsedTlsUri = RedisURI.create("rediss://:tls-secret@parsed.example.test:6382/4?verifyPeer=NONE");
+        assertThat(parsedTlsUri.isSsl()).isTrue();
+        assertThat(parsedTlsUri.getHost()).isEqualTo("parsed.example.test");
+        assertThat(parsedTlsUri.getDatabase()).isEqualTo(4);
+        assertThat(parsedTlsUri.getVerifyMode()).isEqualTo(SslVerifyMode.NONE);
+
+        RedisURI sentinelUri = RedisURI.Builder
+                .sentinel("sentinel-one.example.test", 26379, "primary")
+                .withSentinel("sentinel-two.example.test", 26380)
+                .withAuthentication("default", "data-pw")
+                .withDatabase(2)
+                .build();
+
+        assertThat(sentinelUri.getSentinelMasterId()).isEqualTo("primary");
+        assertThat(sentinelUri.getSentinels())
+                .extracting(RedisURI::getHost)
+                .containsExactly("sentinel-one.example.test", "sentinel-two.example.test");
+        assertThat(sentinelUri.getSentinels())
+                .extracting(RedisURI::getPort)
+                .containsExactly(26379, 26380);
+        assertThat(sentinelUri.getDatabase()).isEqualTo(2);
+    }
+
+    @Test
+    void configuresClientSocketSslTimeoutAndClusterOptionsWithoutConnecting() {
+        TimeoutOptions timeoutOptions = TimeoutOptions.builder()
+                .timeoutCommands(true)
+                .fixedTimeout(Duration.ofSeconds(3))
+                .build();
+        SocketOptions socketOptions = SocketOptions.builder()
+                .connectTimeout(1500, TimeUnit.MILLISECONDS)
+                .keepAlive(true)
+                .tcpNoDelay(false)
+                .build();
+        SslOptions sslOptions = SslOptions.builder()
+                .jdkSslProvider()
+                .protocols("TLSv1.3", "TLSv1.2")
+                .cipherSuites("TLS_AES_128_GCM_SHA256")
+                .handshakeTimeout(Duration.ofSeconds(4))
+                .build();
+        ClientOptions clientOptions = ClientOptions.builder()
+                .autoReconnect(false)
+                .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                .pingBeforeActivateConnection(false)
+                .protocolVersion(ProtocolVersion.RESP3)
+                .publishOnScheduler(true)
+                .requestQueueSize(128)
+                .socketOptions(socketOptions)
+                .sslOptions(sslOptions)
+                .timeoutOptions(timeoutOptions)
+                .build();
+
+        assertThat(clientOptions.isAutoReconnect()).isFalse();
+        assertThat(clientOptions.getDisconnectedBehavior())
+                .isEqualTo(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS);
+        assertThat(clientOptions.getConfiguredProtocolVersion()).isEqualTo(ProtocolVersion.RESP3);
+        assertThat(clientOptions.getRequestQueueSize()).isEqualTo(128);
+        assertThat(clientOptions.getSocketOptions().getConnectTimeout()).isEqualTo(Duration.ofMillis(1500));
+        assertThat(clientOptions.getSocketOptions().isKeepAlive()).isTrue();
+        assertThat(clientOptions.getSocketOptions().isTcpNoDelay()).isFalse();
+        assertThat(clientOptions.getSslOptions().getSslProvider()).isEqualTo(SslProvider.JDK);
+        assertThat(clientOptions.getSslOptions().getProtocols()).containsExactly("TLSv1.3", "TLSv1.2");
+        assertThat(clientOptions.getSslOptions().getCipherSuites()).containsExactly("TLS_AES_128_GCM_SHA256");
+        assertThat(clientOptions.getTimeoutOptions().isTimeoutCommands()).isTrue();
+
+        ClusterTopologyRefreshOptions refreshOptions = ClusterTopologyRefreshOptions.builder()
+                .enableAdaptiveRefreshTrigger(
+                        ClusterTopologyRefreshOptions.RefreshTrigger.MOVED_REDIRECT,
+                        ClusterTopologyRefreshOptions.RefreshTrigger.PERSISTENT_RECONNECTS)
+                .adaptiveRefreshTriggersTimeout(Duration.ofSeconds(7))
+                .dynamicRefreshSources(false)
+                .enablePeriodicRefresh(Duration.ofMinutes(2))
+                .refreshTriggersReconnectAttempts(3)
+                .build();
+        ClusterClientOptions clusterOptions = ClusterClientOptions.builder(clientOptions)
+                .maxRedirects(5)
+                .topologyRefreshOptions(refreshOptions)
+                .validateClusterNodeMembership(false)
+                .nodeFilter(redisClusterNode -> !redisClusterNode.is(RedisClusterNode.NodeFlag.FAIL))
+                .build();
+
+        assertThat(clusterOptions.getMaxRedirects()).isEqualTo(5);
+        assertThat(clusterOptions.isValidateClusterNodeMembership()).isFalse();
+        assertThat(clusterOptions.getTopologyRefreshOptions().isPeriodicRefreshEnabled()).isTrue();
+        assertThat(clusterOptions.getTopologyRefreshOptions().getRefreshPeriod()).isEqualTo(Duration.ofMinutes(2));
+        assertThat(clusterOptions.getTopologyRefreshOptions().getAdaptiveRefreshTriggers())
+                .containsExactlyInAnyOrder(
+                        ClusterTopologyRefreshOptions.RefreshTrigger.MOVED_REDIRECT,
+                        ClusterTopologyRefreshOptions.RefreshTrigger.PERSISTENT_RECONNECTS);
+        RedisClusterNode healthyNode = RedisClusterNode.of(
+                "127.0.0.1:7000@17000 myself,master - 0 0 1 connected 0");
+        assertThat(clusterOptions.getNodeFilter().test(healthyNode)).isTrue();
+
+        RedisClient client = RedisClient.create(RedisURI.create("redis://localhost:6379/0"));
+        try {
+            client.setDefaultTimeout(Duration.ofSeconds(2));
+            client.setOptions(clientOptions);
+
+            assertThat(client.getDefaultTimeout()).isEqualTo(Duration.ofSeconds(2));
+            assertThat(client.getOptions().getConfiguredProtocolVersion()).isEqualTo(ProtocolVersion.RESP3);
+            assertThat(client.getOptions().getRequestQueueSize()).isEqualTo(128);
+            assertThat(client.getResources()).isNotNull();
+        } finally {
+            client.shutdown(Duration.ZERO, Duration.ZERO);
+        }
+    }
+
+    @Test
+    void encodesCommandsAndBuildsRedisArgumentObjects() {
+        CommandArgs<String, String> setArgs = new CommandArgs<>(StringCodec.UTF8)
+                .addKey("cache:key")
+                .addValue("payload");
+        new SetArgs().ex(Duration.ofSeconds(60)).nx().build(setArgs);
+        Command<String, String, String> setCommand = new Command<>(
+                CommandType.SET, new StatusOutput<>(StringCodec.UTF8), setArgs);
+
+        ByteBuf commandBuffer = Unpooled.buffer();
+        try {
+            setCommand.encode(commandBuffer);
+
+            assertThat(readBuffer(commandBuffer)).isEqualTo(
+                    "*6\r\n"
+                            + "$3\r\nSET\r\n"
+                            + "$9\r\ncache:key\r\n"
+                            + "$7\r\npayload\r\n"
+                            + "$2\r\nEX\r\n"
+                            + "$2\r\n60\r\n"
+                            + "$2\r\nNX\r\n");
+        } finally {
+            commandBuffer.release();
+        }
+
+        String scanArgs = commandString(new ScanArgs().match("user:*").limit(25));
+        assertThat(scanArgs).isEqualTo("MATCH dXNlcjoq COUNT 25");
+
+        String geoArgs = commandString(new GeoArgs()
+                .withDistance()
+                .withCoordinates()
+                .withHash()
+                .withCount(5, true)
+                .desc());
+        assertThat(geoArgs).contains("WITHDIST", "WITHCOORD", "WITHHASH", "COUNT 5", "ANY", "desc");
+
+        String sortArgs = commandString(new SortArgs()
+                .by("weight_*")
+                .limit(Limit.create(2, 4))
+                .get("object_*")
+                .get("#")
+                .desc()
+                .alpha());
+        assertThat(sortArgs).isEqualTo("BY weight_* GET object_* GET # LIMIT 2 4 DESC ALPHA");
+
+        String bitFieldArgs = commandString(new BitFieldArgs()
+                .overflow(BitFieldArgs.OverflowType.SAT)
+                .get(BitFieldArgs.signed(8), BitFieldArgs.offset(0))
+                .set(BitFieldArgs.unsigned(4), BitFieldArgs.typeWidthBasedOffset(2), 7)
+                .incrBy(BitFieldArgs.signed(16), BitFieldArgs.offset(4), -2));
+        assertThat(bitFieldArgs).isEqualTo("OVERFLOW U0FU GET i8 0 SET u4 #2 7 INCRBY i16 4 -2");
+
+        CommandArgs<String, String> streamArgs = new CommandArgs<>(StringCodec.UTF8);
+        new XReadArgs().block(Duration.ofMillis(500)).count(10).build(streamArgs);
+        assertThat(streamArgs.toCommandString()).isEqualTo("BLOCK 500 COUNT 10");
+    }
+
+    @Test
+    void roundTripsCodecsAndCommandOutputs() {
+        String unicodeValue = "caf\u00e9";
+        ByteBuffer encodedString = StringCodec.UTF8.encodeValue(unicodeValue);
+        assertThat(StringCodec.UTF8.decodeValue(encodedString)).isEqualTo(unicodeValue);
+
+        byte[] bytes = new byte[] { 1, 2, 3, 4 };
+        ByteBuffer encodedBytes = ByteArrayCodec.INSTANCE.encodeValue(bytes);
+        assertThat(ByteArrayCodec.INSTANCE.decodeValue(encodedBytes)).containsExactly(bytes);
+
+        RedisCodec<String, byte[]> mixedCodec = RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE);
+        assertThat(mixedCodec.decodeKey(utf8Buffer("key-one"))).isEqualTo("key-one");
+        assertThat(mixedCodec.decodeValue(ByteBuffer.wrap(new byte[] { 9, 8, 7 }))).containsExactly(9, 8, 7);
+
+        StatusOutput<String, String> statusOutput = new StatusOutput<>(StringCodec.UTF8);
+        statusOutput.set(utf8Buffer("QUEUED"));
+        assertThat(statusOutput.get()).isEqualTo("QUEUED");
+
+        IntegerOutput<String, String> integerOutput = new IntegerOutput<>(StringCodec.UTF8);
+        integerOutput.set(42L);
+        assertThat(integerOutput.get()).isEqualTo(42L);
+
+        ValueOutput<String, String> valueOutput = new ValueOutput<>(StringCodec.UTF8);
+        valueOutput.set(utf8Buffer("stored-value"));
+        assertThat(valueOutput.get()).isEqualTo("stored-value");
+
+        Command<String, String, String> getCommand = new Command<>(CommandType.GET, valueOutput);
+        getCommand.complete();
+        assertThat(getCommand.isDone()).isTrue();
+        assertThat(getCommand.get()).isEqualTo("stored-value");
+    }
+
+    @Test
+    void mapsOptionalValueGeoScoreStreamAndRangeDomainObjects() {
+        Value<String> value = Value.just("redis");
+        assertThat(value.hasValue()).isTrue();
+        assertThat(value.map(String::toUpperCase).getValue()).isEqualTo("REDIS");
+        assertThat(Value.<String>empty().getValueOrElse("fallback")).isEqualTo("fallback");
+        assertThatThrownBy(() -> Value.<String>empty().getValueOrElseThrow(() -> new IllegalStateException("missing")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("missing");
+
+        KeyValue<String, Integer> keyValue = KeyValue.just("counter", 41);
+        assertThat(keyValue.getKey()).isEqualTo("counter");
+        assertThat(keyValue.map(count -> count + 1).getValue()).isEqualTo(42);
+        assertThat(KeyValue.empty("absent").isEmpty()).isTrue();
+
+        ScoredValue<String> scoredValue = ScoredValue.just(12.5D, "alice");
+        assertThat(scoredValue.getScore()).isEqualTo(12.5D);
+        assertThat(scoredValue.map(String::toUpperCase).getValue()).isEqualTo("ALICE");
+        assertThat(scoredValue.mapScore(score -> score.doubleValue() + 0.5D).getScore()).isEqualTo(13D);
+
+        GeoCoordinates coordinates = GeoCoordinates.create(13.361389D, 38.115556D);
+        GeoValue<String> geoValue = GeoValue.just(coordinates, "Palermo");
+        GeoWithin<String> geoWithin = new GeoWithin<>("Palermo", 190.4424D, 3479099956230698L, coordinates);
+        assertThat(geoValue.getLongitude()).isEqualTo(13.361389D);
+        assertThat(geoValue.getLatitude()).isEqualTo(38.115556D);
+        assertThat(geoWithin.getMember()).isEqualTo("Palermo");
+        assertThat(geoWithin.toValue()).isEqualTo(geoValue);
+
+        Map<String, String> streamBody = new LinkedHashMap<>();
+        streamBody.put("sensor-id", "1234");
+        streamBody.put("temperature", "21.5");
+        StreamMessage<String, String> streamMessage = new StreamMessage<>("readings", "1650000000000-0", streamBody);
+        assertThat(streamMessage.getStream()).isEqualTo("readings");
+        assertThat(streamMessage.getBody()).containsEntry("temperature", "21.5");
+
+        PendingMessage pendingMessage = new PendingMessage("1650000000000-0", "consumer-a", 1200L, 3L);
+        assertThat(pendingMessage.getConsumer()).isEqualTo("consumer-a");
+        assertThat(pendingMessage.getSinceLastDelivery()).isEqualTo(Duration.ofMillis(1200));
+        assertThat(pendingMessage.getRedeliveryCount()).isEqualTo(3L);
+
+        Range<Long> inclusiveRange = Range.create(10L, 20L);
+        Range<Long> exclusiveLowerRange = Range.from(Range.Boundary.excluding(10L), Range.Boundary.including(20L));
+        assertThat(inclusiveRange.getLower().isIncluding()).isTrue();
+        assertThat(inclusiveRange.getUpper().getValue()).isEqualTo(20L);
+        assertThat(exclusiveLowerRange.getLower().isIncluding()).isFalse();
+        assertThat(Limit.unlimited().isLimited()).isFalse();
+        assertThat(Limit.from(3).getOffset()).isZero();
+        assertThat(Limit.from(3).getCount()).isEqualTo(3L);
+    }
+
+    @Test
+    void calculatesClusterSlotsAndBuildsTopologyModels() {
+        int userSlot = SlotHash.getSlot("{user1000}.following");
+        assertThat(SlotHash.getSlot("{user1000}.followers")).isEqualTo(userSlot);
+        assertThat(userSlot).isBetween(0, SlotHash.SLOT_COUNT - 1);
+
+        RedisClusterNode upstream = new RedisClusterNode(
+                RedisURI.create("redis://127.0.0.1:7000"),
+                "node-a",
+                true,
+                null,
+                1L,
+                2L,
+                3L,
+                Arrays.asList(0, 1, 2),
+                EnumSet.of(RedisClusterNode.NodeFlag.UPSTREAM));
+        upstream.addAlias(RedisURI.create("redis://localhost:7000"));
+
+        assertThat(upstream.isConnected()).isTrue();
+        assertThat(upstream.hasSlot(1)).isTrue();
+        assertThat(upstream.getRole()).isEqualTo(RedisInstance.Role.UPSTREAM);
+        assertThat(upstream.getAliases()).extracting(RedisURI::getHost).containsExactly("localhost");
+
+        RedisClusterNode replica = new RedisClusterNode(
+                RedisURI.create("redis://127.0.0.2:7001"),
+                "node-b",
+                true,
+                "node-a",
+                0L,
+                0L,
+                3L,
+                Collections.emptyList(),
+                EnumSet.of(RedisClusterNode.NodeFlag.REPLICA));
+        ClusterSlotRange slotRange = new ClusterSlotRange(0, 2, upstream, Collections.singletonList(replica));
+        assertThat(slotRange.getFrom()).isZero();
+        assertThat(slotRange.getTo()).isEqualTo(2);
+        assertThat(slotRange.getUpstream()).isEqualTo(upstream);
+        assertThat(slotRange.getReplicaNodes()).containsExactly(replica);
+
+        Partitions partitions = new Partitions();
+        partitions.addPartition(upstream);
+        partitions.addPartition(replica);
+        partitions.updateCache();
+        assertThat(partitions.getPartitionBySlot(2)).isEqualTo(upstream);
+        assertThat(partitions.getPartitionByNodeId("node-b")).isEqualTo(replica);
+        assertThat(partitions.clone()).hasSize(2);
+
+        List<Object> rawClusterSlots = Arrays.asList(
+                Arrays.asList(
+                        0L,
+                        2L,
+                        Arrays.asList("127.0.0.1", 7000L, "node-a"),
+                        Arrays.asList("127.0.0.2", 7001L, "node-b")),
+                Arrays.asList(
+                        3L,
+                        5L,
+                        Arrays.asList("127.0.0.3", 7002L, "node-c")));
+        List<ClusterSlotRange> parsedRanges = ClusterSlotsParser.parse(rawClusterSlots);
+
+        assertThat(parsedRanges).hasSize(2);
+        assertThat(parsedRanges.get(0).getFrom()).isEqualTo(0);
+        assertThat(parsedRanges.get(0).getTo()).isEqualTo(2);
+        assertThat(parsedRanges.get(0).getUpstream().getNodeId()).isEqualTo("node-a");
+        assertThat(parsedRanges.get(0).getReplicaNodes())
+                .extracting(RedisClusterNode::getNodeId)
+                .containsExactly("node-b");
+        assertThat(parsedRanges.get(1).getUpstream().getUri().getPort()).isEqualTo(7002);
+    }
+
+    private static String commandString(CompositeArgument argument) {
+        CommandArgs<String, String> commandArgs = new CommandArgs<>(StringCodec.UTF8);
+        argument.build(commandArgs);
+        return commandArgs.toCommandString();
+    }
+
+    private static ByteBuffer utf8Buffer(String value) {
+        return ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String readBuffer(ByteBuf byteBuf) {
+        byte[] bytes = new byte[byteBuf.readableBytes()];
+        byteBuf.getBytes(byteBuf.readerIndex(), bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -42,6 +42,10 @@ import io.lettuce.core.cluster.models.slots.ClusterSlotsParser;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.event.DefaultEventBus;
+import io.lettuce.core.event.Event;
+import io.lettuce.core.event.connection.ConnectedEvent;
+import io.lettuce.core.event.connection.ConnectEvent;
 import io.lettuce.core.models.role.RedisInstance;
 import io.lettuce.core.models.stream.PendingMessage;
 import io.lettuce.core.output.IntegerOutput;
@@ -54,9 +58,12 @@ import io.lettuce.core.protocol.ProtocolVersion;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.ssl.SslProvider;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -65,6 +72,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Schedulers;
 
 public class Lettuce_coreTest {
     @Test
@@ -203,6 +212,30 @@ public class Lettuce_coreTest {
             assertThat(client.getResources()).isNotNull();
         } finally {
             client.shutdown(Duration.ZERO, Duration.ZERO);
+        }
+    }
+
+    @Test
+    void publishesConnectionLifecycleEventsOnEventBus() {
+        DefaultEventBus eventBus = new DefaultEventBus(Schedulers.immediate());
+        List<Event> receivedEvents = new ArrayList<>();
+        Disposable subscription = eventBus.get().subscribe(receivedEvents::add);
+        try {
+            SocketAddress localAddress = InetSocketAddress.createUnresolved("client.example.test", 55000);
+            SocketAddress remoteAddress = InetSocketAddress.createUnresolved("redis.example.test", 6379);
+            ConnectEvent connectEvent = new ConnectEvent("redis://redis.example.test:6379/0", "endpoint-1");
+            ConnectedEvent connectedEvent = new ConnectedEvent(localAddress, remoteAddress);
+
+            eventBus.publish(connectEvent);
+            eventBus.publish(connectedEvent);
+
+            assertThat(receivedEvents).containsExactly(connectEvent, connectedEvent);
+            assertThat(connectEvent.getRedisUri()).isEqualTo("redis://redis.example.test:6379/0");
+            assertThat(connectEvent.getEpId()).isEqualTo("endpoint-1");
+            assertThat(connectedEvent.localAddress()).isEqualTo(localAddress);
+            assertThat(connectedEvent.remoteAddress()).isEqualTo(remoteAddress);
+        } finally {
+            subscription.dispose();
         }
     }
 

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -19,6 +19,7 @@ import io.lettuce.core.GeoWithin;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.Limit;
 import io.lettuce.core.Range;
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.ScanArgs;
@@ -47,6 +48,7 @@ import io.lettuce.core.event.Event;
 import io.lettuce.core.event.connection.ConnectedEvent;
 import io.lettuce.core.event.connection.ConnectEvent;
 import io.lettuce.core.models.role.RedisInstance;
+import io.lettuce.core.models.role.RedisNodeDescription;
 import io.lettuce.core.models.stream.PendingMessage;
 import io.lettuce.core.output.IntegerOutput;
 import io.lettuce.core.output.StatusOutput;
@@ -67,10 +69,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;
@@ -302,13 +306,13 @@ public class Lettuce_coreTest {
         ByteBuffer encodedString = StringCodec.UTF8.encodeValue(unicodeValue);
         assertThat(StringCodec.UTF8.decodeValue(encodedString)).isEqualTo(unicodeValue);
 
-        byte[] bytes = new byte[] { 1, 2, 3, 4 };
+        byte[] bytes = new byte[] {1, 2, 3, 4};
         ByteBuffer encodedBytes = ByteArrayCodec.INSTANCE.encodeValue(bytes);
         assertThat(ByteArrayCodec.INSTANCE.decodeValue(encodedBytes)).containsExactly(bytes);
 
         RedisCodec<String, byte[]> mixedCodec = RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE);
         assertThat(mixedCodec.decodeKey(utf8Buffer("key-one"))).isEqualTo("key-one");
-        assertThat(mixedCodec.decodeValue(ByteBuffer.wrap(new byte[] { 9, 8, 7 }))).containsExactly(9, 8, 7);
+        assertThat(mixedCodec.decodeValue(ByteBuffer.wrap(new byte[] {9, 8, 7}))).containsExactly(9, 8, 7);
 
         StatusOutput<String, String> statusOutput = new StatusOutput<>(StringCodec.UTF8);
         statusOutput.set(utf8Buffer("QUEUED"));
@@ -379,6 +383,29 @@ public class Lettuce_coreTest {
     }
 
     @Test
+    void selectsReadNodesUsingReadFromPolicies() {
+        TestRedisNode upstream = new TestRedisNode(
+                "redis-primary.example.test", 6379, RedisInstance.Role.UPSTREAM);
+        TestRedisNode replicaEast = new TestRedisNode(
+                "redis-replica-east.example.test", 6380, RedisInstance.Role.REPLICA);
+        TestRedisNode replicaWest = new TestRedisNode(
+                "redis-replica-west.example.test", 6381, RedisInstance.Role.REPLICA);
+        TestReadFromNodes topology = new TestReadFromNodes(
+                Arrays.<RedisNodeDescription>asList(upstream, replicaEast, replicaWest));
+
+        assertThat(ReadFrom.UPSTREAM.select(topology)).containsExactly(upstream);
+        assertThat(ReadFrom.REPLICA.select(topology)).containsExactly(replicaEast, replicaWest);
+        assertThat(ReadFrom.ANY_REPLICA.select(topology)).containsExactly(replicaEast, replicaWest);
+        assertThat(ReadFrom.UPSTREAM_PREFERRED.select(topology)).containsExactly(upstream, replicaEast, replicaWest);
+        assertThat(ReadFrom.REPLICA_PREFERRED.select(topology)).containsExactly(replicaEast, replicaWest, upstream);
+        assertThat(ReadFrom.ANY.select(topology)).containsExactly(upstream, replicaEast, replicaWest);
+        assertThat(ReadFrom.regex(Pattern.compile("redis-replica-.*\\.example\\.test")).select(topology))
+                .containsExactly(replicaEast, replicaWest);
+        assertThat(ReadFrom.valueOf("replicaPreferred").select(topology))
+                .containsExactly(replicaEast, replicaWest, upstream);
+    }
+
+    @Test
     void calculatesClusterSlotsAndBuildsTopologyModels() {
         int userSlot = SlotHash.getSlot("{user1000}.following");
         assertThat(SlotHash.getSlot("{user1000}.followers")).isEqualTo(userSlot);
@@ -445,6 +472,44 @@ public class Lettuce_coreTest {
                 .extracting(RedisClusterNode::getNodeId)
                 .containsExactly("node-b");
         assertThat(parsedRanges.get(1).getUpstream().getUri().getPort()).isEqualTo(7002);
+    }
+
+    private static final class TestRedisNode implements RedisNodeDescription {
+        private final RedisURI uri;
+        private final RedisInstance.Role role;
+
+        private TestRedisNode(String host, int port, RedisInstance.Role role) {
+            this.uri = RedisURI.create("redis://" + host + ":" + port);
+            this.role = role;
+        }
+
+        @Override
+        public RedisURI getUri() {
+            return uri;
+        }
+
+        @Override
+        public RedisInstance.Role getRole() {
+            return role;
+        }
+    }
+
+    private static final class TestReadFromNodes implements ReadFrom.Nodes {
+        private final List<RedisNodeDescription> nodes;
+
+        private TestReadFromNodes(List<RedisNodeDescription> nodes) {
+            this.nodes = nodes;
+        }
+
+        @Override
+        public List<RedisNodeDescription> getNodes() {
+            return nodes;
+        }
+
+        @Override
+        public Iterator<RedisNodeDescription> iterator() {
+            return nodes.iterator();
+        }
     }
 
     private static String commandString(CompositeArgument argument) {

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.lettuce.core.**"
+      "includeClasses" : "io.lettuce.core.**"
     }
   ]
 }

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.lettuce.core.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3649

This PR introduces tests and metadata for io.lettuce:lettuce-core:6.1.10.RELEASE, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 337225
- Cached input tokens: 4174336
- Output tokens: 33104
- Metadata entries: 65
- Iterations: 7
- Library coverage percentage: 8.49
- Generated lines of code: 470
- Tested library lines of code: 1956

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3721cf138689bc7a5e27699773806f01b4c4a1f8`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 12175/120331 (10.12%)
- Line: 1956/23047 (8.49%)
- Method: 606/8321 (7.28%)
