### PR TITLE
[GenAI] Test fix for com.jamesmurty.utils:java-xmlbuilder:1.1 using gpt-5.5

### DIFF
--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/1.1/reachability-metadata.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/1.1/reachability-metadata.json
@@ -1,0 +1,85 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "type": "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "glob": "META-INF/services/java.nio.charset.spi.CharsetProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.transform.TransformerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "glob": "META-INF/services/javax.xml.xpath.XPathFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/Encodings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.jamesmurty.utils.BaseXMLBuilder"
+      },
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xml/internal/serializer/XMLEntities_en_US.properties"
+    },
+    {
+      "bundle": "com.sun.org.apache.xml.internal.serializer.XMLEntities"
+    }
+  ]
+}

--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/1.1/java-xmlbuilder-1.1-sources.jar",
+    "repository-url" : "https://github.com/jmurty/java-xmlbuilder",
+    "test-code-url" : "https://github.com/jmurty/java-xmlbuilder/tree/v1.1/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/1.1/java-xmlbuilder-1.1-javadoc.jar",
+    "description" : "java-xmlbuilder is a Java utility for constructing XML documents with a fluent, chainable builder API instead of manual string concatenation or verbose JAXP DOM code. It builds on standard JAXP and DOM APIs so callers can serialize the result, parse existing XML, query with XPath, or access the underlying W3C document for further manipulation.",
     "tested-versions" : [
       "1.1"
     ],

