### PR TITLE
[GenAI] Test fix for jakarta.persistence:jakarta.persistence-api:4.0.0-M2 using gpt-5.5

### DIFF
--- a/metadata/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/reachability-metadata.json
+++ b/metadata/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/reachability-metadata.json
@@ -1,0 +1,29 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.persistence.spi.PersistenceProviderResolverHolder$DefaultPersistenceProviderResolver"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.persistence.spi.PersistenceProviderResolverHolder$DefaultPersistenceProviderResolver"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.persistence.spi.PersistenceProviderResolverHolder$DefaultPersistenceProviderResolver"
+      },
+      "glob" : "META-INF/services/jakarta.persistence.spi.PersistenceProvider"
+    }
+  ]
+}

--- a/metadata/jakarta.persistence/jakarta.persistence-api/index.json
+++ b/metadata/jakarta.persistence/jakarta.persistence-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0-M2",
+    "source-code-url" : "https://repo1.maven.org/maven2/jakarta/persistence/jakarta.persistence-api/4.0.0-M2/jakarta.persistence-api-4.0.0-M2-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/persistence",
+    "test-code-url" : "https://repo1.maven.org/maven2/jakarta/persistence/persistence-tck-dist/4.0.0-M2/persistence-tck-dist-4.0.0-M2.zip",
+    "documentation-url" : "https://repo1.maven.org/maven2/jakarta/persistence/jakarta.persistence-api/4.0.0-M2/jakarta.persistence-api-4.0.0-M2-javadoc.jar",
+    "description" : "Jakarta Persistence API defines the standard Java API for persistence and object/relational mapping in Jakarta EE and Java SE environments. It provides annotations and interfaces for mapping domain objects to relational data, managing entity lifecycle, querying, transactions, caching, and schema-related metadata.",
     "tested-versions" : [
       "4.0.0-M2"
     ],

