### PR TITLE
[GenAI] Add support for org.apache.maven.resolver:maven-resolver-named-locks:1.9.25 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.named.support.NamedLockFactorySupport"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.25",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-named-locks/1.9.25/maven-resolver-named-locks-1.9.25-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/1.9.25/maven-resolver-1.9.25-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-named-locks/1.9.25/maven-resolver-named-locks-1.9.25-javadoc.jar",
+    "description" : "Maven Resolver Named Locks provides synchronization primitives for named lock coordination within Maven Artifact Resolver. It includes local, file-based, and no-op named lock factories used to guard concurrent access to shared resolver resources.",
+    "tested-versions" : [
+      "1.9.25"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.named"
+    ]
+  }
+]

--- a/stats/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T00:46:54.933101Z",
+    "library": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.25",
+    "starting_commit": "df67a9d51579f9c1a43713520d260064db8bf3b4",
+    "ending_commit": "578007d75f64f4d9936f525c1450cd070716d878",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.25",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1134,
+          "missed": 224,
+          "ratio": 0.835052,
+          "total": 1358
+        },
+        "line": {
+          "covered": 285,
+          "missed": 39,
+          "ratio": 0.87963,
+          "total": 324
+        },
+        "method": {
+          "covered": 72,
+          "missed": 4,
+          "ratio": 0.947368,
+          "total": 76
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 196873,
+      "cached_input_tokens_used": 1691136,
+      "output_tokens_used": 20569,
+      "iterations": 3,
+      "cost_usd": 1.4627,
+      "generated_loc": 308,
+      "tested_library_loc": 285,
+      "metadata_entries": 1,
+      "code_coverage_percent": 87.96
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.9.25",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1134,
+        "missed" : 224,
+        "ratio" : 0.835052,
+        "total" : 1358
+      },
+      "line" : {
+        "covered" : 285,
+        "missed" : 39,
+        "ratio" : 0.87963,
+        "total" : 324
+      },
+      "method" : {
+        "covered" : 72,
+        "missed" : 4,
+        "ratio" : 0.947368,
+        "total" : 76
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-named-locks:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-named-locks:1.9.25
+library.version = 1.9.25
+metadata.dir = org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-named-locks_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -199,6 +199,25 @@ public class Maven_resolver_named_locksTest {
                 .isSameAs(failure);
     }
 
+    @Test
+    void retryStopsImmediatelyWhenFailurePredicateRejectsException() {
+        AtomicInteger attempts = new AtomicInteger();
+        IllegalArgumentException failure = new IllegalArgumentException("permanent");
+
+        assertThatThrownBy(() -> Retry.retry(
+                        5,
+                        0L,
+                        () -> {
+                            attempts.incrementAndGet();
+                            throw failure;
+                        },
+                        exception -> false,
+                        "fallback"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCause(failure);
+        assertThat(attempts).hasValue(1);
+    }
+
     private static void assertStatefulLockCoordinatesReadersAndWriters(NamedLockFactorySupport factory, String lockName)
             throws Exception {
         NamedLock owner = factory.getLock(lockName);

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -6,11 +6,298 @@
  */
 package org_apache_maven_resolver.maven_resolver_named_locks;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Maven_resolver_named_locksTest {
+import java.nio.file.Path;
+import java.util.Deque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.eclipse.aether.named.NamedLock;
+import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
+import org.eclipse.aether.named.providers.NoopNamedLockFactory;
+import org.eclipse.aether.named.support.LockUpgradeNotSupportedException;
+import org.eclipse.aether.named.support.NamedLockFactorySupport;
+import org.eclipse.aether.named.support.NamedLockSupport;
+import org.eclipse.aether.named.support.ReadWriteLockNamedLock;
+import org.eclipse.aether.named.support.Retry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Maven_resolver_named_locksTest {
+    private static final long LOCK_TIMEOUT_MILLIS = 25L;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void providerNamesIdentifyAvailableImplementations() {
+        assertThat(NoopNamedLockFactory.NAME).isEqualTo("noop");
+        assertThat(LocalReadWriteLockNamedLockFactory.NAME).isEqualTo("rwlock-local");
+        assertThat(LocalSemaphoreNamedLockFactory.NAME).isEqualTo("semaphore-local");
+        assertThat(FileLockNamedLockFactory.NAME).isEqualTo("file-lock");
+    }
+
+    @Test
+    void factoryReusesNamedLockUntilEveryHandleIsClosed() {
+        LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
+        NamedLockSupport first = factory.getLock("repository");
+        NamedLockSupport second = factory.getLock("repository");
+        NamedLockSupport differentName = factory.getLock("metadata");
+
+        assertThat(first).isSameAs(second);
+        assertThat(first).isNotSameAs(differentName);
+        assertThat(first.name()).isEqualTo("repository");
+        assertThat(first).hasToString("ReadWriteLockNamedLock{name='repository'}");
+        assertThat(first.diagnosticState()).isEmpty();
+
+        first.close();
+        second.close();
+
+        NamedLockSupport replacement = factory.getLock("repository");
+        assertThat(replacement).isNotSameAs(first);
+
+        replacement.close();
+        differentName.close();
+        factory.closeLock("already-closed");
+        factory.shutdown();
+    }
+
+    @Test
+    void noopProviderAcceptsEverySharedAndExclusiveRequest() throws Exception {
+        NoopNamedLockFactory factory = new NoopNamedLockFactory();
+        NamedLock lock = factory.getLock("anything");
+        NamedLock competingHandle = factory.getLock("anything");
+
+        try {
+            assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(lockSharedInWorker(competingHandle)).isTrue();
+            assertThat(lockExclusivelyInWorker(competingHandle)).isTrue();
+
+            assertThat(lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(lockSharedInWorker(competingHandle)).isTrue();
+            assertThat(lockExclusivelyInWorker(competingHandle)).isTrue();
+
+            lock.unlock();
+            lock.unlock();
+            lock.unlock();
+        } finally {
+            lock.close();
+            competingHandle.close();
+        }
+    }
+
+    @Test
+    void localReadWriteLockCoordinatesReadersAndWriters() throws Exception {
+        LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, "artifact");
+    }
+
+    @Test
+    void localSemaphoreLockCoordinatesReadersAndWriters() throws Exception {
+        LocalSemaphoreNamedLockFactory factory = new LocalSemaphoreNamedLockFactory();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, "artifact");
+    }
+
+    @Test
+    void fileLockCoordinatesReadersAndWriters(@TempDir Path tempDir) throws Exception {
+        FileLockNamedLockFactory factory = new FileLockNamedLockFactory();
+        String lockName = tempDir.resolve("locks").resolve("repository.lck").toString();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, lockName);
+    }
+
+    @Test
+    void statefulLocksRejectSharedToExclusiveUpgrade(@TempDir Path tempDir) throws Exception {
+        assertSharedToExclusiveUpgradeIsRejected(new LocalReadWriteLockNamedLockFactory(), "rw-upgrade");
+        assertSharedToExclusiveUpgradeIsRejected(new LocalSemaphoreNamedLockFactory(), "semaphore-upgrade");
+        assertSharedToExclusiveUpgradeIsRejected(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toString());
+    }
+
+    @Test
+    void statefulLocksRejectUnlockWithoutHeldLock(@TempDir Path tempDir) {
+        assertUnlockWithoutHeldLockFails(new LocalReadWriteLockNamedLockFactory(), "rw-unlocked");
+        assertUnlockWithoutHeldLockFails(new LocalSemaphoreNamedLockFactory(), "semaphore-unlocked");
+        assertUnlockWithoutHeldLockFails(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toString());
+    }
+
+    @Test
+    void diagnosticFactoryTracksCurrentThreadLockStateAndReturnsFailures() throws Exception {
+        DiagnosticReadWriteLockFactory factory = new DiagnosticReadWriteLockFactory();
+        NamedLockSupport lock = factory.getLock("diagnostic");
+        RuntimeException failure = new RuntimeException("boom");
+
+        assertThat(factory.isDiagnosticEnabled()).isTrue();
+        assertThat(lock.diagnosticState()).isEmpty();
+
+        assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+        try {
+            Deque<String> currentThreadState = lock.diagnosticState().get(Thread.currentThread());
+            assertThat(currentThreadState).containsExactly("shared");
+            assertThat(factory.onFailure(failure)).isSameAs(failure);
+        } finally {
+            lock.unlock();
+            lock.close();
+        }
+
+        assertThat(lock.diagnosticState().get(Thread.currentThread())).isEmpty();
+    }
+
+    @Test
+    void retryReturnsFirstNonNullResult() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = Retry.retry(
+                1L,
+                TimeUnit.SECONDS,
+                0L,
+                () -> attempts.incrementAndGet() == 3 ? "resolved" : null,
+                exception -> true,
+                "fallback");
+
+        assertThat(result).isEqualTo("resolved");
+        assertThat(attempts).hasValue(3);
+    }
+
+    @Test
+    void retryReturnsFallbackAfterRetryableFailuresAndStopsOnNonRetryableFailures() throws Exception {
+        AtomicInteger retryableAttempts = new AtomicInteger();
+
+        String fallback = Retry.retry(
+                3,
+                0L,
+                () -> {
+                    retryableAttempts.incrementAndGet();
+                    throw new IllegalArgumentException("temporary");
+                },
+                IllegalArgumentException.class::isInstance,
+                "fallback");
+
+        assertThat(fallback).isEqualTo("fallback");
+        assertThat(retryableAttempts).hasValue(3);
+
+        NonRetryableException failure = new NonRetryableException("fatal");
+        assertThatThrownBy(() -> Retry.retry(3, 0L, throwing(failure), exception -> true, "fallback"))
+                .isSameAs(failure);
+    }
+
+    private static void assertStatefulLockCoordinatesReadersAndWriters(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock owner = factory.getLock(lockName);
+        NamedLock competitor = factory.getLock(lockName);
+
+        try {
+            assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            try {
+                assertThat(lockSharedInWorker(competitor)).isTrue();
+                assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+            } finally {
+                owner.unlock();
+            }
+
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            try {
+                assertThat(lockSharedInWorker(competitor)).isFalse();
+                assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+            } finally {
+                owner.unlock();
+            }
+
+            assertThat(lockExclusivelyInWorker(competitor)).isTrue();
+        } finally {
+            owner.close();
+            competitor.close();
+        }
+    }
+
+    private static void assertSharedToExclusiveUpgradeIsRejected(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock lock = factory.getLock(lockName);
+
+        try {
+            assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThatThrownBy(() -> lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS))
+                    .isInstanceOf(LockUpgradeNotSupportedException.class)
+                    .hasMessageContaining(lockName);
+        } finally {
+            lock.unlock();
+            lock.close();
+        }
+    }
+
+    private static void assertUnlockWithoutHeldLockFails(NamedLockFactorySupport factory, String lockName) {
+        NamedLock lock = factory.getLock(lockName);
+
+        try {
+            assertThatIllegalStateException()
+                    .isThrownBy(lock::unlock)
+                    .withMessage("Wrong API usage: unlock without lock");
+        } finally {
+            lock.close();
+        }
+    }
+
+    private static boolean lockSharedInWorker(NamedLock lock) throws Exception {
+        return runInWorker(() -> {
+            boolean locked = lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (locked) {
+                lock.unlock();
+            }
+            return locked;
+        });
+    }
+
+    private static boolean lockExclusivelyInWorker(NamedLock lock) throws Exception {
+        return runInWorker(() -> {
+            boolean locked = lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (locked) {
+                lock.unlock();
+            }
+            return locked;
+        });
+    }
+
+    private static boolean runInWorker(Callable<Boolean> callable) throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(callable);
+        try {
+            return future.get(5L, TimeUnit.SECONDS);
+        } finally {
+            executorService.shutdownNow();
+            assertThat(executorService.awaitTermination(5L, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static Callable<String> throwing(RuntimeException exception) {
+        return () -> {
+            throw exception;
+        };
+    }
+
+    private static final class DiagnosticReadWriteLockFactory extends NamedLockFactorySupport {
+        private DiagnosticReadWriteLockFactory() {
+            super(true);
+        }
+
+        @Override
+        protected NamedLockSupport createLock(String name) {
+            return new ReadWriteLockNamedLock(name, this, new ReentrantReadWriteLock());
+        }
+    }
+
+    private static final class NonRetryableException extends RuntimeException implements Retry.DoNotRetry {
+        private NonRetryableException(String message) {
+            super(message);
+        }
     }
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_named_locks;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_resolver_named_locksTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -124,6 +124,14 @@ public class Maven_resolver_named_locksTest {
     }
 
     @Test
+    void statefulLocksAllowExclusiveReentryAndSharedDowngrade(@TempDir Path tempDir) throws Exception {
+        assertExclusiveReentryAndSharedDowngrade(new LocalReadWriteLockNamedLockFactory(), "rw-downgrade");
+        assertExclusiveReentryAndSharedDowngrade(new LocalSemaphoreNamedLockFactory(), "semaphore-downgrade");
+        assertExclusiveReentryAndSharedDowngrade(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toString());
+    }
+
+    @Test
     void statefulLocksRejectUnlockWithoutHeldLock(@TempDir Path tempDir) {
         assertUnlockWithoutHeldLockFails(new LocalReadWriteLockNamedLockFactory(), "rw-unlocked");
         assertUnlockWithoutHeldLockFails(new LocalSemaphoreNamedLockFactory(), "semaphore-unlocked");
@@ -232,6 +240,40 @@ public class Maven_resolver_named_locksTest {
         } finally {
             lock.unlock();
             lock.close();
+        }
+    }
+
+    private static void assertExclusiveReentryAndSharedDowngrade(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock owner = factory.getLock(lockName);
+        NamedLock competitor = factory.getLock(lockName);
+        int ownerHeldLocks = 0;
+
+        try {
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+            assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+
+            assertThat(lockSharedInWorker(competitor)).isFalse();
+            assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+
+            owner.unlock();
+            ownerHeldLocks--;
+            assertThat(lockSharedInWorker(competitor)).isFalse();
+
+            owner.unlock();
+            ownerHeldLocks--;
+            assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+        } finally {
+            while (ownerHeldLocks > 0) {
+                owner.unlock();
+                ownerHeldLocks--;
+            }
+            owner.close();
+            competitor.close();
         }
     }
 

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.aether.named.**"
+      "includeClasses" : "org.eclipse.aether.named.**"
     }
   ]
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.aether.named.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3749

This PR introduces tests and metadata for org.apache.maven.resolver:maven-resolver-named-locks:1.9.25, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 196873
- Cached input tokens: 1691136
- Output tokens: 20569
- Metadata entries: 1
- Iterations: 3
- Library coverage percentage: 87.96
- Generated lines of code: 308
- Tested library lines of code: 285

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9f121fff18eefbefcd0a56ef53fc60ba6fdc9e25`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1134/1358 (83.51%)
- Line: 285/324 (87.96%)
- Method: 72/76 (94.74%)
