### PR TITLE
[GenAI] Test fix for redis.clients:jedis:4.4.0 using gpt-5.5

### DIFF
--- a/metadata/redis.clients/jedis/4.4.0/reachability-metadata.json
+++ b/metadata/redis.clients/jedis/4.4.0/reachability-metadata.json
@@ -1,0 +1,103 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.util.LinkedHashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "redis.clients.jedis.StreamEntryID",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamPendingEntry"
+      },
+      "type": "redis.clients.jedis.StreamEntryID",
+      "serializable": true
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "java.util.LinkedHashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "redis.clients.jedis.StreamEntryID"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamEntry"
+      },
+      "type": "redis.clients.jedis.resps.StreamEntry"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamPendingEntry"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamPendingEntry"
+      },
+      "type": "redis.clients.jedis.StreamEntryID"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.resps.StreamPendingEntry"
+      },
+      "type": "redis.clients.jedis.resps.StreamPendingEntry"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.util.JedisMetaInfo"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "condition": {
+        "typeReached": "redis.clients.jedis.util.JedisMetaInfo"
+      },
+      "glob": "pom.properties"
+    }
+  ]
+}

--- a/metadata/redis.clients/jedis/index.json
+++ b/metadata/redis.clients/jedis/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/4.4.0/jedis-4.4.0-sources.jar",
+    "repository-url" : "https://github.com/redis/jedis",
+    "test-code-url" : "https://github.com/redis/jedis/tree/v4.4.0/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/4.4.0/jedis-4.4.0-javadoc.jar",
+    "description" : "Jedis is a Java client library for Redis that provides synchronous APIs for commands, pooling, transactions, pipelining, and Redis cluster usage. It lets Java applications communicate with Redis servers while exposing Redis data structures and operations through a compact client interface.",
     "tested-versions" : [
       "4.4.0"
     ],

--- a/metadata/redis.clients/jedis/index.json
+++ b/metadata/redis.clients/jedis/index.json
@@ -1,15 +1,24 @@
 [
   {
     "latest" : true,
-    "metadata-version" : "4.0.0",
+    "metadata-version" : "4.4.0",
     "tested-versions" : [
-      "4.0.0"
+      "4.4.0"
     ],
+    "allowed-packages" : [
+      "redis.clients.jedis"
+    ]
+  },
+  {
+    "metadata-version" : "4.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/4.0.0/jedis-4.0.0-sources.jar",
     "repository-url" : "https://github.com/redis/jedis",
     "test-code-url" : "https://github.com/redis/jedis/tree/v4.0.0/src/test/java",
     "documentation-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/4.0.0/jedis-4.0.0-javadoc.jar",
     "description" : "Jedis is a Java client library for Redis that provides synchronous APIs for commands, pooling, transactions, pipelining, and Redis cluster usage. It lets Java applications communicate with Redis servers while exposing Redis data structures and operations through a compact client interface.",
+    "tested-versions" : [
+      "4.0.0"
+    ],
     "allowed-packages" : [
       "redis.clients.jedis"
     ]

--- a/stats/redis.clients/jedis/4.4.0/execution-metrics.json
+++ b/stats/redis.clients/jedis/4.4.0/execution-metrics.json
@@ -1,0 +1,104 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T02:54:19.348791Z",
+    "library": "redis.clients:jedis:4.4.0",
+    "starting_commit": "d736ff0110aaef52bbbc53a817317e5c60de3831",
+    "ending_commit": "7ff0f27685fb2cc9b6443ceb2fe16c116e57c014",
+    "previous_library": "redis.clients:jedis:4.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10125,
+          "missed": 91041,
+          "ratio": 0.100083,
+          "total": 101166
+        },
+        "line": {
+          "covered": 1091,
+          "missed": 14183,
+          "ratio": 0.071429,
+          "total": 15274
+        },
+        "method": {
+          "covered": 345,
+          "missed": 7528,
+          "ratio": 0.043821,
+          "total": 7873
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8928,
+          "missed": 60841,
+          "ratio": 0.127965,
+          "total": 69769
+        },
+        "line": {
+          "covered": 941,
+          "missed": 9390,
+          "ratio": 0.091085,
+          "total": 10331
+        },
+        "method": {
+          "covered": 302,
+          "missed": 5094,
+          "ratio": 0.055967,
+          "total": 5396
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 66748,
+      "cached_input_tokens_used": 620032,
+      "output_tokens_used": 7267,
+      "iterations": 1,
+      "cost_usd": 0.528,
+      "tested_library_loc": 1091,
+      "metadata_entries": 12,
+      "previous_library_metadata_entries": 15,
+      "code_coverage_percent": 7.14,
+      "previous_library_coverage_percent": 9.11
+    },
+    "artifacts": {
+      "test_file": "tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java",
+      "metadata_file": "metadata/redis.clients/jedis/4.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/redis.clients/jedis/4.4.0/stats.json
+++ b/stats/redis.clients/jedis/4.4.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10125,
+        "missed" : 91041,
+        "ratio" : 0.100083,
+        "total" : 101166
+      },
+      "line" : {
+        "covered" : 1091,
+        "missed" : 14183,
+        "ratio" : 0.071429,
+        "total" : 15274
+      },
+      "method" : {
+        "covered" : 345,
+        "missed" : 7528,
+        "ratio" : 0.043821,
+        "total" : 7873
+      }
+    }
+  } ]
+}

