### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-alpn-java-server:12.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-alpn-java-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-java-server/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "12.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-java-server/12.0.0/jetty-alpn-java-server-12.0.0-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-12.0.0/jetty-core/jetty-alpn/jetty-alpn-java-server/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-java-server/12.0.0/jetty-alpn-java-server-12.0.0-javadoc.jar",
+    "description" : "Jetty ALPN Java Server provides the JDK 9+ server-side ALPN processor used by Eclipse Jetty to negotiate application protocols during TLS handshakes. It integrates Jetty's Java ALPN implementation with server connections so secure sessions can select HTTP/1.1, HTTP/2, or other supported protocols.",
     "tested-versions" : [
       "12.0.0"
     ],

--- a/metadata/org.eclipse.jetty/jetty-alpn-java-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-java-server/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.0.0",
+    "tested-versions" : [
+      "12.0.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.alpn.java.server"
+    ]
+  },
+  {
     "metadata-version" : "11.0.24",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-java-server/11.0.24/jetty-alpn-java-server-11.0.24-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/stats/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:32:25.212342Z",
+    "library": "org.eclipse.jetty:jetty-alpn-java-server:12.0.0",
+    "starting_commit": "8836e5e9a7aa6869f7cf425f3370c07367f583b2",
+    "ending_commit": "4db34b8b89499a4ca8d90e48b65051f87faaf5a9",
+    "previous_library": "org.eclipse.jetty:jetty-alpn-java-server:11.0.24",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "12.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 76,
+          "missed": 32,
+          "ratio": 0.703704,
+          "total": 108
+        },
+        "line": {
+          "covered": 23,
+          "missed": 6,
+          "ratio": 0.793103,
+          "total": 29
+        },
+        "method": {
+          "covered": 8,
+          "missed": 1,
+          "ratio": 0.888889,
+          "total": 9
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "11.0.24",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 74,
+          "missed": 32,
+          "ratio": 0.698113,
+          "total": 106
+        },
+        "line": {
+          "covered": 22,
+          "missed": 6,
+          "ratio": 0.785714,
+          "total": 28
+        },
+        "method": {
+          "covered": 8,
+          "missed": 1,
+          "ratio": 0.888889,
+          "total": 9
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 32582,
+      "cached_input_tokens_used": 206336,
+      "output_tokens_used": 1734,
+      "iterations": 1,
+      "cost_usd": 0.1552,
+      "tested_library_loc": 23,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 79.31,
+      "previous_library_coverage_percent": 78.57
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/stats.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "12.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 76,
+        "missed" : 32,
+        "ratio" : 0.703704,
+        "total" : 108
+      },
+      "line" : {
+        "covered" : 23,
+        "missed" : 6,
+        "ratio" : 0.793103,
+        "total" : 29
+      },
+      "method" : {
+        "covered" : 8,
+        "missed" : 1,
+        "ratio" : 0.888889,
+        "total" : 9
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-alpn-java-server:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-alpn-java-server:12.0.0
+library.version = 12.0.0
+metadata.dir = org.eclipse.jetty/jetty-alpn-java-server/12.0.0/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-alpn-java-server_tests'

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_alpn_java_server;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.BiFunction;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor;
+import org.eclipse.jetty.alpn.server.ALPNServerConnection;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.ssl.ALPNProcessor;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.io.ssl.SslHandshakeListener;
+import org.eclipse.jetty.server.AbstractConnectionFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.NegotiatingServerConnection.CipherDiscriminator;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class Jetty_alpn_java_serverTest {
+    private static final List<String> SERVER_PROTOCOLS = List.of("h2", "http/1.1");
+    private static final String DEFAULT_PROTOCOL = "http/1.1";
+
+    @Test
+    void initAcceptsCurrentJdkAndProcessorAppliesToJdkSslEngine() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        SSLEngine sslEngine = newServerEngine();
+
+        assertThatCode(processor::init).doesNotThrowAnyException();
+        assertThat(processor.appliesTo(sslEngine)).isTrue();
+        assertThat(sslEngine.getHandshakeApplicationProtocolSelector()).isNull();
+    }
+
+    @Test
+    void serverAlpnProcessorIsAvailableThroughServiceLoader() {
+        ServiceLoader<ALPNProcessor.Server> processors = ServiceLoader.load(ALPNProcessor.Server.class);
+
+        assertThat(processors)
+                .anySatisfy(processor -> assertThat(processor).isInstanceOf(JDK9ServerALPNProcessor.class));
+    }
+
+    @Test
+    void configureInstallsApplicationProtocolSelectorOnSslEngine() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        ALPNTestContext context = newALPNTestContext(new HttpConnectionFactory());
+
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        BiFunction<SSLEngine, List<String>, String> selector =
+                context.sslEngine.getHandshakeApplicationProtocolSelector();
+        assertThat(selector).isNotNull();
+        assertThat(context.alpnConnection.getProtocol()).isNull();
+    }
+
+    @Test
+    void selectorChoosesFirstServerPreferredProtocolOfferedByClient() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        ALPNTestContext context = newALPNTestContext(new HttpConnectionFactory());
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        String selectedProtocol = select(context, List.of("http/1.1", "h2"));
+
+        assertThat(selectedProtocol).isEqualTo("h2");
+        assertThat(context.alpnConnection.getProtocol()).isEqualTo("h2");
+    }
+
+    @Test
+    void selectorUsesDefaultProtocolWhenClientDoesNotAdvertiseAlpnProtocols() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        ALPNTestContext context = newALPNTestContext(new HttpConnectionFactory());
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        String selectedProtocol = select(context, List.of());
+
+        assertThat(selectedProtocol).isEqualTo(DEFAULT_PROTOCOL);
+        assertThat(context.alpnConnection.getProtocol()).isEqualTo(DEFAULT_PROTOCOL);
+    }
+
+    @Test
+    void selectorReturnsNullWhenThereIsNoCommonProtocol() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        ALPNTestContext context = newALPNTestContext(new HttpConnectionFactory());
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        String selectedProtocol = select(context, List.of("acme-tls/1"));
+
+        assertThat(selectedProtocol).isNull();
+        assertThat(context.alpnConnection.getProtocol()).isNull();
+    }
+
+    @Test
+    void selectorHonorsConnectorCipherDiscriminatorForCandidateProtocols() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        RejectingConnectionFactory rejectingH2Factory = new RejectingConnectionFactory("h2");
+        ALPNTestContext context = newALPNTestContext(rejectingH2Factory, new HttpConnectionFactory());
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        String selectedProtocol = select(context, List.of("h2", "http/1.1"));
+
+        assertThat(selectedProtocol).isEqualTo("http/1.1");
+        assertThat(context.alpnConnection.getProtocol()).isEqualTo("http/1.1");
+        assertThat(rejectingH2Factory.seenProtocol).isEqualTo("h2");
+        assertThat(rejectingH2Factory.seenTlsProtocol).isNotBlank();
+        assertThat(rejectingH2Factory.seenCipherSuite).isNotBlank();
+    }
+
+    @Test
+    void handshakeSucceededFallsBackToDefaultProtocolWhenNoProtocolWasNegotiated() throws Exception {
+        JDK9ServerALPNProcessor processor = new JDK9ServerALPNProcessor();
+        ALPNTestContext context = newALPNTestContext(new HttpConnectionFactory());
+        processor.configure(context.sslEngine, context.alpnConnection);
+
+        SslHandshakeListener listener = handshakeListener(context);
+        listener.handshakeSucceeded(new SslHandshakeListener.Event(context.sslEngine));
+
+        assertThat(context.alpnConnection.getProtocol()).isEqualTo(DEFAULT_PROTOCOL);
+    }
+
+    private static String select(ALPNTestContext context, List<String> clientProtocols) {
+        BiFunction<SSLEngine, List<String>, String> selector =
+                context.sslEngine.getHandshakeApplicationProtocolSelector();
+        assertThat(selector).isNotNull();
+        return selector.apply(context.sslEngine, clientProtocols);
+    }
+
+    private static SslHandshakeListener handshakeListener(ALPNTestContext context) {
+        BiFunction<SSLEngine, List<String>, String> selector =
+                context.sslEngine.getHandshakeApplicationProtocolSelector();
+        assertThat(selector).isInstanceOf(SslHandshakeListener.class);
+        return (SslHandshakeListener) selector;
+    }
+
+    private static ALPNTestContext newALPNTestContext(ConnectionFactory... connectionFactories) throws Exception {
+        ServerConnector connector = new ServerConnector(new Server(), connectionFactories);
+        SSLEngine sslEngine = newServerEngine();
+        ByteArrayEndPoint encryptedEndPoint = new ByteArrayEndPoint();
+        SslConnection sslConnection = new SslConnection(
+                connector.getByteBufferPool(),
+                connector.getExecutor(),
+                encryptedEndPoint,
+                sslEngine);
+        encryptedEndPoint.setConnection(sslConnection);
+        EndPoint decryptedEndPoint = sslConnection.getDecryptedEndPoint();
+        ALPNServerConnection alpnConnection = new ALPNServerConnection(
+                connector,
+                decryptedEndPoint,
+                sslEngine,
+                SERVER_PROTOCOLS,
+                DEFAULT_PROTOCOL);
+        decryptedEndPoint.setConnection(alpnConnection);
+        return new ALPNTestContext(sslEngine, alpnConnection);
+    }
+
+    private static SSLEngine newServerEngine() throws Exception {
+        SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine();
+        sslEngine.setUseClientMode(false);
+        return sslEngine;
+    }
+
+    private static final class ALPNTestContext {
+        private final SSLEngine sslEngine;
+        private final ALPNServerConnection alpnConnection;
+
+        private ALPNTestContext(SSLEngine sslEngine, ALPNServerConnection alpnConnection) {
+            this.sslEngine = sslEngine;
+            this.alpnConnection = alpnConnection;
+        }
+    }
+
+    private static final class RejectingConnectionFactory extends AbstractConnectionFactory
+            implements CipherDiscriminator {
+        private String seenProtocol;
+        private String seenTlsProtocol;
+        private String seenCipherSuite;
+
+        private RejectingConnectionFactory(String protocol) {
+            super(protocol);
+        }
+
+        @Override
+        public boolean isAcceptable(String protocol, String tlsProtocol, String cipherSuite) {
+            seenProtocol = protocol;
+            seenTlsProtocol = tlsProtocol;
+            seenCipherSuite = cipherSuite;
+            return false;
+        }
+
+        @Override
+        public org.eclipse.jetty.io.Connection newConnection(Connector connector, EndPoint endPoint) {
+            throw new UnsupportedOperationException("Test connection factory does not create connections");
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
@@ -154,7 +154,7 @@ public class Jetty_alpn_java_serverTest {
                 encryptedEndPoint,
                 sslEngine);
         encryptedEndPoint.setConnection(sslConnection);
-        EndPoint decryptedEndPoint = sslConnection.getDecryptedEndPoint();
+        EndPoint decryptedEndPoint = sslConnection.getSslEndPoint();
         ALPNServerConnection alpnConnection = new ALPNServerConnection(
                 connector,
                 decryptedEndPoint,

--- a/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.java.server.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3954

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-alpn-java-server:12.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 32582
- Cached input tokens: 206336
- Output tokens: 1734
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 79.31
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 78.57

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-alpn-java-server:11.0.24: 0/0 covered calls (100.00%)
- org.eclipse.jetty:jetty-alpn-java-server:12.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-alpn-java-server:11.0.24: 74/106 (69.81%)
- org.eclipse.jetty:jetty-alpn-java-server:12.0.0: 76/108 (70.37%)

**Line:**
- org.eclipse.jetty:jetty-alpn-java-server:11.0.24: 22/28 (78.57%)
- org.eclipse.jetty:jetty-alpn-java-server:12.0.0: 23/29 (79.31%)

**Method:**
- org.eclipse.jetty:jetty-alpn-java-server:11.0.24: 8/9 (88.89%)
- org.eclipse.jetty:jetty-alpn-java-server:12.0.0: 8/9 (88.89%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-alpn-java-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java 2/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
index f6fbe9e88a..36babdded8 100644
--- 1/tests/src/org.eclipse.jetty/jetty-alpn-java-server/11.0.24/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-alpn-java-server/12.0.0/src/test/java/org_eclipse_jetty/jetty_alpn_java_server/Jetty_alpn_java_serverTest.java
@@ -154,7 +154,7 @@ public class Jetty_alpn_java_serverTest {
                 encryptedEndPoint,
                 sslEngine);
         encryptedEndPoint.setConnection(sslConnection);
-        EndPoint decryptedEndPoint = sslConnection.getDecryptedEndPoint();
+        EndPoint decryptedEndPoint = sslConnection.getSslEndPoint();
         ALPNServerConnection alpnConnection = new ALPNServerConnection(
                 connector,
                 decryptedEndPoint,

```
