### PR TITLE
[GenAI] Test fix for org.jboss.logmanager:jboss-logmanager:1.3.0.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/reachability-metadata.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/reachability-metadata.json
@@ -1,0 +1,386 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "com.sun.jmx.trace.Trace"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.Enum",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        },
+        {
+          "name" : "serialPersistentFields"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        },
+        {
+          "name" : "serialPersistentFields"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "org.jboss.logmanager.AtomicArray",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "remove",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "clear",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "type" : "java.util.HexFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.PatternFormatter"
+      },
+      "type" : "org.jboss.logmanager.formatters.PatternFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "type" : "org.jboss.logmanager.formatters.Formatters$12"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "type" : "org.jboss.logmanager.formatters.Formatters$12$2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logmanager.formatters.Formatters$12",
+            "java.lang.ClassLoader",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "readObject",
+          "parameterTypes" : [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.Level"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogContext"
+      },
+      "type" : "org.jboss.logmanager.LogContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LoggerNode"
+      },
+      "type" : "org.jboss.logmanager.LoggerNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtLogRecord"
+      },
+      "glob" : "org/jboss/logmanager/ExtLogRecord$FormatStyle.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "glob" : "org/jboss/logmanager/ExtLogRecord.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.NDC"
+      },
+      "glob" : "org/jboss/logmanager/NDC$Holder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.NDC$Holder"
+      },
+      "glob" : "org/jboss/logmanager/NDC$Stack.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtLogRecord"
+      },
+      "glob" : "org/jboss/logmanager/NDC.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ExtFormatter"
+      },
+      "glob" : "org/jboss/logmanager/WrappedExtLogRecord.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.MultistepFormatter"
+      },
+      "glob" : "org/jboss/logmanager/formatters/FormatStep.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.PatternFormatter"
+      },
+      "glob" : "org/jboss/logmanager/formatters/FormatStringParser.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.FormatStringParser"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$1.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$11.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$12.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$15.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$JustifyingFormatStep.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.FormatStringParser"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters.class"
+    },
+    {
+      "glob" : "org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test$BootstrapFormattingInvoker.class"
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "org.jboss.logmanager.FastCopyHashMap"
+    }
+  ]
+}

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.3.0.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.3.0.Final/jboss-logmanager-1.3.0.Final-sources.jar",
+    "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",
+    "test-code-url" : "https://github.com/jboss-logging/jboss-logmanager/tree/1.3.0.Final/src/test",
+    "documentation-url" : "N/A",
+    "description" : "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
     "tested-versions" : [
       "1.3.0.Final"
     ],

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.3.0.Final",
+    "tested-versions" : [
+      "1.3.0.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.logmanager"
+    ]
+  },
+  {
     "metadata-version" : "1.2.1.GA",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.2.1.GA/jboss-logmanager-1.2.1.GA-sources.jar",
     "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/execution-metrics.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T18:13:48.849259Z",
+    "library": "org.jboss.logmanager:jboss-logmanager:1.3.0.Final",
+    "starting_commit": "33decd125c13c4ccbb68ba902e41f3579f37ba25",
+    "ending_commit": "0b917832788a0bb22c293ec33d645ba2ff1c2d85",
+    "previous_library": "org.jboss.logmanager:jboss-logmanager:1.2.1.GA",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.3.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.958333,
+            "coveredCalls": 23,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.965517,
+        "coveredCalls": 28,
+        "totalCalls": 29
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5423,
+          "missed": 14412,
+          "ratio": 0.273406,
+          "total": 19835
+        },
+        "line": {
+          "covered": 1234,
+          "missed": 3374,
+          "ratio": 0.267795,
+          "total": 4608
+        },
+        "method": {
+          "covered": 305,
+          "missed": 778,
+          "ratio": 0.281625,
+          "total": 1083
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.2.1.GA",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.9375,
+            "coveredCalls": 30,
+            "totalCalls": 32
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.945946,
+        "coveredCalls": 35,
+        "totalCalls": 37
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3668,
+          "missed": 10549,
+          "ratio": 0.258001,
+          "total": 14217
+        },
+        "line": {
+          "covered": 910,
+          "missed": 2571,
+          "ratio": 0.261419,
+          "total": 3481
+        },
+        "method": {
+          "covered": 185,
+          "missed": 601,
+          "ratio": 0.235369,
+          "total": 786
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 219072,
+      "cached_input_tokens_used": 2427904,
+      "output_tokens_used": 26075,
+      "iterations": 4,
+      "cost_usd": 1.9963,
+      "tested_library_loc": 1234,
+      "metadata_entries": 62,
+      "test_only_metadata_entries": 41,
+      "previous_library_metadata_entries": 20,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 26.78,
+      "previous_library_coverage_percent": 26.14
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java",
+      "metadata_file": "metadata/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/stats.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.3.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.958333,
+          "coveredCalls" : 23,
+          "totalCalls" : 24
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.965517,
+      "coveredCalls" : 28,
+      "totalCalls" : 29
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5423,
+        "missed" : 14412,
+        "ratio" : 0.273406,
+        "total" : 19835
+      },
+      "line" : {
+        "covered" : 1234,
+        "missed" : 3374,
+        "ratio" : 0.267795,
+        "total" : 4608
+      },
+      "method" : {
+        "covered" : 305,
+        "missed" : 778,
+        "ratio" : 0.281625,
+        "total" : 1083
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/.gitignore
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/build.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.logmanager:jboss-logmanager:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/gradle.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.logmanager:jboss-logmanager:1.3.0.Final
+library.version = 1.3.0.Final
+metadata.dir = org.jboss.logmanager/jboss-logmanager/1.3.0.Final/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/settings.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.logmanager.jboss-logmanager_tests'

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void constructorPropertyTypeIsResolvedFromPublicGetter() throws IOException {
+        String loggerName = AbstractPropertyConfigurationTest.class.getName() + ".constructorProperty";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    logger.%1$s.level=INFO
+                    logger.%1$s.handlers=constructorHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.constructorHandler=%2$s
+                    handler.constructorHandler.level=INFO
+                    handler.constructorHandler.formatter=constructorFormatter
+                    formatter.constructorFormatter=%3$s
+                    formatter.constructorFormatter.constructorProperties=prefix
+                    formatter.constructorFormatter.properties=prefix
+                    formatter.constructorFormatter.prefix=constructed:
+                    """.formatted(
+                    loggerName,
+                    CapturingHandler.class.getName(),
+                    ConstructorBackedFormatter.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(CapturingHandler.class, handler -> {
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(ConstructorBackedFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("constructed:"));
+            });
+
+            CapturingHandler handler = (CapturingHandler) logger.getHandlers()[0];
+            logger.info("message");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("constructed:message");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class ConstructorBackedFormatter extends Formatter {
+        private final String prefix;
+
+        public ConstructorBackedFormatter(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class CapturingHandler extends Handler {
+        private String lastPublishedMessage;
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AtomicArrayTest {
+
+    @Test
+    void addAndRemoveSupportNonHandlerComponentTypes() throws Exception {
+        Holder holder = new Holder();
+        AtomicReferenceFieldUpdater<Holder, String[]> updater =
+                AtomicReferenceFieldUpdater.newUpdater(Holder.class, String[].class, "values");
+        Object atomicArray = newAtomicArray(updater, String.class);
+
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "console");
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "file");
+
+        assertThat(holder.values).containsExactly("console", "file");
+        assertThat(invokeMethod(
+                atomicArray,
+                "remove",
+                new Class<?>[] {Object.class, Object.class, boolean.class },
+                holder,
+                "console",
+                false
+        )).isEqualTo(Boolean.TRUE);
+        assertThat(holder.values).containsExactly("file");
+
+        invokeMethod(atomicArray, "clear", new Class<?>[] {Object.class }, holder);
+        assertThat(holder.values).isEmpty();
+    }
+
+    private static Object newAtomicArray(
+            final AtomicReferenceFieldUpdater<Holder, String[]> updater,
+            final Class<String> componentType
+    ) throws Exception {
+        Class<?> atomicArrayType = Class.forName("org.jboss.logmanager.AtomicArray");
+        Constructor<?> constructor = atomicArrayType.getDeclaredConstructor(AtomicReferenceFieldUpdater.class, Class.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(updater, componentType);
+    }
+
+    private static Object invokeMethod(
+            final Object target,
+            final String methodName,
+            final Class<?>[] parameterTypes,
+            final Object... arguments
+    ) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static final class Holder {
+        volatile String[] values = new String[0];
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentReferenceHashMapTest {
+
+    @Test
+    void serializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> map = newConcurrentReferenceHashMap();
+        Map<String, String> expectedEntries = new LinkedHashMap<>();
+        expectedEntries.put("logger", "main");
+        expectedEntries.put("handler", "console");
+        map.putAll(expectedEntries);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(map);
+            objectOutputStream.flush();
+            serialized = outputStream.toByteArray();
+        }
+
+        Object restored;
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            restored = objectInputStream.readObject();
+        }
+
+        assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        @SuppressWarnings("unchecked")
+        Map<String, String> restoredMap = (Map<String, String>) restored;
+        assertThat(restoredMap)
+                .hasSize(expectedEntries.size())
+                .containsAllEntriesOf(expectedEntries);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Map<String, String> newConcurrentReferenceHashMap() throws Exception {
+        Class<?> mapType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        Class enumType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType");
+        Object strongReference = Enum.valueOf(enumType, "STRONG");
+        Constructor<?> constructor = mapType.getDeclaredConstructor(int.class, enumType, enumType);
+        constructor.setAccessible(true);
+        return (Map<String, String>) constructor.newInstance(4, strongReference, strongReference);
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.logmanager.DefaultConfigurationLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultConfigurationLocatorTest {
+
+    @Test
+    void findConfigurationLoadsLoggingPropertiesFromThreadContextClassLoader() throws Exception {
+        String originalConfiguration = System.getProperty("logging.configuration");
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            System.clearProperty("logging.configuration");
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+            DefaultConfigurationLocator locator = new DefaultConfigurationLocator();
+            try (InputStream stream = locator.findConfiguration()) {
+                assertThat(stream).isNotNull();
+                assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+                        .contains("test.resource=thread-context-class-loader");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalConfiguration == null) {
+                System.clearProperty("logging.configuration");
+            } else {
+                System.setProperty("logging.configuration", originalConfiguration);
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.logmanager.MDC;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastCopyHashMapTest {
+
+    @Test
+    void mdcCopySerializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> originalMdc = MDC.copy();
+        try {
+            MDC.clear();
+            Map<String, String> expectedEntries = new LinkedHashMap<>();
+            expectedEntries.put("logger", "main");
+            expectedEntries.put("handler", "console");
+            expectedEntries.forEach(MDC::put);
+
+            Map<String, String> map = MDC.copy();
+            assertThat(map.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+
+            byte[] serialized = serialize(map);
+            Object restored = deserialize(serialized);
+
+            assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+            assertThat(restored).isInstanceOf(Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> restoredMap = (Map<String, String>) restored;
+            assertThat(restoredMap).isEqualTo(expectedEntries);
+        } finally {
+            MDC.clear();
+            originalMdc.forEach(MDC::put);
+        }
+    }
+
+    private static byte[] serialize(final Object value) throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+            objectOutputStream.flush();
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static Object deserialize(final byte[] serialized) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return objectInputStream.readObject();
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.security.PrivilegedAction;
+
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Anonymous2Test {
+
+    @Test
+    void resourceActionUsesClassLoaderResourceWhenFrameClassHasAClassLoader() throws Throwable {
+        final String resourceName = "org/example/FrameClass.class";
+        final URL resourceUrl = new URL("file:/active-class-loader-resource");
+        final TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(resourceName, resourceUrl);
+
+        final URL result = newResourceLookupAction(classLoader, resourceName).run();
+
+        assertThat(result).isSameAs(resourceUrl);
+        assertThat(classLoader.requestedResource()).isEqualTo(resourceName);
+    }
+
+    @Test
+    void resourceActionUsesSystemResourceWhenFrameClassIsLoadedByBootstrapLoader() throws Throwable {
+        final String resourceName = "logging.properties";
+        final URL expected = ClassLoader.getSystemResource(resourceName);
+
+        final URL result = newResourceLookupAction(null, resourceName).run();
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PrivilegedAction<URL> newResourceLookupAction(
+            final ClassLoader classLoader,
+            final String resourceName
+    ) throws Throwable {
+        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
+                .findConstructor(
+                        resourceActionClass,
+                        MethodType.methodType(
+                                void.class,
+                                enclosingFormatterStepClass,
+                                ClassLoader.class,
+                                String.class
+                        )
+                );
+        return (PrivilegedAction<URL>) constructor.invoke(null, classLoader, resourceName);
+    }
+
+    private static final class TrackingResourceClassLoader extends ClassLoader {
+        private final String expectedResource;
+        private final URL resourceUrl;
+        private String requestedResource;
+
+        private TrackingResourceClassLoader(final String expectedResource, final URL resourceUrl) {
+            super(FormattersAnonymous12Anonymous2Test.class.getClassLoader());
+            this.expectedResource = expectedResource;
+            this.resourceUrl = resourceUrl;
+        }
+
+        String requestedResource() {
+            return requestedResource;
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResource = name;
+            if (expectedResource.equals(name)) {
+                return resourceUrl;
+            }
+            return super.getResource(name);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Test {
+
+    @Test
+    void extendedExceptionFormattingUsesThreadContextClassLoaderForBootstrapFrameClass() {
+        String className = String.class.getName();
+
+        String formatted = formatWithTccl(FormattersAnonymous12Test.class.getClassLoader(), newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            PatternFormatter formatter = new PatternFormatter("%E");
+            ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous12Test.class.getName()
+            );
+            record.setThrown(thrown);
+            return formatter.format(record);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static IllegalStateException newFailure(final String className) {
+        IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
+        });
+        return failure;
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -43,7 +43,9 @@ public class FormattersAnonymous12Test {
         String formatted = formatWithTccl(rejectingClassLoader, newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
-        assertThat(rejectingClassLoader.wasRejected()).isTrue();
+        if (!isNativeImageRuntime()) {
+            assertThat(rejectingClassLoader.wasRejected()).isTrue();
+        }
     }
 
     @Test
@@ -57,7 +59,9 @@ public class FormattersAnonymous12Test {
             String formatted = formattingAction.format(newFailure(className));
 
             assertThat(formatted).contains("\tat " + className + ".invoke");
-            assertThat(classLoader.getRejectedCount()).isGreaterThanOrEqualTo(2);
+            if (!isNativeImageRuntime()) {
+                assertThat(classLoader.getRejectedCount()).isGreaterThanOrEqualTo(2);
+            }
         } catch (Error error) {
             if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
                 throw error;
@@ -88,6 +92,10 @@ public class FormattersAnonymous12Test {
                 new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
         });
         return failure;
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 
     public interface BootstrapFormattingAction {

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -6,8 +6,13 @@
  */
 package org_jboss_logmanager.jboss_logmanager;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.util.Objects;
 import java.util.logging.Level;
 
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
@@ -23,6 +28,39 @@ public class FormattersAnonymous12Test {
         String formatted = formatWithTccl(FormattersAnonymous12Test.class.getClassLoader(), newFailure(className));
 
         assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    @Test
+    void extendedExceptionFormattingFallsBackFromContextClassLoaderToFormatterClassLoader() {
+        String className = PatternFormatter.class.getName();
+        RejectingClassLoader rejectingClassLoader = new RejectingClassLoader(
+                FormattersAnonymous12Test.class.getClassLoader(),
+                className
+        );
+
+        String formatted = formatWithTccl(rejectingClassLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        assertThat(rejectingClassLoader.wasRejected()).isTrue();
+    }
+
+    @Test
+    void extendedExceptionFormattingFallsBackToBootstrapClassLoaderWhenOwningLoaderCannotLoadFrameClass()
+            throws Exception {
+        try {
+            String className = "java.util.HexFormat";
+            BootstrapFallbackClassLoader classLoader = new BootstrapFallbackClassLoader(className);
+            BootstrapFormattingAction formattingAction = classLoader.loadFormattingAction();
+
+            String formatted = formattingAction.format(newFailure(className));
+
+            assertThat(formatted).contains("\tat " + className + ".invoke");
+            assertThat(classLoader.wasRejected()).isTrue();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
     }
 
     private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
@@ -48,5 +86,114 @@ public class FormattersAnonymous12Test {
                 new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
         });
         return failure;
+    }
+
+    public interface BootstrapFormattingAction {
+        String format(Throwable thrown);
+    }
+
+    public static final class BootstrapFormattingInvoker implements BootstrapFormattingAction {
+        public BootstrapFormattingInvoker() {
+        }
+
+        @Override
+        public String format(final Throwable thrown) {
+            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                PatternFormatter formatter = new PatternFormatter("%E");
+                ExtLogRecord record = new ExtLogRecord(
+                        Level.SEVERE,
+                        "coverage",
+                        BootstrapFormattingInvoker.class.getName()
+                );
+                record.setThrown(thrown);
+                return formatter.format(record);
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalTccl);
+            }
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private boolean rejected;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        boolean wasRejected() {
+            return rejected;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                rejected = true;
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class BootstrapFallbackClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private boolean rejected;
+
+        private BootstrapFallbackClassLoader(final String rejectedClassName) {
+            super(FormattersAnonymous12Test.class.getClassLoader());
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        BootstrapFormattingAction loadFormattingAction() throws Exception {
+            Class<?> actionClass = loadClass(BootstrapFormattingInvoker.class.getName());
+            Constructor<?> constructor = actionClass.getConstructor();
+            return BootstrapFormattingAction.class.cast(constructor.newInstance());
+        }
+
+        boolean wasRejected() {
+            return rejected;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> alreadyLoaded = findLoadedClass(name);
+                if (alreadyLoaded != null) {
+                    return alreadyLoaded;
+                }
+                if (rejectedClassName.equals(name)) {
+                    rejected = true;
+                    throw new ClassNotFoundException(name);
+                }
+                if (shouldDefineLocally(name)) {
+                    Class<?> localClass = findClass(name);
+                    if (resolve) {
+                        resolveClass(localClass);
+                    }
+                    return localClass;
+                }
+                return super.loadClass(name, resolve);
+            }
+        }
+
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream inputStream = FormattersAnonymous12Test.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
+                byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+                return defineClass(name, classBytes, 0, classBytes.length);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+
+        private boolean shouldDefineLocally(final String name) {
+            return name.startsWith("org.jboss.logmanager.")
+                    || BootstrapFormattingInvoker.class.getName().equals(name);
+        }
     }
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -8,9 +8,11 @@ package org_jboss_logmanager.jboss_logmanager;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.Objects;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import org.graalvm.internal.tck.NativeImageSupport;
 import org.jboss.logmanager.ExtLogRecord;
@@ -46,7 +48,7 @@ public class FormattersAnonymous12Test {
 
     @Test
     void extendedExceptionFormattingFallsBackToBootstrapClassLoaderWhenOwningLoaderCannotLoadFrameClass()
-            throws Exception {
+            throws Throwable {
         try {
             String className = "java.util.HexFormat";
             BootstrapFallbackClassLoader classLoader = new BootstrapFallbackClassLoader(className);
@@ -55,7 +57,7 @@ public class FormattersAnonymous12Test {
             String formatted = formattingAction.format(newFailure(className));
 
             assertThat(formatted).contains("\tat " + className + ".invoke");
-            assertThat(classLoader.wasRejected()).isTrue();
+            assertThat(classLoader.getRejectedCount()).isGreaterThanOrEqualTo(2);
         } catch (Error error) {
             if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
                 throw error;
@@ -93,7 +95,9 @@ public class FormattersAnonymous12Test {
     }
 
     public static final class BootstrapFormattingInvoker implements BootstrapFormattingAction {
-        public BootstrapFormattingInvoker() {
+        public static final BootstrapFormattingAction INSTANCE = new BootstrapFormattingInvoker();
+
+        private BootstrapFormattingInvoker() {
         }
 
         @Override
@@ -102,11 +106,7 @@ public class FormattersAnonymous12Test {
             try {
                 Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
                 PatternFormatter formatter = new PatternFormatter("%E");
-                ExtLogRecord record = new ExtLogRecord(
-                        Level.SEVERE,
-                        "coverage",
-                        BootstrapFormattingInvoker.class.getName()
-                );
+                LogRecord record = new LogRecord(Level.SEVERE, "coverage");
                 record.setThrown(thrown);
                 return formatter.format(record);
             } finally {
@@ -140,21 +140,25 @@ public class FormattersAnonymous12Test {
 
     private static final class BootstrapFallbackClassLoader extends ClassLoader {
         private final String rejectedClassName;
-        private boolean rejected;
+        private int rejectedCount;
 
         private BootstrapFallbackClassLoader(final String rejectedClassName) {
             super(FormattersAnonymous12Test.class.getClassLoader());
             this.rejectedClassName = rejectedClassName;
         }
 
-        BootstrapFormattingAction loadFormattingAction() throws Exception {
-            Class<?> actionClass = loadClass(BootstrapFormattingInvoker.class.getName());
-            Constructor<?> constructor = actionClass.getConstructor();
-            return BootstrapFormattingAction.class.cast(constructor.newInstance());
+        BootstrapFormattingAction loadFormattingAction() throws Throwable {
+            Class<?> actionClass = Class.forName(BootstrapFormattingInvoker.class.getName(), true, this);
+            VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
+                    actionClass,
+                    "INSTANCE",
+                    BootstrapFormattingAction.class
+            );
+            return BootstrapFormattingAction.class.cast(instanceHandle.get());
         }
 
-        boolean wasRejected() {
-            return rejected;
+        int getRejectedCount() {
+            return rejectedCount;
         }
 
         @Override
@@ -165,7 +169,7 @@ public class FormattersAnonymous12Test {
                     return alreadyLoaded;
                 }
                 if (rejectedClassName.equals(name)) {
-                    rejected = true;
+                    rejectedCount++;
                     throw new ClassNotFoundException(name);
                 }
                 if (shouldDefineLocally(name)) {

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.logmanager.ConfigurationLocator;
+import org.jboss.logmanager.LogManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogManagerTest {
+
+    @Test
+    void readConfigurationLoadsLocatorFromThreadContextClassLoader() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        TcclConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, TcclConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(TcclConfigurationLocator.class.getClassLoader());
+
+            new LogManager().readConfiguration();
+
+            assertThat(TcclConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(TcclConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            TcclConfigurationLocator.reset();
+        }
+    }
+
+    @Test
+    void readConfigurationFallsBackToLogManagerClassLoaderWhenTcclCannotLoadLocator() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        FallbackConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, FallbackConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(
+                    new RejectingClassLoader(originalTccl, FallbackConfigurationLocator.class.getName())
+            );
+
+            new LogManager().readConfiguration();
+
+            assertThat(FallbackConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(FallbackConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            FallbackConfigurationLocator.reset();
+        }
+    }
+
+    public static final class TcclConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public TcclConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    public static final class FallbackConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public FallbackConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyConfiguratorTest {
+
+    @Test
+    void configureInstantiatesAndConfiguresNamedComponents() throws IOException {
+        String loggerName = PropertyConfiguratorTest.class.getName() + ".configured";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    logger.%1$s.level=INFO
+                    logger.%1$s.filter=coverageFilter
+                    logger.%1$s.handlers=coverageHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.coverageHandler=%2$s
+                    handler.coverageHandler.level=INFO
+                    handler.coverageHandler.encoding=UTF-8
+                    handler.coverageHandler.errorManager=coverageErrorManager
+                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.formatter=coverageFormatter
+                    handler.coverageHandler.properties=label
+                    handler.coverageHandler.label=primary
+                    filter.coverageFilter=%3$s
+                    filter.coverageFilter.properties=enabled
+                    filter.coverageFilter.enabled=true
+                    formatter.coverageFormatter=%4$s
+                    formatter.coverageFormatter.properties=prefix
+                    formatter.coverageFormatter.prefix=formatted:
+                    errorManager.coverageErrorManager=%5$s
+                    errorManager.coverageErrorManager.properties=name
+                    errorManager.coverageErrorManager.name=once
+                    """.formatted(
+                    loggerName,
+                    TrackingHandler.class.getName(),
+                    TrackingFilter.class.getName(),
+                    TrackingFormatter.class.getName(),
+                    TrackingErrorManager.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
+                assertThat(handler.getLevel()).isEqualTo(Level.INFO);
+                assertThat(handler.getEncoding()).isEqualTo("UTF-8");
+                assertThat(handler.getLabel()).isEqualTo("primary");
+                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
+                assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,
+                        errorManager -> assertThat(errorManager.getName()).isEqualTo("once"));
+            });
+
+            TrackingHandler handler = (TrackingHandler) logger.getHandlers()[0];
+            logger.info("hello");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("formatted:hello");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class TrackingHandler extends Handler {
+        private String label;
+        private String lastPublishedMessage;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(final String label) {
+            this.label = label;
+        }
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        public ErrorManager getConfiguredErrorManager() {
+            return getErrorManager();
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    public static final class TrackingFilter implements Filter {
+        private boolean enabled;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean isLoggable(final LogRecord record) {
+            return enabled;
+        }
+    }
+
+    public static final class TrackingFormatter extends Formatter {
+        private String prefix = "";
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class TrackingErrorManager extends ErrorManager {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -34,17 +34,17 @@ public class PropertyConfiguratorTest {
             String configuration = """
                     loggers=%1$s
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
                     handler.coverageHandler.level=INFO
                     handler.coverageHandler.encoding=UTF-8
                     handler.coverageHandler.errorManager=coverageErrorManager
-                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.filter=filter coverageFilter
                     handler.coverageHandler.formatter=coverageFormatter
                     handler.coverageHandler.properties=label
                     handler.coverageHandler.label=primary
+                    filters=coverageFilter
                     filter.coverageFilter=%3$s
                     filter.coverageFilter.properties=enabled
                     filter.coverageFilter.enabled=true
@@ -68,13 +68,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
+      },
+      "glob" : "logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,258 @@
         "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
       },
       "glob" : "logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12$2"
+      },
+      "glob" : "logging.properties"
+    }
+  ],
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$CapturingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.HandlerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$CapturingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$ConstructorBackedFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$ConstructorBackedFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$ConstructorBackedFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FormatterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$ConstructorBackedFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.ErrorManagerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FilterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "setPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FormatterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.HandlerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
     }
   ]
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/logging.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+test.resource=thread-context-class-loader

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.logmanager.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4061

This PR provides test fixes and new metadata for org.jboss.logmanager:jboss-logmanager:1.3.0.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 219072
- Cached input tokens: 2427904
- Output tokens: 26075
- Metadata entries: 62
- Test-only metadata entries: 41
- Iterations: 4
- Library coverage percentage: 26.78
- Previous library version metadata entries: 20
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 26.14

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `f4f0f9be0e5eced44cb1b5ea24941f18c06b9a4f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 35/37 covered calls (94.59%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 28/29 covered calls (96.55%)

**Reflection:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 30/32 covered calls (93.75%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 23/24 covered calls (95.83%)

**Resources:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 5/5 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 3668/14217 (25.80%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5423/19835 (27.34%)

**Line:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 910/3481 (26.14%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 1234/4608 (26.78%)

**Method:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 185/786 (23.54%)
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 305/1083 (28.16%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
new file mode 100644
index 0000000000..bd2415d433
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -0,0 +1,118 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void constructorPropertyTypeIsResolvedFromPublicGetter() throws IOException {
+        String loggerName = AbstractPropertyConfigurationTest.class.getName() + ".constructorProperty";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    logger.%1$s.level=INFO
+                    logger.%1$s.handlers=constructorHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.constructorHandler=%2$s
+                    handler.constructorHandler.level=INFO
+                    handler.constructorHandler.formatter=constructorFormatter
+                    formatter.constructorFormatter=%3$s
+                    formatter.constructorFormatter.constructorProperties=prefix
+                    formatter.constructorFormatter.properties=prefix
+                    formatter.constructorFormatter.prefix=constructed:
+                    """.formatted(
+                    loggerName,
+                    CapturingHandler.class.getName(),
+                    ConstructorBackedFormatter.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(CapturingHandler.class, handler -> {
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(ConstructorBackedFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("constructed:"));
+            });
+
+            CapturingHandler handler = (CapturingHandler) logger.getHandlers()[0];
+            logger.info("message");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("constructed:message");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class ConstructorBackedFormatter extends Formatter {
+        private final String prefix;
+
+        public ConstructorBackedFormatter(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class CapturingHandler extends Handler {
+        private String lastPublishedMessage;
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
index 68821c95cc..a62ee56843 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -6,8 +6,15 @@
  */
 package org_jboss_logmanager.jboss_logmanager;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Test;
@@ -25,6 +32,43 @@ public class FormattersAnonymous12Test {
         assertThat(formatted).contains("\tat " + className + ".invoke");
     }
 
+    @Test
+    void extendedExceptionFormattingFallsBackFromContextClassLoaderToFormatterClassLoader() {
+        String className = PatternFormatter.class.getName();
+        RejectingClassLoader rejectingClassLoader = new RejectingClassLoader(
+                FormattersAnonymous12Test.class.getClassLoader(),
+                className
+        );
+
+        String formatted = formatWithTccl(rejectingClassLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+        if (!isNativeImageRuntime()) {
+            assertThat(rejectingClassLoader.wasRejected()).isTrue();
+        }
+    }
+
+    @Test
+    void extendedExceptionFormattingFallsBackToBootstrapClassLoaderWhenOwningLoaderCannotLoadFrameClass()
+            throws Throwable {
+        try {
+            String className = "java.util.HexFormat";
+            BootstrapFallbackClassLoader classLoader = new BootstrapFallbackClassLoader(className);
+            BootstrapFormattingAction formattingAction = classLoader.loadFormattingAction();
+
+            String formatted = formattingAction.format(newFailure(className));
+
+            assertThat(formatted).contains("\tat " + className + ".invoke");
+            if (!isNativeImageRuntime()) {
+                assertThat(classLoader.getRejectedCount()).isGreaterThanOrEqualTo(2);
+            }
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
     private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
         ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         try {
@@ -49,4 +93,119 @@ public class FormattersAnonymous12Test {
         });
         return failure;
     }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+
+    public interface BootstrapFormattingAction {
+        String format(Throwable thrown);
+    }
+
+    public static final class BootstrapFormattingInvoker implements BootstrapFormattingAction {
+        public static final BootstrapFormattingAction INSTANCE = new BootstrapFormattingInvoker();
+
+        private BootstrapFormattingInvoker() {
+        }
+
+        @Override
+        public String format(final Throwable thrown) {
+            ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                PatternFormatter formatter = new PatternFormatter("%E");
+                LogRecord record = new LogRecord(Level.SEVERE, "coverage");
+                record.setThrown(thrown);
+                return formatter.format(record);
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalTccl);
+            }
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private boolean rejected;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        boolean wasRejected() {
+            return rejected;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                rejected = true;
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class BootstrapFallbackClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+        private int rejectedCount;
+
+        private BootstrapFallbackClassLoader(final String rejectedClassName) {
+            super(FormattersAnonymous12Test.class.getClassLoader());
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        BootstrapFormattingAction loadFormattingAction() throws Throwable {
+            Class<?> actionClass = Class.forName(BootstrapFormattingInvoker.class.getName(), true, this);
+            VarHandle instanceHandle = MethodHandles.publicLookup().findStaticVarHandle(
+                    actionClass,
+                    "INSTANCE",
+                    BootstrapFormattingAction.class
+            );
+            return BootstrapFormattingAction.class.cast(instanceHandle.get());
+        }
+
+        int getRejectedCount() {
+            return rejectedCount;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> alreadyLoaded = findLoadedClass(name);
+                if (alreadyLoaded != null) {
+                    return alreadyLoaded;
+                }
+                if (rejectedClassName.equals(name)) {
+                    rejectedCount++;
+                    throw new ClassNotFoundException(name);
+                }
+                if (shouldDefineLocally(name)) {
+                    Class<?> localClass = findClass(name);
+                    if (resolve) {
+                        resolveClass(localClass);
+                    }
+                    return localClass;
+                }
+                return super.loadClass(name, resolve);
+            }
+        }
+
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream inputStream = FormattersAnonymous12Test.class.getClassLoader()
+                    .getResourceAsStream(resourceName)) {
+                byte[] classBytes = Objects.requireNonNull(inputStream, resourceName).readAllBytes();
+                return defineClass(name, classBytes, 0, classBytes.length);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+
+        private boolean shouldDefineLocally(final String name) {
+            return name.startsWith("org.jboss.logmanager.")
+                    || BootstrapFormattingInvoker.class.getName().equals(name);
+        }
+    }
 }
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
index c9014d0ca0..5572032ab6 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -34,17 +34,17 @@ public class PropertyConfiguratorTest {
             String configuration = """
                     loggers=%1$s
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
                     handler.coverageHandler.level=INFO
                     handler.coverageHandler.encoding=UTF-8
                     handler.coverageHandler.errorManager=coverageErrorManager
-                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.filter=filter coverageFilter
                     handler.coverageHandler.formatter=coverageFormatter
                     handler.coverageHandler.properties=label
                     handler.coverageHandler.label=primary
+                    filters=coverageFilter
                     filter.coverageFilter=%3$s
                     filter.coverageFilter.properties=enabled
                     filter.coverageFilter.enabled=true
@@ -68,13 +68,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,

```
