### PR TITLE
Fix Forge work queue auth and random offsets

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -3893,6 +3893,41 @@ def should_skip_issue_from_preflight(
     return False
 
 
+def resolve_next_issue_claim_candidate_batch(
+        unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]],
+) -> list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]]:
+    """Resolve the next candidate batch through cache/local state or batched preflight."""
+    batch_entries: list[tuple[dict, CachedIssueClaimSkip | None, bool]] = []
+    preflight_candidates: list[dict] = []
+
+    while unresolved_candidates and len(preflight_candidates) < ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE:
+        issue, cached_skip = unresolved_candidates.pop(0)
+        needs_preflight = cached_skip is None and issue_needs_claim_preflight(issue)
+        batch_entries.append((issue, cached_skip, needs_preflight))
+        if needs_preflight:
+            preflight_candidates.append(issue)
+
+    issue_preflights = get_issue_claim_preflights_or_empty(preflight_candidates)
+    preflight_cache_observations = [
+        observation
+        for observation in (
+            get_issue_claim_cache_observation_from_preflight(preflight)
+            for preflight in issue_preflights.values()
+        )
+        if observation is not None
+    ]
+    record_issue_claim_cache_observations(preflight_cache_observations)
+
+    return [
+        (
+            issue,
+            issue_preflights.get(issue["number"]) if needs_preflight else None,
+            cached_skip,
+        )
+        for issue, cached_skip, needs_preflight in batch_entries
+    ]
+
+
 def get_active_sibling_blocker_numbers(issue_number: int) -> list[int]:
     """
     Return active open issues that block the same downstream issues as issue_number.
@@ -4177,11 +4212,6 @@ def get_issue_scan_batch_size(_remaining_limit: int, _available_slots: int) -> i
     return DEFAULT_ISSUE_SCAN_BATCH_SIZE
 
 
-def get_issue_preflight_batch_size() -> int:
-    """Return how many candidates to preflight from one sorted issue scan."""
-    return ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE
-
-
 def resolve_random_issue_scan_offset(label: str) -> int:
     """Choose a random searchable offset for an issue label."""
     issue_count = count_issues_with_label(label)
@@ -4222,76 +4252,66 @@ def process_issues_with_label(
     regular_offset = 0
     exhausted = False
     priority_exhausted = False
+    unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
     active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue] = {}
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=parallelism)
     try:
         while processed_count < limit or active_futures:
-            while not exhausted and processed_count < limit and len(active_futures) < parallelism:
+            while processed_count < limit and len(active_futures) < parallelism:
                 remaining_limit = limit - processed_count
                 available_slots = min(remaining_limit, parallelism - len(active_futures))
                 if not pending_issues:
-                    fetch_limit = get_issue_scan_batch_size(remaining_limit, available_slots)
-                    if offset == 0:
-                        issues, priority_offset, regular_offset, priority_exhausted, exhausted = (
-                            get_prioritized_issues_with_label(
-                                label,
-                                fetch_limit,
-                                priority_offset,
-                                regular_offset,
-                                priority_exhausted,
+                    if unresolved_candidates:
+                        pending_issues.extend(resolve_next_issue_claim_candidate_batch(unresolved_candidates))
+                    elif not exhausted:
+                        fetch_limit = get_issue_scan_batch_size(remaining_limit, available_slots)
+                        if offset == 0:
+                            issues, priority_offset, regular_offset, priority_exhausted, exhausted = (
+                                get_prioritized_issues_with_label(
+                                    label,
+                                    fetch_limit,
+                                    priority_offset,
+                                    regular_offset,
+                                    priority_exhausted,
+                                )
                             )
-                        )
-                        if not issues:
-                            if priority_offset == 0 and regular_offset == 0:
-                                print()
-                                log_stage("issue-scan", f"No open issues found with label '{label}'")
-                            break
-                    else:
-                        issues = get_issues_with_label(label, fetch_limit, current_offset)
-                        current_offset += len(issues)
-                        if not issues:
-                            if current_offset == offset:
-                                print()
-                                log_stage("issue-scan", f"No open issues found with label '{label}'")
-                            exhausted = True
-                            break
+                            if not issues:
+                                if priority_offset == 0 and regular_offset == 0:
+                                    print()
+                                    log_stage("issue-scan", f"No open issues found with label '{label}'")
+                                break
+                        else:
+                            issues = get_issues_with_label(label, fetch_limit, current_offset)
+                            current_offset += len(issues)
+                            if not issues:
+                                if current_offset == offset:
+                                    print()
+                                    log_stage("issue-scan", f"No open issues found with label '{label}'")
+                                exhausted = True
+                                break
 
-                    payload_cache_observations = [
-                        observation
-                        for observation in (
-                            get_issue_claim_cache_observation_from_payload(issue)
+                        payload_cache_observations = [
+                            observation
+                            for observation in (
+                                get_issue_claim_cache_observation_from_payload(issue)
+                                for issue in issues
+                            )
+                            if observation is not None
+                        ]
+                        record_issue_claim_cache_observations(payload_cache_observations)
+
+                        cached_skips = get_cached_issue_claim_skips(issues)
+                        unresolved_candidates.extend(
+                            (issue, cached_skips.get(issue["number"]))
                             for issue in issues
                         )
-                        if observation is not None
-                    ]
-                    record_issue_claim_cache_observations(payload_cache_observations)
-
-                    cached_skips = get_cached_issue_claim_skips(issues)
-                    preflight_candidates = [
-                        issue
-                        for issue in issues
-                        if issue["number"] not in cached_skips
-                        and issue_needs_claim_preflight(issue)
-                    ]
-                    issues_needing_preflight = preflight_candidates[:get_issue_preflight_batch_size()]
-                    issue_preflights = get_issue_claim_preflights_or_empty(issues_needing_preflight)
-                    preflight_cache_observations = [
-                        observation
-                        for observation in (
-                            get_issue_claim_cache_observation_from_preflight(preflight)
-                            for preflight in issue_preflights.values()
-                        )
-                        if observation is not None
-                    ]
-                    record_issue_claim_cache_observations(preflight_cache_observations)
-                    pending_issues.extend(
-                        (issue, issue_preflights.get(issue["number"]), cached_skips.get(issue["number"]))
-                        for issue in issues
-                    )
-                    print()
-                    log_stage("issue-scan", f"Found {len(issues)} issue(s) to consider")
+                        print()
+                        log_stage("issue-scan", f"Found {len(issues)} issue(s) to consider")
+                        continue
+                    else:
+                        break
 
                 while pending_issues and processed_count < limit and len(active_futures) < parallelism:
                     issue, preflight, cached_skip = pending_issues.pop(0)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -1004,6 +1004,17 @@ def get_authenticated_user() -> str:
     return result.stdout.strip()
 
 
+def resolve_authenticated_user(authenticated_user: str | None = None) -> str:
+    """Resolve and log the authenticated GitHub username when remote work needs it."""
+    if authenticated_user is not None:
+        return authenticated_user
+    ensure_gh_authenticated()
+    resolved_user = get_authenticated_user()
+    print()
+    log_stage("github-auth", f"Authenticated as: {resolved_user}")
+    return resolved_user
+
+
 def is_authored_by_user(pr: dict, username: str) -> bool:
     """Return True when the GitHub pull request author matches the authenticated user."""
     author = pr.get("author")
@@ -2792,6 +2803,7 @@ def get_env_zero_one_bool(name: str, default: bool) -> bool:
 
 def get_work_queue_configs_from_environment(
         work_strategy_name_override: str | None = None,
+        random_offset_override: bool | None = None,
 ) -> list[WorkQueueConfig]:
     """Return issue work queue configuration from the FORGE_* environment."""
     work_label = os.environ.get("FORGE_WORK_LABEL", LABEL_LIBRARY_NEW)
@@ -2828,7 +2840,11 @@ def get_work_queue_configs_from_environment(
                 or os.environ.get("FORGE_STRATEGY_NAME")
                 or DEFAULT_WORK_QUEUE_STRATEGY_NAME
             ),
-            random_offset=get_env_zero_one_bool("FORGE_RANDOM_WORK_OFFSET", False),
+            random_offset=(
+                random_offset_override
+                if random_offset_override is not None
+                else get_env_zero_one_bool("FORGE_RANDOM_WORK_OFFSET", True)
+            ),
         ),
     ]
 
@@ -4183,7 +4199,7 @@ def process_issues_with_label(
         canonical_metrics_repo_path: str,
         strategy_name: str | None,
         keep_tests_without_dynamic_access: bool,
-        authenticated_user: str,
+        authenticated_user: str | None,
         parallelism: int,
         in_metadata_repo: bool = True,
         environment_already_validated: bool = False,
@@ -4197,6 +4213,8 @@ def process_issues_with_label(
     in_metadata_repo = True
     if not environment_already_validated:
         validate_issue_processing_environment()
+
+    authenticated_user = resolve_authenticated_user(authenticated_user)
 
     processed_count = 0
     current_offset = offset
@@ -4335,15 +4353,16 @@ def process_issues_with_label(
 def process_work_queues(
         base_reachability_metadata_path: str,
         canonical_metrics_repo_path: str,
-        authenticated_user: str,
+        authenticated_user: str | None,
         work_strategy_name_override: str | None = None,
         keep_tests_without_dynamic_access_override: bool = False,
         parallelism_default: int = DEFAULT_PARALLELISM,
         in_metadata_repo: bool = True,
+        random_offset_override: bool | None = None,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
     in_metadata_repo = True
-    queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override)
+    queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
     review_queue_configs = get_review_queue_configs_from_environment()
     validate_work_queue_strategies(queue_configs)
 
@@ -4363,6 +4382,7 @@ def process_work_queues(
             log_stage("work-queue", f"Skipping issue queue '{queue_config.label}' because its limit is 0")
             continue
 
+        authenticated_user = resolve_authenticated_user(authenticated_user)
         print()
         log_stage(
             "work-queue",
@@ -4396,6 +4416,7 @@ def process_work_queues(
             log_stage("work-queue", f"Skipping review queue '{review_queue_config.label}' because its limit is 0")
             continue
 
+        authenticated_user = resolve_authenticated_user(authenticated_user)
         print()
         log_stage(
             "work-queue",
@@ -4480,11 +4501,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--random-offset",
+        dest="random_offset",
         action="store_true",
+        default=None,
         help=(
-            "Start issue scanning at a random open issue offset for the selected label. "
+            "Start issue scanning at a random open issue offset for the selected label "
+            "or run-work-queues work queue. "
             f"The random range is capped at GitHub search's first {GITHUB_SEARCH_MAX_RESULTS} results."
         ),
+    )
+    parser.add_argument(
+        "--no-random-offset",
+        dest="random_offset",
+        action="store_false",
+        help="Disable random issue scan offsets for run-work-queues or selected-label runs.",
     )
     parser.add_argument(
         "--parallelism",
@@ -4496,9 +4526,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.period is not None and args.review_pr is None:
         parser.error("--period can only be used with --review-pr")
-    if args.random_offset and args.label is None:
-        parser.error("--random-offset can only be used with --label")
-    if args.random_offset and args.offset != 0:
+    if args.random_offset is not None and args.label is None and not args.run_work_queues:
+        parser.error("--random-offset/--no-random-offset can only be used with --label or --run-work-queues")
+    if args.random_offset is True and args.offset != 0:
         parser.error("--random-offset cannot be combined with --offset")
     return args
 
@@ -4551,7 +4581,6 @@ def main() -> None:
             require_strategy_by_name(args.strategy_name)
         if args.review_pr is None and not args.run_work_queues:
             validate_issue_processing_environment()
-        ensure_gh_authenticated()
         reachability_metadata_path, metrics_repo_path = resolve_repo_roots(
             args.reachability_metadata_path,
             None,
@@ -4562,21 +4591,19 @@ def main() -> None:
             print("ERROR: GITHUB_PROJECT_NUMBER env var is not set.", file=sys.stderr)
             sys.exit(1)
 
-        authenticated_user = get_authenticated_user()
-        print()
-        log_stage("github-auth", f"Authenticated as: {authenticated_user}")
-
         if args.run_work_queues:
             process_work_queues(
                 reachability_metadata_path,
                 metrics_repo_path,
-                authenticated_user,
+                None,
                 args.strategy_name,
                 args.keep_tests_without_dynamic_access,
                 args.parallelism,
                 in_metadata_repo=args.in_metadata_repo,
+                random_offset_override=args.random_offset,
             )
         elif args.review_pr is not None:
+            authenticated_user = resolve_authenticated_user()
             run_pull_request_review_loop(
                 args.review_pr,
                 args.limit,
@@ -4586,6 +4613,7 @@ def main() -> None:
                 args.period,
             )
         elif args.issue_number is not None:
+            authenticated_user = resolve_authenticated_user()
             process_single_issue(
                 args.issue_number,
                 reachability_metadata_path,
@@ -4596,8 +4624,9 @@ def main() -> None:
                 in_metadata_repo=args.in_metadata_repo,
             )
         else:
+            authenticated_user = resolve_authenticated_user()
             issue_scan_offset = args.offset
-            if args.random_offset:
+            if args.random_offset is True:
                 issue_scan_offset = resolve_random_issue_scan_offset(args.label)
                 print()
                 log_stage("issue-scan", f"Selected random start offset {issue_scan_offset} for label '{args.label}'")

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -60,6 +60,7 @@ from git_scripts.common_git import (
     get_issue_project_item_status,
     get_origin_owner,
     is_github_rate_limit_text,
+    log_github_query,
     run_github_json_with_retries,
 )
 from git_scripts.make_pr_javac_fix import main as run_make_pr_javac_fix
@@ -317,17 +318,20 @@ def gh(
         *args: str,
         check: bool = True,
         input_text: str | None = None,
+        cwd: str | None = None,
         quiet: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run a gh CLI command and return the completed process."""
     cmd = ["gh", *args]
     env = {**os.environ, "GH_PROMPT_DISABLED": "1", "GH_PAGER": ""}
