### PR TITLE
[GenAI] Add support for io.jsonwebtoken:jjwt-impl:0.11.5 using gpt-5.5

### DIFF
--- a/metadata/io.jsonwebtoken/jjwt-impl/0.11.5/reachability-metadata.json
+++ b/metadata/io.jsonwebtoken/jjwt-impl/0.11.5/reachability-metadata.json
@@ -1,0 +1,654 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacSigner"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacSigner"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacSigner"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacProvider"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacProvider"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacProvider"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtParserBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.CompressionCodecs"
+      },
+      "type": "io.jsonwebtoken.impl.compression.DeflateCompressionCodec",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.CompressionCodecs"
+      },
+      "type": "io.jsonwebtoken.impl.compression.GzipCompressionCodec",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.crypto.EllipticCurveProvider",
+      "methods": [
+        {
+          "name": "generateKeyPair",
+          "parameterTypes": [
+            "io.jsonwebtoken.SignatureAlgorithm"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.crypto.MacProvider",
+      "methods": [
+        {
+          "name": "generateKey",
+          "parameterTypes": [
+            "io.jsonwebtoken.SignatureAlgorithm"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.crypto.RsaProvider",
+      "methods": [
+        {
+          "name": "generateKeyPair",
+          "parameterTypes": [
+            "io.jsonwebtoken.SignatureAlgorithm"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveProvider"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSigner"
+      },
+      "type": "java.security.interfaces.ECPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSigner"
+      },
+      "type": "java.security.interfaces.ECPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "org.bouncycastle.jce.provider.BouncyCastleProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacProvider"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.SignatureProvider"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.SignatureProvider"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSigner"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacSigner"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.SignatureProvider"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.DefaultJwtSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.SignatureProvider"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.DefaultJwtSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.EllipticCurveSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.SignatureProvider"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.rsa.RSAKeyPairGenerator$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaProvider"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSignatureValidator"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.RsaSigner"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.Services"
+      },
+      "glob": "META-INF/services/io.jsonwebtoken.CompressionCodec"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.crypto.MacProvider"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/io.jsonwebtoken/jjwt-impl/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-impl/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.11.5",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.11.5/impl/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-javadoc.jar",
+    "description" : "JJWT is a Java library for creating, parsing, and validating JSON Web Tokens on the JVM and Android. The jjwt-impl artifact provides the runtime implementation behind the public jjwt-api interfaces, including JWT builders, parsers, signature handling, and compression support.",
+    "tested-versions" : [
+      "0.11.5"
+    ],
+    "allowed-packages" : [
+      "io.jsonwebtoken.impl"
+    ]
+  }
+]

--- a/metadata/io.jsonwebtoken/jjwt-impl/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-impl/index.json
@@ -1,17 +1,19 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "0.11.5",
-    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-sources.jar",
-    "repository-url" : "https://github.com/jwtk/jjwt",
-    "test-code-url" : "https://github.com/jwtk/jjwt/tree/0.11.5/impl/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-javadoc.jar",
-    "description" : "JJWT is a Java library for creating, parsing, and validating JSON Web Tokens on the JVM and Android. The jjwt-impl artifact provides the runtime implementation behind the public jjwt-api interfaces, including JWT builders, parsers, signature handling, and compression support.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "0.11.5",
+    "source-code-url": "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-sources.jar",
+    "repository-url": "https://github.com/jwtk/jjwt",
+    "test-code-url": "https://github.com/jwtk/jjwt/tree/0.11.5/impl/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/0.11.5/jjwt-impl-0.11.5-javadoc.jar",
+    "description": "JJWT is a Java library for creating, parsing, and validating JSON Web Tokens on the JVM and Android. The jjwt-impl artifact provides the runtime implementation behind the public jjwt-api interfaces, including JWT builders, parsers, signature handling, and compression support.",
+    "tested-versions": [
       "0.11.5"
     ],
-    "allowed-packages" : [
-      "io.jsonwebtoken.impl"
+    "allowed-packages": [
+      "io.jsonwebtoken.impl",
+      "io.jsonwebtoken",
+      "io.jsonwebtoken.security"
     ]
   }
 ]

--- a/stats/io.jsonwebtoken/jjwt-impl/0.11.5/execution-metrics.json
+++ b/stats/io.jsonwebtoken/jjwt-impl/0.11.5/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T17:09:06.380796Z",
+    "library": "io.jsonwebtoken:jjwt-impl:0.11.5",
+    "starting_commit": "79171cac10abfe04a8c46b880755b324865a4c20",
+    "ending_commit": "8d7fc12caf9d0204e104c2a08a8159893e44ab55",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.11.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3003,
+          "missed": 1949,
+          "ratio": 0.606422,
+          "total": 4952
+        },
+        "line": {
+          "covered": 729,
+          "missed": 385,
+          "ratio": 0.654399,
+          "total": 1114
+        },
+        "method": {
+          "covered": 203,
+          "missed": 112,
+          "ratio": 0.644444,
+          "total": 315
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 260190,
+      "cached_input_tokens_used": 2800640,
+      "output_tokens_used": 28539,
+      "iterations": 4,
+      "cost_usd": 2.2565,
+      "generated_loc": 498,
+      "tested_library_loc": 729,
+      "metadata_entries": 106,
+      "code_coverage_percent": 65.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java",
+      "metadata_file": "metadata/io.jsonwebtoken/jjwt-impl/0.11.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.jsonwebtoken/jjwt-impl/0.11.5/stats.json
+++ b/stats/io.jsonwebtoken/jjwt-impl/0.11.5/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.11.5",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3003,
+        "missed" : 1949,
+        "ratio" : 0.606422,
+        "total" : 4952
+      },
+      "line" : {
+        "covered" : 729,
+        "missed" : 385,
+        "ratio" : 0.654399,
+        "total" : 1114
+      },
+      "method" : {
+        "covered" : 203,
+        "missed" : 112,
+        "ratio" : 0.644444,
+        "total" : 315
+      }
+    }
+  } ]
+}

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/.gitignore
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/build.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.jsonwebtoken:jjwt-impl:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/gradle.properties
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.jsonwebtoken:jjwt-impl:0.11.5
+library.version = 0.11.5
+metadata.dir = io.jsonwebtoken/jjwt-impl/0.11.5/

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/settings.gradle
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.jsonwebtoken.jjwt-impl_tests'

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
@@ -6,11 +6,462 @@
  */
 package io_jsonwebtoken.jjwt_impl;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.CompressionCodec;