--- a/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
+++ b/metadata/com.jamesmurty.utils/java-xmlbuilder/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.1",
+    "tested-versions" : [
+      "1.1"
+    ],
+    "allowed-packages" : [
+      "com.jamesmurty.utils"
+    ]
+  },
+  {
     "metadata-version" : "0.6",
     "source-code-url" : "https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/0.6/java-xmlbuilder-0.6-sources.jar",
     "repository-url" : "https://github.com/jmurty/java-xmlbuilder",

--- a/stats/com.jamesmurty.utils/java-xmlbuilder/1.1/execution-metrics.json
+++ b/stats/com.jamesmurty.utils/java-xmlbuilder/1.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-01": {
+    "timestamp": "2026-05-01T03:14:37.156735Z",
+    "library": "com.jamesmurty.utils:java-xmlbuilder:1.1",
+    "starting_commit": "b5ad37bf79726d7a3cc9aab0d1cdbfb09c133d67",
+    "ending_commit": "be4c2cd4ea0c1377f309eaa960585e27c019b682",
+    "previous_library": "com.jamesmurty.utils:java-xmlbuilder:0.6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 458,
+          "missed": 1015,
+          "ratio": 0.31093,
+          "total": 1473
+        },
+        "line": {
+          "covered": 127,
+          "missed": 255,
+          "ratio": 0.332461,
+          "total": 382
+        },
+        "method": {
+          "covered": 41,
+          "missed": 106,
+          "ratio": 0.278912,
+          "total": 147
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 452,
+          "missed": 452,
+          "ratio": 0.5,
+          "total": 904
+        },
+        "line": {
+          "covered": 115,
+          "missed": 83,
+          "ratio": 0.580808,
+          "total": 198
+        },
+        "method": {
+          "covered": 33,
+          "missed": 32,
+          "ratio": 0.507692,
+          "total": 65
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 33605,
+      "cached_input_tokens_used": 236032,
+      "output_tokens_used": 3274,
+      "iterations": 1,
+      "cost_usd": 0.2162,
+      "tested_library_loc": 127,
+      "metadata_entries": 17,
+      "previous_library_metadata_entries": 17,
+      "code_coverage_percent": 33.25,
+      "previous_library_coverage_percent": 58.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java",
+      "metadata_file": "metadata/com.jamesmurty.utils/java-xmlbuilder/1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.jamesmurty.utils/java-xmlbuilder/1.1/stats.json
+++ b/stats/com.jamesmurty.utils/java-xmlbuilder/1.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 458,
+        "missed" : 1015,
+        "ratio" : 0.31093,
+        "total" : 1473
+      },
+      "line" : {
+        "covered" : 127,
+        "missed" : 255,
+        "ratio" : 0.332461,
+        "total" : 382
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 106,
+        "ratio" : 0.278912,
+        "total" : 147
+      }
+    }
+  } ]
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/.gitignore
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/build.gradle
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.jamesmurty.utils:java-xmlbuilder:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/gradle.properties
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.jamesmurty.utils:java-xmlbuilder:1.1
+library.version = 1.1
+metadata.dir = com.jamesmurty.utils/java-xmlbuilder/1.1/

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/settings.gradle
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.jamesmurty.utils.java-xmlbuilder_tests'

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_jamesmurty_utils.java_xmlbuilder;
+
+import com.jamesmurty.utils.XMLBuilder;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+import java.util.Properties;
+
+import javax.xml.transform.OutputKeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Base64Test {
+    @Test
+    void xmlDocumentCanBeBuiltSerializedParsedAndQueried() throws Exception {
+        XMLBuilder builder = XMLBuilder.create("catalog")
+                .namespace("bk", "https://example.com/book")
+                .e("bk:book")
+                .a("id", "java-xmlbuilder")
+                .e("title")
+                .t("Reachability Metadata")
+                .up()
+                .e("description")
+                .data("<native-image ready>")
+                .up()
+                .up()
+                .e("count")
+                .t("1");
+        Properties outputProperties = new Properties();
+        outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+
+        String xml = builder.asString(outputProperties);
+        XMLBuilder parsed = XMLBuilder.parse(new InputSource(new StringReader(xml)));
+        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", parsed.buildDocumentNamespaceContext());
+        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", parsed.buildDocumentNamespaceContext());
+        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", parsed.buildDocumentNamespaceContext());
+        XMLBuilder count = parsed.xpathFind("/catalog/count");
+
+        assertThat(xml).contains("xmlns:bk=\"https://example.com/book\"");
+        assertThat(book.getElement().getAttribute("id")).isEqualTo("java-xmlbuilder");
+        assertThat(title.getElement().getTextContent()).isEqualTo("Reachability Metadata");
+        assertThat(description.getElement().getTextContent()).isEqualTo("<native-image ready>");
+        assertThat(count.getElement().getTextContent()).isEqualTo("1");
+    }
+}

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -11,8 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.InputSource;
 
 import java.io.StringReader;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Properties;
 
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.transform.OutputKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,9 +42,10 @@ public class Base64Test {
 
         String xml = builder.asString(outputProperties);
         XMLBuilder parsed = XMLBuilder.parse(new InputSource(new StringReader(xml)));
-        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", parsed.buildDocumentNamespaceContext());
-        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", parsed.buildDocumentNamespaceContext());
-        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", parsed.buildDocumentNamespaceContext());
+        NamespaceContext namespaceContext = namespaceContext("bk", "https://example.com/book");
+        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", namespaceContext);
+        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", namespaceContext);
+        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", namespaceContext);
         XMLBuilder count = parsed.xpathFind("/catalog/count");
 
         assertThat(xml).contains("xmlns:bk=\"https://example.com/book\"");
@@ -48,5 +53,33 @@ public class Base64Test {
         assertThat(title.getElement().getTextContent()).isEqualTo("Reachability Metadata");
         assertThat(description.getElement().getTextContent()).isEqualTo("<native-image ready>");
         assertThat(count.getElement().getTextContent()).isEqualTo("1");
+    }
+
+    private static NamespaceContext namespaceContext(String prefix, String namespaceUri) {
+        return new NamespaceContext() {
+            @Override
+            public String getNamespaceURI(String requestedPrefix) {
+                if (prefix.equals(requestedPrefix)) {
+                    return namespaceUri;
+                }
+                return XMLConstants.NULL_NS_URI;
+            }
+
+            @Override
+            public String getPrefix(String requestedNamespaceUri) {
+                if (namespaceUri.equals(requestedNamespaceUri)) {
+                    return prefix;
+                }
+                return null;
+            }
+
+            @Override
+            public Iterator<String> getPrefixes(String requestedNamespaceUri) {
+                if (namespaceUri.equals(requestedNamespaceUri)) {
+                    return Collections.singleton(prefix).iterator();
+                }
+                return Collections.emptyIterator();
+            }
+        };
     }
 }