+    log_github_query(args)
     result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         env=env,
         input=input_text,
+        cwd=cwd,
     )
     if check and result.returncode != 0:
         error_text = "\n".join(part for part in (result.stderr, result.stdout) if part)
@@ -3022,13 +3026,13 @@ def create_review_workspace(base_reachability_metadata_path: str, pr_number: int
         f"Failed to create review worktree for PR #{pr_number}",
     )
     try:
-        subprocess.run(
-            ["gh", "pr", "checkout", str(pr_number), "--detach"],
+        gh(
+            "pr",
+            "checkout",
+            str(pr_number),
+            "--detach",
             cwd=review_worktree_path,
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
         )
     except subprocess.CalledProcessError as exc:
         remove_worktree(base_reachability_metadata_path, review_worktree_path)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -511,6 +511,26 @@ def get_issue_payload_assignees(issue: dict) -> Optional[list[str]]:
     ]
 
 
+def is_assigned_only_to_authenticated_user(
+        assignees: list[str] | tuple[str, ...] | None,
+        authenticated_user: str | None,
+) -> bool:
+    """Return True when the assignee list is exactly the current worker user."""
+    if not authenticated_user:
+        return False
+    return tuple(assignees or ()) == (authenticated_user,)
+
+
+def cached_skip_blocks_authenticated_user(
+        cached_skip: CachedIssueClaimSkip,
+        authenticated_user: str | None,
+) -> bool:
+    """Return True when a cached negative observation should still block this worker."""
+    if cached_skip.reason != ISSUE_CLAIM_CACHE_REASON_ASSIGNED:
+        return True
+    return not is_assigned_only_to_authenticated_user(cached_skip.assignees, authenticated_user)
+
+
 class LocalIssueClaimLock:
     """Non-blocking per-issue lock for scripts running as the same GitHub user."""
 