+import io.jsonwebtoken.CompressionCodecs;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.JwtHandlerAdapter;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import io.jsonwebtoken.io.DeserializationException;
+import io.jsonwebtoken.io.Deserializer;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.io.SerializationException;
+import io.jsonwebtoken.io.Serializer;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.junit.jupiter.api.Test;
 
-class Jjwt_implTest {
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.KeyPair;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Jjwt_implTest {
+    private static final SimpleJsonCodec JSON = new SimpleJsonCodec();
+    private static final Date ISSUED_AT = Date.from(Instant.parse("2026-01-01T00:00:00Z"));
+    private static final Date NOT_BEFORE = Date.from(Instant.parse("2026-01-01T00:01:00Z"));
+    private static final Date EXPIRATION = Date.from(Instant.parse("2036-01-01T00:00:00Z"));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void signedClaimsJwtRoundTripsHeadersRegisteredClaimsAndCustomClaims() {
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String jws = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setHeaderParam(JwsHeader.KEY_ID, "primary-hmac-key")
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer("https://issuer.example")
+                .setSubject("integration-test-subject")
+                .setAudience("native-image-tests")
+                .setIssuedAt(ISSUED_AT)
+                .setNotBefore(NOT_BEFORE)
+                .setExpiration(EXPIRATION)
+                .setId("jwt-id-123")
+                .claim("scope", "read:messages")
+                .claim("admin", true)
+                .claim("loginCount", 7)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        JwtParser parser = parserBuilder()
+                .requireIssuer("https://issuer.example")
+                .requireSubject("integration-test-subject")
+                .requireAudience("native-image-tests")
+                .requireIssuedAt(ISSUED_AT)
+                .requireNotBefore(NOT_BEFORE)
+                .requireExpiration(EXPIRATION)
+                .requireId("jwt-id-123")
+                .require("scope", "read:messages")
+                .require("admin", true)
+                .require("loginCount", 7)
+                .setSigningKey(key)
+                .build();
+
+        Jws<Claims> parsed = parser.parseClaimsJws(jws);
+
+        assertThat(parser.isSigned(jws)).isTrue();
+        assertThat(parsed.getHeader().getAlgorithm()).isEqualTo(SignatureAlgorithm.HS256.getValue());
+        assertThat(parsed.getHeader().getKeyId()).isEqualTo("primary-hmac-key");
+        assertThat(parsed.getHeader().getType()).isEqualTo(Header.JWT_TYPE);
+        assertThat(parsed.getBody().getIssuer()).isEqualTo("https://issuer.example");
+        assertThat(parsed.getBody().getSubject()).isEqualTo("integration-test-subject");
+        assertThat(parsed.getBody().getAudience()).isEqualTo("native-image-tests");
+        assertThat(parsed.getBody().getIssuedAt()).isEqualTo(ISSUED_AT);
+        assertThat(parsed.getBody().getNotBefore()).isEqualTo(NOT_BEFORE);
+        assertThat(parsed.getBody().getExpiration()).isEqualTo(EXPIRATION);
+        assertThat(parsed.getBody().getId()).isEqualTo("jwt-id-123");
+        assertThat(parsed.getBody().get("scope", String.class)).isEqualTo("read:messages");
+        assertThat(parsed.getBody().get("admin", Boolean.class)).isTrue();
+        assertThat(parsed.getBody().get("loginCount", Integer.class)).isEqualTo(7);
+        assertThat(parsed.getSignature()).isNotBlank();
+    }
+
+    @Test
+    void compressionCodecsRoundTripDirectlyAndInsideSignedClaimsJwt() {
+        byte[] payload = "compressible payload compressible payload compressible payload"
+                .getBytes(StandardCharsets.UTF_8);
+        assertCompressionRoundTrip(CompressionCodecs.GZIP, payload);
+        assertCompressionRoundTrip(CompressionCodecs.DEFLATE, payload);
+
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS384);
+        Stream.of(CompressionCodecs.GZIP, CompressionCodecs.DEFLATE).forEach(codec -> {
+            String jws = Jwts.builder()
+                    .serializeToJsonWith(JSON)
+                    .setSubject("compressed-claims")
+                    .claim("codec", codec.getAlgorithmName())
+                    .compressWith(codec)
+                    .signWith(key, SignatureAlgorithm.HS384)
+                    .compact();
+
+            Jws<Claims> parsed = parserBuilder().setSigningKey(key).build().parseClaimsJws(jws);
+
+            assertThat(parsed.getHeader().getCompressionAlgorithm()).isEqualTo(codec.getAlgorithmName());
+            assertThat(parsed.getBody().getSubject()).isEqualTo("compressed-claims");
+            assertThat(parsed.getBody().get("codec", String.class)).isEqualTo(codec.getAlgorithmName());
+        });
+    }
+
+    @Test
+    void hmacRsaAndEllipticCurveSignaturesAreVerifiedWithMatchingKeys() {
+        Stream.of(SignatureAlgorithm.HS256, SignatureAlgorithm.HS384, SignatureAlgorithm.HS512).forEach(algorithm -> {
+            SecretKey key = Keys.secretKeyFor(algorithm);
+            String jws = signedSubject("hmac-" + algorithm.name(), key, algorithm);
+
+            assertThat(parserBuilder().setSigningKey(key).build().parseClaimsJws(jws).getBody().getSubject())
+                    .isEqualTo("hmac-" + algorithm.name());
+        });
+
+        Stream.of(SignatureAlgorithm.RS256, SignatureAlgorithm.RS384, SignatureAlgorithm.RS512,
+                SignatureAlgorithm.PS256, SignatureAlgorithm.PS384, SignatureAlgorithm.PS512,
+                SignatureAlgorithm.ES256, SignatureAlgorithm.ES384, SignatureAlgorithm.ES512).forEach(algorithm -> {
+                    KeyPair keyPair = Keys.keyPairFor(algorithm);
+                    String jws = signedSubject("asymmetric-" + algorithm.name(), keyPair.getPrivate(), algorithm);
+
+                    assertThat(parserBuilder().setSigningKey(keyPair.getPublic()).build().parseClaimsJws(jws)
+                            .getBody().getSubject()).isEqualTo("asymmetric-" + algorithm.name());
+                });
+    }
+
+    @Test
+    void signingKeyResolverSelectsVerificationKeyFromJwsHeader() {
+        SecretKey firstKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        SecretKey secondKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        Map<String, Key> keys = new LinkedHashMap<>();
+        keys.put("first", firstKey);
+        keys.put("second", secondKey);
+        String jws = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setHeaderParam(JwsHeader.KEY_ID, "second")
+                .setSubject("resolved-by-kid")
+                .signWith(secondKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        Jws<Claims> parsed = parserBuilder().setSigningKeyResolver(new SigningKeyResolverAdapter() {
+            @Override
+            public Key resolveSigningKey(JwsHeader header, Claims claims) {
+                return keys.get(header.getKeyId());
+            }
+        }).build().parseClaimsJws(jws);
+
+        assertThat(parsed.getHeader().getKeyId()).isEqualTo("second");
+        assertThat(parsed.getBody().getSubject()).isEqualTo("resolved-by-kid");
+    }
+
+    @Test
+    void plaintextJwsUsesCustomBase64UrlEncoderAndHandlerDispatch() {
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String jws = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .base64UrlEncodeWith(Encoders.BASE64URL)
+                .setHeaderParam(Header.CONTENT_TYPE, "text/plain")
+                .setPayload("plain-text-payload")
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        JwtParser parser = parserBuilder().setSigningKey(key).build();
+        Jws<String> parsed = parser.parsePlaintextJws(jws);
+        String handledPayload = parser.parse(jws, new JwtHandlerAdapter<String>() {
+            @Override
+            public String onPlaintextJws(Jws<String> jws) {
+                return jws.getBody();
+            }
+        });
+
+        assertThat(parsed.getHeader().getContentType()).isEqualTo("text/plain");
+        assertThat(parsed.getBody()).isEqualTo("plain-text-payload");
+        assertThat(handledPayload).isEqualTo("plain-text-payload");
+    }
+
+    @Test
+    void parserRejectsTamperedSignaturesWrongClaimsAndExpiredTokens() {
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String jws = signedSubject("protected-subject", key, SignatureAlgorithm.HS256);
+        int lastDot = jws.lastIndexOf('.');
+        String tampered = jws.substring(0, lastDot + 1) + "tamperedSignature";
+
+        assertThrows(SignatureException.class, () -> parserBuilder().setSigningKey(key).build().parseClaimsJws(tampered));
+        assertThrows(IncorrectClaimException.class, () -> parserBuilder()
+                .requireSubject("somebody-else")
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(jws));
+
+        String expired = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setSubject("expired")
+                .setExpiration(Date.from(Instant.parse("2026-01-01T00:00:00Z")))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThrows(ExpiredJwtException.class, () -> parserBuilder()
+                .setClock(() -> Date.from(Instant.parse("2026-01-01T00:00:01Z")))
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(expired));
+        assertThat(parserBuilder()
+                .setClock(() -> Date.from(Instant.parse("2026-01-01T00:00:01Z")))
+                .setAllowedClockSkewSeconds(2)
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(expired)
+                .getBody()
+                .getSubject()).isEqualTo("expired");
+    }
+
+    private static void assertCompressionRoundTrip(CompressionCodec codec, byte[] payload) {
+        byte[] compressed = codec.compress(payload);
+        byte[] decompressed = codec.decompress(compressed);
+
+        assertThat(codec.getAlgorithmName()).isNotBlank();
+        assertThat(compressed).isNotEqualTo(payload);
+        assertThat(decompressed).isEqualTo(payload);
+    }
+
+    private static String signedSubject(String subject, Key key, SignatureAlgorithm algorithm) {
+        return Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setSubject(subject)
+                .signWith(key, algorithm)
+                .compact();
+    }
+
+    private static JwtParserBuilder parserBuilder() {
+        return Jwts.parserBuilder().deserializeJsonWith(JSON);
+    }
+
+    private static final class SimpleJsonCodec implements Serializer<Map<String, ?>>, Deserializer<Map<String, ?>> {
+        @Override
+        public byte[] serialize(Map<String, ?> map) throws SerializationException {
+            return toJsonObject(map).getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public Map<String, ?> deserialize(byte[] bytes) throws DeserializationException {
+            return new JsonParser(new String(bytes, StandardCharsets.UTF_8)).parseObject();
+        }
+
+        private static String toJsonObject(Map<String, ?> map) {
+            StringBuilder json = new StringBuilder("{");
+            boolean first = true;
+            for (Map.Entry<String, ?> entry : map.entrySet()) {
+                Object value = entry.getValue();
+                if (value == null) {
+                    continue;
+                }
+                if (!first) {
+                    json.append(',');
+                }
+                json.append(toJsonString(entry.getKey())).append(':').append(toJsonValue(value));
+                first = false;
+            }
+            return json.append('}').toString();
+        }
+
+        private static String toJsonValue(Object value) {
+            if (value instanceof Date) {
+                return Long.toString(((Date) value).getTime() / 1000L);
+            }
+            if (value instanceof Number || value instanceof Boolean) {
+                return value.toString();
+            }
+            if (value instanceof Iterable<?>) {
+                return toJsonArray((Iterable<?>) value);
+            }
+            return toJsonString(value.toString());
+        }
+
+        private static String toJsonArray(Iterable<?> values) {
+            StringBuilder json = new StringBuilder("[");
+            boolean first = true;
+            for (Object value : values) {
+                if (!first) {
+                    json.append(',');
+                }
+                json.append(toJsonValue(value));
+                first = false;
+            }
+            return json.append(']').toString();
+        }
+
+        private static String toJsonString(String value) {
+            StringBuilder json = new StringBuilder("\"");
+            for (int index = 0; index < value.length(); index++) {
+                char character = value.charAt(index);
+                if (character == '\\' || character == '\"') {
+                    json.append('\\').append(character);
+                } else if (character == '\n') {
+                    json.append("\\n");
+                } else if (character == '\r') {
+                    json.append("\\r");
+                } else if (character == '\t') {
+                    json.append("\\t");
+                } else {
+                    json.append(character);
+                }
+            }
+            return json.append('"').toString();
+        }
+    }
+
+    private static final class JsonParser {
+        private final String json;
+        private int position;
+
+        private JsonParser(String json) {
+            this.json = json;
+        }
+
+        private Map<String, Object> parseObject() {
+            expect('{');
+            Map<String, Object> values = new LinkedHashMap<>();
+            skipWhitespace();
+            if (consume('}')) {
+                return values;
+            }
+            do {
+                String key = parseString();
+                expect(':');
+                values.put(key, parseValue());
+            } while (consume(','));
+            expect('}');
+            return values;
+        }
+
+        private Object parseValue() {
+            skipWhitespace();
+            char current = peek();
+            if (current == '"') {
+                return parseString();
+            }
+            if (current == '[') {
+                return parseArray();
+            }
+            if (json.startsWith("true", position)) {
+                position += 4;
+                return Boolean.TRUE;
+            }
+            if (json.startsWith("false", position)) {
+                position += 5;
+                return Boolean.FALSE;
+            }
+            return parseInteger();
+        }
+
+        private List<Object> parseArray() {
+            expect('[');
+            List<Object> values = new ArrayList<>();
+            skipWhitespace();
+            if (consume(']')) {
+                return values;
+            }
+            do {
+                values.add(parseValue());
+            } while (consume(','));
+            expect(']');
+            return values;
+        }
+
+        private String parseString() {
+            expect('"');
+            StringBuilder value = new StringBuilder();
+            while (position < json.length()) {
+                char character = json.charAt(position++);
+                if (character == '"') {
+                    return value.toString();
+                }
+                if (character == '\\') {
+                    value.append(parseEscapedCharacter());
+                } else {
+                    value.append(character);
+                }
+            }
+            throw new DeserializationException("Unterminated JSON string");
+        }
+
+        private char parseEscapedCharacter() {
+            char escaped = json.charAt(position++);
+            if (escaped == 'n') {
+                return '\n';
+            }
+            if (escaped == 'r') {
+                return '\r';
+            }
+            if (escaped == 't') {
+                return '\t';
+            }
+            return escaped;
+        }
+
+        private Number parseInteger() {
+            int start = position;
+            if (peek() == '-') {
+                position++;
+            }
+            while (position < json.length() && Character.isDigit(json.charAt(position))) {
+                position++;
+            }
+            long value = Long.parseLong(json.substring(start, position));
+            if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+                return (int) value;
+            }
+            return value;
+        }
+
+        private boolean consume(char expected) {
+            skipWhitespace();
+            if (position < json.length() && json.charAt(position) == expected) {
+                position++;
+                return true;
+            }
+            return false;
+        }
+
+        private void expect(char expected) {
+            skipWhitespace();
+            if (position >= json.length() || json.charAt(position) != expected) {
+                throw new DeserializationException("Expected '" + expected + "' at position " + position);
+            }
+            position++;
+        }
+
+        private char peek() {
+            if (position >= json.length()) {
+                throw new DeserializationException("Unexpected end of JSON input");
+            }
+            return json.charAt(position);
+        }
+
+        private void skipWhitespace() {
+            while (position < json.length() && Character.isWhitespace(json.charAt(position))) {
+                position++;
+            }
+        }
     }
 }

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
@@ -12,6 +12,7 @@ import io.jsonwebtoken.CompressionCodecs;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtHandlerAdapter;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.JwtParserBuilder;
@@ -202,6 +203,36 @@ public class Jjwt_implTest {
 
         assertThat(parsed.getHeader().getKeyId()).isEqualTo("second");
         assertThat(parsed.getBody().getSubject()).isEqualTo("resolved-by-kid");
+    }
+
+    @Test
+    void unsignedClaimsJwtParsesWithoutVerificationKeyAndDispatchesToClaimsJwtHandler() {
+        String jwt = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject("unsigned-claims")
+                .claim("roles", List.of("reader", "writer"))
+                .compact();
+
+        JwtParser parser = parserBuilder().build();
+        Jwt<Header, Claims> parsed = parser.parseClaimsJwt(jwt);
+        String handledSubject = parser.parse(jwt, new JwtHandlerAdapter<String>() {
+            @Override
+            public String onClaimsJwt(Jwt<Header, Claims> jwt) {
+                assertThat(jwt.getHeader().getType()).isEqualTo(Header.JWT_TYPE);
+                return jwt.getBody().getSubject();
+            }
+        });
+
+        Object roles = parsed.getBody().get("roles");
+        assertThat(parser.isSigned(jwt)).isFalse();
+        assertThat(parsed.getHeader().getType()).isEqualTo(Header.JWT_TYPE);
+        assertThat(parsed.getBody().getSubject()).isEqualTo("unsigned-claims");
+        assertThat(roles).isInstanceOf(List.class);
+        assertThat((List<?>) roles).hasSize(2);
+        assertThat(((List<?>) roles).get(0)).isEqualTo("reader");
+        assertThat(((List<?>) roles).get(1)).isEqualTo("writer");
+        assertThat(handledSubject).isEqualTo("unsigned-claims");
     }
 
     @Test

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
@@ -129,6 +129,36 @@ public class Jjwt_implTest {
     }
 
     @Test
+    void customCompressionCodecResolverInflatesSignedClaimsJwt() {
+        CompressionCodec codec = new ReversingCompressionCodec();
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String jws = Jwts.builder()
+                .serializeToJsonWith(JSON)
+                .setSubject("custom-compression")
+                .claim("departments", List.of("engineering", "support"))
+                .compressWith(codec)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        Jws<Claims> parsed = parserBuilder()
+                .setCompressionCodecResolver(header -> {
+                    assertThat(header.getCompressionAlgorithm()).isEqualTo(codec.getAlgorithmName());
+                    return codec;
+                })
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(jws);
+
+        Object departments = parsed.getBody().get("departments");
+        assertThat(parsed.getHeader().getCompressionAlgorithm()).isEqualTo(codec.getAlgorithmName());
+        assertThat(parsed.getBody().getSubject()).isEqualTo("custom-compression");
+        assertThat(departments).isInstanceOf(List.class);
+        assertThat((List<?>) departments).hasSize(2);
+        assertThat(((List<?>) departments).get(0)).isEqualTo("engineering");
+        assertThat(((List<?>) departments).get(1)).isEqualTo("support");
+    }
+
+    @Test
     void hmacRsaAndEllipticCurveSignaturesAreVerifiedWithMatchingKeys() {
         Stream.of(SignatureAlgorithm.HS256, SignatureAlgorithm.HS384, SignatureAlgorithm.HS512).forEach(algorithm -> {
             SecretKey key = Keys.secretKeyFor(algorithm);
@@ -254,6 +284,35 @@ public class Jjwt_implTest {
 
     private static JwtParserBuilder parserBuilder() {
         return Jwts.parserBuilder().deserializeJsonWith(JSON);
+    }
+
+    private static final class ReversingCompressionCodec implements CompressionCodec {
+        private static final String ALGORITHM_NAME = "REV";
+
+        @Override
+        public String getAlgorithmName() {
+            return ALGORITHM_NAME;
+        }
+
+        @Override
+        public byte[] compress(byte[] bytes) {
+            return reverse(bytes);
+        }
+
+        @Override
+        public byte[] decompress(byte[] bytes) {
+            return reverse(bytes);
+        }
+
+        private static byte[] reverse(byte[] bytes) {
+            byte[] reversed = bytes.clone();
+            for (int left = 0, right = reversed.length - 1; left < right; left++, right--) {
+                byte value = reversed[left];
+                reversed[left] = reversed[right];
+                reversed[right] = value;
+            }
+            return reversed;
+        }
     }
 
     private static final class SimpleJsonCodec implements Serializer<Map<String, ?>>, Deserializer<Map<String, ?>> {

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/src/test/java/io_jsonwebtoken/jjwt_impl/Jjwt_implTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_jsonwebtoken.jjwt_impl;
+
+import org.junit.jupiter.api.Test;
+
+class Jjwt_implTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/user-code-filter.json
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.jsonwebtoken.impl.**"
+    }
+  ]
+}

--- a/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/user-code-filter.json
+++ b/tests/src/io.jsonwebtoken/jjwt-impl/0.11.5/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.jsonwebtoken.impl.**"
+      "includeClasses" : "io.jsonwebtoken.impl.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3853

This PR introduces tests and metadata for io.jsonwebtoken:jjwt-impl:0.11.5, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 260190
- Cached input tokens: 2800640
- Output tokens: 28539
- Metadata entries: 106
- Iterations: 4
- Library coverage percentage: 65.44
- Generated lines of code: 498
- Tested library lines of code: 729

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `f4f0f9be0e5eced44cb1b5ea24941f18c06b9a4f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3003/4952 (60.64%)
- Line: 729/1114 (65.44%)
- Method: 203/315 (64.44%)
