### PR TITLE
Increase scheduled workflow cadence

### DIFF
--- a/.github/workflows/publish-scheduled-coverage.yml
+++ b/.github/workflows/publish-scheduled-coverage.yml
@@ -2,7 +2,7 @@ name: "Publish coverage"
 
 on:
   schedule:
-    - cron: "15 */4 * * *"
+    - cron: "15 */2 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -2,7 +2,7 @@ name: "Verify compatibility with latest library versions"
 
 on:
   schedule:
-    - cron: '0 */8 * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -39,7 +39,7 @@ Workflows testing metadata using [ci.json](../ci.json):
   - Triggers: PRs to master that change exploded stats files under [stats/](../stats/), [stats/schemas/library-stats-schema-v1.0.2.json](../stats/schemas/library-stats-schema-v1.0.2.json), or mirrored files under [metadata/](../metadata/).
   - Uses: [`validateLibraryStats`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to enforce schema compliance and normalized sorting.
 - Verify new library version compatibility ([.github/workflows/verify-new-library-version-compatibility.yml](../.github/workflows/verify-new-library-version-compatibility.yml))
-  - Triggers: every 8 hours and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
+  - Triggers: every 4 hours and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
   - Uses: [`fetchExistingLibrariesWithNewerVersions`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) plus [`generateNewLibraryVersionCompatibilityMatrix`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to build a [`ci.json`](../ci.json)-driven matrix. The matrix generator limits the number of libraries per run, limits each library to at most 30 newer versions per run before expanding across the configured GraalVM JDK/OS combinations, records tested versions only after they pass on every required environment, and creates a single aggregated failure issue per failed library version while preserving the prior failure issue format with added OS and JDK lines.
 
 Workflows for style and security:

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -60,7 +60,7 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [CI.md](CI.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
-- Schedule-driven: full metadata sweep, new-library-version compatibility (every 8 hours), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
+- Schedule-driven: full metadata sweep, new-library-version compatibility (every 4 hours), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
@@ -20,8 +20,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -149,9 +152,13 @@ public final class ReadmeBadgeSummarySupport {
     }
 
     public static void writeMetricsOverviewGraph(Path graphFile, ReadmeMetricsHistory history) {
+        writeMetricsOverviewGraph(graphFile, history, Instant.now());
+    }
+
+    public static void writeMetricsOverviewGraph(Path graphFile, ReadmeMetricsHistory history, Instant generatedAt) {
         writeTextWithTrailingNewline(
                 graphFile,
-                buildMetricsOverviewGraph(history),
+                buildMetricsOverviewGraph(history, generatedAt),
                 "Failed to write README metrics graph to "
         );
     }
@@ -391,7 +398,7 @@ public final class ReadmeBadgeSummarySupport {
         }
     }
 
-    private static String buildMetricsOverviewGraph(ReadmeMetricsHistory history) {
+    private static String buildMetricsOverviewGraph(ReadmeMetricsHistory history, Instant generatedAt) {
         List<PanelSpec> panels = List.of(
                 new PanelSpec(
                         "libraries-supported",
@@ -479,6 +486,8 @@ public final class ReadmeBadgeSummarySupport {
                 .append(DASHBOARD_PADDING)
                 .append("\" y=\"92\" fill=\"#5f748c\" font-size=\"17\">Updated ")
                 .append(escapeXml(latestDate.toString()))
+                .append(" | Generated ")
+                .append(escapeXml(formatGeneratedAt(generatedAt)))
                 .append("</text>\n");
         for (int index = 0; index < panels.size(); index++) {
             int panelX = DASHBOARD_PADDING + (index % 2) * (PANEL_WIDTH + DASHBOARD_GAP);
@@ -942,6 +951,10 @@ public final class ReadmeBadgeSummarySupport {
 
     private static String formatPercent(BigDecimal value) {
         return value.setScale(1, RoundingMode.HALF_UP).toPlainString() + "%";
+    }
+
+    private static String formatGeneratedAt(Instant generatedAt) {
+        return DateTimeFormatter.ISO_INSTANT.format(generatedAt.truncatedTo(ChronoUnit.SECONDS));
     }
 
     public record ReadmeBadgeSummary(

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupportTests.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -283,7 +284,11 @@ class ReadmeBadgeSummarySupportTests {
                 )
         );
 
-        ReadmeBadgeSummarySupport.writeMetricsOverviewGraph(graphFile, history);
+        ReadmeBadgeSummarySupport.writeMetricsOverviewGraph(
+                graphFile,
+                history,
+                Instant.parse("2026-04-07T12:34:56Z")
+        );
 
         String svg = Files.readString(graphFile, StandardCharsets.UTF_8);
         assertThat(svg).contains("<svg");
@@ -296,7 +301,7 @@ class ReadmeBadgeSummarySupportTests {
         assertThat(svg).contains("Tested library versions recorded across metadata indexes");
         assertThat(svg).contains("Tested lines of code");
         assertThat(svg).contains("Covered lines reported across library coverage stats");
-        assertThat(svg).contains("Updated 2026-04-07");
+        assertThat(svg).contains("Updated 2026-04-07 | Generated 2026-04-07T12:34:56Z");
         assertThat(svg).contains("35.8%");
         assertThat(svg).contains("text-anchor=\"start\">Apr 5</text>");
         assertThat(svg).contains("text-anchor=\"middle\">Apr 6</text>");


### PR DESCRIPTION
Closes #3986

Summary:
- Run `verify-new-library-version-compatibility` every 4 hours instead of every 8 hours.
- Run `publish-scheduled-coverage` every 2 hours instead of every 4 hours.
- Update the CI and functional specification docs for the new compatibility cadence.

Testing:
- `git diff --check -- .github/workflows/publish-scheduled-coverage.yml .github/workflows/verify-new-library-version-compatibility.yml docs/CI.md docs/FUNCTIONAL_SPEC.md`