@@ -3673,7 +3693,10 @@ def _extract_issue_claim_preflight(issue_number: int, issue_node: dict | None) -
     )
 
 
-def get_issue_claim_cache_observation_from_payload(issue: dict) -> IssueClaimCacheObservation | None:
+def get_issue_claim_cache_observation_from_payload(
+        issue: dict,
+        authenticated_user: str | None = None,
+) -> IssueClaimCacheObservation | None:
     """Return a cache observation for locally visible negative issue state."""
     issue_number = issue.get("number")
     if not isinstance(issue_number, int):
@@ -3684,7 +3707,7 @@ def get_issue_claim_cache_observation_from_payload(issue: dict) -> IssueClaimCac
             reason=ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
         )
     payload_assignees = get_issue_payload_assignees(issue)
-    if payload_assignees:
+    if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
         return IssueClaimCacheObservation(
             issue_number=issue_number,
             reason=ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
@@ -3695,11 +3718,12 @@ def get_issue_claim_cache_observation_from_payload(issue: dict) -> IssueClaimCac
 
 def get_issue_claim_cache_observation_from_preflight(
         preflight: IssueClaimPreflight,
+        authenticated_user: str | None = None,
 ) -> IssueClaimCacheObservation | None:
     """Return a cache observation for negative GraphQL preflight state."""
     if not preflight.complete:
         return None
-    if preflight.assignees:
+    if preflight.assignees and not is_assigned_only_to_authenticated_user(preflight.assignees, authenticated_user):
         return IssueClaimCacheObservation(
             issue_number=preflight.issue_number,
             reason=ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
@@ -3752,7 +3776,10 @@ def format_cached_issue_claim_skip(cached_skip: CachedIssueClaimSkip) -> str:
     return f"recently cached as {cached_skip.reason}"
 
 
-def get_cached_issue_claim_skips(issues: list[dict]) -> dict[int, CachedIssueClaimSkip]:
+def get_cached_issue_claim_skips(
+        issues: list[dict],
+        authenticated_user: str | None = None,
+) -> dict[int, CachedIssueClaimSkip]:
     """Return fresh cached skips for the given issue payloads."""
     cache = read_issue_claim_cache()
     if not cache:
@@ -3766,6 +3793,7 @@ def get_cached_issue_claim_skips(issues: list[dict]) -> dict[int, CachedIssueCla
         issue_number: cached_skip
         for issue_number, cached_skip in cache.items()
         if issue_number in issue_numbers
+        and cached_skip_blocks_authenticated_user(cached_skip, authenticated_user)
     }
 
 
@@ -3821,22 +3849,25 @@ def get_issue_claim_preflights(
     return preflights
 
 
-def issue_needs_claim_preflight(issue: dict) -> bool:
+def issue_needs_claim_preflight(issue: dict, authenticated_user: str | None = None) -> bool:
     """Return True when an issue needs GraphQL preflight before claim attempts."""
     if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
         return False
     payload_assignees = get_issue_payload_assignees(issue)
-    if payload_assignees:
+    if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
         return False
     return True
 
 
-def get_issue_claim_preflights_or_empty(issues: list[dict]) -> dict[int, IssueClaimPreflight]:
+def get_issue_claim_preflights_or_empty(
+        issues: list[dict],
+        authenticated_user: str | None = None,
+) -> dict[int, IssueClaimPreflight]:
     issue_numbers = [
         issue["number"]
         for issue in issues
         if isinstance(issue, dict) and isinstance(issue.get("number"), int)
-        and issue_needs_claim_preflight(issue)
+        and issue_needs_claim_preflight(issue, authenticated_user)
     ]
     if not issue_numbers:
         return {}
@@ -3857,6 +3888,7 @@ def should_skip_issue_from_preflight(
         issue: dict,
         preflight: IssueClaimPreflight | None,
         cached_skip: CachedIssueClaimSkip | None = None,
+        authenticated_user: str | None = None,
 ) -> bool:
     number = issue["number"]
 
@@ -3866,12 +3898,12 @@ def should_skip_issue_from_preflight(
         return True
 
     payload_assignees = get_issue_payload_assignees(issue)
-    if payload_assignees:
+    if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
         print()
         log_stage("issue-claim", f"Issue #{number} already assigned to {payload_assignees}. Skipping.")
         return True
 
-    if cached_skip is not None:
+    if cached_skip is not None and cached_skip_blocks_authenticated_user(cached_skip, authenticated_user):
         print()
         log_stage("issue-claim", f"Issue #{number} {format_cached_issue_claim_skip(cached_skip)}. Skipping.")
         return True
@@ -3879,7 +3911,7 @@ def should_skip_issue_from_preflight(
     if preflight is None or not preflight.complete:
         return False
 
-    if preflight.assignees:
+    if preflight.assignees and not is_assigned_only_to_authenticated_user(preflight.assignees, authenticated_user):
         print()
         log_stage("issue-claim", f"Issue #{number} already assigned to {list(preflight.assignees)}. Skipping.")
         return True
@@ -4016,7 +4048,7 @@ def try_claim_issue(issue: dict, authenticated_user: str) -> Optional[str]:
 
     1. Take a non-blocking local per-issue lock so same-machine runners using the
        same GitHub account cannot both interpret the same assignee as ownership.
-    2. Skip if the issue already has assignees (someone else claimed it).
+    2. Skip if the issue is assigned to someone else.
     3. SET ourselves as the sole assignee (replaces, not appends).
     4. Wait a random 5-10 s backoff so concurrent runners' SETs have time to land.
     5. Re-read assignees — if we are still the sole assignee, the claim is ours.
@@ -4070,7 +4102,7 @@ def try_claim_issue_with_local_lock(issue: dict, authenticated_user: str) -> Opt
     # The issue-list payload can be stale when another local runner just claimed
     # the same issue as the same GitHub user, so always re-read after the lock.
     assignees = get_issue_assignees(number)
-    if assignees:
+    if assignees and not is_assigned_only_to_authenticated_user(assignees, authenticated_user):
         print()
         log_stage("issue-claim", f"Issue #{number} already assigned to {assignees}. Skipping.")
         record_issue_claim_cache_observations([
@@ -4289,14 +4321,14 @@ def process_issues_with_label(
                         payload_cache_observations = [
                             observation
                             for observation in (
-                                get_issue_claim_cache_observation_from_payload(issue)
+                                get_issue_claim_cache_observation_from_payload(issue, authenticated_user)
                                 for issue in issues
                             )
                             if observation is not None
                         ]
                         record_issue_claim_cache_observations(payload_cache_observations)
 
-                        cached_skips = get_cached_issue_claim_skips(issues)
+                        cached_skips = get_cached_issue_claim_skips(issues, authenticated_user)
                         unresolved_candidates.extend(
                             (issue, cached_skips.get(issue["number"]))
                             for issue in issues
@@ -4309,7 +4341,7 @@ def process_issues_with_label(
 
                 while pending_issues and processed_count < limit and len(active_futures) < parallelism:
                     issue, preflight, cached_skip = pending_issues.pop(0)
-                    if should_skip_issue_from_preflight(issue, preflight, cached_skip):
+                    if should_skip_issue_from_preflight(issue, preflight, cached_skip, authenticated_user):
                         continue
                     claimed_issue = claim_issue_for_processing(
                         issue,

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -140,6 +140,7 @@ ISSUE_CLAIM_LOCK_DIRNAME = "metadata-forge-issue-claim-locks"
 ISSUE_CLAIM_CACHE_REASON_ASSIGNED = "assigned"
 ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION = "human_intervention"
 ISSUE_CLAIM_CACHE_REASON_BLOCKED = "blocked"
+ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED = "active_sibling_blocked"
 ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM = "missing_project_item"
 ISSUE_CLAIM_CACHE_REASON_NON_TODO = "non_todo"
 ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS = "in_progress"
@@ -147,6 +148,7 @@ ISSUE_CLAIM_CACHE_REASONS = {
     ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
     ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
     ISSUE_CLAIM_CACHE_REASON_BLOCKED,
+    ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED,
     ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM,
     ISSUE_CLAIM_CACHE_REASON_NON_TODO,
     ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS,
@@ -3733,6 +3735,12 @@ def format_cached_issue_claim_skip(cached_skip: CachedIssueClaimSkip) -> str:
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_BLOCKED:
         blockers_text = ", ".join(f"#{blocker}" for blocker in cached_skip.open_blockers)
         return f"recently cached as blocked by open issue(s) {blockers_text}"
+    if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED:
+        blockers_text = ", ".join(f"#{blocker}" for blocker in cached_skip.open_blockers)
+        return (
+            "recently cached as sharing a blocked downstream issue with active "
+            f"issue(s) {blockers_text}"
+        )
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM:
         return f"recently cached as missing project {PROJECT_NUMBER} item"
     if cached_skip.reason in {ISSUE_CLAIM_CACHE_REASON_NON_TODO, ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS}:
@@ -3896,35 +3904,20 @@ def should_skip_issue_from_preflight(
 def resolve_next_issue_claim_candidate_batch(
         unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]],
 ) -> list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]]:
-    """Resolve the next candidate batch through cache/local state or batched preflight."""
-    batch_entries: list[tuple[dict, CachedIssueClaimSkip | None, bool]] = []
-    preflight_candidates: list[dict] = []
+    """Resolve the next candidate batch through cache/local state only."""
+    batch_entries: list[tuple[dict, CachedIssueClaimSkip | None]] = []
 
-    while unresolved_candidates and len(preflight_candidates) < ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE:
+    while unresolved_candidates:
         issue, cached_skip = unresolved_candidates.pop(0)
-        needs_preflight = cached_skip is None and issue_needs_claim_preflight(issue)
-        batch_entries.append((issue, cached_skip, needs_preflight))
-        if needs_preflight:
-            preflight_candidates.append(issue)
-
-    issue_preflights = get_issue_claim_preflights_or_empty(preflight_candidates)
-    preflight_cache_observations = [
-        observation
-        for observation in (
-            get_issue_claim_cache_observation_from_preflight(preflight)
-            for preflight in issue_preflights.values()
-        )
-        if observation is not None
-    ]
-    record_issue_claim_cache_observations(preflight_cache_observations)
+        batch_entries.append((issue, cached_skip))
 
     return [
         (
             issue,
-            issue_preflights.get(issue["number"]) if needs_preflight else None,
+            None,
             cached_skip,
         )
-        for issue, cached_skip, needs_preflight in batch_entries
+        for issue, cached_skip in batch_entries
     ]
 
 
@@ -4124,6 +4117,13 @@ def try_claim_issue_with_local_lock(issue: dict, authenticated_user: str) -> Opt
             "issue-claim",
             f"Issue #{number} shares a blocked downstream issue with active issue(s) {blockers_text}. Skipping.",
         )
+        record_issue_claim_cache_observations([
+            IssueClaimCacheObservation(
+                issue_number=number,
+                reason=ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED,
+                open_blockers=tuple(active_sibling_blockers),
+            )
+        ])
         return None
 
     try:
@@ -4167,6 +4167,13 @@ def try_claim_issue_with_local_lock(issue: dict, authenticated_user: str) -> Opt
                 authenticated_user,
                 f"active sibling issue(s) {blockers_text}",
             )
+            record_issue_claim_cache_observations([
+                IssueClaimCacheObservation(
+                    issue_number=number,
+                    reason=ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED,
+                    open_blockers=tuple(active_sibling_blockers),
+                )
+            ])
             return None
 
         set_item_status(item_id, STATUS_IN_PROGRESS)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4113,23 +4113,6 @@ def try_claim_issue_with_local_lock(issue: dict, authenticated_user: str) -> Opt
         ])
         return None
 
-    active_sibling_blockers = get_active_sibling_blocker_numbers(number)
-    if active_sibling_blockers:
-        blockers_text = ", ".join(f"#{blocker}" for blocker in active_sibling_blockers)
-        print()
-        log_stage(
-            "issue-claim",
-            f"Issue #{number} shares a blocked downstream issue with active issue(s) {blockers_text}. Skipping.",
-        )
-        record_issue_claim_cache_observations([
-            IssueClaimCacheObservation(
-                issue_number=number,
-                reason=ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED,
-                open_blockers=tuple(active_sibling_blockers),
-            )
-        ])
-        return None
-
     try:
         # SET ourselves as the sole assignee
         print()

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import Any, Callable, List
+from typing import Any, Callable, Iterable, List
 from utility_scripts.library_stats import load_library_stats_entry
 from utility_scripts.strategy_loader import load_strategy_by_name
 
@@ -92,6 +92,7 @@ def ensure_gh_authenticated() -> None:
         )
         sys.exit(1)
     try:
+        log_github_query(("auth", "status", "--hostname", "github.com"))
         subprocess.run(
             ["gh", "auth", "status", "--hostname", "github.com"],
             stdout=subprocess.PIPE,
@@ -110,6 +111,14 @@ class GitHubRateLimitExceeded(RuntimeError):
 
 GITHUB_TRANSIENT_RETRY_ATTEMPTS = 3
 GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS = 2.0
+GITHUB_LOG_REDACTED_FLAGS = {
+    "--body",
+    "--body-file",
+    "--input",
+}
+GITHUB_LOG_REDACTED_KEYS = {
+    "body",
+}
 
 
 def is_github_rate_limit_text(text: str) -> bool:
@@ -203,6 +212,45 @@ def _log_github_transient_retry(reason: str, attempt: int, max_attempts: int, qu
     )
 
 
+def _split_github_arg_key_value(arg: str) -> tuple[str, str] | None:
+    if "=" not in arg:
+        return None
+    key, value = arg.split("=", 1)
+    if not key or not value:
+        return None
+    return key, value
+
+
+def _format_github_log_arg(arg: str) -> str:
+    key_value = _split_github_arg_key_value(arg)
+    if key_value is None:
+        return arg
+    key, value = key_value
+    if key.lower() in GITHUB_LOG_REDACTED_KEYS:
+        return f"{key}=<redacted>"
+    return f"{key}={value}"
+
+
+def _format_github_log_args(args: Iterable[str]) -> list[str]:
+    formatted_args: list[str] = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            formatted_args.append("<redacted>")
+            redact_next = False
+            continue
+        formatted_args.append(_format_github_log_arg(arg))
+        if arg in GITHUB_LOG_REDACTED_FLAGS:
+            redact_next = True
+    return formatted_args
+
+
+def log_github_query(args: Iterable[str]) -> None:
+    """Print one console line for a GitHub CLI query."""
+    formatted_args = _format_github_log_args(args)
+    print(f"[github-query] gh {' '.join(formatted_args)}")
+
+
 def gh(
         *args: str,
         check: bool = True,
@@ -213,6 +261,7 @@ def gh(
     """Run a gh CLI command and return the completed process."""
     cmd = ["gh", *args]
     env = {**os.environ, "GH_PROMPT_DISABLED": "1", "GH_PAGER": ""}
+    log_github_query(args)
     result = subprocess.run(
         cmd,
         capture_output=True,

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -12,6 +12,7 @@ import sys
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
+    gh,
     parse_coordinate_parts,
     get_origin_owner,
     stage_and_commit as stage_and_commit_common,
@@ -164,12 +165,7 @@ def create_pull_request(
 
     origin_owner = get_origin_owner(cwd=repo_path)
 
-    view = subprocess.run(
-        ["gh", "pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    view = gh("pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}", check=False)
     if view.returncode == 0:
         print(f"Pull request already exists for branch {branch}.")
         return
@@ -209,7 +205,7 @@ def create_pull_request(
     if REVIEWERS:
         for r in REVIEWERS:
             cmd.extend(["--reviewer", r])
-    subprocess.run(cmd, check=True)
+    gh(*cmd[1:])
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -10,6 +10,7 @@ import sys
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
+    gh,
     parse_coordinate_parts,
     get_origin_owner,
     stage_and_commit as stage_and_commit_common,
@@ -91,12 +92,7 @@ def create_pull_request(
 
     origin_owner = get_origin_owner(cwd=repo_path)
 
-    view = subprocess.run(
-        ["gh", "pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True
-    )
+    view = gh("pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}", check=False)
 
     if view.returncode == 0:
         print(f"Pull request already exists for branch {branch}.")
@@ -192,7 +188,7 @@ Summary:
     if REVIEWERS:
         for reviewer in REVIEWERS:
             cmd.extend(["--reviewer", reviewer])
-    subprocess.run(cmd, check=True)
+    gh(*cmd[1:])
 
 
 def build_parser():

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -12,6 +12,7 @@ import tempfile
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
+    gh,
     parse_coordinate_parts,
     get_origin_owner,
     git_files_under,
@@ -157,12 +158,7 @@ def create_pull_request(
     origin_owner = get_origin_owner(cwd=repo_path)
 
     # If a PR already exists for this branch, do nothing
-    view = subprocess.run(
-        ["gh", "pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True
-    )
+    view = gh("pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}", check=False)
 
     if view.returncode == 0:
         print(f"Pull request already exists for branch {branch}.")
@@ -263,7 +259,7 @@ Summary:
     if REVIEWERS:
         for reviewer in REVIEWERS:
             cmd.extend(["--reviewer", reviewer])
-    subprocess.run(cmd, check=True)
+    gh(*cmd[1:])
 
 
 

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -11,6 +11,7 @@ import argparse
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
+    gh,
     get_origin_owner,
     parse_coordinate_parts,
     stage_and_commit as stage_and_commit_common,
@@ -151,12 +152,7 @@ def create_pull_request(branch, coordinates, metrics_repo_root, repo_path):
 
     origin_owner = get_origin_owner(cwd=repo_path)
 
-    view = subprocess.run(
-        ["gh", "pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True
-    )
+    view = gh("pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}", check=False)
 
     if view.returncode == 0:
         print(f"Pull request already exists for branch {branch}.")
@@ -199,7 +195,7 @@ def create_pull_request(branch, coordinates, metrics_repo_root, repo_path):
     if REVIEWERS:
         for r in REVIEWERS:
             cmd.extend(["--reviewer", r])
-    subprocess.run(cmd, check=True)
+    gh(*cmd[1:])
 
 
 def build_parser():

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -10,6 +10,7 @@ import sys
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
+    gh,
     parse_coordinate_parts,
     get_origin_owner,
     stage_and_commit as stage_and_commit_common,
@@ -84,12 +85,7 @@ def create_pull_request(
     origin_owner = get_origin_owner(cwd=repo_path)
 
     # If a PR already exists for this branch, do nothing
-    view = subprocess.run(
-        ["gh", "pr", "view", "--repo", REPO, "--head", branch],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    view = gh("pr", "view", "--repo", REPO, "--head", branch, check=False)
     if view.returncode == 0:
         print(f"Pull request already exists for branch {branch}.")
         return
@@ -148,7 +144,7 @@ def create_pull_request(
     ]
     for r in REVIEWERS:
         cmd.extend(["--reviewer", r])
-    subprocess.run(cmd, check=True)
+    gh(*cmd[1:])
 
 
 

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -47,6 +47,50 @@ class RemoteBranchDeletionTests(unittest.TestCase):
 
 
 class GitHubRateLimitTests(unittest.TestCase):
+    def test_common_gh_logs_github_query_to_console(self) -> None:
+        completed_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="{}",
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", return_value=completed_process), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            common_git.gh(
+                "api",
+                "graphql",
+                "-f",
+                "query=query { viewer { login } }",
+            )
+
+        self.assertIn(
+            "[github-query] gh api graphql -f query=query { viewer { login } }",
+            stdout.getvalue(),
+        )
+
+    def test_common_gh_log_redacts_body_argument(self) -> None:
+        completed_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", return_value=completed_process), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            common_git.gh(
+                "issue",
+                "comment",
+                "1412",
+                "--body",
+                "long generated comment",
+            )
+
+        output = stdout.getvalue()
+        self.assertIn("[github-query] gh issue comment 1412 --body <redacted>", output)
+        self.assertNotIn("long generated comment", output)
+
     def test_common_gh_raises_typed_rate_limit_error_from_stderr(self) -> None:
         completed_process = subprocess.CompletedProcess(
             ["gh"],

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -455,7 +455,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         randrange.assert_called_once_with(500)
 
-    def test_process_loop_uses_preflight_to_skip_unclaimable_candidates(self) -> None:
+    def test_process_loop_uses_cache_to_skip_unclaimable_candidates_without_preflight(self) -> None:
         skipped_issue = {
             "number": 1,
             "title": "Add support for org.example:skipped:1.0.0",
@@ -470,6 +470,17 @@ class IssueClaimPreflightTests(unittest.TestCase):
         }
 
         with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root):
+                forge_metadata.record_issue_claim_cache_observations(
+                    [
+                        forge_metadata.IssueClaimCacheObservation(
+                            issue_number=1,
+                            reason=forge_metadata.ISSUE_CLAIM_CACHE_REASON_BLOCKED,
+                            open_blockers=(99,),
+                        ),
+                    ],
+                )
+
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
                     patch.object(forge_metadata, "validate_issue_processing_environment"), \
                     patch.object(
@@ -483,10 +494,6 @@ class IssueClaimPreflightTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_issue_claim_preflights_or_empty",
-                        side_effect=[
-                            {1: _preflight(issue_number=1, assignees=("automation-user",))},
-                            {2: _preflight(issue_number=2)},
-                        ],
                     ) as get_issue_claim_preflights_or_empty, \
                     patch.object(
                         forge_metadata,
@@ -533,13 +540,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
                 ),
             ],
         )
-        self.assertEqual(
-            get_issue_claim_preflights_or_empty.call_args_list,
-            [
-                call([skipped_issue]),
-                call([claimable_issue]),
-            ],
-        )
+        get_issue_claim_preflights_or_empty.assert_not_called()
         claim_issue_for_processing.assert_called_once_with(
             claimable_issue,
             forge_metadata.LABEL_LIBRARY_NEW,
@@ -855,7 +856,6 @@ class IssueClaimCacheTests(unittest.TestCase):
                         patch.object(
                             forge_metadata,
                             "get_issue_claim_preflights_or_empty",
-                            return_value={2: _preflight(issue_number=2)},
                         ) as get_issue_claim_preflights_or_empty, \
                         patch.object(
                             forge_metadata,
@@ -880,15 +880,27 @@ class IssueClaimCacheTests(unittest.TestCase):
                     )
 
         self.assertEqual(processed, 1)
-        get_issue_claim_preflights_or_empty.assert_called_once_with([claimable_issue])
+        get_issue_claim_preflights_or_empty.assert_not_called()
 
-    def test_process_loop_records_preflight_negative_result(self) -> None:
+    def test_process_loop_accepts_claim_negative_result_without_preflight(self) -> None:
         issue = {
             "number": 1,
             "title": "Add support for org.example:blocked:1.0.0",
             "labels": [],
             "assignees": [],
         }
+
+        def claim_and_cache_negative_result(*_args: object, **_kwargs: object) -> None:
+            forge_metadata.record_issue_claim_cache_observations(
+                [
+                    forge_metadata.IssueClaimCacheObservation(
+                        issue_number=1,
+                        reason=forge_metadata.ISSUE_CLAIM_CACHE_REASON_BLOCKED,
+                        open_blockers=(99,),
+                    ),
+                ],
+            )
+            return None
 
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
@@ -904,9 +916,12 @@ class IssueClaimCacheTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_issue_claim_preflights_or_empty",
-                        return_value={1: _preflight(issue_number=1, open_blockers=(99,))},
-                    ), \
-                    patch.object(forge_metadata, "claim_issue_for_processing") as claim_issue_for_processing:
+                    ) as get_issue_claim_preflights_or_empty, \
+                    patch.object(
+                        forge_metadata,
+                        "claim_issue_for_processing",
+                        side_effect=claim_and_cache_negative_result,
+                    ) as claim_issue_for_processing:
                 processed = forge_metadata.process_issues_with_label(
                     forge_metadata.LABEL_LIBRARY_NEW,
                     1,
@@ -924,9 +939,10 @@ class IssueClaimCacheTests(unittest.TestCase):
                 self.assertEqual(cache[1].open_blockers, (99,))
 
         self.assertEqual(processed, 0)
-        claim_issue_for_processing.assert_not_called()
+        get_issue_claim_preflights_or_empty.assert_not_called()
+        claim_issue_for_processing.assert_called_once()
 
-    def test_process_loop_preflights_uncached_candidates_in_chunks_before_claiming(self) -> None:
+    def test_process_loop_attempts_uncached_candidates_without_preflight(self) -> None:
         issues = [
             {
                 "number": issue_number,
@@ -948,27 +964,11 @@ class IssueClaimCacheTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_issue_claim_preflights_or_empty",
-                        side_effect=[
-                            {
-                                issue["number"]: _preflight(
-                                    issue_number=issue["number"],
-                                    open_blockers=(99,),
-                                )
-                                for issue in issues[:forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE]
-                            },
-                            {
-                                issues[-2]["number"]: _preflight(
-                                    issue_number=issues[-2]["number"],
-                                    open_blockers=(99,),
-                                ),
-                                issues[-1]["number"]: _preflight(issue_number=issues[-1]["number"]),
-                            },
-                        ],
                     ) as get_issue_claim_preflights_or_empty, \
                     patch.object(
                         forge_metadata,
                         "claim_issue_for_processing",
-                        return_value=_claimed_issue(),
+                        side_effect=[None, None, None, None, None, _claimed_issue()],
                     ) as claim_issue_for_processing, \
                     patch.object(
                         forge_metadata,
@@ -990,20 +990,20 @@ class IssueClaimCacheTests(unittest.TestCase):
                     1,
                 )
 
+        get_issue_claim_preflights_or_empty.assert_not_called()
         self.assertEqual(
-            get_issue_claim_preflights_or_empty.call_args_list,
+            claim_issue_for_processing.call_args_list,
             [
-                call(issues[:forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE]),
-                call(issues[forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE:]),
+                call(
+                    issue,
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    "/tmp/reachability",
+                    "/tmp/metrics",
+                    "automation-user",
+                    in_metadata_repo=True,
+                )
+                for issue in issues
             ],
-        )
-        claim_issue_for_processing.assert_called_once_with(
-            issues[-1],
-            forge_metadata.LABEL_LIBRARY_NEW,
-            "/tmp/reachability",
-            "/tmp/metrics",
-            "automation-user",
-            in_metadata_repo=True,
         )
 
 
@@ -1224,6 +1224,38 @@ class IssueClaimLockTests(unittest.TestCase):
                 cache = forge_metadata.read_issue_claim_cache()
                 self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_ASSIGNED)
                 self.assertEqual(cache[1412].assignees, ("automation-user",))
+
+    def test_try_claim_issue_caches_active_sibling_blockers(self) -> None:
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:lib:1.0.0",
+            "labels": [],
+            "assignees": [],
+        }
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
+                    patch.object(forge_metadata, "get_issue_assignees", return_value=[]), \
+                    patch.object(
+                        forge_metadata,
+                        "get_project_item_state",
+                        return_value=("project-item", forge_metadata.STATUS_TODO),
+                    ), \
+                    patch.object(
+                        forge_metadata,
+                        "get_active_sibling_blocker_numbers",
+                        return_value=[3759, 3763],
+                    ), \
+                    patch.object(forge_metadata, "set_issue_assignee") as set_issue_assignee:
+                self.assertIsNone(forge_metadata.try_claim_issue(issue, "automation-user"))
+                cache = forge_metadata.read_issue_claim_cache()
+                self.assertEqual(
+                    cache[1412].reason,
+                    forge_metadata.ISSUE_CLAIM_CACHE_REASON_ACTIVE_SIBLING_BLOCKED,
+                )
+                self.assertEqual(cache[1412].open_blockers, (3759, 3763))
+
+        set_issue_assignee.assert_not_called()
 
     def test_try_claim_issue_uses_combined_project_status_lookup(self) -> None:
         issue = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -284,6 +284,16 @@ class IssueClaimPreflightTests(unittest.TestCase):
             )
         )
 
+    def test_preflight_assigned_to_authenticated_user_does_not_skip(self) -> None:
+        issue = {"number": 1412, "labels": []}
+        self.assertFalse(
+            forge_metadata.should_skip_issue_from_preflight(
+                issue,
+                _preflight(assignees=("automation-user",)),
+                authenticated_user="automation-user",
+            )
+        )
+
     def test_non_todo_preflight_skips_issue(self) -> None:
         issue = {"number": 1412, "labels": []}
         self.assertTrue(
@@ -397,6 +407,11 @@ class IssueClaimPreflightTests(unittest.TestCase):
             "labels": [],
             "assignees": [{"login": "automation-user"}],
         }
+        own_assigned_issue = {
+            "number": 4,
+            "labels": [],
+            "assignees": [{"login": "current-user"}],
+        }
         claimable_issue = {
             "number": 3,
             "labels": [],
@@ -406,16 +421,23 @@ class IssueClaimPreflightTests(unittest.TestCase):
         with patch.object(
                 forge_metadata,
                 "get_issue_claim_preflights",
-                return_value={3: _preflight(issue_number=3)},
+                return_value={
+                    4: _preflight(issue_number=4, assignees=("current-user",)),
+                    3: _preflight(issue_number=3),
+                },
         ) as get_issue_claim_preflights:
             self.assertEqual(
                 forge_metadata.get_issue_claim_preflights_or_empty(
-                    [human_intervention_issue, assigned_issue, claimable_issue]
+                    [human_intervention_issue, assigned_issue, own_assigned_issue, claimable_issue],
+                    authenticated_user="current-user",
                 ),
-                {3: _preflight(issue_number=3)},
+                {
+                    4: _preflight(issue_number=4, assignees=("current-user",)),
+                    3: _preflight(issue_number=3),
+                },
             )
 
-        get_issue_claim_preflights.assert_called_once_with([3])
+        get_issue_claim_preflights.assert_called_once_with([4, 3])
 
     def test_payload_assignees_skip_without_preflight(self) -> None:
         issue = {
@@ -426,6 +448,21 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         self.assertTrue(
             forge_metadata.should_skip_issue_from_preflight(issue, None)
+        )
+
+    def test_payload_assigned_to_authenticated_user_does_not_skip(self) -> None:
+        issue = {
+            "number": 1412,
+            "labels": [],
+            "assignees": [{"login": "automation-user"}],
+        }
+
+        self.assertFalse(
+            forge_metadata.should_skip_issue_from_preflight(
+                issue,
+                None,
+                authenticated_user="automation-user",
+            )
         )
 
     def test_cached_skip_skips_without_preflight(self) -> None:
@@ -443,6 +480,28 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         self.assertTrue(
             forge_metadata.should_skip_issue_from_preflight(issue, None, cached_skip)
+        )
+
+    def test_cached_own_assignment_does_not_skip(self) -> None:
+        issue = {
+            "number": 1412,
+            "labels": [],
+            "assignees": [],
+        }
+        cached_skip = forge_metadata.CachedIssueClaimSkip(
+            issue_number=1412,
+            reason=forge_metadata.ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
+            observed_at_epoch=100.0,
+            assignees=("automation-user",),
+        )
+
+        self.assertFalse(
+            forge_metadata.should_skip_issue_from_preflight(
+                issue,
+                None,
+                cached_skip,
+                authenticated_user="automation-user",
+            )
         )
 
     def test_offset_issue_fetch_uses_search_page_instead_of_expanding_limit(self) -> None:
@@ -848,6 +907,35 @@ class IssueClaimCacheTests(unittest.TestCase):
                 forge_metadata.invalidate_issue_claim_cache_entry(1412, now=101.0)
                 self.assertEqual(forge_metadata.read_issue_claim_cache(now=101.0), {})
 
+    def test_cached_own_assignment_is_not_returned_as_skip(self) -> None:
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:cached:1.0.0",
+            "labels": [],
+            "assignees": [],
+        }
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root):
+                forge_metadata.record_issue_claim_cache_observations(
+                    [
+                        forge_metadata.IssueClaimCacheObservation(
+                            issue_number=1412,
+                            reason=forge_metadata.ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
+                            assignees=("automation-user",),
+                        ),
+                    ],
+                )
+
+                self.assertEqual(
+                    forge_metadata.get_cached_issue_claim_skips([issue], "automation-user"),
+                    {},
+                )
+                self.assertIn(
+                    1412,
+                    forge_metadata.get_cached_issue_claim_skips([issue], "other-user"),
+                )
+
     def test_process_loop_does_not_preflight_cached_issue(self) -> None:
         cached_issue = {
             "number": 1,
@@ -1244,13 +1332,45 @@ class IssueClaimLockTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
-                    patch.object(forge_metadata, "get_issue_assignees", return_value=["automation-user"]), \
+                    patch.object(forge_metadata, "get_issue_assignees", return_value=["other-user"]), \
                     patch.object(forge_metadata, "get_project_item_state") as get_project_item_state:
                 self.assertIsNone(forge_metadata.try_claim_issue(issue, "automation-user"))
                 get_project_item_state.assert_not_called()
                 cache = forge_metadata.read_issue_claim_cache()
                 self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_ASSIGNED)
-                self.assertEqual(cache[1412].assignees, ("automation-user",))
+                self.assertEqual(cache[1412].assignees, ("other-user",))
+
+    def test_try_claim_issue_accepts_existing_authenticated_user_assignment(self) -> None:
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:lib:1.0.0",
+            "labels": [],
+            "assignees": [{"login": "automation-user"}],
+        }
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
+                    patch.object(forge_metadata, "get_issue_assignees", side_effect=[
+                        ["automation-user"],
+                        ["automation-user"],
+                    ]), \
+                    patch.object(
+                        forge_metadata,
+                        "get_project_item_state",
+                        return_value=("project-item", forge_metadata.STATUS_TODO),
+                    ), \
+                    patch.object(forge_metadata, "get_active_sibling_blocker_numbers", return_value=[]), \
+                    patch.object(forge_metadata, "set_issue_assignee") as set_issue_assignee, \
+                    patch.object(forge_metadata, "set_item_status") as set_item_status, \
+                    patch.object(forge_metadata.random, "uniform", return_value=0), \
+                    patch.object(forge_metadata.time, "sleep"):
+                self.assertEqual(
+                    forge_metadata.try_claim_issue(issue, "automation-user"),
+                    "project-item",
+                )
+
+        set_issue_assignee.assert_called_once_with(1412, "automation-user")
+        set_item_status.assert_called_once_with("project-item", forge_metadata.STATUS_IN_PROGRESS)
 
     def test_try_claim_issue_caches_active_sibling_blockers(self) -> None:
         issue = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1262,7 +1262,11 @@ class IssueClaimLockTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
-                    patch.object(forge_metadata, "get_issue_assignees", return_value=[]), \
+                    patch.object(
+                        forge_metadata,
+                        "get_issue_assignees",
+                        side_effect=[[], ["automation-user"]],
+                    ), \
                     patch.object(
                         forge_metadata,
                         "get_project_item_state",
@@ -1272,8 +1276,14 @@ class IssueClaimLockTests(unittest.TestCase):
                         forge_metadata,
                         "get_active_sibling_blocker_numbers",
                         return_value=[3759, 3763],
-                    ), \
-                    patch.object(forge_metadata, "set_issue_assignee") as set_issue_assignee:
+                    ) as get_active_sibling_blocker_numbers, \
+                    patch.object(forge_metadata, "set_issue_assignee") as set_issue_assignee, \
+                    patch.object(
+                        forge_metadata,
+                        "revert_issue_claim_if_still_owned_by_user",
+                    ) as revert_issue_claim_if_still_owned_by_user, \
+                    patch.object(forge_metadata.random, "uniform", return_value=0), \
+                    patch.object(forge_metadata.time, "sleep"):
                 self.assertIsNone(forge_metadata.try_claim_issue(issue, "automation-user"))
                 cache = forge_metadata.read_issue_claim_cache()
                 self.assertEqual(
@@ -1282,7 +1292,9 @@ class IssueClaimLockTests(unittest.TestCase):
                 )
                 self.assertEqual(cache[1412].open_blockers, (3759, 3763))
 
-        set_issue_assignee.assert_not_called()
+        set_issue_assignee.assert_called_once_with(1412, "automation-user")
+        get_active_sibling_blocker_numbers.assert_called_once_with(1412)
+        revert_issue_claim_if_still_owned_by_user.assert_called_once()
 
     def test_try_claim_issue_uses_combined_project_status_lookup(self) -> None:
         issue = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -568,13 +568,13 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             configs = forge_metadata.get_work_queue_configs_from_environment()
 
         self.assertEqual(
-            [(config.label, config.limit, config.strategy_name) for config in configs],
+            [(config.label, config.limit, config.strategy_name, config.random_offset) for config in configs],
             [
-                (forge_metadata.LABEL_JAVAC_FAIL, 0, None),
-                (forge_metadata.LABEL_JAVA_RUN_FAIL, 2, None),
-                (forge_metadata.LABEL_NI_RUN_FAIL, 0, None),
-                (forge_metadata.LABEL_LIBRARY_UPDATE, 0, None),
-                (forge_metadata.LABEL_LIBRARY_NEW, 3, "custom-strategy"),
+                (forge_metadata.LABEL_JAVAC_FAIL, 0, None, False),
+                (forge_metadata.LABEL_JAVA_RUN_FAIL, 2, None, False),
+                (forge_metadata.LABEL_NI_RUN_FAIL, 0, None, False),
+                (forge_metadata.LABEL_LIBRARY_UPDATE, 0, None, False),
+                (forge_metadata.LABEL_LIBRARY_NEW, 3, "custom-strategy", True),
             ],
         )
 
@@ -600,6 +600,43 @@ class WorkQueueSchedulerTests(unittest.TestCase):
                 (forge_metadata.LABEL_PR_LIBRARY_BULK_UPDATE, 4, "review-model"),
             ],
         )
+
+    def test_random_work_offset_can_be_disabled_from_environment(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "1",
+            "FORGE_RANDOM_WORK_OFFSET": "0",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            configs = forge_metadata.get_work_queue_configs_from_environment()
+
+        self.assertFalse(configs[-1].random_offset)
+
+    def test_random_work_offset_can_be_disabled_from_cli_override(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "1",
+            "FORGE_RANDOM_WORK_OFFSET": "1",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            configs = forge_metadata.get_work_queue_configs_from_environment(
+                random_offset_override=False,
+            )
+
+        self.assertFalse(configs[-1].random_offset)
+
+    def test_run_work_queues_accepts_random_offset_flags(self) -> None:
+        random_args = forge_metadata.parse_args(["--run-work-queues", "--random-offset"])
+        no_random_args = forge_metadata.parse_args(["--run-work-queues", "--no-random-offset"])
+
+        self.assertTrue(random_args.random_offset)
+        self.assertFalse(no_random_args.random_offset)
 
     def test_review_label_environment_overrides_default_review_queues(self) -> None:
         env = {
@@ -698,6 +735,39 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             environment_already_validated=True,
         )
         process_reviews.assert_not_called()
+
+    def test_process_work_queues_resolves_auth_for_review_only_queue(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "0",
+            "FORGE_REVIEW_LIMIT": "1",
+            "FORGE_REVIEW_LABEL": forge_metadata.LABEL_LIBRARY_NEW,
+            "FORGE_REVIEW_MODEL": "review-model",
+        }
+
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(
+                    forge_metadata,
+                    "resolve_authenticated_user",
+                    return_value="automation-user",
+                ) as resolve_authenticated_user, \
+                patch.object(forge_metadata, "process_pull_requests_with_label") as process_reviews:
+            forge_metadata.process_work_queues(
+                "/tmp/reachability",
+                "/tmp/metrics",
+                None,
+            )
+
+        resolve_authenticated_user.assert_called_once_with(None)
+        process_reviews.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            1,
+            "/tmp/reachability",
+            "automation-user",
+            "review-model",
+        )
 
 
 class IssueClaimCacheTests(unittest.TestCase):

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -155,6 +155,33 @@ def _claimed_issue(label: str = forge_metadata.LABEL_LIBRARY_NEW) -> forge_metad
 
 
 class IssueClaimPreflightTests(unittest.TestCase):
+    def test_forge_gh_logs_github_query_to_console(self) -> None:
+        completed_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="{}",
+            stderr="",
+        )
+
+        with patch.object(forge_metadata.subprocess, "run", return_value=completed_process), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            forge_metadata.gh(
+                "api",
+                "--method",
+                "GET",
+                "/search/issues",
+                "-f",
+                "q=repo:oracle/graalvm-reachability-metadata is:issue",
+            )
+
+        self.assertIn(
+            (
+                "[github-query] gh api --method GET /search/issues -f "
+                "q=repo:oracle/graalvm-reachability-metadata is:issue"
+            ),
+            stdout.getvalue(),
+        )
+
     def test_gh_raises_typed_rate_limit_error_from_stderr(self) -> None:
         completed_process = subprocess.CompletedProcess(
             ["gh"],

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -926,7 +926,7 @@ class IssueClaimCacheTests(unittest.TestCase):
         self.assertEqual(processed, 0)
         claim_issue_for_processing.assert_not_called()
 
-    def test_process_loop_only_preflights_one_chunk_from_scan_window(self) -> None:
+    def test_process_loop_preflights_uncached_candidates_in_chunks_before_claiming(self) -> None:
         issues = [
             {
                 "number": issue_number,
@@ -948,13 +948,28 @@ class IssueClaimCacheTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_issue_claim_preflights_or_empty",
-                        return_value={1: _preflight(issue_number=1)},
+                        side_effect=[
+                            {
+                                issue["number"]: _preflight(
+                                    issue_number=issue["number"],
+                                    open_blockers=(99,),
+                                )
+                                for issue in issues[:forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE]
+                            },
+                            {
+                                issues[-2]["number"]: _preflight(
+                                    issue_number=issues[-2]["number"],
+                                    open_blockers=(99,),
+                                ),
+                                issues[-1]["number"]: _preflight(issue_number=issues[-1]["number"]),
+                            },
+                        ],
                     ) as get_issue_claim_preflights_or_empty, \
                     patch.object(
                         forge_metadata,
                         "claim_issue_for_processing",
                         return_value=_claimed_issue(),
-                    ), \
+                    ) as claim_issue_for_processing, \
                     patch.object(
                         forge_metadata,
                         "process_claimed_issue_lifecycle",
@@ -975,8 +990,20 @@ class IssueClaimCacheTests(unittest.TestCase):
                     1,
                 )
 
-        get_issue_claim_preflights_or_empty.assert_called_once_with(
-            issues[:forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE]
+        self.assertEqual(
+            get_issue_claim_preflights_or_empty.call_args_list,
+            [
+                call(issues[:forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE]),
+                call(issues[forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE:]),
+            ],
+        )
+        claim_issue_for_processing.assert_called_once_with(
+            issues[-1],
+            forge_metadata.LABEL_LIBRARY_NEW,
+            "/tmp/reachability",
+            "/tmp/metrics",
+            "automation-user",
+            in_metadata_repo=True,
         )
 
 


### PR DESCRIPTION
### Summary
- Keep issue-claim cache behavior scoped to per-issue skip decisions.
- Keep random work offsets enabled by default for work queues and add run-work-queues CLI flags to enable or disable them.
- Resolve the authenticated GitHub user before review-only queues so self-authored PR filtering remains correct.

### Testing
- python3 -m unittest tests/test_forge_metadata.py
- python3 -m py_compile forge_metadata.py tests/test_forge_metadata.py

Fixes #4018