### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-http:9.4.0.M0 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-http/9.4.0.M0/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-http/9.4.0.M0/reachability-metadata.json
@@ -1,0 +1,153 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getUptime",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes$Type"
+      },
+      "type": "java.nio.MappedByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "org.eclipse.jetty.util.log.Slf4jLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging-linux.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime_en_US.properties"
+    },
+    {
+      "bundle": "org/eclipse/jetty/http/encoding"
+    },
+    {
+      "bundle": "org/eclipse/jetty/http/mime"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "9.4.0.M0",
+    "tested-versions" : [
+      "9.4.0.M0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.http"
+    ]
+  },
+  {
     "metadata-version" : "9.3.19.v20170502",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.3.19.v20170502/jetty-http-9.3.19.v20170502-sources.jar",
     "repository-url" : "https://github.com/eclipse/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "9.4.0.M0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.0.M0/jetty-http-9.4.0.M0-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.0.M0/jetty-http-9.4.0.M0-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.0.M0/jetty-http-9.4.0.M0-javadoc.jar",
+    "description" : "Jetty HTTP provides core HTTP utilities for Eclipse Jetty, including request and response metadata, headers, cookies, MIME types, and URI handling. It is used by Jetty server and client components to parse, represent, and generate HTTP protocol data.",
     "tested-versions" : [
       "9.4.0.M0"
     ],

--- a/stats/org.eclipse.jetty/jetty-http/9.4.0.M0/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-http/9.4.0.M0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:32:42.081311Z",
+    "library": "org.eclipse.jetty:jetty-http:9.4.0.M0",
+    "starting_commit": "68e58223dc53ab09a166de5169849759f62e72d5",
+    "ending_commit": "7f628a1a89e645f0a609b219c2a943240819338b",
+    "previous_library": "org.eclipse.jetty:jetty-http:9.3.19.v20170502",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "9.4.0.M0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1980,
+          "missed": 17819,
+          "ratio": 0.100005,
+          "total": 19799
+        },
+        "line": {
+          "covered": 311,
+          "missed": 3668,
+          "ratio": 0.07816,
+          "total": 3979
+        },
+        "method": {
+          "covered": 33,
+          "missed": 528,
+          "ratio": 0.058824,
+          "total": 561
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.3.19.v20170502",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2097,
+          "missed": 17747,
+          "ratio": 0.105674,
+          "total": 19844
+        },
+        "line": {
+          "covered": 349,
+          "missed": 3648,
+          "ratio": 0.087315,
+          "total": 3997
+        },
+        "method": {
+          "covered": 40,
+          "missed": 547,
+          "ratio": 0.068143,
+          "total": 587
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 90205,
+      "cached_input_tokens_used": 589824,
+      "output_tokens_used": 4318,
+      "iterations": 2,
+      "cost_usd": 0.4244,
+      "tested_library_loc": 311,
+      "metadata_entries": 30,
+      "previous_library_metadata_entries": 22,
+      "code_coverage_percent": 7.82,
+      "previous_library_coverage_percent": 8.73
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-http/9.4.0.M0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-http/9.4.0.M0/stats.json
+++ b/stats/org.eclipse.jetty/jetty-http/9.4.0.M0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "9.4.0.M0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1980,
+        "missed" : 17819,
+        "ratio" : 0.100005,
+        "total" : 19799
+      },
+      "line" : {
+        "covered" : 311,
+        "missed" : 3668,
+        "ratio" : 0.07816,
+        "total" : 3979
+      },
+      "method" : {
+        "covered" : 33,
+        "missed" : 528,
+        "ratio" : 0.058824,
+        "total" : 561
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-http:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-http:9.4.0.M0
+library.version = 9.4.0.M0
+metadata.dir = org.eclipse.jetty/jetty-http/9.4.0.M0/

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-http_tests'

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_http;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MimeTypesTest {
+    @Test
+    void loadsDefaultMimeAndEncodingResources() {
+        assertThat(MimeTypes.getDefaultMimeByExtension("index.html"))
+                .isEqualTo(MimeTypes.Type.TEXT_HTML.asString());
+        assertThat(MimeTypes.getDefaultMimeByExtension("IMAGE.PNG"))
+                .isEqualTo("image/png");
+        assertThat(MimeTypes.getKnownMimeTypes())
+                .contains("application/json", "text/css");
+
+        assertThat(MimeTypes.getCharsetInferredFromContentType("text/html"))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.getCharsetAssumedFromContentType("text/json"))
+                .isEqualTo("utf-8");
+    }
+
+    @Test
+    void appliesInstanceMappingsBeforeDefaultResourceMappings() {
+        MimeTypes mimeTypes = new MimeTypes();
+        mimeTypes.addMimeMapping("HTML", "text/plain;charset=UTF-8");
+        mimeTypes.addMimeMapping("custom", "application/vnd.example.Custom");
+
+        assertThat(mimeTypes.getMimeByExtension("page.html"))
+                .isEqualTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
+        assertThat(mimeTypes.getMimeByExtension("download.custom"))
+                .isEqualTo("application/vnd.example.custom");
+        assertThat(mimeTypes.getMimeByExtension("script.js"))
+                .isEqualTo("application/javascript");
+    }
+
+    @Test
+    void parsesAndRemovesCharsetsFromContentTypes() {
+        assertThat(MimeTypes.getCharsetFromContentType("text/plain; charset=\"UTF-8\""))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.getContentTypeWithoutCharset("text/plain; charset=UTF-8; boundary=simple"))
+                .isEqualTo("text/plain;boundary=simple");
+        assertThat(MimeTypes.getContentTypeWithoutCharset("application/json"))
+                .isEqualTo("application/json");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -14,17 +14,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MimeTypesTest {
     @Test
     void loadsDefaultMimeAndEncodingResources() {
-        assertThat(MimeTypes.getDefaultMimeByExtension("index.html"))
+        MimeTypes mimeTypes = new MimeTypes();
+
+        assertThat(mimeTypes.getMimeByExtension("index.html"))
                 .isEqualTo(MimeTypes.Type.TEXT_HTML.asString());
-        assertThat(MimeTypes.getDefaultMimeByExtension("IMAGE.PNG"))
+        assertThat(mimeTypes.getMimeByExtension("IMAGE.PNG"))
                 .isEqualTo("image/png");
         assertThat(MimeTypes.getKnownMimeTypes())
                 .contains("application/json", "text/css");
 
-        assertThat(MimeTypes.getCharsetInferredFromContentType("text/html"))
+        assertThat(MimeTypes.inferCharsetFromContentType("text/html"))
                 .isEqualTo("utf-8");
-        assertThat(MimeTypes.getCharsetAssumedFromContentType("text/json"))
+        assertThat(MimeTypes.Type.TEXT_JSON.getCharsetString())
                 .isEqualTo("utf-8");
+        assertThat(MimeTypes.Type.TEXT_JSON.isCharsetAssumed())
+                .isTrue();
     }
 
     @Test

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3955

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-http:9.4.0.M0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 90205
- Cached input tokens: 589824
- Output tokens: 4318
- Metadata entries: 30
- Iterations: 2
- Library coverage percentage: 7.82
- Previous library version metadata entries: 22
- Previous library version coverage percentage: 8.73

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-http:9.3.19.v20170502: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:9.4.0.M0: 2/2 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-http:9.3.19.v20170502: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:9.4.0.M0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-http:9.3.19.v20170502: 2097/19844 (10.57%)
- org.eclipse.jetty:jetty-http:9.4.0.M0: 1980/19799 (10.00%)

**Line:**
- org.eclipse.jetty:jetty-http:9.3.19.v20170502: 349/3997 (8.73%)
- org.eclipse.jetty:jetty-http:9.4.0.M0: 311/3979 (7.82%)

**Method:**
- org.eclipse.jetty:jetty-http:9.3.19.v20170502: 40/587 (6.81%)
- org.eclipse.jetty:jetty-http:9.4.0.M0: 33/561 (5.88%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-http/9.3.19.v20170502/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java 2/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
index 7ef315bf5e..bde5929d42 100644
--- 1/tests/src/org.eclipse.jetty/jetty-http/9.3.19.v20170502/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -14,17 +14,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MimeTypesTest {
     @Test
     void loadsDefaultMimeAndEncodingResources() {
-        assertThat(MimeTypes.getDefaultMimeByExtension("index.html"))
+        MimeTypes mimeTypes = new MimeTypes();
+
+        assertThat(mimeTypes.getMimeByExtension("index.html"))
                 .isEqualTo(MimeTypes.Type.TEXT_HTML.asString());
-        assertThat(MimeTypes.getDefaultMimeByExtension("IMAGE.PNG"))
+        assertThat(mimeTypes.getMimeByExtension("IMAGE.PNG"))
                 .isEqualTo("image/png");
         assertThat(MimeTypes.getKnownMimeTypes())
                 .contains("application/json", "text/css");
 
-        assertThat(MimeTypes.getCharsetInferredFromContentType("text/html"))
+        assertThat(MimeTypes.inferCharsetFromContentType("text/html"))
                 .isEqualTo("utf-8");
-        assertThat(MimeTypes.getCharsetAssumedFromContentType("text/json"))
+        assertThat(MimeTypes.Type.TEXT_JSON.getCharsetString())
                 .isEqualTo("utf-8");
+        assertThat(MimeTypes.Type.TEXT_JSON.isCharsetAssumed())
+                .isTrue();
     }
 
     @Test

```
