### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-util-ajax:10.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-util-ajax/10.0.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-util-ajax/10.0.0/reachability-metadata.json
@@ -1,0 +1,60 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "java.lang.Integer[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "java.lang.StringBuilder[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONEnumConvertor"
+      },
+      "type" : "java.time.DayOfWeek"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONCollectionConvertor"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.AsyncJSON"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.AsyncJSON"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-util-ajax/index.json
+++ b/metadata/org.eclipse.jetty/jetty-util-ajax/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "10.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/10.0.0/jetty-util-ajax-10.0.0-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-10.0.0/jetty-util-ajax/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/10.0.0/jetty-util-ajax-10.0.0-javadoc.jar",
+    "description" : "Jetty Util Ajax provides JSON and Ajax utility classes for Jetty applications. It includes parsers, generators, and converters for mapping Java objects, collections, dates, enums, and POJOs to and from JSON.",
     "tested-versions" : [
       "10.0.0"
     ],

--- a/metadata/org.eclipse.jetty/jetty-util-ajax/index.json
+++ b/metadata/org.eclipse.jetty/jetty-util-ajax/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "10.0.0",
+    "tested-versions" : [
+      "10.0.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.util.ajax"
+    ]
+  },
+  {
     "metadata-version" : "9.4.38.v20210224",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/9.4.38.v20210224/jetty-util-ajax-9.4.38.v20210224-sources.jar",
     "repository-url" : "https://github.com/eclipse/jetty.project",

--- a/stats/org.eclipse.jetty/jetty-util-ajax/10.0.0/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-util-ajax/10.0.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:29:54.478249Z",
+    "library": "org.eclipse.jetty:jetty-util-ajax:10.0.0",
+    "starting_commit": "cd9da147a108ec53e737a7cbb8f8bc850418a5bd",
+    "ending_commit": "01fbf637086f5e7cac0a49bbd8148ce7f84bdcea",
+    "previous_library": "org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "10.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 24,
+        "totalCalls": 24
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2657,
+          "missed": 2582,
+          "ratio": 0.507158,
+          "total": 5239
+        },
+        "line": {
+          "covered": 665,
+          "missed": 758,
+          "ratio": 0.467323,
+          "total": 1423
+        },
+        "method": {
+          "covered": 115,
+          "missed": 67,
+          "ratio": 0.631868,
+          "total": 182
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.4.38.v20210224",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 26,
+            "totalCalls": 26
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 26,
+        "totalCalls": 26
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2766,
+          "missed": 2941,
+          "ratio": 0.484668,
+          "total": 5707
+        },
+        "line": {
+          "covered": 679,
+          "missed": 824,
+          "ratio": 0.451763,
+          "total": 1503
+        },
+        "method": {
+          "covered": 117,
+          "missed": 98,
+          "ratio": 0.544186,
+          "total": 215
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 70413,
+      "cached_input_tokens_used": 726016,
+      "output_tokens_used": 5477,
+      "iterations": 1,
+      "cost_usd": 0.5273,
+      "tested_library_loc": 665,
+      "metadata_entries": 9,
+      "test_only_metadata_entries": 40,
+      "previous_library_metadata_entries": 23,
+      "previous_library_test_only_metadata_entries": 18,
+      "code_coverage_percent": 46.73,
+      "previous_library_coverage_percent": 45.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-util-ajax/10.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-util-ajax/10.0.0/stats.json
+++ b/stats/org.eclipse.jetty/jetty-util-ajax/10.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "10.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 24,
+          "totalCalls" : 24
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 24,
+      "totalCalls" : 24
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2657,
+        "missed" : 2582,
+        "ratio" : 0.507158,
+        "total" : 5239
+      },
+      "line" : {
+        "covered" : 665,
+        "missed" : 758,
+        "ratio" : 0.467323,
+        "total" : 1423
+      },
+      "method" : {
+        "covered" : 115,
+        "missed" : 67,
+        "ratio" : 0.631868,
+        "total" : 182
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-util-ajax:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-util-ajax:10.0.0
+library.version = 10.0.0
+metadata.dir = org.eclipse.jetty/jetty-util-ajax/10.0.0/

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-util-ajax_tests'

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/AsyncJSONTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/AsyncJSONTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.AsyncJSON;
+import org.eclipse.jetty.util.ajax.JSON.Convertible;
+import org.eclipse.jetty.util.ajax.JSON.Output;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsyncJSONTest {
+    @Test
+    void createsConvertibleObjectDeclaredByClassField() {
+        AsyncJSON parser = new AsyncJSON.Factory().newAsyncJSON();
+        String json = String.format(Locale.ROOT, """
+                {
+                  "class": "%s",
+                  "name": "jetty",
+                  "count": 13,
+                  "active": true,
+                  "tags": ["async", "json"]
+                }
+                """, ConvertiblePayload.class.getName());
+
+        boolean complete = parser.parse(json.getBytes(StandardCharsets.UTF_8));
+        Object parsed = parser.complete();
+
+        assertThat(complete).isTrue();
+        assertThat(parsed).isInstanceOf(ConvertiblePayload.class);
+        ConvertiblePayload payload = (ConvertiblePayload) parsed;
+        assertThat(payload.getName()).isEqualTo("jetty");
+        assertThat(payload.getCount()).isEqualTo(13L);
+        assertThat(payload.isActive()).isTrue();
+        assertThat(payload.getTags()).containsExactly("async", "json");
+    }
+
+    public static class ConvertiblePayload implements Convertible {
+        private String name;
+        private long count;
+        private boolean active;
+        private List<String> tags;
+
+        public ConvertiblePayload() {
+        }
+
+        @Override
+        public void toJSON(Output out) {
+            out.addClass(ConvertiblePayload.class);
+            out.add("name", name);
+            out.add("count", count);
+            out.add("active", active);
+            out.add("tags", tags);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void fromJSON(Map object) {
+            name = (String) object.get("name");
+            count = ((Number) object.get("count")).longValue();
+            active = (Boolean) object.get("active");
+            tags = (List<String>) object.get("tags");
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONCollectionConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONCollectionConvertorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.eclipse.jetty.util.ajax.JSONCollectionConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONCollectionConvertorTest {
+    @Test
+    void recreatesCollectionDeclaredByClassField() {
+        JSON json = new JSON();
+        json.addConvertor(ArrayList.class, new JSONCollectionConvertor());
+        List<String> source = new ArrayList<>();
+        source.add("alpha");
+        source.add("beta");
+
+        Object parsed = json.parse(new JSON.StringSource(json.toJSON(source)));
+
+        assertThat(parsed).isInstanceOf(ArrayList.class);
+        assertThat(parsed).isEqualTo(source);
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONEnumConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONEnumConvertorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.time.DayOfWeek;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.eclipse.jetty.util.ajax.JSONEnumConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONEnumConvertorTest {
+    @Test
+    void roundTripsEnumDeclaredByClassField() {
+        JSON json = new JSON();
+        json.addConvertor(DayOfWeek.class, new JSONEnumConvertor(true));
+
+        String serialized = json.toJSON(DayOfWeek.WEDNESDAY);
+        Object parsed = json.parse(new JSON.StringSource(serialized));
+
+        assertThat(serialized).contains("\"class\":\"java.time.DayOfWeek\"");
+        assertThat(serialized).contains("\"value\":\"WEDNESDAY\"");
+        assertThat(parsed).isEqualTo(DayOfWeek.WEDNESDAY);
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.eclipse.jetty.util.ajax.JSONObjectConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONObjectConvertorTest {
+    @Test
+    void serializesPublicBeanGettersAsJsonObjectFields() {
+        JSON json = new JSON();
+        json.addConvertor(WidgetSnapshot.class, new JSONObjectConvertor(false, new String[] {"secret"}));
+        WidgetSnapshot snapshot = new WidgetSnapshot("jetty", 38, true, "hidden");
+
+        Object parsed = JSON.parse(json.toJSON(snapshot));
+
+        assertThat(parsed).isInstanceOf(Map.class);
+        Map<?, ?> properties = (Map<?, ?>) parsed;
+        assertThat(properties.get("name")).isEqualTo("jetty");
+        assertThat(properties.get("count")).isEqualTo(Long.valueOf(38L));
+        assertThat(properties.get("ready")).isEqualTo(Boolean.TRUE);
+        assertThat(properties.containsKey("secret")).isFalse();
+        assertThat(properties.containsKey("description")).isFalse();
+    }
+
+    public static class WidgetSnapshot {
+        private final String name;
+        private final int count;
+        private final boolean ready;
+        private final String secret;
+
+        public WidgetSnapshot(String name, int count, boolean ready, String secret) {
+            this.name = name;
+            this.count = count;
+            this.ready = ready;
+            this.secret = secret;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public boolean isReady() {
+            return ready;
+        }
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public String description() {
+            return name + ':' + count;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
@@ -21,7 +21,7 @@ public class JSONObjectConvertorTest {
         json.addConvertor(WidgetSnapshot.class, new JSONObjectConvertor(false, new String[] {"secret"}));
         WidgetSnapshot snapshot = new WidgetSnapshot("jetty", 38, true, "hidden");
 
-        Object parsed = JSON.parse(json.toJSON(snapshot));
+        Object parsed = json.fromJSON(json.toJSON(snapshot));
 
         assertThat(parsed).isInstanceOf(Map.class);
         Map<?, ?> properties = (Map<?, ?>) parsed;

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.JSONPojoConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONPojoConvertorInnerSetterTest {
+    @Test
+    void setsNullAndScalarValuesThroughPojoConvertor() {
+        SetterTarget target = new SetterTarget();
+        JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
+
+        int updated = convertor.setProps(target, properties(
+                "nullableText", null,
+                "status", SetterTarget.Status.STARTED,
+                "secondaryStatus", "STOPPED",
+                "quantity", Long.valueOf(42L),
+                "symbol", "Jetty",
+                "label", "converted"));
+
+        assertThat(updated).isEqualTo(6);
+        assertThat(target.nullableText).isNull();
+        assertThat(target.status).isEqualTo(SetterTarget.Status.STARTED);
+        assertThat(target.secondaryStatus).isEqualTo(SetterTarget.Status.STOPPED);
+        assertThat(target.quantity).isEqualTo(42);
+        assertThat(target.symbol).isEqualTo('J');
+        assertThat(target.label).isEqualTo("converted");
+    }
+
+    @Test
+    void copiesCompatibleObjectArraysToTypedPojoArrays() {
+        SetterTarget target = new SetterTarget();
+        JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
+
+        int updated = convertor.setProps(target, properties(
+                "names", new Object[]{"alpha", "beta"},
+                "quantities", new Integer[]{3, 5, 8}));
+
+        assertThat(updated).isEqualTo(2);
+        assertThat(target.names).containsExactly("alpha", "beta");
+        assertThat(target.quantities).containsExactly(3, 5, 8);
+    }
+
+    @Test
+    void fallsBackToOriginalNumericWrapperArrayWhenElementCannotBeConverted() {
+        SetterTarget target = new SetterTarget();
+        JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
+        Integer[] values = new Integer[]{1, null, 3};
+
+        int updated = convertor.setProps(target, properties("boxedQuantities", values));
+
+        assertThat(updated).isOne();
+        assertThat(target.boxedQuantities).isSameAs(values).containsExactly(1, null, 3);
+    }
+
+    @Test
+    void fallsBackToOriginalObjectArrayWhenCopyCannotStoreValues() {
+        SetterTarget target = new SetterTarget();
+        JSONPojoConvertor convertor = new CopyFailureConvertor(SetterTarget.class);
+        Object[] values = new Object[]{"plain-text"};
+
+        int updated = convertor.setProps(target, properties("objects", values));
+
+        assertThat(updated).isOne();
+        assertThat(target.objects).isSameAs(values).containsExactly("plain-text");
+    }
+
+    @Test
+    void ignoresArrayValuesThatCannotBeAdaptedToPojoArrayTypes() {
+        SetterTarget target = new SetterTarget();
+        JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
+
+        int updated = convertor.setProps(target, properties(
+                "names", new Object[]{"alpha", Integer.valueOf(7)},
+                "quantities", new Object[]{Integer.valueOf(1), "not-a-number"}));
+
+        assertThat(updated).isZero();
+        assertThat(target.names).isNull();
+        assertThat(target.quantities).isNull();
+    }
+
+    private static Map<String, Object> properties(Object... entries) {
+        Map<String, Object> properties = new HashMap<>();
+        for (int index = 0; index < entries.length; index += 2) {
+            properties.put((String) entries[index], entries[index + 1]);
+        }
+        return properties;
+    }
+
+    public static class SetterTarget {
+        private String nullableText = "initial";
+        private Status status;
+        private Status secondaryStatus;
+        private int quantity;
+        private char symbol;
+        private String label;
+        private String[] names;
+        private int[] quantities;
+        private Integer[] boxedQuantities;
+        private Object[] objects;
+
+        public void setNullableText(String nullableText) {
+            this.nullableText = nullableText;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public void setSecondaryStatus(Status secondaryStatus) {
+            this.secondaryStatus = secondaryStatus;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+
+        public void setSymbol(char symbol) {
+            this.symbol = symbol;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public void setNames(String[] names) {
+            this.names = names;
+        }
+
+        public void setQuantities(int[] quantities) {
+            this.quantities = quantities;
+        }
+
+        public void setBoxedQuantities(Integer[] boxedQuantities) {
+            this.boxedQuantities = boxedQuantities;
+        }
+
+        public void setObjects(Object[] objects) {
+            this.objects = objects;
+        }
+
+        public enum Status {
+            STARTED,
+            STOPPED
+        }
+    }
+
+    public static class CopyFailureConvertor extends JSONPojoConvertor {
+        public CopyFailureConvertor(Class<?> pojoClass) {
+            super(pojoClass);
+        }
+
+        @Override
+        protected void addSetter(String name, Method method) {
+            if ("objects".equals(name)) {
+                _setters.put(name, new CopyFailureSetter(name, method));
+                return;
+            }
+            super.addSetter(name, method);
+        }
+    }
+
+    public static class CopyFailureSetter extends JSONPojoConvertor.Setter {
+        public CopyFailureSetter(String propertyName, Method method) {
+            super(propertyName, method);
+            _componentType = StringBuilder.class;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
@@ -18,18 +18,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JSONPojoConvertorInnerSetterTest {
     @Test
     void setsNullAndScalarValuesThroughPojoConvertor() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "nullableText", null,
                 "status", SetterTarget.Status.STARTED,
                 "secondaryStatus", "STOPPED",
                 "quantity", Long.valueOf(42L),
                 "symbol", "Jetty",
                 "label", "converted"));
-
-        assertThat(updated).isEqualTo(6);
         assertThat(target.nullableText).isNull();
         assertThat(target.status).isEqualTo(SetterTarget.Status.STARTED);
         assertThat(target.secondaryStatus).isEqualTo(SetterTarget.Status.STOPPED);
@@ -40,54 +37,49 @@ public class JSONPojoConvertorInnerSetterTest {
 
     @Test
     void copiesCompatibleObjectArraysToTypedPojoArrays() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "names", new Object[]{"alpha", "beta"},
                 "quantities", new Integer[]{3, 5, 8}));
-
-        assertThat(updated).isEqualTo(2);
         assertThat(target.names).containsExactly("alpha", "beta");
         assertThat(target.quantities).containsExactly(3, 5, 8);
     }
 
     @Test
     void fallsBackToOriginalNumericWrapperArrayWhenElementCannotBeConverted() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
         Integer[] values = new Integer[]{1, null, 3};
 
-        int updated = convertor.setProps(target, properties("boxedQuantities", values));
-
-        assertThat(updated).isOne();
+        SetterTarget target = convert(convertor, properties("boxedQuantities", values));
         assertThat(target.boxedQuantities).isSameAs(values).containsExactly(1, null, 3);
     }
 
     @Test
     void fallsBackToOriginalObjectArrayWhenCopyCannotStoreValues() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new CopyFailureConvertor(SetterTarget.class);
         Object[] values = new Object[]{"plain-text"};
 
-        int updated = convertor.setProps(target, properties("objects", values));
-
-        assertThat(updated).isOne();
+        SetterTarget target = convert(convertor, properties("objects", values));
         assertThat(target.objects).isSameAs(values).containsExactly("plain-text");
     }
 
     @Test
     void ignoresArrayValuesThatCannotBeAdaptedToPojoArrayTypes() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "names", new Object[]{"alpha", Integer.valueOf(7)},
                 "quantities", new Object[]{Integer.valueOf(1), "not-a-number"}));
-
-        assertThat(updated).isZero();
         assertThat(target.names).isNull();
         assertThat(target.quantities).isNull();
+    }
+
+    private static SetterTarget convert(JSONPojoConvertor convertor, Map<String, Object> properties) {
+        Object converted = convertor.fromJSON(properties);
+
+        assertThat(converted).isInstanceOf(SetterTarget.class);
+        return (SetterTarget) converted;
     }
 
     private static Map<String, Object> properties(Object... entries) {

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.eclipse.jetty.util.ajax.JSONPojoConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONPojoConvertorTest {
+    @Test
+    void createsPojoWithDefaultConstructorAndSettersFromJsonProperties() {
+        JSONPojoConvertor convertor = new JSONPojoConvertor(RoundTripWidget.class);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("name", "jetty");
+        properties.put("count", Long.valueOf(7L));
+        properties.put("enabled", Boolean.TRUE);
+
+        Object converted = convertor.fromJSON(properties);
+
+        assertThat(converted).isInstanceOf(RoundTripWidget.class);
+        RoundTripWidget widget = (RoundTripWidget) converted;
+        assertThat(widget.getName()).isEqualTo("jetty");
+        assertThat(widget.getCount()).isEqualTo(7);
+        assertThat(widget.isEnabled()).isTrue();
+    }
+
+    @Test
+    void serializesPojoByInvokingPublicGetters() {
+        JSON json = new JSON();
+        json.addConvertor(RoundTripWidget.class, new JSONPojoConvertor(RoundTripWidget.class));
+        RoundTripWidget widget = new RoundTripWidget("ajax", 11, true);
+
+        Object parsed = JSON.parse(json.toJSON(widget));
+
+        assertThat(parsed).isInstanceOf(Map.class);
+        Map<?, ?> properties = (Map<?, ?>) parsed;
+        assertThat(properties.get("class")).isEqualTo(RoundTripWidget.class.getName());
+        assertThat(properties.get("name")).isEqualTo("ajax");
+        assertThat(properties.get("count")).isEqualTo(Long.valueOf(11L));
+        assertThat(properties.get("enabled")).isEqualTo(Boolean.TRUE);
+    }
+
+    public static class RoundTripWidget {
+        private String name;
+        private int count;
+        private boolean enabled;
+
+        public RoundTripWidget() {
+        }
+
+        public RoundTripWidget(String name, int count, boolean enabled) {
+            this.name = name;
+            this.count = count;
+            this.enabled = enabled;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
@@ -39,7 +39,7 @@ public class JSONPojoConvertorTest {
         json.addConvertor(RoundTripWidget.class, new JSONPojoConvertor(RoundTripWidget.class));
         RoundTripWidget widget = new RoundTripWidget("ajax", 11, true);
 
-        Object parsed = JSON.parse(json.toJSON(widget));
+        Object parsed = new JSON().fromJSON(json.toJSON(widget));
 
         assertThat(parsed).isInstanceOf(Map.class);
         Map<?, ?> properties = (Map<?, ?>) parsed;

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_util_ajax;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.eclipse.jetty.util.ajax.JSON.Convertible;
+import org.eclipse.jetty.util.ajax.JSON.Output;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JSONTest {
+    @Test
+    void createsConvertibleObjectDeclaredByClassField() {
+        JSON json = new JSON();
+        String source = String.format(Locale.ROOT, """
+                {
+                  "class": "%s",
+                  "name": "jetty",
+                  "count": 21,
+                  "enabled": true
+                }
+                """, ConvertiblePayload.class.getName());
+
+        Object parsed = json.parse(new JSON.StringSource(source));
+
+        assertThat(parsed).isInstanceOf(ConvertiblePayload.class);
+        ConvertiblePayload payload = (ConvertiblePayload) parsed;
+        assertThat(payload.getName()).isEqualTo("jetty");
+        assertThat(payload.getCount()).isEqualTo(21L);
+        assertThat(payload.isEnabled()).isTrue();
+    }
+
+    public static class ConvertiblePayload implements Convertible {
+        private String name;
+        private long count;
+        private boolean enabled;
+
+        public ConvertiblePayload() {
+        }
+
+        @Override
+        public void toJSON(Output out) {
+            out.addClass(ConvertiblePayload.class);
+            out.add("name", name);
+            out.add("count", count);
+            out.add("enabled", enabled);
+        }
+
+        @Override
+        public void fromJSON(Map object) {
+            name = (String) object.get("name");
+            count = ((Number) object.get("count")).longValue();
+            enabled = (Boolean) object.get("enabled");
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,102 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.AsyncJSON"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.AsyncJSONTest$ConvertiblePayload",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONObjectConvertor"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONObjectConvertorTest$WidgetSnapshot",
+      "methods" : [
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isReady",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorInnerSetterTest$SetterTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSON"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorTest$RoundTripWidget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorTest$RoundTripWidget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isEnabled",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSON"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONTest$ConvertiblePayload",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -97,6 +97,136 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorInnerSetterTest$SetterTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorInnerSetterTest$SetterTarget",
+      "methods" : [
+        {
+          "name" : "setBoxedQuantities",
+          "parameterTypes" : [
+            "java.lang.Integer[]"
+          ]
+        },
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setNames",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        },
+        {
+          "name" : "setNullableText",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setObjects",
+          "parameterTypes" : [
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name" : "setQuantities",
+          "parameterTypes" : [
+            "int[]"
+          ]
+        },
+        {
+          "name" : "setQuantity",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setSecondaryStatus",
+          "parameterTypes" : [
+            "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorInnerSetterTest$SetterTarget$Status"
+          ]
+        },
+        {
+          "name" : "setStatus",
+          "parameterTypes" : [
+            "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorInnerSetterTest$SetterTarget$Status"
+          ]
+        },
+        {
+          "name" : "setSymbol",
+          "parameterTypes" : [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorTest$RoundTripWidget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isEnabled",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ajax.JSONPojoConvertor$Setter"
+      },
+      "type" : "org_eclipse_jetty.jetty_util_ajax.JSONPojoConvertorTest$RoundTripWidget",
+      "methods" : [
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.util.ajax.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3957

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-util-ajax:10.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 70413
- Cached input tokens: 726016
- Output tokens: 5477
- Metadata entries: 9
- Test-only metadata entries: 40
- Iterations: 1
- Library coverage percentage: 46.73
- Previous library version metadata entries: 23
- Previous library version test-only metadata entries: 18
- Previous library version coverage percentage: 45.18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224: 26/26 covered calls (100.00%)
- org.eclipse.jetty:jetty-util-ajax:10.0.0: 24/24 covered calls (100.00%)

**Reflection:**
- org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224: 26/26 covered calls (100.00%)
- org.eclipse.jetty:jetty-util-ajax:10.0.0: 24/24 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224: 2766/5707 (48.47%)
- org.eclipse.jetty:jetty-util-ajax:10.0.0: 2657/5239 (50.72%)

**Line:**
- org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224: 679/1503 (45.18%)
- org.eclipse.jetty:jetty-util-ajax:10.0.0: 665/1423 (46.73%)

**Method:**
- org.eclipse.jetty:jetty-util-ajax:9.4.38.v20210224: 117/215 (54.42%)
- org.eclipse.jetty:jetty-util-ajax:10.0.0: 115/182 (63.19%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
index 764086c434..be758f9994 100644
--- 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONObjectConvertorTest.java
@@ -21,7 +21,7 @@ public class JSONObjectConvertorTest {
         json.addConvertor(WidgetSnapshot.class, new JSONObjectConvertor(false, new String[] {"secret"}));
         WidgetSnapshot snapshot = new WidgetSnapshot("jetty", 38, true, "hidden");
 
-        Object parsed = JSON.parse(json.toJSON(snapshot));
+        Object parsed = json.fromJSON(json.toJSON(snapshot));
 
         assertThat(parsed).isInstanceOf(Map.class);
         Map<?, ?> properties = (Map<?, ?>) parsed;
diff --git 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
index 87986db32c..dcf08bbd93 100644
--- 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorInnerSetterTest.java
@@ -18,18 +18,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JSONPojoConvertorInnerSetterTest {
     @Test
     void setsNullAndScalarValuesThroughPojoConvertor() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "nullableText", null,
                 "status", SetterTarget.Status.STARTED,
                 "secondaryStatus", "STOPPED",
                 "quantity", Long.valueOf(42L),
                 "symbol", "Jetty",
                 "label", "converted"));
-
-        assertThat(updated).isEqualTo(6);
         assertThat(target.nullableText).isNull();
         assertThat(target.status).isEqualTo(SetterTarget.Status.STARTED);
         assertThat(target.secondaryStatus).isEqualTo(SetterTarget.Status.STOPPED);
@@ -40,56 +37,51 @@ public class JSONPojoConvertorInnerSetterTest {
 
     @Test
     void copiesCompatibleObjectArraysToTypedPojoArrays() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "names", new Object[]{"alpha", "beta"},
                 "quantities", new Integer[]{3, 5, 8}));
-
-        assertThat(updated).isEqualTo(2);
         assertThat(target.names).containsExactly("alpha", "beta");
         assertThat(target.quantities).containsExactly(3, 5, 8);
     }
 
     @Test
     void fallsBackToOriginalNumericWrapperArrayWhenElementCannotBeConverted() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
         Integer[] values = new Integer[]{1, null, 3};
 
-        int updated = convertor.setProps(target, properties("boxedQuantities", values));
-
-        assertThat(updated).isOne();
+        SetterTarget target = convert(convertor, properties("boxedQuantities", values));
         assertThat(target.boxedQuantities).isSameAs(values).containsExactly(1, null, 3);
     }
 
     @Test
     void fallsBackToOriginalObjectArrayWhenCopyCannotStoreValues() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new CopyFailureConvertor(SetterTarget.class);
         Object[] values = new Object[]{"plain-text"};
 
-        int updated = convertor.setProps(target, properties("objects", values));
-
-        assertThat(updated).isOne();
+        SetterTarget target = convert(convertor, properties("objects", values));
         assertThat(target.objects).isSameAs(values).containsExactly("plain-text");
     }
 
     @Test
     void ignoresArrayValuesThatCannotBeAdaptedToPojoArrayTypes() {
-        SetterTarget target = new SetterTarget();
         JSONPojoConvertor convertor = new JSONPojoConvertor(SetterTarget.class);
 
-        int updated = convertor.setProps(target, properties(
+        SetterTarget target = convert(convertor, properties(
                 "names", new Object[]{"alpha", Integer.valueOf(7)},
                 "quantities", new Object[]{Integer.valueOf(1), "not-a-number"}));
-
-        assertThat(updated).isZero();
         assertThat(target.names).isNull();
         assertThat(target.quantities).isNull();
     }
 
+    private static SetterTarget convert(JSONPojoConvertor convertor, Map<String, Object> properties) {
+        Object converted = convertor.fromJSON(properties);
+
+        assertThat(converted).isInstanceOf(SetterTarget.class);
+        return (SetterTarget) converted;
+    }
+
     private static Map<String, Object> properties(Object... entries) {
         Map<String, Object> properties = new HashMap<>();
         for (int index = 0; index < entries.length; index += 2) {
diff --git 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
index 5c5445104d..664de42f90 100644
--- 1/tests/src/org.eclipse.jetty/jetty-util-ajax/9.4.38.v20210224/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-util-ajax/10.0.0/src/test/java/org_eclipse_jetty/jetty_util_ajax/JSONPojoConvertorTest.java
@@ -39,7 +39,7 @@ public class JSONPojoConvertorTest {
         json.addConvertor(RoundTripWidget.class, new JSONPojoConvertor(RoundTripWidget.class));
         RoundTripWidget widget = new RoundTripWidget("ajax", 11, true);
 
-        Object parsed = JSON.parse(json.toJSON(widget));
+        Object parsed = new JSON().fromJSON(json.toJSON(widget));
 
         assertThat(parsed).isInstanceOf(Map.class);
         Map<?, ?> properties = (Map<?, ?>) parsed;

```
