### PR TITLE
[GenAI] Test fix for org.apache.httpcomponents:httpcore:4.4.15 using gpt-5.5

### DIFF
--- a/metadata/org.apache.httpcomponents/httpcore/4.4.15/reachability-metadata.json
+++ b/metadata/org.apache.httpcomponents/httpcore/4.4.15/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.ExceptionUtils"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "initCause",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.http.entity.SerializableEntity"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.http.util.VersionInfo"
+      },
+      "glob": "org/apache/http/version.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.15",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15-sources.jar",
+    "repository-url" : "https://github.com/apache/httpcomponents-core",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15-javadoc.jar",
+    "description" : "Apache HttpCore provides low-level components for building HTTP clients and servers with blocking I/O. It implements core HTTP message parsing, transport, and connection management primitives used by higher-level HttpComponents libraries.",
     "tested-versions" : [
       "4.4.15"
     ],

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.4.15",
+    "tested-versions" : [
+      "4.4.15"
+    ],
+    "allowed-packages" : [
+      "org.apache.http"
+    ]
+  },
+  {
     "metadata-version" : "4.4.14",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.14/httpcore-4.4.14-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/stats/org.apache.httpcomponents/httpcore/4.4.15/execution-metrics.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.15/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T10:01:18.849759Z",
+    "library": "org.apache.httpcomponents:httpcore:4.4.15",
+    "starting_commit": "a24da2d6c6fe3f0db923319c8a2028845c772019",
+    "ending_commit": "c6ab5872f43f280aee826913662c0ce4d39a2a98",
+    "previous_library": "org.apache.httpcomponents:httpcore:4.4.14",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.15",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24525,
+          "ratio": 0.013118,
+          "total": 24851
+        },
+        "line": {
+          "covered": 85,
+          "missed": 6060,
+          "ratio": 0.013832,
+          "total": 6145
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1408,
+          "ratio": 0.015385,
+          "total": 1430
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.4.14",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 24532,
+          "ratio": 0.013114,
+          "total": 24858
+        },
+        "line": {
+          "covered": 85,
+          "missed": 6067,
+          "ratio": 0.013817,
+          "total": 6152
+        },
+        "method": {
+          "covered": 22,
+          "missed": 1408,
+          "ratio": 0.015385,
+          "total": 1430
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 48447,
+      "cached_input_tokens_used": 411136,
+      "output_tokens_used": 2961,
+      "iterations": 1,
+      "cost_usd": 0.2944,
+      "tested_library_loc": 85,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 1.38,
+      "previous_library_coverage_percent": 1.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java",
+      "metadata_file": "metadata/org.apache.httpcomponents/httpcore/4.4.15/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.httpcomponents/httpcore/4.4.15/stats.json
+++ b/stats/org.apache.httpcomponents/httpcore/4.4.15/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.15",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 326,
+        "missed" : 24525,
+        "ratio" : 0.013118,
+        "total" : 24851
+      },
+      "line" : {
+        "covered" : 85,
+        "missed" : 6060,
+        "ratio" : 0.013832,
+        "total" : 6145
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 1408,
+        "ratio" : 0.015385,
+        "total" : 1430
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/.gitignore
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/build.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.httpcomponents:httpcore:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/gradle.properties
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.httpcomponents:httpcore:4.4.15
+library.version = 4.4.15
+metadata.dir = org.apache.httpcomponents/httpcore/4.4.15/

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/settings.gradle
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.httpcomponents.httpcore_tests'

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/ExceptionUtilsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class ExceptionUtilsTest {
+
+    @Test
+    void initCauseAssignsTheProvidedCause() {
+        IllegalArgumentException throwable = new IllegalArgumentException("outer");
+        IllegalStateException cause = new IllegalStateException("inner");
+
+        ExceptionUtils.initCause(throwable, cause);
+
+        assertThat(throwable).hasCause(cause);
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/SerializableEntityTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.entity.SerializableEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializableEntityTest {
+
+    @Test
+    void bufferizedEntitySerializesContentWhenCreated() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("alpha", "beta"));
+
+        SerializableEntity entity = new SerializableEntity(payload, true);
+        byte[] expectedBytes = serialize(payload);
+
+        assertThat(entity.isRepeatable()).isTrue();
+        assertThat(entity.isStreaming()).isFalse();
+        assertThat(entity.getContentLength()).isEqualTo(expectedBytes.length);
+        assertThat(readAllBytes(entity.getContent())).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    void streamingEntityWritesSerializedObjectToOutputStream() throws Exception {
+        ArrayList<String> payload = new ArrayList<>(List.of("gamma", "delta"));
+
+        SerializableEntity entity = new SerializableEntity(payload);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        assertThat(entity.isStreaming()).isTrue();
+
+        entity.writeTo(out);
+
+        assertThat(out.toByteArray()).isEqualTo(serialize(payload));
+    }
+
+    private static byte[] readAllBytes(InputStream content) throws IOException {
+        try (InputStream inputStream = content) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private static byte[] serialize(Serializable value) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+        }
+        return outputStream.toByteArray();
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_httpcomponents.httpcore;
+
+import org.apache.http.util.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionInfoTest {
+
+    private static final String EXPECTED_RELEASE = "4.4.14";
+
+    @Test
+    void loadVersionInfoReadsPackagedVersionProperties() {
+        ClassLoader classLoader = VersionInfo.class.getClassLoader();
+        VersionInfo versionInfo = VersionInfo.loadVersionInfo("org.apache.http", classLoader);
+
+        assertThat(versionInfo).isNotNull();
+        assertThat(versionInfo.getPackage()).isEqualTo("org.apache.http");
+        assertThat(versionInfo.getModule()).isEqualTo("httpcore");
+        assertThat(versionInfo.getRelease()).isEqualTo(EXPECTED_RELEASE);
+        assertThat(versionInfo.getTimestamp()).isEqualTo(VersionInfo.UNAVAILABLE);
+        assertThat(versionInfo.getClassloader()).isEqualTo(classLoader.toString());
+    }
+
+    @Test
+    void getUserAgentUsesThePackagedRelease() {
+        String userAgent = VersionInfo.getUserAgent("httpcore-test", "org.apache.http", VersionInfo.class);
+
+        assertThat(userAgent)
+                .isEqualTo("httpcore-test/" + EXPECTED_RELEASE + " (Java/" + System.getProperty("java.version") + ")");
+    }
+}

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionInfoTest {
 
-    private static final String EXPECTED_RELEASE = "4.4.14";
+    private static final String EXPECTED_RELEASE = "4.4.15";
 
     @Test
     void loadVersionInfoReadsPackagedVersionProperties() {

--- a/tests/src/org.apache.httpcomponents/httpcore/4.4.15/user-code-filter.json
+++ b/tests/src/org.apache.httpcomponents/httpcore/4.4.15/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4008

This PR provides test fixes and new metadata for org.apache.httpcomponents:httpcore:4.4.15, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 48447
- Cached input tokens: 411136
- Output tokens: 2961
- Metadata entries: 7
- Iterations: 1
- Library coverage percentage: 1.38
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 1.38

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6226ac7f39297d96daae1f599322d66f64173423`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.httpcomponents:httpcore:4.4.14: 4/4 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.15: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.httpcomponents:httpcore:4.4.14: 3/3 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.15: 3/3 covered calls (100.00%)

**Resources:**
- org.apache.httpcomponents:httpcore:4.4.14: 1/1 covered calls (100.00%)
- org.apache.httpcomponents:httpcore:4.4.15: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.httpcomponents:httpcore:4.4.14: 326/24858 (1.31%)
- org.apache.httpcomponents:httpcore:4.4.15: 326/24851 (1.31%)

**Line:**
- org.apache.httpcomponents:httpcore:4.4.14: 85/6152 (1.38%)
- org.apache.httpcomponents:httpcore:4.4.15: 85/6145 (1.38%)

**Method:**
- org.apache.httpcomponents:httpcore:4.4.14: 22/1430 (1.54%)
- org.apache.httpcomponents:httpcore:4.4.15: 22/1430 (1.54%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.httpcomponents/httpcore/4.4.14/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java 2/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
index 126a415fd6..df2be21b54 100644
--- 1/tests/src/org.apache.httpcomponents/httpcore/4.4.14/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
+++ 2/tests/src/org.apache.httpcomponents/httpcore/4.4.15/src/test/java/org_apache_httpcomponents/httpcore/VersionInfoTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionInfoTest {
 
-    private static final String EXPECTED_RELEASE = "4.4.14";
+    private static final String EXPECTED_RELEASE = "4.4.15";
 
     @Test
     void loadVersionInfoReadsPackagedVersionProperties() {

```
