### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-http:9.4.1.v20170120 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-http/9.4.1.v20170120/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-http/9.4.1.v20170120/reachability-metadata.json
@@ -1,0 +1,111 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getUptime",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "org.eclipse.jetty.util.log.Slf4jLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging-linux.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime.properties"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "9.4.1.v20170120"
     ],
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.1.v20170120/jetty-http-9.4.1.v20170120-sources.jar",
+    "repository-url" : "https://github.com/eclipse/jetty.project",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.1.v20170120/jetty-http-9.4.1.v20170120-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.1.v20170120/jetty-http-9.4.1.v20170120-javadoc.jar",
+    "description" : "Jetty HTTP provides core HTTP utilities for Eclipse Jetty, including request and response metadata, headers, cookies, MIME types, and URI handling. It is used by Jetty server and client components to parse, represent, and generate HTTP protocol data.",
     "allowed-packages" : [
       "org.eclipse.jetty.http"
     ]

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "9.4.1.v20170120",
+    "tested-versions" : [
+      "9.4.1.v20170120"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.http"
+    ]
+  },
+  {
     "metadata-version" : "9.4.0.M0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.0.M0/jetty-http-9.4.0.M0-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/stats/org.eclipse.jetty/jetty-http/9.4.1.v20170120/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-http/9.4.1.v20170120/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T10:01:36.218769Z",
+    "library": "org.eclipse.jetty:jetty-http:9.4.1.v20170120",
+    "starting_commit": "a829096f6455a0a75f852a9a2aa32e15d6517273",
+    "ending_commit": "9a0f7cebbaeec96edd8944212fcb1f60c8e69e31",
+    "previous_library": "org.eclipse.jetty:jetty-http:9.4.0.M0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "9.4.1.v20170120",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2123,
+          "missed": 18753,
+          "ratio": 0.101696,
+          "total": 20876
+        },
+        "line": {
+          "covered": 343,
+          "missed": 3835,
+          "ratio": 0.082097,
+          "total": 4178
+        },
+        "method": {
+          "covered": 39,
+          "missed": 559,
+          "ratio": 0.065217,
+          "total": 598
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.4.0.M0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1980,
+          "missed": 17819,
+          "ratio": 0.100005,
+          "total": 19799
+        },
+        "line": {
+          "covered": 311,
+          "missed": 3668,
+          "ratio": 0.07816,
+          "total": 3979
+        },
+        "method": {
+          "covered": 33,
+          "missed": 528,
+          "ratio": 0.058824,
+          "total": 561
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 56277,
+      "cached_input_tokens_used": 505856,
+      "output_tokens_used": 5306,
+      "iterations": 1,
+      "cost_usd": 0.4121,
+      "tested_library_loc": 343,
+      "metadata_entries": 22,
+      "previous_library_metadata_entries": 30,
+      "code_coverage_percent": 8.21,
+      "previous_library_coverage_percent": 7.82
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-http/9.4.1.v20170120/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-http/9.4.1.v20170120/stats.json
+++ b/stats/org.eclipse.jetty/jetty-http/9.4.1.v20170120/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "9.4.1.v20170120",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2123,
+        "missed" : 18753,
+        "ratio" : 0.101696,
+        "total" : 20876
+      },
+      "line" : {
+        "covered" : 343,
+        "missed" : 3835,
+        "ratio" : 0.082097,
+        "total" : 4178
+      },
+      "method" : {
+        "covered" : 39,
+        "missed" : 559,
+        "ratio" : 0.065217,
+        "total" : 598
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-http:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-http:9.4.1.v20170120
+library.version = 9.4.1.v20170120
+metadata.dir = org.eclipse.jetty/jetty-http/9.4.1.v20170120/

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-http_tests'

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_http;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MimeTypesTest {
+    @Test
+    void loadsDefaultMimeAndEncodingResources() {
+        MimeTypes mimeTypes = new MimeTypes();
+
+        assertThat(mimeTypes.getMimeByExtension("index.html"))
+                .isEqualTo(MimeTypes.Type.TEXT_HTML.asString());
+        assertThat(mimeTypes.getMimeByExtension("IMAGE.PNG"))
+                .isEqualTo("image/png");
+        assertThat(MimeTypes.getKnownMimeTypes())
+                .contains("application/json", "text/css");
+
+        assertThat(MimeTypes.inferCharsetFromContentType("text/html"))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.Type.TEXT_JSON.getCharsetString())
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.Type.TEXT_JSON.isCharsetAssumed())
+                .isTrue();
+    }
+
+    @Test
+    void appliesInstanceMappingsBeforeDefaultResourceMappings() {
+        MimeTypes mimeTypes = new MimeTypes();
+        mimeTypes.addMimeMapping("HTML", "text/plain;charset=UTF-8");
+        mimeTypes.addMimeMapping("custom", "application/vnd.example.Custom");
+
+        assertThat(mimeTypes.getMimeByExtension("page.html"))
+                .isEqualTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
+        assertThat(mimeTypes.getMimeByExtension("download.custom"))
+                .isEqualTo("application/vnd.example.custom");
+        assertThat(mimeTypes.getMimeByExtension("script.js"))
+                .isEqualTo("application/javascript");
+    }
+
+    @Test
+    void parsesAndRemovesCharsetsFromContentTypes() {
+        assertThat(MimeTypes.getCharsetFromContentType("text/plain; charset=\"UTF-8\""))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.getContentTypeWithoutCharset("text/plain; charset=UTF-8; boundary=simple"))
+                .isEqualTo("text/plain;boundary=simple");
+        assertThat(MimeTypes.getContentTypeWithoutCharset("application/json"))
+                .isEqualTo("application/json");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -23,7 +23,9 @@ public class MimeTypesTest {
         assertThat(MimeTypes.getKnownMimeTypes())
                 .contains("application/json", "text/css");
 
-        assertThat(MimeTypes.inferCharsetFromContentType("text/html"))
+        assertThat(MimeTypes.getCharsetInferredFromContentType("text/html"))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.getCharsetAssumedFromContentType("application/vnd.api+json"))
                 .isEqualTo("utf-8");
         assertThat(MimeTypes.Type.TEXT_JSON.getCharsetString())
                 .isEqualTo("utf-8");