--- a/metadata/jakarta.persistence/jakarta.persistence-api/index.json
+++ b/metadata/jakarta.persistence/jakarta.persistence-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0-M2",
+    "tested-versions" : [
+      "4.0.0-M2"
+    ],
+    "allowed-packages" : [
+      "jakarta.persistence"
+    ]
+  },
+  {
     "metadata-version" : "4.0.0-M1",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/persistence/jakarta.persistence-api/4.0.0-M1/jakarta.persistence-api-4.0.0-M1-sources.jar",
     "repository-url" : "https://github.com/jakartaee/persistence",

--- a/stats/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/execution-metrics.json
+++ b/stats/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:44:39.271142Z",
+    "library": "jakarta.persistence:jakarta.persistence-api:4.0.0-M2",
+    "starting_commit": "751f53ed5f14a8968a3c0c01e8cb9d0b5f390279",
+    "ending_commit": "154c4f22e406e28496f08a2e964d2f6fd317c3e6",
+    "previous_library": "jakarta.persistence:jakarta.persistence-api:4.0.0-M1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0-M2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 607,
+          "missed": 2158,
+          "ratio": 0.21953,
+          "total": 2765
+        },
+        "line": {
+          "covered": 156,
+          "missed": 515,
+          "ratio": 0.232489,
+          "total": 671
+        },
+        "method": {
+          "covered": 52,
+          "missed": 200,
+          "ratio": 0.206349,
+          "total": 252
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.0-M1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 603,
+          "missed": 2116,
+          "ratio": 0.221773,
+          "total": 2719
+        },
+        "line": {
+          "covered": 167,
+          "missed": 509,
+          "ratio": 0.247041,
+          "total": 676
+        },
+        "method": {
+          "covered": 48,
+          "missed": 193,
+          "ratio": 0.19917,
+          "total": 241
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 52946,
+      "cached_input_tokens_used": 459264,
+      "output_tokens_used": 4223,
+      "iterations": 1,
+      "cost_usd": 0.3563,
+      "tested_library_loc": 156,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 23.25,
+      "previous_library_coverage_percent": 24.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java",
+      "metadata_file": "metadata/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/stats.json
+++ b/stats/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0-M2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 607,
+        "missed" : 2158,
+        "ratio" : 0.21953,
+        "total" : 2765
+      },
+      "line" : {
+        "covered" : 156,
+        "missed" : 515,
+        "ratio" : 0.232489,
+        "total" : 671
+      },
+      "method" : {
+        "covered" : 52,
+        "missed" : 200,
+        "ratio" : 0.206349,
+        "total" : 252
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/.gitignore
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/build.gradle
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.persistence:jakarta.persistence-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/gradle.properties
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.persistence:jakarta.persistence-api:4.0.0-M2
+library.version = 4.0.0-M2
+metadata.dir = jakarta.persistence/jakarta.persistence-api/4.0.0-M2/

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/settings.gradle
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.persistence.jakarta.persistence-api_tests'

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
@@ -1,0 +1,1463 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_persistence.jakarta_persistence_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Cache;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityAgent;
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityHandler;
+import jakarta.persistence.EntityListenerRegistration;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.Parameter;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.PersistenceConfiguration;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.PersistenceUnitTransactionType;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.PessimisticLockException;
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Query;
+import jakarta.persistence.QueryTimeoutException;
+import jakarta.persistence.RollbackException;
+import jakarta.persistence.SchemaManager;
+import jakarta.persistence.Statement;
+import jakarta.persistence.StatementReference;
+import jakarta.persistence.SynchronizationType;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
+import jakarta.persistence.TransactionRequiredException;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.TypedQueryReference;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.metamodel.Type;
+import jakarta.persistence.spi.ClassTransformer;
+import jakarta.persistence.spi.LoadState;
+import jakarta.persistence.spi.PersistenceProvider;
+import jakarta.persistence.spi.PersistenceProviderResolver;
+import jakarta.persistence.spi.PersistenceProviderResolverHolder;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import jakarta.persistence.spi.ProviderUtil;
+import jakarta.persistence.sql.ResultSetMapping;
+import org.junit.jupiter.api.Test;
+
+public class Jakarta_persistence_apiTest {
+
+    @Test
+    void createEntityManagerFactoryUsesConfiguredProvidersInOrder() {
+        RecordingProvider nullProvider = new RecordingProvider(
+                "null-provider",
+                null,
+                false,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        StubEntityManagerFactory entityManagerFactory = new StubEntityManagerFactory();
+        RecordingProvider successProvider = new RecordingProvider(
+                "success-provider",
+                entityManagerFactory,
+                false,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        FixedResolver resolver = new FixedResolver(List.of(nullProvider, successProvider));
+        Map<String, Object> properties = Map.of("jakarta.persistence.jdbc.url", "jdbc:test");
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            EntityManagerFactory factoryWithoutProperties = Persistence.createEntityManagerFactory("default-unit");
+            EntityManagerFactory factoryWithProperties = Persistence.createEntityManagerFactory("custom-unit", properties);
+
+            assertThat(factoryWithoutProperties).isSameAs(entityManagerFactory);
+            assertThat(factoryWithProperties).isSameAs(entityManagerFactory);
+            assertThat(resolver.getPersistenceProvidersCalls).isEqualTo(2);
+            assertThat(nullProvider.createEntityManagerFactoryCalls)
+                    .containsExactly(
+                            new CreateEntityManagerFactoryCall("default-unit", null),
+                            new CreateEntityManagerFactoryCall("custom-unit", properties)
+                    );
+            assertThat(successProvider.createEntityManagerFactoryCalls)
+                    .containsExactly(
+                            new CreateEntityManagerFactoryCall("default-unit", null),
+                            new CreateEntityManagerFactoryCall("custom-unit", properties)
+                    );
+        }
+    }
+
+    @Test
+    void createEntityManagerFactoryThrowsHelpfulMessageWhenNoProviderMatches() {
+        FixedResolver emptyResolver = new FixedResolver(List.of());
+
+        try (ResolverScope ignored = useResolver(emptyResolver)) {
+            assertThatThrownBy(() -> Persistence.createEntityManagerFactory("missing-unit"))
+                    .isInstanceOf(PersistenceException.class)
+                    .hasMessage("No Persistence provider for EntityManager named missing-unit");
+        }
+    }
+
+    @Test
+    void createEntityManagerFactoryPropagatesProviderFailuresWithoutTryingLaterProviders() {
+        IllegalStateException failure = new IllegalStateException("bootstrap-failed");
+        ThrowingProvider failingProvider = new ThrowingProvider(
+                failure,
+                null,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        RecordingProvider fallbackProvider = new RecordingProvider(
+                "fallback-provider",
+                new StubEntityManagerFactory(),
+                false,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        FixedResolver resolver = new FixedResolver(List.of(failingProvider, fallbackProvider));
+        Map<String, Object> properties = Map.of("jakarta.persistence.provider", "test-provider");
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            assertThatThrownBy(() -> Persistence.createEntityManagerFactory("failing-unit", properties))
+                    .isSameAs(failure);
+            assertThat(failingProvider.createEntityManagerFactoryCalls)
+                    .containsExactly(new CreateEntityManagerFactoryCall("failing-unit", properties));
+            assertThat(fallbackProvider.createEntityManagerFactoryCalls).isEmpty();
+        }
+    }
+
+    @Test
+    void generateSchemaStopsAfterFirstProviderThatSucceeds() {
+        RecordingProvider firstProvider = new RecordingProvider(
+                "first-provider",
+                null,
+                false,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        RecordingProvider secondProvider = new RecordingProvider(
+                "second-provider",
+                null,
+                true,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        RecordingProvider thirdProvider = new RecordingProvider(
+                "third-provider",
+                null,
+                true,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        FixedResolver resolver = new FixedResolver(List.of(firstProvider, secondProvider, thirdProvider));
+        Map<String, Object> properties = Map.of("jakarta.persistence.schema-generation.database.action", "drop-and-create");
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            Persistence.generateSchema("schema-unit", properties);
+
+            assertThat(firstProvider.generateSchemaCalls)
+                    .containsExactly(new GenerateSchemaCall("schema-unit", properties));
+            assertThat(secondProvider.generateSchemaCalls)
+                    .containsExactly(new GenerateSchemaCall("schema-unit", properties));
+            assertThat(thirdProvider.generateSchemaCalls).isEmpty();
+        }
+    }
+
+    @Test
+    void generateSchemaThrowsHelpfulMessageWhenNoProviderSucceeds() {
+        FixedResolver resolver = new FixedResolver(List.of(
+                new RecordingProvider(
+                        "only-provider",
+                        null,
+                        false,
+                        new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+                )
+        ));
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            assertThatThrownBy(() -> Persistence.generateSchema("missing-schema-unit", Map.of()))
+                    .isInstanceOf(PersistenceException.class)
+                    .hasMessage("No Persistence provider to generate schema named missing-schema-unit");
+        }
+    }
+
+    @Test
+    void generateSchemaPropagatesProviderFailuresWithoutTryingLaterProviders() {
+        IllegalArgumentException failure = new IllegalArgumentException("schema-failed");
+        ThrowingProvider failingProvider = new ThrowingProvider(
+                null,
+                failure,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        RecordingProvider fallbackProvider = new RecordingProvider(
+                "fallback-provider",
+                null,
+                true,
+                new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN)
+        );
+        FixedResolver resolver = new FixedResolver(List.of(failingProvider, fallbackProvider));
+        Map<String, Object> properties = Map.of("jakarta.persistence.schema-generation.scripts.action", "create");
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            assertThatThrownBy(() -> Persistence.generateSchema("failing-schema-unit", properties))
+                    .isSameAs(failure);
+            assertThat(failingProvider.generateSchemaCalls)
+                    .containsExactly(new GenerateSchemaCall("failing-schema-unit", properties));
+            assertThat(fallbackProvider.generateSchemaCalls).isEmpty();
+        }
+    }
+
+    @Test
+    void persistenceUtilUsesWithoutReferenceBeforeWithReference() {
+        Object entity = new Object();
+        RecordingProviderUtil firstProviderUtil = new RecordingProviderUtil(
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN
+        );
+        RecordingProviderUtil secondProviderUtil = new RecordingProviderUtil(
+                LoadState.UNKNOWN,
+                LoadState.NOT_LOADED,
+                LoadState.LOADED
+        );
+        FixedResolver resolver = new FixedResolver(List.of(
+                new RecordingProvider("first", null, false, firstProviderUtil),
+                new RecordingProvider("second", null, false, secondProviderUtil)
+        ));
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            boolean loaded = Persistence.getPersistenceUtil().isLoaded(entity, "orders");
+
+            assertThat(loaded).isFalse();
+            assertThat(firstProviderUtil.withoutReferenceCalls).isEqualTo(1);
+            assertThat(secondProviderUtil.withoutReferenceCalls).isEqualTo(1);
+            assertThat(firstProviderUtil.withReferenceCalls).isZero();
+            assertThat(secondProviderUtil.withReferenceCalls).isZero();
+            assertThat(secondProviderUtil.lastAttributeName).isEqualTo("orders");
+        }
+    }
+
+    @Test
+    void persistenceUtilFallsBackToWithReferenceAndDefaultsToLoadedForUnknownState() {
+        Object entity = new Object();
+        RecordingProviderUtil firstProviderUtil = new RecordingProviderUtil(
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN
+        );
+        RecordingProviderUtil secondProviderUtil = new RecordingProviderUtil(
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN,
+                LoadState.LOADED
+        );
+        RecordingProviderUtil objectStateUtil = new RecordingProviderUtil(
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN,
+                LoadState.UNKNOWN
+        );
+        FixedResolver resolver = new FixedResolver(List.of(
+                new RecordingProvider("first", null, false, firstProviderUtil),
+                new RecordingProvider("second", null, false, secondProviderUtil),
+                new RecordingProvider("third", null, false, objectStateUtil)
+        ));
+
+        try (ResolverScope ignored = useResolver(resolver)) {
+            boolean attributeLoaded = Persistence.getPersistenceUtil().isLoaded(entity, "customer");
+            boolean entityLoaded = Persistence.getPersistenceUtil().isLoaded(entity);
+
+            assertThat(attributeLoaded).isTrue();
+            assertThat(entityLoaded).isTrue();
+            assertThat(firstProviderUtil.withReferenceCalls).isEqualTo(1);
+            assertThat(secondProviderUtil.withReferenceCalls).isEqualTo(1);
+            assertThat(objectStateUtil.isLoadedCalls).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void queryAndTypedQueryDefaultMethodsDelegateToImplementedOperations() {
+        RecordingQuery query = new RecordingQuery(List.of("alpha", "beta"));
+        TypedQuery<String> untypedQueryAsTyped = query.ofType(String.class);
+        RecordingTypedQuery<String> typedQuery = new RecordingTypedQuery<>(List.of("one", "two"), "one");
+        SimpleParameter<String> titleParameter = new SimpleParameter<>("title", null, String.class);
+        assertThat(untypedQueryAsTyped.getResultStream().toList()).containsExactly("alpha", "beta");
+        assertThat(untypedQueryAsTyped.getSingleResultOrNull()).isEqualTo("alpha");
+        assertThat(untypedQueryAsTyped.getResultCount()).isEqualTo(2);
+        assertThat(new RecordingQuery(List.of(), null).ofType(String.class).getSingleResultOrNull()).isNull();
+        assertThat(typedQuery.getResultStream().toList()).containsExactly("one", "two");
+        assertThat(typedQuery.getSingleResultOrNull()).isEqualTo("one");
+
+        assertThat(typedQuery.setMaxResults(25)).isSameAs(typedQuery);
+        assertThat(typedQuery.setFirstResult(5)).isSameAs(typedQuery);
+        assertThat(typedQuery.setHint("graph", "books")).isSameAs(typedQuery);
+        assertThat(typedQuery.setParameter(titleParameter, "Jakarta Persistence")).isSameAs(typedQuery);
+        assertThat(typedQuery.setParameter("createdBy", "test")).isSameAs(typedQuery);
+        assertThat(typedQuery.setParameter(1, 42)).isSameAs(typedQuery);
+        assertThat(typedQuery.setFlushMode(FlushModeType.COMMIT)).isSameAs(typedQuery);
+        assertThat(typedQuery.setLockMode(LockModeType.PESSIMISTIC_READ)).isSameAs(typedQuery);
+        assertThat(typedQuery.setLockScope(PessimisticLockScope.EXTENDED)).isSameAs(typedQuery);
+        assertThat(typedQuery.setCacheRetrieveMode(CacheRetrieveMode.BYPASS)).isSameAs(typedQuery);
+        assertThat(typedQuery.setCacheStoreMode(CacheStoreMode.REFRESH)).isSameAs(typedQuery);
+        assertThat(typedQuery.setTimeout(Timeout.ms(250))).isSameAs(typedQuery);
+
+        assertThat(typedQuery.getMaxResults()).isEqualTo(25);
+        assertThat(typedQuery.getFirstResult()).isEqualTo(5);
+        assertThat(typedQuery.getHints()).containsEntry("graph", "books");
+        assertThat(typedQuery.getParameterValue("createdBy")).isEqualTo("test");
+        assertThat(typedQuery.getParameterValue(1)).isEqualTo(42);
+        assertThat(typedQuery.getParameterValue(titleParameter)).isEqualTo("Jakarta Persistence");
+        assertThat(typedQuery.getFlushMode()).isEqualTo(FlushModeType.COMMIT);
+        assertThat(typedQuery.getLockMode()).isEqualTo(LockModeType.PESSIMISTIC_READ);
+        assertThat(typedQuery.getLockScope()).isEqualTo(PessimisticLockScope.EXTENDED);
+        assertThat(typedQuery.getCacheRetrieveMode()).isEqualTo(CacheRetrieveMode.BYPASS);
+        assertThat(typedQuery.getCacheStoreMode()).isEqualTo(CacheStoreMode.REFRESH);
+        assertThat(typedQuery.getTimeout()).isEqualTo(250);
+    }
+
+    @Test
+    void persistenceExceptionsRetainMessagesCausesAndAssociatedObjects() {
+        RuntimeException cause = new RuntimeException("boom");
+        Object entity = new Object();
+        RecordingQuery query = new RecordingQuery(List.of("value"));
+
+        PersistenceException persistenceException = new PersistenceException("persistence", cause);
+        EntityExistsException entityExistsException = new EntityExistsException(cause);
+        EntityNotFoundException entityNotFoundException = new EntityNotFoundException("missing-entity");
+        LockTimeoutException lockTimeoutException = new LockTimeoutException("lock-timeout", cause, entity);
+        NoResultException noResultException = new NoResultException("no-result");
+        NonUniqueResultException nonUniqueResultException = new NonUniqueResultException("too-many-results");
+        OptimisticLockException optimisticLockException = new OptimisticLockException("optimistic", cause, entity);
+        PessimisticLockException pessimisticLockException = new PessimisticLockException("pessimistic", cause, entity);
+        QueryTimeoutException queryTimeoutException = new QueryTimeoutException("query-timeout", cause, query);
+        RollbackException rollbackException = new RollbackException(cause);
+        TransactionRequiredException transactionRequiredException = new TransactionRequiredException("tx-required");
+
+        assertThat(persistenceException).hasMessage("persistence").hasCause(cause);
+        assertThat(entityExistsException).hasCause(cause);
+        assertThat(entityNotFoundException).hasMessage("missing-entity");
+        assertThat(lockTimeoutException).hasMessage("lock-timeout").hasCause(cause);
+        assertThat(lockTimeoutException.getObject()).isSameAs(entity);
+        assertThat(noResultException).hasMessage("no-result");
+        assertThat(nonUniqueResultException).hasMessage("too-many-results");
+        assertThat(optimisticLockException).hasMessage("optimistic").hasCause(cause);
+        assertThat(optimisticLockException.getEntity()).isSameAs(entity);
+        assertThat(pessimisticLockException).hasMessage("pessimistic").hasCause(cause);
+        assertThat(pessimisticLockException.getEntity()).isSameAs(entity);
+        assertThat(queryTimeoutException).hasMessage("query-timeout").hasCause(cause);
+        assertThat(queryTimeoutException.getQuery()).isSameAs(query);
+        assertThat(rollbackException).hasCause(cause);
+        assertThat(transactionRequiredException).hasMessage("tx-required");
+    }
+
+    @Test
+    void resettingResolverToNullRestoresDefaultResolver() {
+        PersistenceProviderResolver customResolver = new FixedResolver(List.of());
+        PersistenceProviderResolver originalResolver = PersistenceProviderResolverHolder.getPersistenceProviderResolver();
+
+        PersistenceProviderResolverHolder.setPersistenceProviderResolver(customResolver);
+        try {
+            assertThat(PersistenceProviderResolverHolder.getPersistenceProviderResolver()).isSameAs(customResolver);
+
+            PersistenceProviderResolverHolder.setPersistenceProviderResolver(null);
+
+            assertThat(PersistenceProviderResolverHolder.getPersistenceProviderResolver())
+                    .isNotSameAs(customResolver)
+                    .isNotNull();
+        } finally {
+            PersistenceProviderResolverHolder.setPersistenceProviderResolver(originalResolver);
+        }
+    }
+
+    @Test
+    void defaultResolverDiscoversProvidersFromContextClassLoaderAndReloadsAfterCacheClear() throws Exception {
+        PersistenceProviderResolver originalResolver = PersistenceProviderResolverHolder.getPersistenceProviderResolver();
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Path providerConfigDirectory = createProviderConfigDirectory(DiscoverableProvider.class.getName());
+        DiscoverableProvider.reset();
+
+        PersistenceProviderResolverHolder.setPersistenceProviderResolver(null);
+        try (URLClassLoader providerClassLoader = new URLClassLoader(
+                new java.net.URL[] {providerConfigDirectory.toUri().toURL()},
+                Jakarta_persistence_apiTest.class.getClassLoader()
+        )) {
+            Thread.currentThread().setContextClassLoader(providerClassLoader);
+
+            PersistenceProviderResolver resolver = PersistenceProviderResolverHolder.getPersistenceProviderResolver();
+            List<PersistenceProvider> firstProviders = resolver.getPersistenceProviders();
+            List<PersistenceProvider> secondProviders = resolver.getPersistenceProviders();
+
+            assertThat(firstProviders)
+                    .anySatisfy(provider -> assertThat(provider).isInstanceOf(DiscoverableProvider.class));
+            assertThat(secondProviders).isSameAs(firstProviders);
+            assertThat(DiscoverableProvider.getInstanceCount()).isEqualTo(1);
+
+            resolver.clearCachedProviders();
+
+            List<PersistenceProvider> reloadedProviders = resolver.getPersistenceProviders();
+
+            assertThat(reloadedProviders)
+                    .isNotSameAs(firstProviders)
+                    .anySatisfy(provider -> assertThat(provider).isInstanceOf(DiscoverableProvider.class));
+            assertThat(DiscoverableProvider.getInstanceCount()).isEqualTo(2);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            PersistenceProviderResolverHolder.setPersistenceProviderResolver(originalResolver);
+            deleteRecursively(providerConfigDirectory);
+        }
+    }
+
+    private static Path createProviderConfigDirectory(String... providerClassNames) throws IOException {
+        Path configDirectory = Files.createTempDirectory("jakarta-persistence-provider");
+        Path servicesDirectory = configDirectory.resolve("META-INF").resolve("services");
+        Files.createDirectories(servicesDirectory);
+        Files.writeString(
+                servicesDirectory.resolve(PersistenceProvider.class.getName()),
+                String.join(System.lineSeparator(), providerClassNames),
+                StandardCharsets.UTF_8
+        );
+        return configDirectory;
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        try (Stream<Path> paths = Files.walk(path)) {
+            paths.sorted(Comparator.reverseOrder())
+                    .forEach(currentPath -> {
+                        try {
+                            Files.deleteIfExists(currentPath);
+                        } catch (IOException exception) {
+                            throw new RuntimeException(exception);
+                        }
+                    });
+        } catch (RuntimeException exception) {
+            if (exception.getCause() instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw exception;
+        }
+    }
+
+    private static ResolverScope useResolver(PersistenceProviderResolver resolver) {
+        PersistenceProviderResolver previousResolver =
+                PersistenceProviderResolverHolder.getPersistenceProviderResolver();
+        PersistenceProviderResolverHolder.setPersistenceProviderResolver(resolver);
+        return new ResolverScope(previousResolver);
+    }
+
+    private record CreateEntityManagerFactoryCall(String unitName, Map<String, Object> properties) {
+    }
+
+    private record GenerateSchemaCall(String unitName, Map<String, Object> properties) {
+    }
+
+    private static final class ResolverScope implements AutoCloseable {
+        private final PersistenceProviderResolver previousResolver;
+
+        private ResolverScope(PersistenceProviderResolver previousResolver) {
+            this.previousResolver = previousResolver;
+        }
+
+        @Override
+        public void close() {
+            PersistenceProviderResolverHolder.setPersistenceProviderResolver(previousResolver);
+        }
+    }
+
+    private static final class FixedResolver implements PersistenceProviderResolver {
+        private final List<PersistenceProvider> providers;
+        private int getPersistenceProvidersCalls;
+
+        private FixedResolver(List<PersistenceProvider> providers) {
+            this.providers = List.copyOf(providers);
+        }
+
+        @Override
+        public List<PersistenceProvider> getPersistenceProviders() {
+            getPersistenceProvidersCalls++;
+            return providers;
+        }
+
+        @Override
+        public void clearCachedProviders() {
+        }
+    }
+
+    private static final class RecordingProvider implements PersistenceProvider {
+        private final String providerName;
+        private final EntityManagerFactory entityManagerFactory;
+        private final boolean generateSchemaResult;
+        private final ProviderUtil providerUtil;
+        private final List<CreateEntityManagerFactoryCall> createEntityManagerFactoryCalls = new ArrayList<>();
+        private final List<GenerateSchemaCall> generateSchemaCalls = new ArrayList<>();
+
+        private RecordingProvider(
+                String providerName,
+                EntityManagerFactory entityManagerFactory,
+                boolean generateSchemaResult,
+                ProviderUtil providerUtil
+        ) {
+            this.providerName = providerName;
+            this.entityManagerFactory = entityManagerFactory;
+            this.generateSchemaResult = generateSchemaResult;
+            this.providerUtil = providerUtil;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public EntityManagerFactory createEntityManagerFactory(String emName, Map map) {
+            createEntityManagerFactoryCalls.add(new CreateEntityManagerFactoryCall(emName, (Map<String, Object>) map));
+            return entityManagerFactory;
+        }
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+            createEntityManagerFactoryCalls.add(new CreateEntityManagerFactoryCall(
+                    configuration.name(),
+                    configuration.properties()
+            ));
+            return entityManagerFactory;
+        }
+
+        @Override
+        public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException(providerName);
+        }
+
+        @Override
+        public void generateSchema(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException(providerName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean generateSchema(String persistenceUnitName, Map map) {
+            generateSchemaCalls.add(new GenerateSchemaCall(persistenceUnitName, (Map<String, Object>) map));
+            return generateSchemaResult;
+        }
+
+        @Override
+        public boolean generateSchema(PersistenceConfiguration configuration) {
+            generateSchemaCalls.add(new GenerateSchemaCall(configuration.name(), configuration.properties()));
+            return generateSchemaResult;
+        }
+
+        @Override
+        public ProviderUtil getProviderUtil() {
+            return providerUtil;
+        }
+
+        @Override
+        public ClassTransformer getClassTransformer(PersistenceUnitInfo info, Map<?, ?> map) {
+            return null;
+        }
+    }
+
+    private static final class ThrowingProvider implements PersistenceProvider {
+        private final RuntimeException createEntityManagerFactoryFailure;
+        private final RuntimeException generateSchemaFailure;
+        private final ProviderUtil providerUtil;
+        private final List<CreateEntityManagerFactoryCall> createEntityManagerFactoryCalls = new ArrayList<>();
+        private final List<GenerateSchemaCall> generateSchemaCalls = new ArrayList<>();
+
+        private ThrowingProvider(
+                RuntimeException createEntityManagerFactoryFailure,
+                RuntimeException generateSchemaFailure,
+                ProviderUtil providerUtil
+        ) {
+            this.createEntityManagerFactoryFailure = createEntityManagerFactoryFailure;
+            this.generateSchemaFailure = generateSchemaFailure;
+            this.providerUtil = providerUtil;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public EntityManagerFactory createEntityManagerFactory(String emName, Map map) {
+            createEntityManagerFactoryCalls.add(new CreateEntityManagerFactoryCall(emName, (Map<String, Object>) map));
+            throw createEntityManagerFactoryFailure;
+        }
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+            createEntityManagerFactoryCalls.add(new CreateEntityManagerFactoryCall(
+                    configuration.name(),
+                    configuration.properties()
+            ));
+            throw createEntityManagerFactoryFailure;
+        }
+
+        @Override
+        public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void generateSchema(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean generateSchema(String persistenceUnitName, Map map) {
+            generateSchemaCalls.add(new GenerateSchemaCall(persistenceUnitName, (Map<String, Object>) map));
+            throw generateSchemaFailure;
+        }
+
+        @Override
+        public boolean generateSchema(PersistenceConfiguration configuration) {
+            generateSchemaCalls.add(new GenerateSchemaCall(configuration.name(), configuration.properties()));
+            throw generateSchemaFailure;
+        }
+
+        @Override
+        public ProviderUtil getProviderUtil() {
+            return providerUtil;
+        }
+
+        @Override
+        public ClassTransformer getClassTransformer(PersistenceUnitInfo info, Map<?, ?> map) {
+            return null;
+        }
+    }
+
+    public static final class DiscoverableProvider implements PersistenceProvider {
+        private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+
+        public DiscoverableProvider() {
+            INSTANCE_COUNT.incrementAndGet();
+        }
+
+        static void reset() {
+            INSTANCE_COUNT.set(0);
+        }
+
+        static int getInstanceCount() {
+            return INSTANCE_COUNT.get();
+        }
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(String emName, Map map) {
+            return null;
+        }
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+            return null;
+        }
+
+        @Override
+        public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void generateSchema(PersistenceUnitInfo info, Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean generateSchema(String persistenceUnitName, Map map) {
+            return false;
+        }
+
+        @Override
+        public boolean generateSchema(PersistenceConfiguration configuration) {
+            return false;
+        }
+
+        @Override
+        public ProviderUtil getProviderUtil() {
+            return new RecordingProviderUtil(LoadState.UNKNOWN, LoadState.UNKNOWN, LoadState.UNKNOWN);
+        }
+
+        @Override
+        public ClassTransformer getClassTransformer(PersistenceUnitInfo info, Map<?, ?> map) {
+            return null;
+        }
+    }
+
+    private static final class RecordingProviderUtil implements ProviderUtil {
+        private final LoadState objectLoadState;
+        private final LoadState withoutReferenceLoadState;
+        private final LoadState withReferenceLoadState;
+        private int isLoadedCalls;
+        private int withoutReferenceCalls;
+        private int withReferenceCalls;
+        private String lastAttributeName;
+
+        private RecordingProviderUtil(
+                LoadState objectLoadState,
+                LoadState withoutReferenceLoadState,
+                LoadState withReferenceLoadState
+        ) {
+            this.objectLoadState = objectLoadState;
+            this.withoutReferenceLoadState = withoutReferenceLoadState;
+            this.withReferenceLoadState = withReferenceLoadState;
+        }
+
+        @Override
+        public LoadState isLoadedWithoutReference(Object entity, String attributeName) {
+            Objects.requireNonNull(entity);
+            withoutReferenceCalls++;
+            lastAttributeName = attributeName;
+            return withoutReferenceLoadState;
+        }
+
+        @Override
+        public LoadState isLoadedWithReference(Object entity, String attributeName) {
+            Objects.requireNonNull(entity);
+            withReferenceCalls++;
+            lastAttributeName = attributeName;
+            return withReferenceLoadState;
+        }
+
+        @Override
+        public LoadState isLoaded(Object entity) {
+            Objects.requireNonNull(entity);
+            isLoadedCalls++;
+            return objectLoadState;
+        }
+    }
+
+    private static final class SimpleParameter<T> implements Parameter<T> {
+        private final String name;
+        private final Integer position;
+        private final Class<T> parameterType;
+
+        private SimpleParameter(String name, Integer position, Class<T> parameterType) {
+            this.name = name;
+            this.position = position;
+            this.parameterType = parameterType;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Integer getPosition() {
+            return position;
+        }
+
+        @Override
+        public Class<T> getParameterType() {
+            return parameterType;
+        }
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private static class RecordingQuery implements Query {
+        private final List<Object> results;
+        private final Object singleResult;
+        private final Map<String, Object> hints = new LinkedHashMap<>();
+        private final Map<Parameter<?>, Object> parameterValuesByParameter = new LinkedHashMap<>();
+        private final Map<String, Object> parameterValuesByName = new LinkedHashMap<>();
+        private final Map<Integer, Object> parameterValuesByPosition = new LinkedHashMap<>();
+        private final Map<String, TemporalType> temporalValuesByName = new LinkedHashMap<>();
+        private final Map<Integer, TemporalType> temporalValuesByPosition = new LinkedHashMap<>();
+        private int maxResults;
+        private int firstResult;
+        private FlushModeType flushMode = FlushModeType.AUTO;
+        private LockModeType lockMode = LockModeType.NONE;
+        private CacheRetrieveMode cacheRetrieveMode = CacheRetrieveMode.USE;
+        private CacheStoreMode cacheStoreMode = CacheStoreMode.USE;
+        private Integer timeout;
+
+        private RecordingQuery(List<?> results) {
+            this(results, results.isEmpty() ? null : results.get(0));
+        }
+
+        private RecordingQuery(List<?> results, Object singleResult) {
+            this.results = new ArrayList<>(results);
+            this.singleResult = singleResult;
+        }
+
+        @Override
+        public Statement asStatement() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R> TypedQuery<R> ofType(Class<R> resultType) {
+            return new RecordingTypedQuery<>(
+                    results.stream().map(resultType::cast).toList(),
+                    singleResult == null ? null : (R) resultType.cast(singleResult)
+            );
+        }
+
+        @Override
+        public <R> TypedQuery<R> withEntityGraph(EntityGraph<R> graph) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public List getResultList() {
+            return results;
+        }
+
+        @Override
+        public Object getSingleResult() {
+            return singleResult;
+        }
+
+        @Override
+        public Object getSingleResultOrNull() {
+            return singleResult;
+        }
+
+        @Override
+        public int executeUpdate() {
+            return results.size();
+        }
+
+        @Override
+        public Query setMaxResults(int maxResult) {
+            this.maxResults = maxResult;
+            return this;
+        }
+
+        @Override
+        public int getMaxResults() {
+            return maxResults;
+        }
+
+        @Override
+        public Query setFirstResult(int startPosition) {
+            this.firstResult = startPosition;
+            return this;
+        }
+
+        @Override
+        public int getFirstResult() {
+            return firstResult;
+        }
+
+        @Override
+        public Query setHint(String hintName, Object value) {
+            hints.put(hintName, value);
+            return this;
+        }
+
+        @Override
+        public Map<String, Object> getHints() {
+            return Collections.unmodifiableMap(hints);
+        }
+
+        @Override
+        public <T> Query setParameter(Parameter<T> param, T value) {
+            parameterValuesByParameter.put(param, value);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
+            parameterValuesByParameter.put(param, value);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
+            parameterValuesByParameter.put(param, value);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(String name, Object value) {
+            parameterValuesByName.put(name, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setParameter(String name, P value, Class<P> type) {
+            parameterValuesByName.put(name, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setParameter(String name, P value, Type<P> type) {
+            parameterValuesByName.put(name, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setConvertedParameter(
+                String name,
+                P value,
+                Class<? extends AttributeConverter<P, ?>> converter
+        ) {
+            parameterValuesByName.put(name, value);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(String name, Calendar value, TemporalType temporalType) {
+            parameterValuesByName.put(name, value);
+            temporalValuesByName.put(name, temporalType);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(String name, Date value, TemporalType temporalType) {
+            parameterValuesByName.put(name, value);
+            temporalValuesByName.put(name, temporalType);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(int position, Object value) {
+            parameterValuesByPosition.put(position, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setParameter(int position, P value, Class<P> type) {
+            parameterValuesByPosition.put(position, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setParameter(int position, P value, Type<P> type) {
+            parameterValuesByPosition.put(position, value);
+            return this;
+        }
+
+        @Override
+        public <P> Query setConvertedParameter(
+                int position,
+                P value,
+                Class<? extends AttributeConverter<P, ?>> converter
+        ) {
+            parameterValuesByPosition.put(position, value);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(int position, Calendar value, TemporalType temporalType) {
+            parameterValuesByPosition.put(position, value);
+            temporalValuesByPosition.put(position, temporalType);
+            return this;
+        }
+
+        @Override
+        public Query setParameter(int position, Date value, TemporalType temporalType) {
+            parameterValuesByPosition.put(position, value);
+            temporalValuesByPosition.put(position, temporalType);
+            return this;
+        }
+
+        @Override
+        public Set<Parameter<?>> getParameters() {
+            return parameterValuesByParameter.keySet();
+        }
+
+        @Override
+        public Parameter<?> getParameter(String name) {
+            throw new UnsupportedOperationException(name);
+        }
+
+        @Override
+        public <T> Parameter<T> getParameter(String name, Class<T> type) {
+            throw new UnsupportedOperationException(name + type.getName());
+        }
+
+        @Override
+        public Parameter<?> getParameter(int position) {
+            throw new UnsupportedOperationException(String.valueOf(position));
+        }
+
+        @Override
+        public <T> Parameter<T> getParameter(int position, Class<T> type) {
+            throw new UnsupportedOperationException(position + type.getName());
+        }
+
+        @Override
+        public boolean isBound(Parameter<?> param) {
+            return parameterValuesByParameter.containsKey(param);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getParameterValue(Parameter<T> param) {
+            return (T) parameterValuesByParameter.get(param);
+        }
+
+        @Override
+        public Object getParameterValue(String name) {
+            return parameterValuesByName.get(name);
+        }
+
+        @Override
+        public Object getParameterValue(int position) {
+            return parameterValuesByPosition.get(position);
+        }
+
+        @Override
+        public Query setFlushMode(FlushModeType flushMode) {
+            this.flushMode = flushMode;
+            return this;
+        }
+
+        @Override
+        public FlushModeType getFlushMode() {
+            return flushMode;
+        }
+
+        @Override
+        public Query setLockMode(LockModeType lockMode) {
+            this.lockMode = lockMode;
+            return this;
+        }
+
+        @Override
+        public LockModeType getLockMode() {
+            return lockMode;
+        }
+
+        @Override
+        public Query setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+            this.cacheRetrieveMode = cacheRetrieveMode;
+            return this;
+        }
+
+        @Override
+        public Query setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+            this.cacheStoreMode = cacheStoreMode;
+            return this;
+        }
+
+        @Override
+        public CacheRetrieveMode getCacheRetrieveMode() {
+            return cacheRetrieveMode;
+        }
+
+        @Override
+        public CacheStoreMode getCacheStoreMode() {
+            return cacheStoreMode;
+        }
+
+        @Override
+        public Query setTimeout(Integer timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        @Override
+        public Query setTimeout(Timeout timeout) {
+            this.timeout = timeout == null ? null : timeout.milliseconds();
+            return this;
+        }
+
+        @Override
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> cls) {
+            if (cls.isInstance(this)) {
+                return cls.cast(this);
+            }
+            throw new IllegalArgumentException(cls.getName());
+        }
+
+        TemporalType getNamedTemporalType(String name) {
+            return temporalValuesByName.get(name);
+        }
+
+        TemporalType getIndexedTemporalType(int position) {
+            return temporalValuesByPosition.get(position);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class RecordingTypedQuery<T> extends RecordingQuery implements TypedQuery<T> {
+        private final List<T> typedResults;
+        private final T typedSingleResult;
+        private EntityGraph<? super T> entityGraph;
+        private PessimisticLockScope lockScope;
+
+        private RecordingTypedQuery(List<T> results, T singleResult) {
+            super(results, singleResult);
+            this.typedResults = new ArrayList<>(results);
+            this.typedSingleResult = singleResult;
+        }
+
+        @Override
+        public List<T> getResultList() {
+            return typedResults;
+        }
+
+        @Override
+        public T getSingleResult() {
+            return typedSingleResult;
+        }
+
+        @Override
+        public T getSingleResultOrNull() {
+            return typedSingleResult;
+        }
+
+        @Override
+        public long getResultCount() {
+            return typedResults.size();
+        }
+
+        @Override
+        public TypedQuery<T> setEntityGraph(EntityGraph<? super T> entityGraph) {
+            this.entityGraph = entityGraph;
+            return this;
+        }
+
+        @Override
+        public EntityGraph<? super T> getEntityGraph() {
+            return entityGraph;
+        }
+
+        @Override
+        public TypedQuery<T> setMaxResults(int maxResult) {
+            super.setMaxResults(maxResult);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setFirstResult(int startPosition) {
+            super.setFirstResult(startPosition);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setHint(String hintName, Object value) {
+            super.setHint(hintName, value);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setParameter(Parameter<P> param, P value) {
+            super.setParameter(param, value);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
+            super.setParameter(param, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
+            super.setParameter(param, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(String name, Object value) {
+            super.setParameter(name, value);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setParameter(String name, P value, Class<P> type) {
+            super.setParameter(name, value, type);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setParameter(String name, P value, Type<P> type) {
+            super.setParameter(name, value, type);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setConvertedParameter(
+                String name,
+                P value,
+                Class<? extends AttributeConverter<P, ?>> converter
+        ) {
+            super.setConvertedParameter(name, value, converter);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(String name, Calendar value, TemporalType temporalType) {
+            super.setParameter(name, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(String name, Date value, TemporalType temporalType) {
+            super.setParameter(name, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(int position, Object value) {
+            super.setParameter(position, value);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setParameter(int position, P value, Class<P> type) {
+            super.setParameter(position, value, type);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setParameter(int position, P value, Type<P> type) {
+            super.setParameter(position, value, type);
+            return this;
+        }
+
+        @Override
+        public <P> TypedQuery<T> setConvertedParameter(
+                int position,
+                P value,
+                Class<? extends AttributeConverter<P, ?>> converter
+        ) {
+            super.setConvertedParameter(position, value, converter);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(int position, Calendar value, TemporalType temporalType) {
+            super.setParameter(position, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setParameter(int position, Date value, TemporalType temporalType) {
+            super.setParameter(position, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setFlushMode(FlushModeType flushMode) {
+            super.setFlushMode(flushMode);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setLockMode(LockModeType lockMode) {
+            super.setLockMode(lockMode);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setLockScope(PessimisticLockScope lockScope) {
+            this.lockScope = lockScope;
+            return this;
+        }
+
+        @Override
+        public PessimisticLockScope getLockScope() {
+            return lockScope;
+        }
+
+        @Override
+        public TypedQuery<T> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+            super.setCacheRetrieveMode(cacheRetrieveMode);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+            super.setCacheStoreMode(cacheStoreMode);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setTimeout(Integer timeout) {
+            super.setTimeout(timeout);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setTimeout(Timeout timeout) {
+            super.setTimeout(timeout);
+            return this;
+        }
+    }
+
+    private static final class StubEntityManagerFactory implements EntityManagerFactory {
+        @Override
+        public EntityManager createEntityManager() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityManager createEntityManager(Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityManager createEntityManager(SynchronizationType synchronizationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityManager createEntityManager(SynchronizationType synchronizationType, Map map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityAgent createEntityAgent() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityAgent createEntityAgent(Map<?, ?> map) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CriteriaBuilder getCriteriaBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Metamodel getMetamodel() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public String getName() {
+            return "stub-unit";
+        }
+
+        @Override
+        public Map<String, Object> getProperties() {
+            return Map.of();
+        }
+
+        @Override
+        public Cache getCache() {
+            return null;
+        }
+
+        @Override
+        public PersistenceUnitUtil getPersistenceUnitUtil() {
+            return null;
+        }
+
+        @Override
+        public PersistenceUnitTransactionType getTransactionType() {
+            return PersistenceUnitTransactionType.RESOURCE_LOCAL;
+        }
+
+        @Override
+        public SchemaManager getSchemaManager() {
+            return null;
+        }
+
+        @Override
+        public void addNamedQuery(String name, Query query) {
+            throw new UnsupportedOperationException(name);
+        }
+
+        @Override
+        public <R> TypedQueryReference<R> addNamedQuery(String name, TypedQuery<R> query) {
+            throw new UnsupportedOperationException(name);
+        }
+
+        @Override
+        public StatementReference addNamedStatement(String name, Statement statement) {
+            throw new UnsupportedOperationException(name);
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> cls) {
+            throw new IllegalArgumentException(cls.getName());
+        }
+
+        @Override
+        public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph) {
+            throw new UnsupportedOperationException(graphName);
+        }
+
+        @Override
+        public <R> Map<String, TypedQueryReference<R>> getNamedQueries(Class<R> resultType) {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, StatementReference> getNamedStatements() {
+            return Map.of();
+        }
+
+        @Override
+        public <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType) {
+            return Map.of();
+        }
+
+        @Override
+        public <R> Map<String, ResultSetMapping<R>> getResultSetMappings(Class<R> resultType) {
+            return Map.of();
+        }
+
+        @Override
+        public <E> EntityListenerRegistration addListener(
+                Class<E> entityType,
+                Class<? extends Annotation> callbackType,
+                Consumer<? super E> listener
+        ) {
+            throw new UnsupportedOperationException(entityType.getName());
+        }
+
+        @Override
+        public void runInTransaction(Consumer<EntityManager> work) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R> R callInTransaction(Function<EntityManager, R> work) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <H extends EntityHandler> void runInTransaction(Class<H> handlerClass, Consumer<H> work) {
+            throw new UnsupportedOperationException(handlerClass.getName());
+        }
+
+        @Override
+        public <R, H extends EntityHandler> R callInTransaction(Class<H> handlerClass, Function<H, R> work) {
+            throw new UnsupportedOperationException(handlerClass.getName());
+        }
+    }
+}

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
@@ -57,6 +57,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.PessimisticLockException;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Query;
+import jakarta.persistence.QueryFlushMode;
 import jakarta.persistence.QueryTimeoutException;
 import jakarta.persistence.RollbackException;
 import jakarta.persistence.SchemaManager;
@@ -321,7 +322,7 @@ public class Jakarta_persistence_apiTest {
         assertThat(typedQuery.setParameter(titleParameter, "Jakarta Persistence")).isSameAs(typedQuery);
         assertThat(typedQuery.setParameter("createdBy", "test")).isSameAs(typedQuery);
         assertThat(typedQuery.setParameter(1, 42)).isSameAs(typedQuery);
-        assertThat(typedQuery.setFlushMode(FlushModeType.COMMIT)).isSameAs(typedQuery);
+        assertThat(typedQuery.setQueryFlushMode(QueryFlushMode.FLUSH)).isSameAs(typedQuery);
         assertThat(typedQuery.setLockMode(LockModeType.PESSIMISTIC_READ)).isSameAs(typedQuery);
         assertThat(typedQuery.setLockScope(PessimisticLockScope.EXTENDED)).isSameAs(typedQuery);
         assertThat(typedQuery.setCacheRetrieveMode(CacheRetrieveMode.BYPASS)).isSameAs(typedQuery);
@@ -334,7 +335,7 @@ public class Jakarta_persistence_apiTest {
         assertThat(typedQuery.getParameterValue("createdBy")).isEqualTo("test");
         assertThat(typedQuery.getParameterValue(1)).isEqualTo(42);
         assertThat(typedQuery.getParameterValue(titleParameter)).isEqualTo("Jakarta Persistence");
-        assertThat(typedQuery.getFlushMode()).isEqualTo(FlushModeType.COMMIT);
+        assertThat(typedQuery.getQueryFlushMode()).isEqualTo(QueryFlushMode.FLUSH);
         assertThat(typedQuery.getLockMode()).isEqualTo(LockModeType.PESSIMISTIC_READ);
         assertThat(typedQuery.getLockScope()).isEqualTo(PessimisticLockScope.EXTENDED);
         assertThat(typedQuery.getCacheRetrieveMode()).isEqualTo(CacheRetrieveMode.BYPASS);
@@ -784,6 +785,7 @@ public class Jakarta_persistence_apiTest {
         private final Map<Integer, TemporalType> temporalValuesByPosition = new LinkedHashMap<>();
         private int maxResults;
         private int firstResult;
+        private QueryFlushMode queryFlushMode = QueryFlushMode.DEFAULT;
         private FlushModeType flushMode = FlushModeType.AUTO;
         private LockModeType lockMode = LockModeType.NONE;
         private CacheRetrieveMode cacheRetrieveMode = CacheRetrieveMode.USE;
@@ -799,12 +801,10 @@ public class Jakarta_persistence_apiTest {
             this.singleResult = singleResult;
         }
 
-        @Override
         public Statement asStatement() {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         @SuppressWarnings("unchecked")
         public <R> TypedQuery<R> ofType(Class<R> resultType) {
             return new RecordingTypedQuery<>(
@@ -813,7 +813,6 @@ public class Jakarta_persistence_apiTest {
             );
         }
 
-        @Override
         public <R> TypedQuery<R> withEntityGraph(EntityGraph<R> graph) {
             throw new UnsupportedOperationException();
         }
@@ -1021,6 +1020,17 @@ public class Jakarta_persistence_apiTest {
         }
 
         @Override
+        public Query setQueryFlushMode(QueryFlushMode flushMode) {
+            this.queryFlushMode = flushMode;
+            return this;
+        }
+
+        @Override
+        public QueryFlushMode getQueryFlushMode() {
+            return queryFlushMode;
+        }
+
+        @Override
         public Query setFlushMode(FlushModeType flushMode) {
             this.flushMode = flushMode;
             return this;
@@ -1131,13 +1141,11 @@ public class Jakarta_persistence_apiTest {
             return typedResults.size();
         }
 
-        @Override
         public TypedQuery<T> setEntityGraph(EntityGraph<? super T> entityGraph) {
             this.entityGraph = entityGraph;
             return this;
         }
 
-        @Override
         public EntityGraph<? super T> getEntityGraph() {
             return entityGraph;
         }
@@ -1255,6 +1263,12 @@ public class Jakarta_persistence_apiTest {
         @Override
         public TypedQuery<T> setParameter(int position, Date value, TemporalType temporalType) {
             super.setParameter(position, value, temporalType);
+            return this;
+        }
+
+        @Override
+        public TypedQuery<T> setQueryFlushMode(QueryFlushMode flushMode) {
+            super.setQueryFlushMode(flushMode);
             return this;
         }
 

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.persistence.spi.PersistenceProviderResolverHolder$DefaultPersistenceProviderResolver"
+      },
+      "type" : "jakarta_persistence.jakarta_persistence_api.Jakarta_persistence_apiTest$DiscoverableProvider"
+    }
+  ]
+}

--- a/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/user-code-filter.json
+++ b/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "jakarta.persistence.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3947

This PR provides test fixes and new metadata for jakarta.persistence:jakarta.persistence-api:4.0.0-M2, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 52946
- Cached input tokens: 459264
- Output tokens: 4223
- Metadata entries: 4
- Test-only metadata entries: 1
- Iterations: 1
- Library coverage percentage: 23.25
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 24.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.persistence:jakarta.persistence-api:4.0.0-M1: 0/0 covered calls (100.00%)
- jakarta.persistence:jakarta.persistence-api:4.0.0-M2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.persistence:jakarta.persistence-api:4.0.0-M1: 603/2719 (22.18%)
- jakarta.persistence:jakarta.persistence-api:4.0.0-M2: 607/2765 (21.95%)

**Line:**
- jakarta.persistence:jakarta.persistence-api:4.0.0-M1: 167/676 (24.70%)
- jakarta.persistence:jakarta.persistence-api:4.0.0-M2: 156/671 (23.25%)

**Method:**
- jakarta.persistence:jakarta.persistence-api:4.0.0-M1: 48/241 (19.92%)
- jakarta.persistence:jakarta.persistence-api:4.0.0-M2: 52/252 (20.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M1/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java 2/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
index 73667ea105..3711e0c988 100644
--- 1/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M1/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
+++ 2/tests/src/jakarta.persistence/jakarta.persistence-api/4.0.0-M2/src/test/java/jakarta_persistence/jakarta_persistence_api/Jakarta_persistence_apiTest.java
@@ -57,6 +57,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.PessimisticLockException;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Query;
+import jakarta.persistence.QueryFlushMode;
 import jakarta.persistence.QueryTimeoutException;
 import jakarta.persistence.RollbackException;
 import jakarta.persistence.SchemaManager;
@@ -321,7 +322,7 @@ public class Jakarta_persistence_apiTest {
         assertThat(typedQuery.setParameter(titleParameter, "Jakarta Persistence")).isSameAs(typedQuery);
         assertThat(typedQuery.setParameter("createdBy", "test")).isSameAs(typedQuery);
         assertThat(typedQuery.setParameter(1, 42)).isSameAs(typedQuery);
-        assertThat(typedQuery.setFlushMode(FlushModeType.COMMIT)).isSameAs(typedQuery);
+        assertThat(typedQuery.setQueryFlushMode(QueryFlushMode.FLUSH)).isSameAs(typedQuery);
         assertThat(typedQuery.setLockMode(LockModeType.PESSIMISTIC_READ)).isSameAs(typedQuery);
         assertThat(typedQuery.setLockScope(PessimisticLockScope.EXTENDED)).isSameAs(typedQuery);
         assertThat(typedQuery.setCacheRetrieveMode(CacheRetrieveMode.BYPASS)).isSameAs(typedQuery);
@@ -334,7 +335,7 @@ public class Jakarta_persistence_apiTest {
         assertThat(typedQuery.getParameterValue("createdBy")).isEqualTo("test");
         assertThat(typedQuery.getParameterValue(1)).isEqualTo(42);
         assertThat(typedQuery.getParameterValue(titleParameter)).isEqualTo("Jakarta Persistence");
-        assertThat(typedQuery.getFlushMode()).isEqualTo(FlushModeType.COMMIT);
+        assertThat(typedQuery.getQueryFlushMode()).isEqualTo(QueryFlushMode.FLUSH);
         assertThat(typedQuery.getLockMode()).isEqualTo(LockModeType.PESSIMISTIC_READ);
         assertThat(typedQuery.getLockScope()).isEqualTo(PessimisticLockScope.EXTENDED);
         assertThat(typedQuery.getCacheRetrieveMode()).isEqualTo(CacheRetrieveMode.BYPASS);
@@ -784,6 +785,7 @@ public class Jakarta_persistence_apiTest {
         private final Map<Integer, TemporalType> temporalValuesByPosition = new LinkedHashMap<>();
         private int maxResults;
         private int firstResult;
+        private QueryFlushMode queryFlushMode = QueryFlushMode.DEFAULT;
         private FlushModeType flushMode = FlushModeType.AUTO;
         private LockModeType lockMode = LockModeType.NONE;
         private CacheRetrieveMode cacheRetrieveMode = CacheRetrieveMode.USE;
@@ -799,12 +801,10 @@ public class Jakarta_persistence_apiTest {
             this.singleResult = singleResult;
         }
 
-        @Override
         public Statement asStatement() {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         @SuppressWarnings("unchecked")
         public <R> TypedQuery<R> ofType(Class<R> resultType) {
             return new RecordingTypedQuery<>(
@@ -813,7 +813,6 @@ public class Jakarta_persistence_apiTest {
             );
         }
 
-        @Override
         public <R> TypedQuery<R> withEntityGraph(EntityGraph<R> graph) {
             throw new UnsupportedOperationException();
         }
@@ -1020,6 +1019,17 @@ public class Jakarta_persistence_apiTest {
             return parameterValuesByPosition.get(position);
         }
 
+        @Override
+        public Query setQueryFlushMode(QueryFlushMode flushMode) {
+            this.queryFlushMode = flushMode;
+            return this;
+        }
+
+        @Override
+        public QueryFlushMode getQueryFlushMode() {
+            return queryFlushMode;
+        }
+
         @Override
         public Query setFlushMode(FlushModeType flushMode) {
             this.flushMode = flushMode;
@@ -1131,13 +1141,11 @@ public class Jakarta_persistence_apiTest {
             return typedResults.size();
         }
 
-        @Override
         public TypedQuery<T> setEntityGraph(EntityGraph<? super T> entityGraph) {
             this.entityGraph = entityGraph;
             return this;
         }
 
-        @Override
         public EntityGraph<? super T> getEntityGraph() {
             return entityGraph;
         }
@@ -1258,6 +1266,12 @@ public class Jakarta_persistence_apiTest {
             return this;
         }
 
+        @Override
+        public TypedQuery<T> setQueryFlushMode(QueryFlushMode flushMode) {
+            super.setQueryFlushMode(flushMode);
+            return this;
+        }
+
         @Override
         public TypedQuery<T> setFlushMode(FlushModeType flushMode) {
             super.setFlushMode(flushMode);

```