--- a/tests/src/redis.clients/jedis/4.4.0/.gitignore
+++ b/tests/src/redis.clients/jedis/4.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/redis.clients/jedis/4.4.0/build.gradle
+++ b/tests/src/redis.clients/jedis/4.4.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "redis.clients:jedis:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/redis.clients/jedis/4.4.0/gradle.properties
+++ b/tests/src/redis.clients/jedis/4.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = redis.clients:jedis:4.4.0
+library.version = 4.4.0
+metadata.dir = redis.clients/jedis/4.4.0/

--- a/tests/src/redis.clients/jedis/4.4.0/settings.gradle
+++ b/tests/src/redis.clients/jedis/4.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'redis.clients.jedis_tests'

--- a/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ b/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package redis_clients.jedis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.GeoCoordinate;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.args.Rawable;
+import redis.clients.jedis.exceptions.JedisAskDataException;
+import redis.clients.jedis.exceptions.JedisBusyException;
+import redis.clients.jedis.exceptions.JedisClusterException;
+import redis.clients.jedis.exceptions.JedisMovedDataException;
+import redis.clients.jedis.exceptions.JedisNoScriptException;
+import redis.clients.jedis.params.BitPosParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.IParams;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.params.SortingParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
+import redis.clients.jedis.params.ZParams;
+import redis.clients.jedis.resps.GeoRadiusResponse;
+import redis.clients.jedis.resps.Slowlog;
+import redis.clients.jedis.resps.Tuple;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterHashTag;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+
+public class JedisTest {
+    @Test
+    void writesRedisProtocolCommandsAndReadsAllReplyTypes() throws Exception {
+        ByteArrayOutputStream commandBytes = new ByteArrayOutputStream();
+        RedisOutputStream outputStream = new RedisOutputStream(commandBytes);
+
+        Protocol.sendCommand(outputStream, new CommandArguments(Protocol.Command.SET).key(bytes("client:key")).add(bytes("value")));
+        outputStream.flush();
+
+        assertThat(asString(commandBytes.toByteArray()))
+                .isEqualTo("*3\r\n$3\r\nSET\r\n$10\r\nclient:key\r\n$5\r\nvalue\r\n");
+        assertThat(asString((byte[]) Protocol.read(input("+OK\r\n")))).isEqualTo("OK");
+        assertThat(Protocol.read(input(":42\r\n"))).isEqualTo(42L);
+        assertThat(asString((byte[]) Protocol.read(input("$5\r\nhello\r\n")))).isEqualTo("hello");
+        assertThat(Protocol.read(input("$-1\r\n"))).isNull();
+
+        Object multiBulk = Protocol.read(input("*4\r\n+PONG\r\n:7\r\n$5\r\nworld\r\n$-1\r\n"));
+
+        assertThat(multiBulk).isInstanceOf(List.class);
+        List<?> replies = (List<?>) multiBulk;
+        assertThat(asString((byte[]) replies.get(0))).isEqualTo("PONG");
+        assertThat(replies.get(1)).isEqualTo(7L);
+        assertThat(asString((byte[]) replies.get(2))).isEqualTo("world");
+        assertThat(replies.get(3)).isNull();
+    }
+
+    @Test
+    void mapsRedisErrorRepliesToSpecificJedisExceptions() {
+        assertThatThrownBy(() -> Protocol.read(input("-MOVED 3999 127.0.0.1:6381\r\n")))
+                .isInstanceOfSatisfying(JedisMovedDataException.class, exception -> {
+                    assertThat(exception.getSlot()).isEqualTo(3999);
+                    assertThat(exception.getTargetNode()).isEqualTo(new HostAndPort("127.0.0.1", 6381));
+                });
+        assertThatThrownBy(() -> Protocol.read(input("-ASK 4000 redis.example.test:6382\r\n")))
+                .isInstanceOfSatisfying(JedisAskDataException.class, exception -> {
+                    assertThat(exception.getSlot()).isEqualTo(4000);
+                    assertThat(exception.getTargetNode()).isEqualTo(new HostAndPort("redis.example.test", 6382));
+                });
+        assertThatThrownBy(() -> Protocol.read(input("-CLUSTERDOWN Hash slot not served\r\n")))
+                .isInstanceOf(JedisClusterException.class);
+        assertThatThrownBy(() -> Protocol.read(input("-BUSY Redis is busy running a script\r\n")))
+                .isInstanceOf(JedisBusyException.class);
+        assertThatThrownBy(() -> Protocol.read(input("-NOSCRIPT No matching script\r\n")))
+                .isInstanceOf(JedisNoScriptException.class);
+
+        assertThat(Protocol.readErrorLineIfPossible(input("-ERR invalid command\r\n")))
+                .isEqualTo("ERR invalid command");
+        assertThat(Protocol.readErrorLineIfPossible(input("+OK\r\n"))).isNull();
+    }
+
+    @Test
+    void buildsCommandParameterObjectsInRedisArgumentOrder() {
+        SortingParams sortingParams = new SortingParams()
+                .by("weight_*")
+                .limit(2, 5)
+                .get("object_*", "#")
+                .desc()
+                .alpha();
+        assertThat(strings(sortingParams.getParams()))
+                .containsExactly("BY", "weight_*", "LIMIT", "2", "5", "GET", "object_*", "GET", "#", "DESC", "ALPHA");
+
+        ScanParams scanParams = new ScanParams().match("user:*").count(25);
+        assertThat(commandArguments(Protocol.Command.SCAN, scanParams))
+                .containsExactly("SCAN", "MATCH", "user:*", "COUNT", "25");
+        assertThat(asString(ScanParams.SCAN_POINTER_START_BINARY)).isEqualTo("0");
+
+        ZParams zParams = new ZParams().weights(1.5D, 2D, 0.25D).aggregate(ZParams.Aggregate.MAX);
+        assertThat(commandArguments(Protocol.Command.ZUNIONSTORE, zParams))
+                .containsExactly("ZUNIONSTORE", "WEIGHTS", "1.5", "2.0", "0.25", "AGGREGATE", "MAX");
+
+        BitPosParams bitPosParams = new BitPosParams(3L, 14L);
+        assertThat(commandArguments(Protocol.Command.BITPOS, bitPosParams)).containsExactly("BITPOS", "3", "14");
+    }
+
+    @Test
+    void buildsSortedSetAndGeoParameterObjects() {
+        CommandArguments zaddParams = new CommandArguments(Protocol.Command.ZADD)
+                .key("leaders")
+                .addParams(ZAddParams.zAddParams().nx().ch())
+                .add(9.5D)
+                .add("alice");
+        assertThat(strings(zaddParams)).containsExactly("ZADD", "leaders", "nx", "ch", "9.5", "alice");
+
+        CommandArguments zincrByParams = new CommandArguments(Protocol.Command.ZADD)
+                .key("leaders")
+                .addParams(ZIncrByParams.zIncrByParams().xx())
+                .add(2.0D)
+                .add("bob");
+        assertThat(strings(zincrByParams)).containsExactly("ZADD", "leaders", "xx", "incr", "2.0", "bob");
+
+        CommandArguments geoRadiusParams = new CommandArguments(Protocol.Command.GEORADIUS)
+                .key("Sicily")
+                .add(15)
+                .add(37)
+                .add(200)
+                .add("km")
+                .addParams(GeoRadiusParam.geoRadiusParam()
+                        .withCoord()
+                        .withDist()
+                        .count(3)
+                        .sortDescending());
+        assertThat(strings(geoRadiusParams))
+                .containsExactly("GEORADIUS", "Sicily", "15", "37", "200", "km", "WITHCOORD", "WITHDIST", "COUNT", "3", "DESC");
+    }
+
+    @Test
+    void convertsRawRedisResponsesWithBuilderFactory() {
+        assertThat(BuilderFactory.STRING.build(bytes("plain"))).isEqualTo("plain");
+        assertThat(BuilderFactory.BOOLEAN.build(1L)).isTrue();
+        assertThat(BuilderFactory.DOUBLE.build(bytes("12.75"))).isEqualTo(12.75D);
+        assertThat(BuilderFactory.STRING_LIST.build(Arrays.asList(bytes("first"), null, bytes("second"))))
+                .containsExactly("first", null, "second");
+
+        Map<String, String> stringMap = BuilderFactory.STRING_MAP.build(Arrays.asList(
+                bytes("field-one"), bytes("value-one"), bytes("field-two"), bytes("value-two")));
+        assertThat(stringMap).containsEntry("field-one", "value-one").containsEntry("field-two", "value-two");
+
+        Set<Tuple> scoredMembers = BuilderFactory.TUPLE_ZSET.build(Arrays.asList(
+                bytes("alice"), bytes("8.5"), bytes("bob"), bytes("9.25")));
+        assertThat(scoredMembers)
+                .extracting(Tuple::getElement)
+                .containsExactly("alice", "bob");
+        assertThat(scoredMembers)
+                .extracting(Tuple::getScore)
+                .containsExactly(8.5D, 9.25D);
+
+        Object encodedResult = BuilderFactory.ENCODED_OBJECT.build(Arrays.asList(
+                bytes("root"), Arrays.asList(bytes("nested"), 5L)));
+        assertThat(encodedResult).isEqualTo(Arrays.asList("root", Arrays.asList("nested", 5L)));
+    }
+
+    @Test
+    void convertsGeoResponsesAndValueObjects() {
+        GeoCoordinate coordinate = new GeoCoordinate(13.361389D, 38.115556D);
+        GeoCoordinate sameCoordinate = new GeoCoordinate(13.361389D, 38.115556D);
+        assertThat(coordinate).isEqualTo(sameCoordinate);
+        assertThat(coordinate.toString()).isEqualTo("(13.361389,38.115556)");
+
+        List<GeoCoordinate> coordinates = BuilderFactory.GEO_COORDINATE_LIST.build(Arrays.asList(
+                Arrays.asList(bytes("13.361389"), bytes("38.115556")),
+                null,
+                Arrays.asList(bytes("15.087269"), bytes("37.502669"))));
+        assertThat(coordinates).containsExactly(
+                new GeoCoordinate(13.361389D, 38.115556D),
+                null,
+                new GeoCoordinate(15.087269D, 37.502669D));
+
+        List<GeoRadiusResponse> responses = BuilderFactory.GEORADIUS_WITH_PARAMS_RESULT.build(Arrays.asList(
+                Arrays.asList(
+                        bytes("Palermo"),
+                        bytes("190.4424"),
+                        Arrays.asList(bytes("13.361389"), bytes("38.115556"))),
+                Arrays.asList(
+                        bytes("Catania"),
+                        bytes("56.4413"),
+                        Arrays.asList(bytes("15.087269"), bytes("37.502669")))));
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getMemberByString()).isEqualTo("Palermo");
+        assertThat(responses.get(0).getDistance()).isEqualTo(190.4424D);
+        assertThat(responses.get(0).getCoordinate()).isEqualTo(new GeoCoordinate(13.361389D, 38.115556D));
+        assertThat(responses.get(1).getMemberByString()).isEqualTo("Catania");
+    }
+
+    @Test
+    void convertsSlowlogRepliesIntoDomainObjects() {
+        List<Object> rawEntries = Arrays.<Object>asList(
+                Arrays.<Object>asList(
+                        7L,
+                        1_460_000_000L,
+                        321L,
+                        Arrays.asList(bytes("SET"), bytes("slowlog:key"), bytes("value"))),
+                Arrays.<Object>asList(
+                        8L,
+                        1_460_000_001L,
+                        42L,
+                        Arrays.asList(bytes("GET"), bytes("slowlog:key"))));
+
+        List<Slowlog> entries = Slowlog.from(rawEntries);
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).getId()).isEqualTo(7L);
+        assertThat(entries.get(0).getTimeStamp()).isEqualTo(1_460_000_000L);
+        assertThat(entries.get(0).getExecutionTime()).isEqualTo(321L);
+        assertThat(entries.get(0).getArgs()).containsExactly("SET", "slowlog:key", "value");
+        assertThat(entries.get(0).toString()).isEqualTo("7,1460000000,321,[SET, slowlog:key, value]");
+        assertThat(entries.get(1).getId()).isEqualTo(8L);
+        assertThat(entries.get(1).getArgs()).containsExactly("GET", "slowlog:key");
+    }
+
+    @Test
+    void createsJedisFromUriAndClientConfiguration() throws Exception {
+        DefaultJedisClientConfig config = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(700)
+                .socketTimeoutMillis(900)
+                .password("changed")
+                .database(3)
+                .clientName("primary")
+                .ssl(true)
+                .build();
+        assertThat(config.getConnectionTimeoutMillis()).isEqualTo(700);
+        assertThat(config.getSocketTimeoutMillis()).isEqualTo(900);
+        assertThat(config.getPassword()).isEqualTo("changed");
+        assertThat(config.getDatabase()).isEqualTo(3);
+        assertThat(config.getClientName()).isEqualTo("primary");
+        assertThat(config.isSsl()).isTrue();
+
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            CompletableFuture<Void> acceptedConnection = acceptSingleConnection(serverSocket);
+            URI redisUri = URI.create("redis://localhost:" + serverSocket.getLocalPort() + "/0");
+
+            try (Jedis jedis = new Jedis(redisUri, 500)) {
+                assertThat(jedis.isConnected()).isTrue();
+                assertThat(jedis.toString()).contains("localhost").contains(String.valueOf(serverSocket.getLocalPort()));
+            }
+            acceptedConnection.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void handlesHostAndPortParsingAndClusterHashSlots() {
+        HostAndPort parsed = HostAndPort.from("redis.example.test:7001");
+        assertThat(parsed.getHost()).isEqualTo("redis.example.test");
+        assertThat(parsed.getPort()).isEqualTo(7001);
+        assertThat(parsed.toString()).isEqualTo("redis.example.test:7001");
+        HostAndPort ipv6 = HostAndPort.from("2001:db8::10:7002");
+        assertThat(ipv6.getHost()).isEqualTo("2001:db8::10");
+        assertThat(ipv6.getPort()).isEqualTo(7002);
+        assertThat(new HostAndPort("127.0.0.1", 6379)).isEqualTo(new HostAndPort("127.0.0.1", 6379));
+
+        String taggedKey = "cart:{user-42}:items";
+        assertThat(JedisClusterHashTag.getHashTag(taggedKey)).isEqualTo("user-42");
+        assertThat(JedisClusterCRC16.getSlot(taggedKey)).isEqualTo(JedisClusterCRC16.getSlot("profile:{user-42}"));
+        assertThat(JedisClusterHashTag.isClusterCompliantMatchPattern("cart:{user-42}:*")).isTrue();
+        assertThat(JedisClusterHashTag.isClusterCompliantMatchPattern("cart:user-*"))
+                .isFalse();
+        assertThat(JedisClusterCRC16.getCRC16("123456789")).isEqualTo(12739);
+    }
+
+    private static CompletableFuture<Void> acceptSingleConnection(ServerSocket serverSocket) {
+        CompletableFuture<Void> acceptedConnection = new CompletableFuture<>();
+        Thread serverThread = new Thread(() -> {
+            try (Socket socket = serverSocket.accept()) {
+                acceptedConnection.complete(null);
+                socket.getInputStream().read();
+            } catch (IOException exception) {
+                if (acceptedConnection.isDone() || serverSocket.isClosed()) {
+                    acceptedConnection.complete(null);
+                } else {
+                    acceptedConnection.completeExceptionally(exception);
+                }
+            }
+        }, "jedis-test-server");
+        serverThread.setDaemon(true);
+        serverThread.start();
+        return acceptedConnection;
+    }
+
+    private static RedisInputStream input(String data) {
+        return new RedisInputStream(new ByteArrayInputStream(bytes(data)));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String asString(byte[] value) {
+        return new String(value, StandardCharsets.UTF_8);
+    }
+
+    private static List<String> strings(Collection<byte[]> values) {
+        return values.stream().map(JedisTest::asString).collect(Collectors.toList());
+    }
+
+    private static List<String> strings(CommandArguments arguments) {
+        List<String> values = new ArrayList<>();
+        for (Rawable argument : arguments) {
+            values.add(asString(argument.getRaw()));
+        }
+        return values;
+    }
+
+    private static List<String> commandArguments(Protocol.Command command, IParams params) {
+        CommandArguments arguments = new CommandArguments(command);
+        params.addParams(arguments);
+        return strings(arguments);
+    }
+}

--- a/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ b/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -299,10 +300,22 @@ public class JedisTest {
         CompletableFuture<Void> acceptedConnection = new CompletableFuture<>();
         Thread serverThread = new Thread(() -> {
             try (Socket socket = serverSocket.accept()) {
+                ByteArrayOutputStream receivedCommands = new ByteArrayOutputStream();
+                byte[] buffer = new byte[256];
+                int repliesSent = 0;
+                int read;
+                while ((read = socket.getInputStream().read(buffer)) != -1) {
+                    receivedCommands.write(buffer, 0, read);
+                    int completedCommands = completeRespCommandCount(asString(receivedCommands.toByteArray()));
+                    while (repliesSent < completedCommands) {
+                        socket.getOutputStream().write(bytes("+OK\r\n"));
+                        socket.getOutputStream().flush();
+                        repliesSent++;
+                    }
+                }
                 acceptedConnection.complete(null);
-                socket.getInputStream().read();
             } catch (IOException exception) {
-                if (acceptedConnection.isDone() || serverSocket.isClosed()) {
+                if (serverSocket.isClosed() || exception instanceof SocketException) {
                     acceptedConnection.complete(null);
                 } else {
                     acceptedConnection.completeExceptionally(exception);
@@ -312,6 +325,41 @@ public class JedisTest {
         serverThread.setDaemon(true);
         serverThread.start();
         return acceptedConnection;
+    }
+
+    private static int completeRespCommandCount(String data) {
+        int completedCommands = 0;
+        int index = 0;
+        while (index < data.length()) {
+            if (data.charAt(index) != '*') {
+                return completedCommands;
+            }
+
+            int argumentCountEnd = data.indexOf("\r\n", index);
+            if (argumentCountEnd == -1) {
+                return completedCommands;
+            }
+            int argumentCount = Integer.parseInt(data.substring(index + 1, argumentCountEnd));
+            index = argumentCountEnd + 2;
+
+            for (int argumentIndex = 0; argumentIndex < argumentCount; argumentIndex++) {
+                if (index >= data.length() || data.charAt(index) != '$') {
+                    return completedCommands;
+                }
+                int lengthEnd = data.indexOf("\r\n", index);
+                if (lengthEnd == -1) {
+                    return completedCommands;
+                }
+                int length = Integer.parseInt(data.substring(index + 1, lengthEnd));
+                int argumentEnd = lengthEnd + 2 + length;
+                if (argumentEnd + 2 > data.length()) {
+                    return completedCommands;
+                }
+                index = argumentEnd + 2;
+            }
+            completedCommands++;
+        }
+        return completedCommands;
     }
 
     private static RedisInputStream input(String data) {

--- a/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/StreamEntryTest.java
+++ b/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/StreamEntryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package redis_clients.jedis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.resps.StreamEntry;
+
+public class StreamEntryTest {
+    @Test
+    void buildsStreamEntryIdAndFieldsFromRedisResponse() {
+        StreamEntryID entryId = new StreamEntryID(1_628_784_000_000L, 7L);
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("event", "order-created");
+        fields.put("region", "eu-central");
+
+        StreamEntry directEntry = new StreamEntry(entryId, fields);
+        StreamEntry builtEntry = BuilderFactory.STREAM_ENTRY.build(Arrays.asList(
+                bytes("1628784000000-7"),
+                Arrays.asList(bytes("event"), bytes("order-created"), bytes("region"), bytes("eu-central"))));
+
+        assertThat(directEntry.getID()).isEqualTo(entryId);
+        assertThat(directEntry.getFields()).isEqualTo(fields);
+        assertThat(directEntry.toString()).isEqualTo("1628784000000-7 {event=order-created, region=eu-central}");
+        assertThat(builtEntry.getID()).isEqualTo(entryId);
+        assertThat(builtEntry.getFields()).isEqualTo(fields);
+    }
+
+    @Test
+    void serializesAndDeserializesStreamEntryIdAndFields() throws Exception {
+        StreamEntryID entryId = new StreamEntryID(1_628_784_000_000L, 8L);
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("event", "order-shipped");
+        fields.put("region", "us-west");
+        StreamEntry original = new StreamEntry(entryId, fields);
+
+        StreamEntry restored = deserialize(serialize(original));
+
+        assertThat(restored).isNotSameAs(original);
+        assertThat(restored.getID()).isEqualTo(entryId);
+        assertThat(restored.getFields()).isEqualTo(fields);
+        assertThat(restored.toString()).isEqualTo("1628784000000-8 {event=order-shipped, region=us-west}");
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] serialize(Serializable value) throws Exception {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectStream = new ObjectOutputStream(byteStream)) {
+            objectStream.writeObject(value);
+        }
+        return byteStream.toByteArray();
+    }
+
+    private static StreamEntry deserialize(byte[] value) throws Exception {
+        try (ObjectInputStream objectStream = new ObjectInputStream(new ByteArrayInputStream(value))) {
+            return (StreamEntry) objectStream.readObject();
+        }
+    }
+}

--- a/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/StreamPendingEntryTest.java
+++ b/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/StreamPendingEntryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package redis_clients.jedis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.resps.StreamPendingEntry;
+
+public class StreamPendingEntryTest {
+    @Test
+    void buildsPendingEntryStateFromRedisResponse() {
+        StreamEntryID entryId = new StreamEntryID(1_628_784_000_000L, 9L);
+        StreamPendingEntry directEntry = new StreamPendingEntry(entryId, "consumer-a", 125L, 3L);
+
+        List<StreamPendingEntry> builtEntries = BuilderFactory.STREAM_PENDING_ENTRY_LIST.build(Arrays.asList(
+                Arrays.asList(bytes("1628784000000-9"), bytes("consumer-a"), 125L, 3L)));
+
+        assertThat(directEntry.getID()).isEqualTo(entryId);
+        assertThat(directEntry.getConsumerName()).isEqualTo("consumer-a");
+        assertThat(directEntry.getIdleTime()).isEqualTo(125L);
+        assertThat(directEntry.getDeliveredTimes()).isEqualTo(3L);
+        assertThat(directEntry.toString()).isEqualTo("1628784000000-9 consumer-a idle:125 times:3");
+        assertThat(builtEntries).hasSize(1);
+        assertThat(builtEntries.get(0).getID()).isEqualTo(entryId);
+        assertThat(builtEntries.get(0).getConsumerName()).isEqualTo("consumer-a");
+        assertThat(builtEntries.get(0).getIdleTime()).isEqualTo(125L);
+        assertThat(builtEntries.get(0).getDeliveredTimes()).isEqualTo(3L);
+    }
+
+    @Test
+    void serializesAndDeserializesPendingEntryState() throws Exception {
+        StreamEntryID entryId = new StreamEntryID(1_628_784_000_001L, 10L);
+        StreamPendingEntry original = new StreamPendingEntry(entryId, "consumer-b", 250L, 4L);
+
+        StreamPendingEntry restored = deserialize(serialize(original));
+
+        assertThat(restored).isNotSameAs(original);
+        assertThat(restored.getID()).isEqualTo(entryId);
+        assertThat(restored.getConsumerName()).isEqualTo("consumer-b");
+        assertThat(restored.getIdleTime()).isEqualTo(250L);
+        assertThat(restored.getDeliveredTimes()).isEqualTo(4L);
+        assertThat(restored.toString()).isEqualTo("1628784000001-10 consumer-b idle:250 times:4");
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] serialize(Serializable value) throws Exception {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectStream = new ObjectOutputStream(byteStream)) {
+            objectStream.writeObject(value);
+        }
+        return byteStream.toByteArray();
+    }
+
+    private static StreamPendingEntry deserialize(byte[] value) throws Exception {
+        try (ObjectInputStream objectStream = new ObjectInputStream(new ByteArrayInputStream(value))) {
+            return (StreamPendingEntry) objectStream.readObject();
+        }
+    }
+}

--- a/tests/src/redis.clients/jedis/4.4.0/user-code-filter.json
+++ b/tests/src/redis.clients/jedis/4.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "redis.clients.jedis.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3960

This PR provides test fixes and new metadata for redis.clients:jedis:4.4.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 66748
- Cached input tokens: 620032
- Output tokens: 7267
- Metadata entries: 12
- Iterations: 1
- Library coverage percentage: 7.14
- Previous library version metadata entries: 15
- Previous library version coverage percentage: 9.11

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- redis.clients:jedis:4.0.0: 6/6 covered calls (100.00%)
- redis.clients:jedis:4.4.0: 7/7 covered calls (100.00%)

**Reflection:**
- redis.clients:jedis:4.0.0: 6/6 covered calls (100.00%)
- redis.clients:jedis:4.4.0: 6/6 covered calls (100.00%)

**Resources:**
- redis.clients:jedis:4.0.0: N/A
- redis.clients:jedis:4.4.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- redis.clients:jedis:4.0.0: 8928/69769 (12.80%)
- redis.clients:jedis:4.4.0: 10125/101166 (10.01%)

**Line:**
- redis.clients:jedis:4.0.0: 941/10331 (9.11%)
- redis.clients:jedis:4.4.0: 1091/15274 (7.14%)

**Method:**
- redis.clients:jedis:4.0.0: 302/5396 (5.60%)
- redis.clients:jedis:4.4.0: 345/7873 (4.38%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/redis.clients/jedis/4.0.0/src/test/java/redis_clients/jedis/JedisTest.java 2/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
index 835ca2fdbb..31ecde7bdf 100644
--- 1/tests/src/redis.clients/jedis/4.0.0/src/test/java/redis_clients/jedis/JedisTest.java
+++ 2/tests/src/redis.clients/jedis/4.4.0/src/test/java/redis_clients/jedis/JedisTest.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -299,10 +300,22 @@ public class JedisTest {
         CompletableFuture<Void> acceptedConnection = new CompletableFuture<>();
         Thread serverThread = new Thread(() -> {
             try (Socket socket = serverSocket.accept()) {
+                ByteArrayOutputStream receivedCommands = new ByteArrayOutputStream();
+                byte[] buffer = new byte[256];
+                int repliesSent = 0;
+                int read;
+                while ((read = socket.getInputStream().read(buffer)) != -1) {
+                    receivedCommands.write(buffer, 0, read);
+                    int completedCommands = completeRespCommandCount(asString(receivedCommands.toByteArray()));
+                    while (repliesSent < completedCommands) {
+                        socket.getOutputStream().write(bytes("+OK\r\n"));
+                        socket.getOutputStream().flush();
+                        repliesSent++;
+                    }
+                }
                 acceptedConnection.complete(null);
-                socket.getInputStream().read();
             } catch (IOException exception) {
-                if (acceptedConnection.isDone() || serverSocket.isClosed()) {
+                if (serverSocket.isClosed() || exception instanceof SocketException) {
                     acceptedConnection.complete(null);
                 } else {
                     acceptedConnection.completeExceptionally(exception);
@@ -314,6 +327,41 @@ public class JedisTest {
         return acceptedConnection;
     }
 
+    private static int completeRespCommandCount(String data) {
+        int completedCommands = 0;
+        int index = 0;
+        while (index < data.length()) {
+            if (data.charAt(index) != '*') {
+                return completedCommands;
+            }
+
+            int argumentCountEnd = data.indexOf("\r\n", index);
+            if (argumentCountEnd == -1) {
+                return completedCommands;
+            }
+            int argumentCount = Integer.parseInt(data.substring(index + 1, argumentCountEnd));
+            index = argumentCountEnd + 2;
+
+            for (int argumentIndex = 0; argumentIndex < argumentCount; argumentIndex++) {
+                if (index >= data.length() || data.charAt(index) != '$') {
+                    return completedCommands;
+                }
+                int lengthEnd = data.indexOf("\r\n", index);
+                if (lengthEnd == -1) {
+                    return completedCommands;
+                }
+                int length = Integer.parseInt(data.substring(index + 1, lengthEnd));
+                int argumentEnd = lengthEnd + 2 + length;
+                if (argumentEnd + 2 > data.length()) {
+                    return completedCommands;
+                }
+                index = argumentEnd + 2;
+            }
+            completedCommands++;
+        }
+        return completedCommands;
+    }
+
     private static RedisInputStream input(String data) {
         return new RedisInputStream(new ByteArrayInputStream(bytes(data)));
     }

```