--- a/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.http.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4009

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-http:9.4.1.v20170120, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 56277
- Cached input tokens: 505856
- Output tokens: 5306
- Metadata entries: 22
- Iterations: 1
- Library coverage percentage: 8.21
- Previous library version metadata entries: 30
- Previous library version coverage percentage: 7.82

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6226ac7f39297d96daae1f599322d66f64173423`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-http:9.4.0.M0: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-http:9.4.0.M0: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-http:9.4.0.M0: 1980/19799 (10.00%)
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2123/20876 (10.17%)

**Line:**
- org.eclipse.jetty:jetty-http:9.4.0.M0: 311/3979 (7.82%)
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 343/4178 (8.21%)

**Method:**
- org.eclipse.jetty:jetty-http:9.4.0.M0: 33/561 (5.88%)
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 39/598 (6.52%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java 2/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
index bde5929d42..00decb9f83 100644
--- 1/tests/src/org.eclipse.jetty/jetty-http/9.4.0.M0/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-http/9.4.1.v20170120/src/test/java/org_eclipse_jetty/jetty_http/MimeTypesTest.java
@@ -23,7 +23,9 @@ public class MimeTypesTest {
         assertThat(MimeTypes.getKnownMimeTypes())
                 .contains("application/json", "text/css");
 
-        assertThat(MimeTypes.inferCharsetFromContentType("text/html"))
+        assertThat(MimeTypes.getCharsetInferredFromContentType("text/html"))
+                .isEqualTo("utf-8");
+        assertThat(MimeTypes.getCharsetAssumedFromContentType("application/vnd.api+json"))
                 .isEqualTo("utf-8");
         assertThat(MimeTypes.Type.TEXT_JSON.getCharsetString())
                 .isEqualTo("utf-8");

```
