### PR TITLE
[GenAI] Test fix for org.slf4j:jcl-over-slf4j:1.7.0 using gpt-5.5

### DIFF
--- a/metadata/org.slf4j/jcl-over-slf4j/1.7.0/reachability-metadata.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/1.7.0/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SimpleLog"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.logging.impl.SLF4JLogFactory"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.slf4j/jcl-over-slf4j/index.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/index.json
@@ -1,13 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.7.0",
+    "tested-versions" : [
+      "1.7.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.logging"
+    ]
+  },
+  {
     "metadata-version" : "1.5.7",
+    "test-version" : "1.5.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.7/jcl-over-slf4j-1.5.7-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",
     "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_1.5.7_FINAL/jcl-over-slf4j/src/test/java",
     "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_1.5.7_FINAL/slf4j-site/src/site/pages/legacy.html",
     "description" : "jcl-over-slf4j provides a drop-in implementation of the Jakarta Commons Logging 1.1.1 API that routes logging calls through SLF4J. It lets applications or dependencies that still call JCL use the SLF4J-selected backend without keeping the original Commons Logging runtime on the classpath.",
-    "test-version" : "1.5.6",
     "tested-versions" : [
       "1.5.7"
     ],

--- a/metadata/org.slf4j/jcl-over-slf4j/index.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.7.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.0/jcl-over-slf4j-1.7.0-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/v_1.7.0/jcl-over-slf4j/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.0/jcl-over-slf4j-1.7.0-javadoc.jar",
+    "description" : "jcl-over-slf4j provides a drop-in implementation of the Jakarta Commons Logging API that redirects logging calls to SLF4J. It lets applications and dependencies written for Commons Logging use the SLF4J-selected backend without keeping the original Commons Logging runtime on the classpath.",
     "tested-versions" : [
       "1.7.0"
     ],

--- a/stats/org.slf4j/jcl-over-slf4j/1.7.0/execution-metrics.json
+++ b/stats/org.slf4j/jcl-over-slf4j/1.7.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T03:00:40.406567Z",
+    "library": "org.slf4j:jcl-over-slf4j:1.7.0",
+    "starting_commit": "78037d7b7e71bb44c3cc0c16ea88b7f95ecd6227",
+    "ending_commit": "99cf9495d813227d27f908e61ecb882891ef0615",
+    "previous_library": "org.slf4j:jcl-over-slf4j:1.5.6",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.7.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 676,
+          "missed": 578,
+          "ratio": 0.539075,
+          "total": 1254
+        },
+        "line": {
+          "covered": 179,
+          "missed": 148,
+          "ratio": 0.547401,
+          "total": 327
+        },
+        "method": {
+          "covered": 49,
+          "missed": 73,
+          "ratio": 0.401639,
+          "total": 122
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 679,
+          "missed": 562,
+          "ratio": 0.547139,
+          "total": 1241
+        },
+        "line": {
+          "covered": 171,
+          "missed": 144,
+          "ratio": 0.542857,
+          "total": 315
+        },
+        "method": {
+          "covered": 49,
+          "missed": 71,
+          "ratio": 0.408333,
+          "total": 120
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 213356,
+      "cached_input_tokens_used": 2527232,
+      "output_tokens_used": 28460,
+      "iterations": 3,
+      "cost_usd": 2.1174,
+      "tested_library_loc": 179,
+      "metadata_entries": 3,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 54.74,
+      "previous_library_coverage_percent": 54.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java",
+      "metadata_file": "metadata/org.slf4j/jcl-over-slf4j/1.7.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.slf4j/jcl-over-slf4j/1.7.0/stats.json
+++ b/stats/org.slf4j/jcl-over-slf4j/1.7.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.7.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 676,
+        "missed" : 578,
+        "ratio" : 0.539075,
+        "total" : 1254
+      },
+      "line" : {
+        "covered" : 179,
+        "missed" : 148,
+        "ratio" : 0.547401,
+        "total" : 327
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 73,
+        "ratio" : 0.401639,
+        "total" : 122
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/.gitignore
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/build.gradle
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:jcl-over-slf4j:$libraryVersion"
+    testImplementation "org.slf4j:slf4j-jdk14:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/gradle.properties
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:jcl-over-slf4j:1.7.0
+library.version = 1.7.0
+metadata.dir = org.slf4j/jcl-over-slf4j/1.7.0/

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/settings.gradle
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.jcl-over-slf4j_tests'

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SLF4JLocationAwareLogTest.java
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SLF4JLocationAwareLogTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.jcl_over_slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.impl.SLF4JLogFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SLF4JLocationAwareLogTest {
+
+    @Test
+    void factoryCreatesLocationAwareLogThatBridgesEveryJclLevelToJul() {
+        try (TestLoggerContext context = TestLoggerContext.create(uniqueLoggerName("levels"))) {
+            Log log = new SLF4JLogFactory().getInstance(context.loggerName());
+            IllegalStateException failure = new IllegalStateException("boom");
+
+            assertThat(log.isTraceEnabled()).isTrue();
+            assertThat(log.isDebugEnabled()).isTrue();
+            assertThat(log.isInfoEnabled()).isTrue();
+            assertThat(log.isWarnEnabled()).isTrue();
+            assertThat(log.isErrorEnabled()).isTrue();
+            assertThat(log.isFatalEnabled()).isTrue();
+
+            log.trace("trace message");
+            log.debug("debug message");
+            log.info("info message");
+            log.warn("warn message");
+            log.error("error message");
+            log.fatal("fatal message", failure);
+
+            List<LogRecord> records = context.records();
+            assertThat(records).hasSize(6);
+            assertThat(records).extracting(LogRecord::getLevel)
+                    .containsExactly(Level.FINEST, Level.FINE, Level.INFO, Level.WARNING, Level.SEVERE, Level.SEVERE);
+            assertThat(records).extracting(LogRecord::getMessage)
+                    .containsExactly("trace message", "debug message", "info message", "warn message", "error message",
+                            "fatal message");
+            assertThat(records).extracting(LogRecord::getLoggerName).containsOnly(context.loggerName());
+            assertThat(records.get(5).getThrown()).isSameAs(failure);
+        }
+    }
+
+    @Test
+    void loggingUsesCallerLocationAndStringValueMessages() {
+        try (TestLoggerContext context = TestLoggerContext.create(uniqueLoggerName("caller"))) {
+            Log log = new SLF4JLogFactory().getInstance(context.loggerName());
+            Object message = new Object() {
+                @Override
+                public String toString() {
+                    return "converted object message";
+                }
+            };
+
+            log.warn(message);
+
+            assertThat(context.records()).singleElement().satisfies(record -> {
+                assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+                assertThat(record.getMessage()).isEqualTo("converted object message");
+                assertThat(record.getSourceClassName()).isEqualTo(SLF4JLocationAwareLogTest.class.getName());
+                assertThat(record.getSourceMethodName()).isEqualTo("loggingUsesCallerLocationAndStringValueMessages");
+            });
+        }
+    }
+
+    private static String uniqueLoggerName(String suffix) {
+        return SLF4JLocationAwareLogTest.class.getName() + "." + suffix + "." + System.nanoTime();
+    }
+
+    private static final class TestLoggerContext implements AutoCloseable {
+
+        private final String loggerName;
+        private final Logger julLogger;
+        private final Level previousLevel;
+        private final boolean previousUseParentHandlers;
+        private final Handler[] previousHandlers;
+        private final RecordingHandler handler;
+
+        private TestLoggerContext(String loggerName) {
+            this.loggerName = loggerName;
+            this.julLogger = Logger.getLogger(loggerName);
+            this.previousLevel = this.julLogger.getLevel();
+            this.previousUseParentHandlers = this.julLogger.getUseParentHandlers();
+            this.previousHandlers = this.julLogger.getHandlers();
+            this.handler = new RecordingHandler();
+
+            for (Handler previousHandler : this.previousHandlers) {
+                this.julLogger.removeHandler(previousHandler);
+            }
+
+            this.julLogger.setUseParentHandlers(false);
+            this.julLogger.setLevel(Level.ALL);
+            this.handler.setLevel(Level.ALL);
+            this.julLogger.addHandler(this.handler);
+        }
+
+        private static TestLoggerContext create(String loggerName) {
+            return new TestLoggerContext(loggerName);
+        }
+
+        private String loggerName() {
+            return this.loggerName;
+        }
+
+        private List<LogRecord> records() {
+            return List.copyOf(this.handler.records);
+        }
+
+        @Override
+        public void close() {
+            this.julLogger.removeHandler(this.handler);
+            this.julLogger.setLevel(this.previousLevel);
+            this.julLogger.setUseParentHandlers(this.previousUseParentHandlers);
+            for (Handler previousHandler : this.previousHandlers) {
+                this.julLogger.addHandler(previousHandler);
+            }
+        }
+    }
+
+    private static final class RecordingHandler extends Handler {
+
+        private final List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            this.records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SLF4JLogFactoryTest.java
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SLF4JLogFactoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.jcl_over_slf4j;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.impl.SLF4JLogFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SLF4JLogFactoryTest {
+
+    @Test
+    void getInstanceReturnsCachedLoggerForNameAndClass() {
+        SLF4JLogFactory factory = new SLF4JLogFactory();
+        String loggerName = SLF4JLogFactoryTest.class.getName();
+
+        Log namedLog = factory.getInstance(loggerName);
+        Log secondNamedLog = factory.getInstance(loggerName);
+        Log classLog = factory.getInstance(SLF4JLogFactoryTest.class);
+
+        assertThat(namedLog).isNotNull();
+        assertThat(namedLog).isSameAs(secondNamedLog);
+        assertThat(classLog).isSameAs(namedLog);
+    }
+
+    @Test
+    void attributesCanBeListedRetrievedAndRemoved() {
+        SLF4JLogFactory factory = new SLF4JLogFactory();
+
+        factory.setAttribute("alpha", "one");
+        factory.setAttribute("beta", 2);
+
+        assertThat(factory.getAttribute("alpha")).isEqualTo("one");
+        assertThat(factory.getAttribute("beta")).isEqualTo(2);
+        assertThat(factory.getAttributeNames()).containsExactlyInAnyOrder("alpha", "beta");
+
+        factory.setAttribute("alpha", null);
+        factory.removeAttribute("beta");
+
+        assertThat(factory.getAttribute("alpha")).isNull();
+        assertThat(factory.getAttribute("beta")).isNull();
+        assertThat(factory.getAttributeNames()).isEmpty();
+    }
+
+    @Test
+    void releaseWarnsAboutUnsupportedCommonsLoggingDeployment() {
+        SLF4JLogFactory factory = new SLF4JLogFactory();
+
+        String output = captureStandardOut(factory::release);
+
+        assertThat(output).contains(
+                "WARN: The method",
+                SLF4JLogFactory.class.getName(),
+                "#release() was invoked.",
+                "http://www.slf4j.org/codes.html#release");
+    }
+
+    private static String captureStandardOut(Runnable action) {
+        PrintStream previousOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (PrintStream capturedOut = new PrintStream(out, true, StandardCharsets.UTF_8)) {
+            System.setOut(capturedOut);
+            action.run();
+        } finally {
+            System.setOut(previousOut);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.jcl_over_slf4j;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.apache.commons.logging.impl.SimpleLog;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleLogAnonymous1Test {
+    private static final String SIMPLE_LOG_CLASS_CACHE = "class$org$apache$commons$logging$impl$SimpleLog";
+
+    @Test
+    void readsFromSystemResourcesWhenNoClassLoaderIsAvailable() throws Exception {
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Field simpleLogClassCache = SimpleLog.class.getDeclaredField(SIMPLE_LOG_CLASS_CACHE);
+        simpleLogClassCache.setAccessible(true);
+        Method getResourceAsStream = SimpleLog.class.getDeclaredMethod("getResourceAsStream", String.class);
+        getResourceAsStream.setAccessible(true);
+        Object previousSimpleLogClass = simpleLogClassCache.get(null);
+        Thread.currentThread().setContextClassLoader(null);
+        simpleLogClassCache.set(null, String.class);
+
+        try {
+            InputStream resource = (InputStream) getResourceAsStream.invoke(
+                    null,
+                    "org_slf4j/jcl_over_slf4j/missing-simplelog.properties"
+            );
+
+            assertThat(resource).isNull();
+        } finally {
+            simpleLogClassCache.set(null, previousSimpleLogClass);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
@@ -6,39 +6,143 @@
  */
 package org_slf4j.jcl_over_slf4j;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.lang.reflect.Field;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.security.PrivilegedAction;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.impl.SimpleLog;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleLogAnonymous1Test {
-    private static final String SIMPLE_LOG_CLASS_CACHE = "class$org$apache$commons$logging$impl$SimpleLog";
+    private static final String SIMPLE_LOG_CLASS = "org.apache.commons.logging.impl.SimpleLog";
+    private static final String SIMPLE_LOG_ANONYMOUS_CLASS = "org.apache.commons.logging.impl.SimpleLog$1";
+    private static final byte[] NULL_CONTEXT_SIMPLE_LOG_BYTES = decode(
+            "yv66vgAAADQADwoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW" +
+            "BwAIAQApb3JnL2FwYWNoZS9jb21tb25zL2xvZ2dpbmcvaW1wbC9TaW1wbGVMb2cBAARDb2RlAQAP" +
+            "TGluZU51bWJlclRhYmxlAQAKYWNjZXNzJDAwMAEAGSgpTGphdmEvbGFuZy9DbGFzc0xvYWRlcjsB" +
+            "AApTb3VyY2VGaWxlAQAOU2ltcGxlTG9nLmphdmEAMQAHAAIAAAAAAAIAAQAFAAYAAQAJAAAAHQAB" +
+            "AAEAAAAFKrcAAbEAAAABAAoAAAAGAAEAAAACAAgACwAMAAEACQAAABoAAQAAAAAAAgGwAAAAAQAK" +
+            "AAAABgABAAAABAABAA0AAAACAA4="
+    );
+    private static final byte[] SIMPLE_LOG_ANONYMOUS_BYTES = decode(
+            "yv66vgAAADEALQkABgAdCgAHAB4KABsAHwoAIAAcCgAgACEHACIHACMHACQBAAh2YWwkbmFtZQEA" +
+            "EkxqYXZhL2xhbmcvU3RyaW5nOwEABjxpbml0PgEAFShMamF2YS9sYW5nL1N0cmluZzspVgEABENv" +
+            "ZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAAAQAMSW5u" +
+            "ZXJDbGFzc2VzAQAtTG9yZy9hcGFjaGUvY29tbW9ucy9sb2dnaW5nL2ltcGwvU2ltcGxlTG9nJDE7" +
+            "AQADcnVuAQAUKClMamF2YS9sYW5nL09iamVjdDsBAAh0aHJlYWRDTAEAF0xqYXZhL2xhbmcvQ2xh" +
+            "c3NMb2FkZXI7AQAKU291cmNlRmlsZQEADlNpbXBsZUxvZy5qYXZhAQAPRW5jbG9zaW5nTWV0aG9k" +
+            "BwAlDAAmACcMAAkACgwACwAoDAApACoHACsMACwAJwEAK29yZy9hcGFjaGUvY29tbW9ucy9sb2dn" +
+            "aW5nL2ltcGwvU2ltcGxlTG9nJDEBABBqYXZhL2xhbmcvT2JqZWN0AQAeamF2YS9zZWN1cml0eS9Q" +
+            "cml2aWxlZ2VkQWN0aW9uAQApb3JnL2FwYWNoZS9jb21tb25zL2xvZ2dpbmcvaW1wbC9TaW1wbGVM" +
+            "b2cBABNnZXRSZXNvdXJjZUFzU3RyZWFtAQApKExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9pby9J" +
+            "bnB1dFN0cmVhbTsBAAMoKVYBAAphY2Nlc3MkMDAwAQAZKClMamF2YS9sYW5nL0NsYXNzTG9hZGVy" +
+            "OwEAFWphdmEvbGFuZy9DbGFzc0xvYWRlcgEAGWdldFN5c3RlbVJlc291cmNlQXNTdHJlYW0AMAAG" +
+            "AAcAAQAIAAEQEAAJAAoAAAACAAAACwAMAAEADQAAADQAAgACAAAACiortQABKrcAArEAAAACAA4A" +
+            "AAAGAAEAAAKlAA8AAAAMAAEAAAAKABAAEwAAAAEAFAAVAAEADQAAAFkAAgACAAAAGbgAA0wrxgAM" +
+            "Kyq0AAG2AASwKrQAAbgABbAAAAACAA4AAAASAAQAAAKnAAQCqQAIAqoAEQKsAA8AAAAWAAIAAAAZ" +
+            "ABAAEwAAAAQAFQAWABcAAQADABgAAAACABkAGgAAAAQAGwAcABIAAAAKAAEABgAAAAAACA=="
+    );
+    private static final String TEST_RESOURCE = "simplelog.properties";
+    private static final String TEST_RESOURCE_CONTENT = "org.apache.commons.logging.simplelog.defaultlog=debug";
 
     @Test
-    void readsFromSystemResourcesWhenNoClassLoaderIsAvailable() throws Exception {
+    void readsFromContextClassLoaderAndHandlesUnavailableContextClassLoader() throws Exception {
         ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
-        Field simpleLogClassCache = SimpleLog.class.getDeclaredField(SIMPLE_LOG_CLASS_CACHE);
-        simpleLogClassCache.setAccessible(true);
         Method getResourceAsStream = SimpleLog.class.getDeclaredMethod("getResourceAsStream", String.class);
         getResourceAsStream.setAccessible(true);
-        Object previousSimpleLogClass = simpleLogClassCache.get(null);
-        Thread.currentThread().setContextClassLoader(null);
-        simpleLogClassCache.set(null, String.class);
+        ClassLoader resourceClassLoader = new ClassLoader(null) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                if (TEST_RESOURCE.equals(name)) {
+                    return new ByteArrayInputStream(TEST_RESOURCE_CONTENT.getBytes(UTF_8));
+                }
+                return null;
+            }
+        };
 
         try {
-            InputStream resource = (InputStream) getResourceAsStream.invoke(
-                    null,
+            Thread.currentThread().setContextClassLoader(resourceClassLoader);
+            try (InputStream resource = getResourceAsStream(getResourceAsStream, TEST_RESOURCE)) {
+                assertThat(resource).isNotNull();
+                assertThat(new String(resource.readAllBytes(), UTF_8)).isEqualTo(TEST_RESOURCE_CONTENT);
+            }
+
+            Thread.currentThread().setContextClassLoader(null);
+            try (InputStream resource = getResourceAsStream(
+                    getResourceAsStream,
+                    "org_slf4j/jcl_over_slf4j/missing-simplelog.properties")) {
+                assertThat(resource).isNull();
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    void readsFromSystemResourcesWhenTheOwningClassHasNoClassLoader() throws Exception {
+        try {
+            IsolatedSimpleLogClassLoader classLoader = new IsolatedSimpleLogClassLoader(
+                    SimpleLogAnonymous1Test.class.getClassLoader()
+            );
+            Class<?> anonymousClass = classLoader.loadClass(SIMPLE_LOG_ANONYMOUS_CLASS);
+            PrivilegedAction<?> action = newPrivilegedAction(
+                    anonymousClass,
                     "org_slf4j/jcl_over_slf4j/missing-simplelog.properties"
             );
 
-            assertThat(resource).isNull();
-        } finally {
-            simpleLogClassCache.set(null, previousSimpleLogClass);
-            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+            assertThat(action.run()).isNull();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static InputStream getResourceAsStream(Method getResourceAsStream, String name) throws Exception {
+        return (InputStream) getResourceAsStream.invoke(null, name);
+    }
+
+    private static byte[] decode(String content) {
+        return Base64.getDecoder().decode(content);
+    }
+
+    private static PrivilegedAction<?> newPrivilegedAction(Class<?> actionClass, String resourceName) throws Exception {
+        Constructor<?> constructor = actionClass.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        return (PrivilegedAction<?>) constructor.newInstance(resourceName);
+    }
+
+    private static final class IsolatedSimpleLogClassLoader extends ClassLoader {
+        private final Map<String, Class<?>> definedClasses = new ConcurrentHashMap<>();
+
+        private IsolatedSimpleLogClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (SIMPLE_LOG_CLASS.equals(name) || SIMPLE_LOG_ANONYMOUS_CLASS.equals(name)) {
+                Class<?> loadedClass = definedClasses.computeIfAbsent(name, this::defineSimpleLogClass);
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineSimpleLogClass(String name) {
+            byte[] bytes = SIMPLE_LOG_CLASS.equals(name) ? NULL_CONTEXT_SIMPLE_LOG_BYTES : SIMPLE_LOG_ANONYMOUS_BYTES;
+            return defineClass(name, bytes, 0, bytes.length, SimpleLog.class.getProtectionDomain());
         }
     }
 }

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogTest.java
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.jcl_over_slf4j;
+
+import org.apache.commons.logging.impl.SimpleLog;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleLogTest {
+    static {
+        System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "info");
+    }
+
+    @Test
+    void constructorUsesThreadContextClassLoaderWhileInitializingConfiguration() {
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(SimpleLogTest.class.getClassLoader());
+
+            SimpleLog log = new SimpleLog(uniqueLoggerName("initialization"));
+
+            assertThat(log.getLevel()).isEqualTo(SimpleLog.LOG_LEVEL_INFO);
+            assertThat(log.isTraceEnabled()).isFalse();
+            assertThat(log.isDebugEnabled()).isFalse();
+            assertThat(log.isInfoEnabled()).isTrue();
+            assertThat(log.isWarnEnabled()).isTrue();
+            assertThat(log.isErrorEnabled()).isTrue();
+            assertThat(log.isFatalEnabled()).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    void levelChangesControlWhichMessagesAreWritten() {
+        SimpleLog log = new SimpleLog(uniqueLoggerName("levels"));
+        log.setLevel(SimpleLog.LOG_LEVEL_WARN);
+
+        String output = captureStandardError(() -> {
+            log.debug("debug is disabled");
+            log.info("info is disabled");
+            log.warn("warn is enabled");
+            log.error("error is enabled");
+        });
+
+        assertThat(output)
+                .doesNotContain("debug is disabled", "info is disabled")
+                .contains("[WARN]", "warn is enabled", "[ERROR]", "error is enabled");
+    }
+
+    @Test
+    void loggingWritesEveryLevelAndThrowableDetailsToStandardError() {
+        SimpleLog log = new SimpleLog(uniqueLoggerName("logging"));
+        log.setLevel(SimpleLog.LOG_LEVEL_ALL);
+        RuntimeException failure = new RuntimeException("boom");
+
+        String output = captureStandardError(() -> {
+            log.trace("trace message");
+            log.debug("debug message");
+            log.info("info message");
+            log.warn("warn message");
+            log.error("error message");
+            log.fatal("fatal message", failure);
+        });
+
+        assertThat(output).contains(
+                "[TRACE]",
+                "trace message",
+                "[DEBUG]",
+                "debug message",
+                "[INFO]",
+                "info message",
+                "[WARN]",
+                "warn message",
+                "[ERROR]",
+                "error message",
+                "[FATAL]",
+                "fatal message",
+                "java.lang.RuntimeException: boom");
+    }
+
+    private static String captureStandardError(Runnable action) {
+        PrintStream previousErr = System.err;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        try (PrintStream capturedErr = new PrintStream(err, true, StandardCharsets.UTF_8)) {
+            System.setErr(capturedErr);
+            action.run();
+        } finally {
+            System.setErr(previousErr);
+        }
+        return err.toString(StandardCharsets.UTF_8);
+    }
+
+    private static String uniqueLoggerName(String suffix) {
+        return SimpleLogTest.class.getName() + "." + suffix + "." + System.nanoTime();
+    }
+}

--- a/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/user-code-filter.json
+++ b/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.commons.logging.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3958

This PR provides test fixes and new metadata for org.slf4j:jcl-over-slf4j:1.7.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 213356
- Cached input tokens: 2527232
- Output tokens: 28460
- Metadata entries: 3
- Iterations: 3
- Library coverage percentage: 54.74
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 54.29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `410568e8ee191a4dda036118c7ffd36da9dfe08e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:jcl-over-slf4j:1.5.6: 7/7 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.7.0: 3/3 covered calls (100.00%)

**Reflection:**
- org.slf4j:jcl-over-slf4j:1.5.6: 5/5 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.7.0: 1/1 covered calls (100.00%)

**Resources:**
- org.slf4j:jcl-over-slf4j:1.5.6: 2/2 covered calls (100.00%)
- org.slf4j:jcl-over-slf4j:1.7.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:jcl-over-slf4j:1.5.6: 679/1241 (54.71%)
- org.slf4j:jcl-over-slf4j:1.7.0: 676/1254 (53.91%)

**Line:**
- org.slf4j:jcl-over-slf4j:1.5.6: 171/315 (54.29%)
- org.slf4j:jcl-over-slf4j:1.7.0: 179/327 (54.74%)

**Method:**
- org.slf4j:jcl-over-slf4j:1.5.6: 49/120 (40.83%)
- org.slf4j:jcl-over-slf4j:1.7.0: 49/122 (40.16%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.slf4j/jcl-over-slf4j/1.5.6/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java 2/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
index 42997f8bfd..f058a06aa4 100644
--- 1/tests/src/org.slf4j/jcl-over-slf4j/1.5.6/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
+++ 2/tests/src/org.slf4j/jcl-over-slf4j/1.7.0/src/test/java/org_slf4j/jcl_over_slf4j/SimpleLogAnonymous1Test.java
@@ -6,39 +6,143 @@
  */
 package org_slf4j.jcl_over_slf4j;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.lang.reflect.Field;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.security.PrivilegedAction;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.impl.SimpleLog;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleLogAnonymous1Test {
-    private static final String SIMPLE_LOG_CLASS_CACHE = "class$org$apache$commons$logging$impl$SimpleLog";
+    private static final String SIMPLE_LOG_CLASS = "org.apache.commons.logging.impl.SimpleLog";
+    private static final String SIMPLE_LOG_ANONYMOUS_CLASS = "org.apache.commons.logging.impl.SimpleLog$1";
+    private static final byte[] NULL_CONTEXT_SIMPLE_LOG_BYTES = decode(
+            "yv66vgAAADQADwoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW" +
+            "BwAIAQApb3JnL2FwYWNoZS9jb21tb25zL2xvZ2dpbmcvaW1wbC9TaW1wbGVMb2cBAARDb2RlAQAP" +
+            "TGluZU51bWJlclRhYmxlAQAKYWNjZXNzJDAwMAEAGSgpTGphdmEvbGFuZy9DbGFzc0xvYWRlcjsB" +
+            "AApTb3VyY2VGaWxlAQAOU2ltcGxlTG9nLmphdmEAMQAHAAIAAAAAAAIAAQAFAAYAAQAJAAAAHQAB" +
+            "AAEAAAAFKrcAAbEAAAABAAoAAAAGAAEAAAACAAgACwAMAAEACQAAABoAAQAAAAAAAgGwAAAAAQAK" +
+            "AAAABgABAAAABAABAA0AAAACAA4="
+    );
+    private static final byte[] SIMPLE_LOG_ANONYMOUS_BYTES = decode(
+            "yv66vgAAADEALQkABgAdCgAHAB4KABsAHwoAIAAcCgAgACEHACIHACMHACQBAAh2YWwkbmFtZQEA" +
+            "EkxqYXZhL2xhbmcvU3RyaW5nOwEABjxpbml0PgEAFShMamF2YS9sYW5nL1N0cmluZzspVgEABENv" +
+            "ZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAAAQAMSW5u" +
+            "ZXJDbGFzc2VzAQAtTG9yZy9hcGFjaGUvY29tbW9ucy9sb2dnaW5nL2ltcGwvU2ltcGxlTG9nJDE7" +
+            "AQADcnVuAQAUKClMamF2YS9sYW5nL09iamVjdDsBAAh0aHJlYWRDTAEAF0xqYXZhL2xhbmcvQ2xh" +
+            "c3NMb2FkZXI7AQAKU291cmNlRmlsZQEADlNpbXBsZUxvZy5qYXZhAQAPRW5jbG9zaW5nTWV0aG9k" +
+            "BwAlDAAmACcMAAkACgwACwAoDAApACoHACsMACwAJwEAK29yZy9hcGFjaGUvY29tbW9ucy9sb2dn" +
+            "aW5nL2ltcGwvU2ltcGxlTG9nJDEBABBqYXZhL2xhbmcvT2JqZWN0AQAeamF2YS9zZWN1cml0eS9Q" +
+            "cml2aWxlZ2VkQWN0aW9uAQApb3JnL2FwYWNoZS9jb21tb25zL2xvZ2dpbmcvaW1wbC9TaW1wbGVM" +
+            "b2cBABNnZXRSZXNvdXJjZUFzU3RyZWFtAQApKExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9pby9J" +
+            "bnB1dFN0cmVhbTsBAAMoKVYBAAphY2Nlc3MkMDAwAQAZKClMamF2YS9sYW5nL0NsYXNzTG9hZGVy" +
+            "OwEAFWphdmEvbGFuZy9DbGFzc0xvYWRlcgEAGWdldFN5c3RlbVJlc291cmNlQXNTdHJlYW0AMAAG" +
+            "AAcAAQAIAAEQEAAJAAoAAAACAAAACwAMAAEADQAAADQAAgACAAAACiortQABKrcAArEAAAACAA4A" +
+            "AAAGAAEAAAKlAA8AAAAMAAEAAAAKABAAEwAAAAEAFAAVAAEADQAAAFkAAgACAAAAGbgAA0wrxgAM" +
+            "Kyq0AAG2AASwKrQAAbgABbAAAAACAA4AAAASAAQAAAKnAAQCqQAIAqoAEQKsAA8AAAAWAAIAAAAZ" +
+            "ABAAEwAAAAQAFQAWABcAAQADABgAAAACABkAGgAAAAQAGwAcABIAAAAKAAEABgAAAAAACA=="
+    );
+    private static final String TEST_RESOURCE = "simplelog.properties";
+    private static final String TEST_RESOURCE_CONTENT = "org.apache.commons.logging.simplelog.defaultlog=debug";
 
     @Test
-    void readsFromSystemResourcesWhenNoClassLoaderIsAvailable() throws Exception {
+    void readsFromContextClassLoaderAndHandlesUnavailableContextClassLoader() throws Exception {
         ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
-        Field simpleLogClassCache = SimpleLog.class.getDeclaredField(SIMPLE_LOG_CLASS_CACHE);
-        simpleLogClassCache.setAccessible(true);
         Method getResourceAsStream = SimpleLog.class.getDeclaredMethod("getResourceAsStream", String.class);
         getResourceAsStream.setAccessible(true);
-        Object previousSimpleLogClass = simpleLogClassCache.get(null);
-        Thread.currentThread().setContextClassLoader(null);
-        simpleLogClassCache.set(null, String.class);
+        ClassLoader resourceClassLoader = new ClassLoader(null) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                if (TEST_RESOURCE.equals(name)) {
+                    return new ByteArrayInputStream(TEST_RESOURCE_CONTENT.getBytes(UTF_8));
+                }
+                return null;
+            }
+        };
 
         try {
-            InputStream resource = (InputStream) getResourceAsStream.invoke(
-                    null,
-                    "org_slf4j/jcl_over_slf4j/missing-simplelog.properties"
-            );
+            Thread.currentThread().setContextClassLoader(resourceClassLoader);
+            try (InputStream resource = getResourceAsStream(getResourceAsStream, TEST_RESOURCE)) {
+                assertThat(resource).isNotNull();
+                assertThat(new String(resource.readAllBytes(), UTF_8)).isEqualTo(TEST_RESOURCE_CONTENT);
+            }
 
-            assertThat(resource).isNull();
+            Thread.currentThread().setContextClassLoader(null);
+            try (InputStream resource = getResourceAsStream(
+                    getResourceAsStream,
+                    "org_slf4j/jcl_over_slf4j/missing-simplelog.properties")) {
+                assertThat(resource).isNull();
+            }
         } finally {
-            simpleLogClassCache.set(null, previousSimpleLogClass);
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);
         }
     }
+
+    @Test
+    void readsFromSystemResourcesWhenTheOwningClassHasNoClassLoader() throws Exception {
+        try {
+            IsolatedSimpleLogClassLoader classLoader = new IsolatedSimpleLogClassLoader(
+                    SimpleLogAnonymous1Test.class.getClassLoader()
+            );
+            Class<?> anonymousClass = classLoader.loadClass(SIMPLE_LOG_ANONYMOUS_CLASS);
+            PrivilegedAction<?> action = newPrivilegedAction(
+                    anonymousClass,
+                    "org_slf4j/jcl_over_slf4j/missing-simplelog.properties"
+            );
+
+            assertThat(action.run()).isNull();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static InputStream getResourceAsStream(Method getResourceAsStream, String name) throws Exception {
+        return (InputStream) getResourceAsStream.invoke(null, name);
+    }
+
+    private static byte[] decode(String content) {
+        return Base64.getDecoder().decode(content);
+    }
+
+    private static PrivilegedAction<?> newPrivilegedAction(Class<?> actionClass, String resourceName) throws Exception {
+        Constructor<?> constructor = actionClass.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        return (PrivilegedAction<?>) constructor.newInstance(resourceName);
+    }
+
+    private static final class IsolatedSimpleLogClassLoader extends ClassLoader {
+        private final Map<String, Class<?>> definedClasses = new ConcurrentHashMap<>();
+
+        private IsolatedSimpleLogClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (SIMPLE_LOG_CLASS.equals(name) || SIMPLE_LOG_ANONYMOUS_CLASS.equals(name)) {
+                Class<?> loadedClass = definedClasses.computeIfAbsent(name, this::defineSimpleLogClass);
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineSimpleLogClass(String name) {
+            byte[] bytes = SIMPLE_LOG_CLASS.equals(name) ? NULL_CONTEXT_SIMPLE_LOG_BYTES : SIMPLE_LOG_ANONYMOUS_BYTES;
+            return defineClass(name, bytes, 0, bytes.length, SimpleLog.class.getProtectionDomain());
+        }
+    }
 }

```
