### PR TITLE
[GenAI] Test fix for org.apache.maven.resolver:maven-resolver-named-locks:2.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.named.support.NamedLockFactorySupport"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.named.support.NamedLockFactorySupport"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0",
+    "tested-versions" : [
+      "2.0.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.named"
+    ]
+  },
+  {
     "metadata-version" : "1.9.25",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-named-locks/1.9.25/maven-resolver-named-locks-1.9.25-sources.jar",
     "repository-url" : "https://github.com/apache/maven-resolver",

--- a/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-named-locks/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-named-locks/2.0.0/maven-resolver-named-locks-2.0.0-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/2.0.0/maven-resolver-2.0.0-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-named-locks/2.0.0/maven-resolver-named-locks-2.0.0-javadoc.jar",
+    "description" : "Maven Resolver Named Locks provides synchronization primitives for named lock coordination within Maven Artifact Resolver. It includes local, file-based, and no-op named lock factories used to guard concurrent access to shared resolver resources.",
     "tested-versions" : [
       "2.0.0"
     ],

--- a/stats/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:37:25.908452Z",
+    "library": "org.apache.maven.resolver:maven-resolver-named-locks:2.0.0",
+    "starting_commit": "50c92095dcfc93d6f5e5892d0229736492eaf60f",
+    "ending_commit": "a3b18045da2862833b2a50c9b8d3f8d35fe57617",
+    "previous_library": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.25",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1311,
+          "missed": 519,
+          "ratio": 0.716393,
+          "total": 1830
+        },
+        "line": {
+          "covered": 319,
+          "missed": 95,
+          "ratio": 0.770531,
+          "total": 414
+        },
+        "method": {
+          "covered": 85,
+          "missed": 16,
+          "ratio": 0.841584,
+          "total": 101
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.9.25",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1134,
+          "missed": 224,
+          "ratio": 0.835052,
+          "total": 1358
+        },
+        "line": {
+          "covered": 285,
+          "missed": 39,
+          "ratio": 0.87963,
+          "total": 324
+        },
+        "method": {
+          "covered": 72,
+          "missed": 4,
+          "ratio": 0.947368,
+          "total": 76
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 55342,
+      "cached_input_tokens_used": 510976,
+      "output_tokens_used": 5755,
+      "iterations": 1,
+      "cost_usd": 0.4281,
+      "tested_library_loc": 319,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 77.05,
+      "previous_library_coverage_percent": 87.96
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1311,
+        "missed" : 519,
+        "ratio" : 0.716393,
+        "total" : 1830
+      },
+      "line" : {
+        "covered" : 319,
+        "missed" : 95,
+        "ratio" : 0.770531,
+        "total" : 414
+      },
+      "method" : {
+        "covered" : 85,
+        "missed" : 16,
+        "ratio" : 0.841584,
+        "total" : 101
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-named-locks:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-named-locks:2.0.0
+library.version = 2.0.0
+metadata.dir = org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-named-locks_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_named_locks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.util.Deque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.eclipse.aether.named.NamedLock;
+import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
+import org.eclipse.aether.named.providers.NoopNamedLockFactory;
+import org.eclipse.aether.named.support.LockUpgradeNotSupportedException;
+import org.eclipse.aether.named.support.NamedLockFactorySupport;
+import org.eclipse.aether.named.support.NamedLockSupport;
+import org.eclipse.aether.named.support.ReadWriteLockNamedLock;
+import org.eclipse.aether.named.support.Retry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Maven_resolver_named_locksTest {
+    private static final long LOCK_TIMEOUT_MILLIS = 25L;
+
+    @Test
+    void providerNamesIdentifyAvailableImplementations() {
+        assertThat(NoopNamedLockFactory.NAME).isEqualTo("noop");
+        assertThat(LocalReadWriteLockNamedLockFactory.NAME).isEqualTo("rwlock-local");
+        assertThat(LocalSemaphoreNamedLockFactory.NAME).isEqualTo("semaphore-local");
+        assertThat(FileLockNamedLockFactory.NAME).isEqualTo("file-lock");
+    }
+
+    @Test
+    void factoryReusesNamedLockUntilEveryHandleIsClosed() {
+        LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
+        NamedLockSupport first = factory.getLock("repository");
+        NamedLockSupport second = factory.getLock("repository");
+        NamedLockSupport differentName = factory.getLock("metadata");
+
+        assertThat(first).isSameAs(second);
+        assertThat(first).isNotSameAs(differentName);
+        assertThat(first.name()).isEqualTo("repository");
+        assertThat(first).hasToString("ReadWriteLockNamedLock{name='repository'}");
+        assertThat(first.diagnosticState()).isEmpty();
+
+        first.close();
+        second.close();
+
+        NamedLockSupport replacement = factory.getLock("repository");
+        assertThat(replacement).isNotSameAs(first);
+
+        replacement.close();
+        differentName.close();
+        factory.closeLock("already-closed");
+        factory.shutdown();
+    }
+
+    @Test
+    void noopProviderAcceptsEverySharedAndExclusiveRequest() throws Exception {
+        NoopNamedLockFactory factory = new NoopNamedLockFactory();
+        NamedLock lock = factory.getLock("anything");
+        NamedLock competingHandle = factory.getLock("anything");
+
+        try {
+            assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(lockSharedInWorker(competingHandle)).isTrue();
+            assertThat(lockExclusivelyInWorker(competingHandle)).isTrue();
+
+            assertThat(lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(lockSharedInWorker(competingHandle)).isTrue();
+            assertThat(lockExclusivelyInWorker(competingHandle)).isTrue();
+
+            lock.unlock();
+            lock.unlock();
+            lock.unlock();
+        } finally {
+            lock.close();
+            competingHandle.close();
+        }
+    }
+
+    @Test
+    void localReadWriteLockCoordinatesReadersAndWriters() throws Exception {
+        LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, "artifact");
+    }
+
+    @Test
+    void localSemaphoreLockCoordinatesReadersAndWriters() throws Exception {
+        LocalSemaphoreNamedLockFactory factory = new LocalSemaphoreNamedLockFactory();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, "artifact");
+    }
+
+    @Test
+    void fileLockCoordinatesReadersAndWriters(@TempDir Path tempDir) throws Exception {
+        FileLockNamedLockFactory factory = new FileLockNamedLockFactory();
+        String lockName = tempDir.resolve("locks").resolve("repository.lck").toString();
+
+        assertStatefulLockCoordinatesReadersAndWriters(factory, lockName);
+    }
+
+    @Test
+    void statefulLocksRejectSharedToExclusiveUpgrade(@TempDir Path tempDir) throws Exception {
+        assertSharedToExclusiveUpgradeIsRejected(new LocalReadWriteLockNamedLockFactory(), "rw-upgrade");
+        assertSharedToExclusiveUpgradeIsRejected(new LocalSemaphoreNamedLockFactory(), "semaphore-upgrade");
+        assertSharedToExclusiveUpgradeIsRejected(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toString());
+    }
+
+    @Test
+    void statefulLocksAllowExclusiveReentryAndSharedDowngrade(@TempDir Path tempDir) throws Exception {
+        assertExclusiveReentryAndSharedDowngrade(new LocalReadWriteLockNamedLockFactory(), "rw-downgrade");
+        assertExclusiveReentryAndSharedDowngrade(new LocalSemaphoreNamedLockFactory(), "semaphore-downgrade");
+        assertExclusiveReentryAndSharedDowngrade(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toString());
+    }
+
+    @Test
+    void statefulLocksRejectUnlockWithoutHeldLock(@TempDir Path tempDir) {
+        assertUnlockWithoutHeldLockFails(new LocalReadWriteLockNamedLockFactory(), "rw-unlocked");
+        assertUnlockWithoutHeldLockFails(new LocalSemaphoreNamedLockFactory(), "semaphore-unlocked");
+        assertUnlockWithoutHeldLockFails(
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toString());
+    }
+
+    @Test
+    void diagnosticFactoryTracksCurrentThreadLockStateAndReturnsFailures() throws Exception {
+        DiagnosticReadWriteLockFactory factory = new DiagnosticReadWriteLockFactory();
+        NamedLockSupport lock = factory.getLock("diagnostic");
+        RuntimeException failure = new RuntimeException("boom");
+
+        assertThat(factory.isDiagnosticEnabled()).isTrue();
+        assertThat(lock.diagnosticState()).isEmpty();
+
+        assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+        try {
+            Deque<String> currentThreadState = lock.diagnosticState().get(Thread.currentThread());
+            assertThat(currentThreadState).containsExactly("shared");
+            assertThat(factory.onFailure(failure)).isSameAs(failure);
+        } finally {
+            lock.unlock();
+            lock.close();
+        }
+
+        assertThat(lock.diagnosticState().get(Thread.currentThread())).isEmpty();
+    }
+
+    @Test
+    void retryReturnsFirstNonNullResult() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = Retry.retry(
+                1L,
+                TimeUnit.SECONDS,
+                0L,
+                () -> attempts.incrementAndGet() == 3 ? "resolved" : null,
+                exception -> true,
+                "fallback");
+
+        assertThat(result).isEqualTo("resolved");
+        assertThat(attempts).hasValue(3);
+    }
+
+    @Test
+    void retryReturnsFallbackAfterRetryableFailuresAndStopsOnNonRetryableFailures() throws Exception {
+        AtomicInteger retryableAttempts = new AtomicInteger();
+
+        String fallback = Retry.retry(
+                3,
+                0L,
+                () -> {
+                    retryableAttempts.incrementAndGet();
+                    throw new IllegalArgumentException("temporary");
+                },
+                IllegalArgumentException.class::isInstance,
+                "fallback");
+
+        assertThat(fallback).isEqualTo("fallback");
+        assertThat(retryableAttempts).hasValue(3);
+
+        NonRetryableException failure = new NonRetryableException("fatal");
+        assertThatThrownBy(() -> Retry.retry(3, 0L, throwing(failure), exception -> true, "fallback"))
+                .isSameAs(failure);
+    }
+
+    @Test
+    void retryStopsImmediatelyWhenFailurePredicateRejectsException() {
+        AtomicInteger attempts = new AtomicInteger();
+        IllegalArgumentException failure = new IllegalArgumentException("permanent");
+
+        assertThatThrownBy(() -> Retry.retry(
+                        5,
+                        0L,
+                        () -> {
+                            attempts.incrementAndGet();
+                            throw failure;
+                        },
+                        exception -> false,
+                        "fallback"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCause(failure);
+        assertThat(attempts).hasValue(1);
+    }
+
+    private static void assertStatefulLockCoordinatesReadersAndWriters(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock owner = factory.getLock(lockName);
+        NamedLock competitor = factory.getLock(lockName);
+
+        try {
+            assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            try {
+                assertThat(lockSharedInWorker(competitor)).isTrue();
+                assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+            } finally {
+                owner.unlock();
+            }
+
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            try {
+                assertThat(lockSharedInWorker(competitor)).isFalse();
+                assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+            } finally {
+                owner.unlock();
+            }
+
+            assertThat(lockExclusivelyInWorker(competitor)).isTrue();
+        } finally {
+            owner.close();
+            competitor.close();
+        }
+    }
+
+    private static void assertSharedToExclusiveUpgradeIsRejected(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock lock = factory.getLock(lockName);
+
+        try {
+            assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThatThrownBy(() -> lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS))
+                    .isInstanceOf(LockUpgradeNotSupportedException.class)
+                    .hasMessageContaining(lockName);
+        } finally {
+            lock.unlock();
+            lock.close();
+        }
+    }
+
+    private static void assertExclusiveReentryAndSharedDowngrade(NamedLockFactorySupport factory, String lockName)
+            throws Exception {
+        NamedLock owner = factory.getLock(lockName);
+        NamedLock competitor = factory.getLock(lockName);
+        int ownerHeldLocks = 0;
+
+        try {
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+            assertThat(owner.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+            assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            ownerHeldLocks++;
+
+            assertThat(lockSharedInWorker(competitor)).isFalse();
+            assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+
+            owner.unlock();
+            ownerHeldLocks--;
+            assertThat(lockSharedInWorker(competitor)).isFalse();
+
+            owner.unlock();
+            ownerHeldLocks--;
+            assertThat(lockExclusivelyInWorker(competitor)).isFalse();
+        } finally {
+            while (ownerHeldLocks > 0) {
+                owner.unlock();
+                ownerHeldLocks--;
+            }
+            owner.close();
+            competitor.close();
+        }
+    }
+
+    private static void assertUnlockWithoutHeldLockFails(NamedLockFactorySupport factory, String lockName) {
+        NamedLock lock = factory.getLock(lockName);
+
+        try {
+            assertThatIllegalStateException()
+                    .isThrownBy(lock::unlock)
+                    .withMessage("Wrong API usage: unlock without lock");
+        } finally {
+            lock.close();
+        }
+    }
+
+    private static boolean lockSharedInWorker(NamedLock lock) throws Exception {
+        return runInWorker(() -> {
+            boolean locked = lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (locked) {
+                lock.unlock();
+            }
+            return locked;
+        });
+    }
+
+    private static boolean lockExclusivelyInWorker(NamedLock lock) throws Exception {
+        return runInWorker(() -> {
+            boolean locked = lock.lockExclusively(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (locked) {
+                lock.unlock();
+            }
+            return locked;
+        });
+    }
+
+    private static boolean runInWorker(Callable<Boolean> callable) throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executorService.submit(callable);
+        try {
+            return future.get(5L, TimeUnit.SECONDS);
+        } finally {
+            executorService.shutdownNow();
+            assertThat(executorService.awaitTermination(5L, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static Callable<String> throwing(RuntimeException exception) {
+        return () -> {
+            throw exception;
+        };
+    }
+
+    private static final class DiagnosticReadWriteLockFactory extends NamedLockFactorySupport {
+        private DiagnosticReadWriteLockFactory() {
+            super(true);
+        }
+
+        @Override
+        protected NamedLockSupport createLock(String name) {
+            return new ReadWriteLockNamedLock(name, this, new ReentrantReadWriteLock());
+        }
+    }
+
+    private static final class NonRetryableException extends RuntimeException implements Retry.DoNotRetry {
+        private NonRetryableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.eclipse.aether.named.NamedLock;
+import org.eclipse.aether.named.NamedLockKey;
 import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
@@ -47,33 +48,34 @@ public class Maven_resolver_named_locksTest {
     @Test
     void factoryReusesNamedLockUntilEveryHandleIsClosed() {
         LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
-        NamedLockSupport first = factory.getLock("repository");
-        NamedLockSupport second = factory.getLock("repository");
-        NamedLockSupport differentName = factory.getLock("metadata");
+        NamedLockSupport first = namedLockSupport(factory, "repository");
+        NamedLockSupport second = namedLockSupport(factory, "repository");
+        NamedLockSupport differentName = namedLockSupport(factory, "metadata");
 
         assertThat(first).isSameAs(second);
         assertThat(first).isNotSameAs(differentName);
-        assertThat(first.name()).isEqualTo("repository");
-        assertThat(first).hasToString("ReadWriteLockNamedLock{name='repository'}");
+        assertThat(first.key().name()).isEqualTo("repository");
+        assertThat(first.key().resources()).isEmpty();
+        assertThat(first).hasToString("ReadWriteLockNamedLock{key='NamedLockKey{name='repository', resources=[]}'}");
         assertThat(first.diagnosticState()).isEmpty();
 
         first.close();
         second.close();
 
-        NamedLockSupport replacement = factory.getLock("repository");
+        NamedLockSupport replacement = namedLockSupport(factory, "repository");
         assertThat(replacement).isNotSameAs(first);
 
         replacement.close();
         differentName.close();
-        factory.closeLock("already-closed");
+        factory.closeLock(namedLockKey("already-closed"));
         factory.shutdown();
     }
 
     @Test
     void noopProviderAcceptsEverySharedAndExclusiveRequest() throws Exception {
         NoopNamedLockFactory factory = new NoopNamedLockFactory();
-        NamedLock lock = factory.getLock("anything");
-        NamedLock competingHandle = factory.getLock("anything");
+        NamedLock lock = namedLock(factory, "anything");
+        NamedLock competingHandle = namedLock(factory, "anything");
 
         try {
             assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -110,7 +112,7 @@ public class Maven_resolver_named_locksTest {
     @Test
     void fileLockCoordinatesReadersAndWriters(@TempDir Path tempDir) throws Exception {
         FileLockNamedLockFactory factory = new FileLockNamedLockFactory();
-        String lockName = tempDir.resolve("locks").resolve("repository.lck").toString();
+        String lockName = tempDir.resolve("locks").resolve("repository.lck").toUri().toString();
 
         assertStatefulLockCoordinatesReadersAndWriters(factory, lockName);
     }
@@ -120,7 +122,7 @@ public class Maven_resolver_named_locksTest {
         assertSharedToExclusiveUpgradeIsRejected(new LocalReadWriteLockNamedLockFactory(), "rw-upgrade");
         assertSharedToExclusiveUpgradeIsRejected(new LocalSemaphoreNamedLockFactory(), "semaphore-upgrade");
         assertSharedToExclusiveUpgradeIsRejected(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toUri().toString());
     }
 
     @Test
@@ -128,7 +130,7 @@ public class Maven_resolver_named_locksTest {
         assertExclusiveReentryAndSharedDowngrade(new LocalReadWriteLockNamedLockFactory(), "rw-downgrade");
         assertExclusiveReentryAndSharedDowngrade(new LocalSemaphoreNamedLockFactory(), "semaphore-downgrade");
         assertExclusiveReentryAndSharedDowngrade(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toUri().toString());
     }
 
     @Test
@@ -136,13 +138,13 @@ public class Maven_resolver_named_locksTest {
         assertUnlockWithoutHeldLockFails(new LocalReadWriteLockNamedLockFactory(), "rw-unlocked");
         assertUnlockWithoutHeldLockFails(new LocalSemaphoreNamedLockFactory(), "semaphore-unlocked");
         assertUnlockWithoutHeldLockFails(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toUri().toString());
     }
 
     @Test
     void diagnosticFactoryTracksCurrentThreadLockStateAndReturnsFailures() throws Exception {
         DiagnosticReadWriteLockFactory factory = new DiagnosticReadWriteLockFactory();
-        NamedLockSupport lock = factory.getLock("diagnostic");
+        NamedLockSupport lock = namedLockSupport(factory, "diagnostic");
         RuntimeException failure = new RuntimeException("boom");
 
         assertThat(factory.isDiagnosticEnabled()).isTrue();
@@ -220,8 +222,8 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertStatefulLockCoordinatesReadersAndWriters(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock owner = factory.getLock(lockName);
-        NamedLock competitor = factory.getLock(lockName);
+        NamedLock owner = namedLock(factory, lockName);
+        NamedLock competitor = namedLock(factory, lockName);
 
         try {
             assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -249,7 +251,7 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertSharedToExclusiveUpgradeIsRejected(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock lock = factory.getLock(lockName);
+        NamedLock lock = namedLock(factory, lockName);
 
         try {
             assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -264,8 +266,8 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertExclusiveReentryAndSharedDowngrade(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock owner = factory.getLock(lockName);
-        NamedLock competitor = factory.getLock(lockName);
+        NamedLock owner = namedLock(factory, lockName);
+        NamedLock competitor = namedLock(factory, lockName);
         int ownerHeldLocks = 0;
 
         try {
@@ -297,7 +299,7 @@ public class Maven_resolver_named_locksTest {
     }
 
     private static void assertUnlockWithoutHeldLockFails(NamedLockFactorySupport factory, String lockName) {
-        NamedLock lock = factory.getLock(lockName);
+        NamedLock lock = namedLock(factory, lockName);
 
         try {
             assertThatIllegalStateException()
@@ -306,6 +308,18 @@ public class Maven_resolver_named_locksTest {
         } finally {
             lock.close();
         }
+    }
+
+    private static NamedLock namedLock(NamedLockFactorySupport factory, String lockName) {
+        return factory.getLock(namedLockKey(lockName));
+    }
+
+    private static NamedLockSupport namedLockSupport(NamedLockFactorySupport factory, String lockName) {
+        return (NamedLockSupport) namedLock(factory, lockName);
+    }
+
+    private static NamedLockKey namedLockKey(String lockName) {
+        return NamedLockKey.of(lockName);
     }
 
     private static boolean lockSharedInWorker(NamedLock lock) throws Exception {
@@ -351,8 +365,8 @@ public class Maven_resolver_named_locksTest {
         }
 
         @Override
-        protected NamedLockSupport createLock(String name) {
-            return new ReadWriteLockNamedLock(name, this, new ReentrantReadWriteLock());
+        protected NamedLockSupport createLock(NamedLockKey key) {
+            return new ReadWriteLockNamedLock(key, this, new ReentrantReadWriteLock());
         }
     }
 

--- a/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.aether.named.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3951

This PR provides test fixes and new metadata for org.apache.maven.resolver:maven-resolver-named-locks:2.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 55342
- Cached input tokens: 510976
- Output tokens: 5755
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 77.05
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 87.96

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.resolver:maven-resolver-named-locks:1.9.25: 0/0 covered calls (100.00%)
- org.apache.maven.resolver:maven-resolver-named-locks:2.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.resolver:maven-resolver-named-locks:1.9.25: 1134/1358 (83.51%)
- org.apache.maven.resolver:maven-resolver-named-locks:2.0.0: 1311/1830 (71.64%)

**Line:**
- org.apache.maven.resolver:maven-resolver-named-locks:1.9.25: 285/324 (87.96%)
- org.apache.maven.resolver:maven-resolver-named-locks:2.0.0: 319/414 (77.05%)

**Method:**
- org.apache.maven.resolver:maven-resolver-named-locks:1.9.25: 72/76 (94.74%)
- org.apache.maven.resolver:maven-resolver-named-locks:2.0.0: 85/101 (84.16%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java 2/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
index 83b27ccbe4..3e34e71320 100644
--- 1/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
+++ 2/tests/src/org.apache.maven.resolver/maven-resolver-named-locks/2.0.0/src/test/java/org_apache_maven_resolver/maven_resolver_named_locks/Maven_resolver_named_locksTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.eclipse.aether.named.NamedLock;
+import org.eclipse.aether.named.NamedLockKey;
 import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
@@ -47,33 +48,34 @@ public class Maven_resolver_named_locksTest {
     @Test
     void factoryReusesNamedLockUntilEveryHandleIsClosed() {
         LocalReadWriteLockNamedLockFactory factory = new LocalReadWriteLockNamedLockFactory();
-        NamedLockSupport first = factory.getLock("repository");
-        NamedLockSupport second = factory.getLock("repository");
-        NamedLockSupport differentName = factory.getLock("metadata");
+        NamedLockSupport first = namedLockSupport(factory, "repository");
+        NamedLockSupport second = namedLockSupport(factory, "repository");
+        NamedLockSupport differentName = namedLockSupport(factory, "metadata");
 
         assertThat(first).isSameAs(second);
         assertThat(first).isNotSameAs(differentName);
-        assertThat(first.name()).isEqualTo("repository");
-        assertThat(first).hasToString("ReadWriteLockNamedLock{name='repository'}");
+        assertThat(first.key().name()).isEqualTo("repository");
+        assertThat(first.key().resources()).isEmpty();
+        assertThat(first).hasToString("ReadWriteLockNamedLock{key='NamedLockKey{name='repository', resources=[]}'}");
         assertThat(first.diagnosticState()).isEmpty();
 
         first.close();
         second.close();
 
-        NamedLockSupport replacement = factory.getLock("repository");
+        NamedLockSupport replacement = namedLockSupport(factory, "repository");
         assertThat(replacement).isNotSameAs(first);
 
         replacement.close();
         differentName.close();
-        factory.closeLock("already-closed");
+        factory.closeLock(namedLockKey("already-closed"));
         factory.shutdown();
     }
 
     @Test
     void noopProviderAcceptsEverySharedAndExclusiveRequest() throws Exception {
         NoopNamedLockFactory factory = new NoopNamedLockFactory();
-        NamedLock lock = factory.getLock("anything");
-        NamedLock competingHandle = factory.getLock("anything");
+        NamedLock lock = namedLock(factory, "anything");
+        NamedLock competingHandle = namedLock(factory, "anything");
 
         try {
             assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -110,7 +112,7 @@ public class Maven_resolver_named_locksTest {
     @Test
     void fileLockCoordinatesReadersAndWriters(@TempDir Path tempDir) throws Exception {
         FileLockNamedLockFactory factory = new FileLockNamedLockFactory();
-        String lockName = tempDir.resolve("locks").resolve("repository.lck").toString();
+        String lockName = tempDir.resolve("locks").resolve("repository.lck").toUri().toString();
 
         assertStatefulLockCoordinatesReadersAndWriters(factory, lockName);
     }
@@ -120,7 +122,7 @@ public class Maven_resolver_named_locksTest {
         assertSharedToExclusiveUpgradeIsRejected(new LocalReadWriteLockNamedLockFactory(), "rw-upgrade");
         assertSharedToExclusiveUpgradeIsRejected(new LocalSemaphoreNamedLockFactory(), "semaphore-upgrade");
         assertSharedToExclusiveUpgradeIsRejected(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("upgrade.lck").toUri().toString());
     }
 
     @Test
@@ -128,7 +130,7 @@ public class Maven_resolver_named_locksTest {
         assertExclusiveReentryAndSharedDowngrade(new LocalReadWriteLockNamedLockFactory(), "rw-downgrade");
         assertExclusiveReentryAndSharedDowngrade(new LocalSemaphoreNamedLockFactory(), "semaphore-downgrade");
         assertExclusiveReentryAndSharedDowngrade(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("downgrade.lck").toUri().toString());
     }
 
     @Test
@@ -136,13 +138,13 @@ public class Maven_resolver_named_locksTest {
         assertUnlockWithoutHeldLockFails(new LocalReadWriteLockNamedLockFactory(), "rw-unlocked");
         assertUnlockWithoutHeldLockFails(new LocalSemaphoreNamedLockFactory(), "semaphore-unlocked");
         assertUnlockWithoutHeldLockFails(
-                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toString());
+                new FileLockNamedLockFactory(), tempDir.resolve("locks").resolve("unlocked.lck").toUri().toString());
     }
 
     @Test
     void diagnosticFactoryTracksCurrentThreadLockStateAndReturnsFailures() throws Exception {
         DiagnosticReadWriteLockFactory factory = new DiagnosticReadWriteLockFactory();
-        NamedLockSupport lock = factory.getLock("diagnostic");
+        NamedLockSupport lock = namedLockSupport(factory, "diagnostic");
         RuntimeException failure = new RuntimeException("boom");
 
         assertThat(factory.isDiagnosticEnabled()).isTrue();
@@ -220,8 +222,8 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertStatefulLockCoordinatesReadersAndWriters(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock owner = factory.getLock(lockName);
-        NamedLock competitor = factory.getLock(lockName);
+        NamedLock owner = namedLock(factory, lockName);
+        NamedLock competitor = namedLock(factory, lockName);
 
         try {
             assertThat(owner.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -249,7 +251,7 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertSharedToExclusiveUpgradeIsRejected(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock lock = factory.getLock(lockName);
+        NamedLock lock = namedLock(factory, lockName);
 
         try {
             assertThat(lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
@@ -264,8 +266,8 @@ public class Maven_resolver_named_locksTest {
 
     private static void assertExclusiveReentryAndSharedDowngrade(NamedLockFactorySupport factory, String lockName)
             throws Exception {
-        NamedLock owner = factory.getLock(lockName);
-        NamedLock competitor = factory.getLock(lockName);
+        NamedLock owner = namedLock(factory, lockName);
+        NamedLock competitor = namedLock(factory, lockName);
         int ownerHeldLocks = 0;
 
         try {
@@ -297,7 +299,7 @@ public class Maven_resolver_named_locksTest {
     }
 
     private static void assertUnlockWithoutHeldLockFails(NamedLockFactorySupport factory, String lockName) {
-        NamedLock lock = factory.getLock(lockName);
+        NamedLock lock = namedLock(factory, lockName);
 
         try {
             assertThatIllegalStateException()
@@ -308,6 +310,18 @@ public class Maven_resolver_named_locksTest {
         }
     }
 
+    private static NamedLock namedLock(NamedLockFactorySupport factory, String lockName) {
+        return factory.getLock(namedLockKey(lockName));
+    }
+
+    private static NamedLockSupport namedLockSupport(NamedLockFactorySupport factory, String lockName) {
+        return (NamedLockSupport) namedLock(factory, lockName);
+    }
+
+    private static NamedLockKey namedLockKey(String lockName) {
+        return NamedLockKey.of(lockName);
+    }
+
     private static boolean lockSharedInWorker(NamedLock lock) throws Exception {
         return runInWorker(() -> {
             boolean locked = lock.lockShared(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
@@ -351,8 +365,8 @@ public class Maven_resolver_named_locksTest {
         }
 
         @Override
-        protected NamedLockSupport createLock(String name) {
-            return new ReadWriteLockNamedLock(name, this, new ReentrantReadWriteLock());
+        protected NamedLockSupport createLock(NamedLockKey key) {
+            return new ReadWriteLockNamedLock(key, this, new ReentrantReadWriteLock());
         }
     }
 

```