--- a/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/user-code-filter.json
+++ b/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.jamesmurty.utils.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3942

This PR provides test fixes and new metadata for com.jamesmurty.utils:java-xmlbuilder:1.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 33605
- Cached input tokens: 236032
- Output tokens: 3274
- Metadata entries: 17
- Iterations: 1
- Library coverage percentage: 33.25
- Previous library version metadata entries: 17
- Previous library version coverage percentage: 58.08

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `298d5934162ce4f85dc4149d59ff15caa2ebc39c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.jamesmurty.utils:java-xmlbuilder:0.6: 0/0 covered calls (100.00%)
- com.jamesmurty.utils:java-xmlbuilder:1.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.jamesmurty.utils:java-xmlbuilder:0.6: 452/904 (50.00%)
- com.jamesmurty.utils:java-xmlbuilder:1.1: 458/1473 (31.09%)

**Line:**
- com.jamesmurty.utils:java-xmlbuilder:0.6: 115/198 (58.08%)
- com.jamesmurty.utils:java-xmlbuilder:1.1: 127/382 (33.25%)

**Method:**
- com.jamesmurty.utils:java-xmlbuilder:0.6: 33/65 (50.77%)
- com.jamesmurty.utils:java-xmlbuilder:1.1: 41/147 (27.89%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
index 86b1360d06..47a5ce190a 100644
--- 1/tests/src/com.jamesmurty.utils/java-xmlbuilder/0.6/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
+++ 2/tests/src/com.jamesmurty.utils/java-xmlbuilder/1.1/src/test/java/com_jamesmurty_utils/java_xmlbuilder/Base64Test.java
@@ -11,8 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.InputSource;
 
 import java.io.StringReader;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Properties;
 
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.transform.OutputKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,9 +42,10 @@ public class Base64Test {
 
         String xml = builder.asString(outputProperties);
         XMLBuilder parsed = XMLBuilder.parse(new InputSource(new StringReader(xml)));
-        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", parsed.buildDocumentNamespaceContext());
-        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", parsed.buildDocumentNamespaceContext());
-        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", parsed.buildDocumentNamespaceContext());
+        NamespaceContext namespaceContext = namespaceContext("bk", "https://example.com/book");
+        XMLBuilder book = parsed.xpathFind("/catalog/bk:book", namespaceContext);
+        XMLBuilder title = parsed.xpathFind("/catalog/bk:book/title", namespaceContext);
+        XMLBuilder description = parsed.xpathFind("/catalog/bk:book/description", namespaceContext);
         XMLBuilder count = parsed.xpathFind("/catalog/count");
 
         assertThat(xml).contains("xmlns:bk=\"https://example.com/book\"");
@@ -49,4 +54,32 @@ public class Base64Test {
         assertThat(description.getElement().getTextContent()).isEqualTo("<native-image ready>");
         assertThat(count.getElement().getTextContent()).isEqualTo("1");
     }
+
+    private static NamespaceContext namespaceContext(String prefix, String namespaceUri) {
+        return new NamespaceContext() {
+            @Override
+            public String getNamespaceURI(String requestedPrefix) {
+                if (prefix.equals(requestedPrefix)) {
+                    return namespaceUri;
+                }
+                return XMLConstants.NULL_NS_URI;
+            }
+
+            @Override
+            public String getPrefix(String requestedNamespaceUri) {
+                if (namespaceUri.equals(requestedNamespaceUri)) {
+                    return prefix;
+                }
+                return null;
+            }
+
+            @Override
+            public Iterator<String> getPrefixes(String requestedNamespaceUri) {
+                if (namespaceUri.equals(requestedNamespaceUri)) {
+                    return Collections.singleton(prefix).iterator();
+                }
+                return Collections.emptyIterator();
+            }
+        };
+    }
 }

```
