### PR TITLE
Add Forge do-work stop markers

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -29,6 +29,9 @@ Common options:
 - `--parallelism N`: run up to `N` issue workflows in parallel. Maximum: 4.
 - `--review-limit N`: process up to `N` PR review tasks per label per cycle.
 - `--once`: run a single update/work cycle through `do_up_to_date_work.sh` and exit.
+- `--stop`: ask all Forge `do-work` loops for the current user to exit by creating `~/.metadata-forge-stop`.
+- `--stop --branch BRANCH`: ask only loops monitoring `BRANCH` to exit, using a branch-scoped marker such as `~/.metadata-forge-stop.master`.
+- `--clear-stop`: remove the matching global or branch-scoped stop marker so future `do-work` loops can run.
 
 Examples:
 
@@ -37,12 +40,17 @@ Examples:
 ./do-work.sh --parallelism 2
 DO_WORK_SLEEP_SECONDS=60 ./do-work.sh --branch master
 FORGE_REVIEW_LABEL=library-new-request ./do-work.sh --review-limit 2
+./do-work.sh --stop
+./do-work.sh --stop --branch master
+./do-work.sh --clear-stop
+./do-work.sh --clear-stop --branch master
 ```
 
 The same limits can be controlled with environment variables such as
 `FORGE_WORK_LIMIT`, `FORGE_JAVAC_WORK_LIMIT`, `FORGE_JAVA_RUN_WORK_LIMIT`,
 `FORGE_NI_RUN_WORK_LIMIT`, `FORGE_PARALLELISM`, `FORGE_REVIEW_LIMIT`,
-`FORGE_BULK_UPDATE_REVIEW_LIMIT`, and `DO_WORK_SLEEP_SECONDS`.
+`FORGE_BULK_UPDATE_REVIEW_LIMIT`, and `DO_WORK_SLEEP_SECONDS`. Set
+`FORGE_DO_WORK_STOP_FILE` to override the shared stop marker path.
 
 ## Setup
 

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -29,6 +29,18 @@ WORK_STRATEGY_NAME="${FORGE_STRATEGY_NAME:-dynamic_access_main_sources_pi_gpt-5.
 GITHUB_RATE_LIMIT_EXIT_CODE=75
 MAX_PARALLELISM=4
 RUN_ONCE=0
+REQUEST_STOP=0
+CLEAR_STOP=0
+BRANCH_ARG_PROVIDED=0
+SLEEP_POLL_SECONDS="${FORGE_DO_WORK_SLEEP_POLL_SECONDS:-5}"
+
+if [[ -n "${FORGE_DO_WORK_STOP_FILE:-}" ]]; then
+    STOP_FILE="$FORGE_DO_WORK_STOP_FILE"
+elif [[ -n "${HOME:-}" ]]; then
+    STOP_FILE="$HOME/.metadata-forge-stop"
+else
+    STOP_FILE=""
+fi
 
 LOCAL_REPOSITORIES_DIR="$SCRIPT_DIR/local_repositories"
 REACHABILITY_REPO_DIR="$LOCAL_REPOSITORIES_DIR/graalvm-reachability-metadata"
@@ -56,6 +68,14 @@ Options:
       Show this help text.
   --once
       Run one update/work cycle and exit without sleeping.
+  --stop
+      Request Forge do-work loops to exit. Without a branch argument this
+      creates the global stop marker ~/.metadata-forge-stop. With --branch or
+      a positional branch, it creates a branch-scoped marker next to the global
+      marker, for example ~/.metadata-forge-stop.master.
+  --clear-stop, --resume
+      Clear the matching global or branch-scoped stop marker so future do-work
+      loops can run.
   --branch BRANCH
       Branch to monitor on origin. Equivalent to the optional positional
       metadata-forge-branch argument.
@@ -94,6 +114,8 @@ Environment:
   DO_WORK_MONITORED_BRANCH
       Branch to monitor when no branch argument is provided. Defaults to
       DO_MY_WORK_MONITORED_BRANCH, then master.
+  FORGE_DO_WORK_STOP_FILE
+      Path to the shared stop marker. Defaults to ~/.metadata-forge-stop.
   FORGE_RANDOM_WORK_OFFSET
       Set to 1 to start new-library issue scans at a random offset, or 0 to
       scan from the beginning. Defaults to 1.
@@ -158,6 +180,72 @@ require_parallelism() {
 
 log() {
     printf '[%(%Y-%m-%d %H:%M:%S)T] %s\n' -1 "$1"
+}
+
+require_stop_file() {
+    if [[ -z "$STOP_FILE" ]]; then
+        echo "HOME is not set; set FORGE_DO_WORK_STOP_FILE to use --stop or run do-work loops." >&2
+        exit 1
+    fi
+}
+
+request_stop() {
+    local target_file="$1"
+    local scope="$2"
+
+    mkdir -p -- "$(dirname -- "$target_file")"
+    printf 'Metadata Forge shutdown requested at %(%Y-%m-%d %H:%M:%S %Z)T\n' -1 > "$target_file"
+    log "Requested ${scope} Forge do-work loops to stop via ${target_file}."
+}
+
+clear_stop() {
+    local target_file="$1"
+    local scope="$2"
+
+    rm -f -- "$target_file"
+    log "Cleared ${scope} Forge do-work stop marker at ${target_file}."
+}
+
+sanitize_branch_for_stop_file() {
+    local branch="${1#origin/}"
+    local sanitized="${branch//\//_}"
+    sanitized="${sanitized//[!a-zA-Z0-9._-]/_}"
+    printf '%s' "$sanitized"
+}
+
+get_branch_stop_file() {
+    local branch="$1"
+    printf '%s.%s' "$STOP_FILE" "$(sanitize_branch_for_stop_file "$branch")"
+}
+
+is_stop_requested() {
+    [[ -e "$STOP_FILE" || -e "$(get_branch_stop_file "$MONITORED_BRANCH")" ]]
+}
+
+exit_if_stop_requested() {
+    if is_stop_requested; then
+        if [[ -e "$STOP_FILE" ]]; then
+            log "Forge do-work stop marker exists at ${STOP_FILE}; exiting."
+        else
+            log "Forge do-work stop marker exists at $(get_branch_stop_file "$MONITORED_BRANCH"); exiting."
+        fi
+        exit 0
+    fi
+}
+
+interruptible_sleep() {
+    local remaining="$1"
+    local sleep_chunk
+
+    while [[ "$remaining" -gt 0 ]]; do
+        exit_if_stop_requested
+        sleep_chunk="$remaining"
+        if [[ "$sleep_chunk" -gt "$SLEEP_POLL_SECONDS" ]]; then
+            sleep_chunk="$SLEEP_POLL_SECONDS"
+        fi
+        sleep "$sleep_chunk"
+        remaining=$((remaining - sleep_chunk))
+    done
 }
 
 display_github_rate_limits() {
@@ -307,6 +395,8 @@ process_work_queues() {
 run_cycle() {
     local iteration="${DO_UP_TO_DATE_WORK_ITERATION:-0}"
 
+    exit_if_stop_requested
+
     if ! [[ "$iteration" =~ ^[0-9]+$ ]]; then
         iteration=0
     fi
@@ -331,6 +421,8 @@ run_cycle() {
     if ! process_work_queues; then
         log "do_up_to_date_work.sh failed; retrying after sleep."
     fi
+
+    exit_if_stop_requested
 }
 
 ORIGINAL_ARGS=("$@")
@@ -346,13 +438,23 @@ while [[ "$#" -gt 0 ]]; do
             RUN_ONCE=1
             shift
             ;;
+        --stop)
+            REQUEST_STOP=1
+            shift
+            ;;
+        --clear-stop|--resume)
+            CLEAR_STOP=1
+            shift
+            ;;
         --branch)
             require_option_value "$1" "${2:-}"
             BRANCH_ARG="$2"
+            BRANCH_ARG_PROVIDED=1
             shift 2
             ;;
         --branch=*)
             BRANCH_ARG="${1#*=}"
+            BRANCH_ARG_PROVIDED=1
             shift
             ;;
         --javac-limit|--javac-work-limit)
@@ -424,6 +526,9 @@ while [[ "$#" -gt 0 ]]; do
                 exit 1
             fi
             BRANCH_ARG="${1:-}"
+            if [[ -n "$BRANCH_ARG" ]]; then
+                BRANCH_ARG_PROVIDED=1
+            fi
             shift "$#"
             ;;
         -*)
@@ -437,6 +542,7 @@ while [[ "$#" -gt 0 ]]; do
                 exit 1
             fi
             BRANCH_ARG="$1"
+            BRANCH_ARG_PROVIDED=1
             shift
             ;;
     esac
@@ -451,6 +557,31 @@ if [[ "$MONITORED_BRANCH" == "" ]]; then
     exit 1
 fi
 
+require_stop_file
+
+if [[ "$REQUEST_STOP" == "1" && "$CLEAR_STOP" == "1" ]]; then
+    echo "--stop cannot be combined with --clear-stop or --resume." >&2
+    exit 1
+fi
+
+if [[ "$REQUEST_STOP" == "1" ]]; then
+    if [[ "$BRANCH_ARG_PROVIDED" == "1" ]]; then
+        request_stop "$(get_branch_stop_file "$MONITORED_BRANCH")" "branch '${MONITORED_BRANCH}'"
+    else
+        request_stop "$STOP_FILE" "all"
+    fi
+    exit 0
+fi
+
+if [[ "$CLEAR_STOP" == "1" ]]; then
+    if [[ "$BRANCH_ARG_PROVIDED" == "1" ]]; then
+        clear_stop "$(get_branch_stop_file "$MONITORED_BRANCH")" "branch '${MONITORED_BRANCH}'"
+    else
+        clear_stop "$STOP_FILE" "all"
+    fi
+    exit 0
+fi
+
 require_positive_integer "DO_WORK_SLEEP_SECONDS" "$SLEEP_SECONDS"
 require_positive_integer "DO_WORK_CLEAN_LOCAL_REPOSITORIES_EVERY" "$CLEAN_LOCAL_REPOSITORIES_EVERY"
 require_nonnegative_integer "FORGE_JAVAC_WORK_LIMIT" "$JAVAC_WORK_LIMIT"
@@ -460,6 +591,7 @@ require_nonnegative_integer "FORGE_LIBRARY_UPDATE_WORK_LIMIT" "$LIBRARY_UPDATE_W
 require_nonnegative_integer "FORGE_WORK_LIMIT" "$WORK_LIMIT"
 require_nonnegative_integer "FORGE_REVIEW_LIMIT" "$REVIEW_LIMIT"
 require_parallelism "$PARALLELISM"
+require_positive_integer "FORGE_DO_WORK_SLEEP_POLL_SECONDS" "$SLEEP_POLL_SECONDS"
 
 if [[ "$RANDOM_WORK_OFFSET" != "0" && "$RANDOM_WORK_OFFSET" != "1" ]]; then
     echo "FORGE_RANDOM_WORK_OFFSET must be 0 or 1." >&2
@@ -467,6 +599,7 @@ if [[ "$RANDOM_WORK_OFFSET" != "0" && "$RANDOM_WORK_OFFSET" != "1" ]]; then
 fi
 
 export_work_configuration
+exit_if_stop_requested
 run_cycle
 
 if [[ "$RUN_ONCE" == "1" ]]; then
@@ -474,5 +607,5 @@ if [[ "$RUN_ONCE" == "1" ]]; then
 fi
 
 log "Sleeping for ${SLEEP_SECONDS} second(s)."
-sleep "$SLEEP_SECONDS"
+interruptible_sleep "$SLEEP_SECONDS"
 exec "$SCRIPT_DIR/do_up_to_date_work.sh" "${ORIGINAL_ARGS[@]}"

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -144,8 +144,9 @@ Key invariants (unchanged from the functional spec):
   parsed.
 - **[do_up_to_date_work.sh](../do_up_to_date_work.sh)** — long-running
   up-to-date worker. Parses arguments, updates the Forge checkout, runs one
-  configured work cycle, sleeps `DO_WORK_SLEEP_SECONDS`, and re-execs the
-  latest script before the next cycle.
+  configured work cycle, sleeps `DO_WORK_SLEEP_SECONDS`, honors the shared
+  stop marker at `~/.metadata-forge-stop` plus branch-scoped markers beside
+  it, and re-execs the latest script before the next cycle.
 - **[forge_metadata.py](../forge_metadata.py)** — dispatcher. Fetches GitHub
   issues by label, claims them via optimistic locking (assignee + verify),
   creates an isolated worktree, routes the claim to the matching workflow

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -58,12 +58,19 @@ supporting tests for the reachability repo.
 ### 4.1 Top-level worker bootstrap
 
 - `do-work.sh` is a fixed bootstrap script and must not be changed for worker
-  behavior updates. Its only user-facing input is the selected branch; it
-  forwards `argv` unchanged to `do_up_to_date_work.sh`, where every option and
-  environment concern is handled.
+  behavior updates. It forwards `argv` unchanged to
+  `do_up_to_date_work.sh`, where every option and environment concern is
+  handled.
 - `do_up_to_date_work.sh` owns argument parsing, environment normalization,
   Forge self-updates, queue dispatch, sleep timing, and re-execing the latest
   worker script.
+- `do_up_to_date_work.sh --stop` creates a shared stop marker for the current
+  user at `~/.metadata-forge-stop` by default. Passing `--branch BRANCH` or a
+  positional branch creates a branch-scoped marker next to it, such as
+  `~/.metadata-forge-stop.master`. Running `--clear-stop` removes the matching
+  marker. Existing worker loops check the global marker and the marker for
+  their monitored branch between queue operations and during sleep, then exit
+  without claiming additional work.
 
 ### 4.2 CLI inputs (common to all entry scripts)
 
@@ -105,6 +112,8 @@ Each entry in `strategies/predefined_strategies.json` must provide:
   script in `git_scripts/` or `complete_pipelines/`.
 - `FORGE_PARALLELISM` controls how many issue workflows the top-level worker
   may run concurrently. Valid values are `1` through `4`; the default is `1`.
+- `FORGE_DO_WORK_STOP_FILE` overrides the shared stop marker path used by
+  `do-work` loops. The default is `~/.metadata-forge-stop`.
 
 ## 5. Outputs
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -78,6 +78,7 @@ from utility_scripts.repo_path_resolver import (
     resolve_repo_roots,
 )
 from utility_scripts.stage_logger import log_stage
+from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
 from utility_scripts.task_logs import (
     build_task_log_path,
@@ -170,8 +171,12 @@ CODEX_REVIEW_TIMEOUT_SECONDS = 1800
 DEFAULT_WORKTREE_BASE_REF = "master"
 POST_GENERATION_GRAALVM_ENV_VAR = "GRAALVM_HOME_25_0"
 INTERRUPT_EXIT_CODES = {130, -int(signal.SIGINT)}
+INTERRUPT_REASON_CTRL_C = "Ctrl+C interrupt"
+INTERRUPT_REASON_SHUTDOWN = "shutdown request"
+SHUTDOWN_SIGNAL_POLL_SECONDS = 5.0
 
 _user_interrupt_requested = threading.Event()
+_user_interrupt_reason = INTERRUPT_REASON_CTRL_C
 
 
 @dataclass(frozen=True)
@@ -262,19 +267,52 @@ class FailurePreservationResult:
     committed_changes: bool
 
 
-def mark_user_interrupt_requested() -> None:
-    """Record that the current run is shutting down because of Ctrl+C."""
+def mark_user_interrupt_requested(reason: str = INTERRUPT_REASON_CTRL_C) -> None:
+    """Record that the current run is shutting down before normal completion."""
+    global _user_interrupt_reason
+
+    _user_interrupt_reason = reason
     _user_interrupt_requested.set()
 
 
 def clear_user_interrupt_requested() -> None:
-    """Clear the Ctrl+C marker before starting a new top-level run."""
+    """Clear the shutdown marker before starting a new top-level run."""
+    global _user_interrupt_reason
+
+    _user_interrupt_reason = INTERRUPT_REASON_CTRL_C
     _user_interrupt_requested.clear()
 
 
 def is_user_interrupt_requested() -> bool:
-    """Return True when the current run is unwinding after Ctrl+C."""
+    """Return True when the current run is unwinding before normal completion."""
     return _user_interrupt_requested.is_set()
+
+
+def get_user_interrupt_reason() -> str:
+    """Return the current run's shutdown reason."""
+    return _user_interrupt_reason
+
+
+def is_shutdown_request_interrupt() -> bool:
+    """Return True when the current run is stopping because of the shared marker."""
+    return is_user_interrupt_requested() and get_user_interrupt_reason() == INTERRUPT_REASON_SHUTDOWN
+
+
+def mark_shutdown_requested() -> None:
+    """Record that the shared Forge stop marker requested shutdown."""
+    mark_user_interrupt_requested(INTERRUPT_REASON_SHUTDOWN)
+
+
+def describe_active_shutdown_signal_path() -> str:
+    """Return the active stop marker path for log messages."""
+    return get_active_shutdown_signal_path() or "the configured stop marker"
+
+
+def raise_if_shutdown_requested() -> None:
+    """Raise KeyboardInterrupt when the shared Forge stop marker exists."""
+    if is_shutdown_requested():
+        mark_shutdown_requested()
+        raise KeyboardInterrupt
 
 
 def is_interrupt_exit_code(returncode: int | None) -> bool:
@@ -292,7 +330,7 @@ def is_interrupt_exception(exc: BaseException) -> bool:
 
 
 def _handle_sigint(_signum, _frame) -> None:
-    mark_user_interrupt_requested()
+    mark_user_interrupt_requested(INTERRUPT_REASON_CTRL_C)
     raise KeyboardInterrupt
 
 
@@ -2932,6 +2970,12 @@ def run_pull_request_review_loop(
     """Run pull request reviews once or repeatedly after each configured period."""
     iteration = 1
     while True:
+        if is_shutdown_requested():
+            log_stage(
+                "shutdown",
+                f"Stop marker exists at {describe_active_shutdown_signal_path()}; skipping pull request review loop",
+            )
+            return
         if period_seconds is not None:
             print(f"\n[Starting review iteration {iteration}.]")
         process_pull_requests_with_label(
@@ -2944,8 +2988,25 @@ def run_pull_request_review_loop(
         if period_seconds is None:
             return
         print(f"[Sleeping {period_seconds} second(s) before the next review iteration.]")
-        time.sleep(period_seconds)
+        if sleep_until_shutdown_or_timeout(period_seconds):
+            return
         iteration += 1
+
+
+def sleep_until_shutdown_or_timeout(period_seconds: int) -> bool:
+    """Sleep for up to the requested period and return True if shutdown was requested."""
+    deadline = time.monotonic() + period_seconds
+    while True:
+        if is_shutdown_requested():
+            log_stage(
+                "shutdown",
+                f"Stop marker exists at {describe_active_shutdown_signal_path()}; exiting sleep",
+            )
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(remaining, SHUTDOWN_SIGNAL_POLL_SECONDS))
 
 
 def build_issue_run_id(issue_number: int) -> str:
@@ -4069,6 +4130,13 @@ def process_issues_with_label(
     reflects only issues that were successfully claimed for processing.
     """
     in_metadata_repo = True
+    if is_shutdown_requested():
+        log_stage(
+            "shutdown",
+            f"Stop marker exists at {describe_active_shutdown_signal_path()}; skipping issue queue '{label}'",
+        )
+        return 0
+
     if not environment_already_validated:
         validate_issue_processing_environment()
 
@@ -4087,7 +4155,9 @@ def process_issues_with_label(
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=parallelism)
     try:
         while processed_count < limit or active_futures:
+            raise_if_shutdown_requested()
             while processed_count < limit and len(active_futures) < parallelism:
+                raise_if_shutdown_requested()
                 remaining_limit = limit - processed_count
                 available_slots = min(remaining_limit, parallelism - len(active_futures))
                 if not pending_issues:
@@ -4142,6 +4212,7 @@ def process_issues_with_label(
                         break
 
                 while pending_issues and processed_count < limit and len(active_futures) < parallelism:
+                    raise_if_shutdown_requested()
                     issue, preflight, cached_skip = pending_issues.pop(0)
                     if should_skip_issue_from_preflight(issue, preflight, cached_skip, authenticated_user):
                         continue
@@ -4173,15 +4244,27 @@ def process_issues_with_label(
 
             done_futures, _ = concurrent.futures.wait(
                 active_futures.keys(),
+                timeout=SHUTDOWN_SIGNAL_POLL_SECONDS,
                 return_when=concurrent.futures.FIRST_COMPLETED,
             )
+            if not done_futures:
+                continue
             for future in done_futures:
                 active_futures.pop(future, None)
                 future.result()
     except KeyboardInterrupt:
-        mark_user_interrupt_requested()
+        if is_shutdown_requested():
+            mark_shutdown_requested()
+        else:
+            mark_user_interrupt_requested()
+        interrupt_reason = get_user_interrupt_reason()
+        interrupt_message = (
+            f"Shutdown requested via {describe_active_shutdown_signal_path()}"
+            if interrupt_reason == INTERRUPT_REASON_SHUTDOWN
+            else "Ctrl+C received"
+        )
         print(
-            "\n[Ctrl+C received. Reverting all active claimed issues before exit.]",
+            f"\n[{interrupt_message}. Reverting all active claimed issues before exit.]",
             file=sys.stderr,
         )
         for future, claimed_issue in list(active_futures.items()):
@@ -4190,7 +4273,7 @@ def process_issues_with_label(
                     f"[Cancelled queued issue #{claimed_issue.issue['number']} future before revert.]",
                     file=sys.stderr,
                 )
-            revert_claimed_issue(claimed_issue, "Ctrl+C interrupt in main loop")
+            revert_claimed_issue(claimed_issue, f"{interrupt_reason} in main loop")
         raise
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
@@ -4221,10 +4304,23 @@ def process_work_queues(
     parallelism = get_env_parallelism("FORGE_PARALLELISM", parallelism_default)
     enabled_issue_queues = [queue_config for queue_config in queue_configs if queue_config.limit > 0]
 
+    if is_shutdown_requested():
+        log_stage(
+            "shutdown",
+            f"Stop marker exists at {describe_active_shutdown_signal_path()}; skipping all work queues",
+        )
+        return
+
     if enabled_issue_queues:
         validate_issue_processing_environment()
 
     for queue_config in queue_configs:
+        if is_shutdown_requested():
+            log_stage(
+                "shutdown",
+                f"Stop marker exists at {describe_active_shutdown_signal_path()}; skipping remaining work queues",
+            )
+            return
         if queue_config.limit <= 0:
             print()
             log_stage("work-queue", f"Skipping issue queue '{queue_config.label}' because its limit is 0")
@@ -4259,6 +4355,12 @@ def process_work_queues(
         )
 
     for review_queue_config in review_queue_configs:
+        if is_shutdown_requested():
+            log_stage(
+                "shutdown",
+                f"Stop marker exists at {describe_active_shutdown_signal_path()}; skipping remaining review queues",
+            )
+            return
         if review_queue_config.limit <= 0:
             print()
             log_stage("work-queue", f"Skipping review queue '{review_queue_config.label}' because its limit is 0")
@@ -4491,7 +4593,16 @@ def main() -> None:
                 in_metadata_repo=args.in_metadata_repo,
             )
     except KeyboardInterrupt:
-        mark_user_interrupt_requested()
+        if is_shutdown_requested():
+            mark_shutdown_requested()
+        else:
+            mark_user_interrupt_requested()
+        if is_shutdown_request_interrupt():
+            print(
+                f"\nRun stopped because the Forge stop marker exists at {describe_active_shutdown_signal_path()}.",
+                file=sys.stderr,
+            )
+            sys.exit(0)
         print("\nERROR: Run interrupted by Ctrl+C.", file=sys.stderr)
         sys.exit(130)
     except GitHubRateLimitExceeded as exc:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -810,6 +810,28 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "review-model",
         )
 
+    def test_process_work_queues_skips_remaining_work_when_shutdown_requested(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "1",
+            "FORGE_REVIEW_LIMIT": "1",
+            "FORGE_REVIEW_LABEL": forge_metadata.LABEL_LIBRARY_NEW,
+        }
+
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(forge_metadata, "is_shutdown_requested", return_value=True), \
+                patch.object(forge_metadata, "validate_issue_processing_environment") as validate_environment, \
+                patch.object(forge_metadata, "process_issues_with_label") as process_issues, \
+                patch.object(forge_metadata, "process_pull_requests_with_label") as process_reviews:
+            forge_metadata.process_work_queues(
+                "/tmp/reachability",
+                "/tmp/metrics",
+                "automation-user",
+            )
+
+        validate_environment.assert_not_called()
+        process_issues.assert_not_called()
+        process_reviews.assert_not_called()
+
 
 class IssueClaimCacheTests(unittest.TestCase):
     def test_read_cache_ignores_missing_corrupt_and_expired_cache(self) -> None:
@@ -1299,6 +1321,26 @@ class InterruptHandlingTests(unittest.TestCase):
 
         post_issue_comment.assert_not_called()
         add_issue_label.assert_not_called()
+
+    def test_process_issues_with_label_skips_queue_when_shutdown_requested(self) -> None:
+        with patch.object(forge_metadata, "is_shutdown_requested", return_value=True), \
+                patch.object(forge_metadata, "validate_issue_processing_environment") as validate_environment, \
+                patch.object(forge_metadata, "resolve_authenticated_user") as resolve_authenticated_user:
+            processed = forge_metadata.process_issues_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                1,
+                0,
+                "/tmp/reachability",
+                "/tmp/metrics",
+                None,
+                False,
+                "automation-user",
+                1,
+            )
+
+        self.assertEqual(processed, 0)
+        validate_environment.assert_not_called()
+        resolve_authenticated_user.assert_not_called()
 
 
 class PullRequestReviewTests(unittest.TestCase):

--- a/forge/tests/test_shutdown_signal.py
+++ b/forge/tests/test_shutdown_signal.py
@@ -1,0 +1,54 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts import shutdown_signal
+
+
+class ShutdownSignalTests(unittest.TestCase):
+    def test_shutdown_signal_defaults_to_home_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as home_dir:
+            with patch.dict(os.environ, {"HOME": home_dir}, clear=True):
+                self.assertEqual(
+                    shutdown_signal.get_shutdown_signal_path(),
+                    os.path.join(home_dir, ".metadata-forge-stop"),
+                )
+
+    def test_shutdown_signal_can_be_requested_and_cleared(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            signal_path = os.path.join(temp_dir, "stop")
+            with patch.dict(os.environ, {"FORGE_DO_WORK_STOP_FILE": signal_path}, clear=True):
+                self.assertFalse(shutdown_signal.is_shutdown_requested())
+                self.assertEqual(shutdown_signal.request_shutdown(), signal_path)
+                self.assertTrue(shutdown_signal.is_shutdown_requested())
+                self.assertEqual(shutdown_signal.clear_shutdown_request(), signal_path)
+                self.assertFalse(shutdown_signal.is_shutdown_requested())
+
+    def test_branch_shutdown_signal_applies_only_to_monitored_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            signal_path = os.path.join(temp_dir, "stop")
+            with patch.dict(os.environ, {"FORGE_DO_WORK_STOP_FILE": signal_path}, clear=True):
+                branch_signal_path = shutdown_signal.request_shutdown("origin/feature/test")
+
+                self.assertEqual(branch_signal_path, f"{signal_path}.feature_test")
+                self.assertFalse(shutdown_signal.is_shutdown_requested())
+
+            with patch.dict(
+                    os.environ,
+                    {
+                        "FORGE_DO_WORK_STOP_FILE": signal_path,
+                        "FORGE_MONITORED_BRANCH": "origin/feature/test",
+                    },
+                    clear=True,
+            ):
+                self.assertTrue(shutdown_signal.is_shutdown_requested())
+                self.assertEqual(shutdown_signal.get_active_shutdown_signal_path(), branch_signal_path)
+
+            with patch.dict(os.environ, {"FORGE_DO_WORK_STOP_FILE": signal_path}, clear=True):
+                shutdown_signal.clear_shutdown_request("feature/test")

--- a/forge/utility_scripts/shutdown_signal.py
+++ b/forge/utility_scripts/shutdown_signal.py
@@ -1,0 +1,83 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Shared stop marker helpers for Forge worker loops."""
+
+import os
+import re
+import time
+
+DEFAULT_SHUTDOWN_SIGNAL_FILENAME = ".metadata-forge-stop"
+SHUTDOWN_SIGNAL_ENV_VAR = "FORGE_DO_WORK_STOP_FILE"
+MONITORED_BRANCH_ENV_VAR = "FORGE_MONITORED_BRANCH"
+
+
+def normalize_monitored_branch(branch_name: str) -> str:
+    """Return the branch name used for branch-scoped stop markers."""
+    return branch_name.removeprefix("origin/")
+
+
+def sanitize_branch_for_signal_path(branch_name: str) -> str:
+    """Return a filesystem-safe branch marker suffix."""
+    normalized_branch = normalize_monitored_branch(branch_name)
+    return re.sub(r"[^A-Za-z0-9._-]", "_", normalized_branch)
+
+
+def get_shutdown_signal_path() -> str:
+    """Return the filesystem path used to request all Forge workers to stop."""
+    configured_path = os.environ.get(SHUTDOWN_SIGNAL_ENV_VAR)
+    if configured_path:
+        return os.path.abspath(os.path.expanduser(configured_path))
+    return os.path.join(os.path.expanduser("~"), DEFAULT_SHUTDOWN_SIGNAL_FILENAME)
+
+
+def get_branch_shutdown_signal_path(branch_name: str) -> str:
+    """Return the filesystem path used to stop workers for one Forge branch."""
+    return f"{get_shutdown_signal_path()}.{sanitize_branch_for_signal_path(branch_name)}"
+
+
+def get_monitored_branch_shutdown_signal_path() -> str | None:
+    """Return the active branch stop marker path, if this process monitors a branch."""
+    monitored_branch = os.environ.get(MONITORED_BRANCH_ENV_VAR)
+    if not monitored_branch:
+        return None
+    return get_branch_shutdown_signal_path(monitored_branch)
+
+
+def get_active_shutdown_signal_path() -> str | None:
+    """Return the existing stop marker path that applies to this process."""
+    global_signal_path = get_shutdown_signal_path()
+    if os.path.exists(global_signal_path):
+        return global_signal_path
+    branch_signal_path = get_monitored_branch_shutdown_signal_path()
+    if branch_signal_path and os.path.exists(branch_signal_path):
+        return branch_signal_path
+    return None
+
+
+def is_shutdown_requested() -> bool:
+    """Return True when a global or monitored-branch Forge stop marker exists."""
+    return get_active_shutdown_signal_path() is not None
+
+
+def request_shutdown(branch_name: str | None = None) -> str:
+    """Create a global or branch-scoped Forge stop marker and return its path."""
+    signal_path = get_branch_shutdown_signal_path(branch_name) if branch_name else get_shutdown_signal_path()
+    signal_dir = os.path.dirname(signal_path)
+    if signal_dir:
+        os.makedirs(signal_dir, exist_ok=True)
+    with open(signal_path, "w", encoding="utf-8") as signal_file:
+        signal_file.write(f"Metadata Forge shutdown requested at {time.strftime('%Y-%m-%d %H:%M:%S %Z')}\n")
+    return signal_path
+
+
+def clear_shutdown_request(branch_name: str | None = None) -> str:
+    """Remove a global or branch-scoped Forge stop marker and return its path."""
+    signal_path = get_branch_shutdown_signal_path(branch_name) if branch_name else get_shutdown_signal_path()
+    try:
+        os.remove(signal_path)
+    except FileNotFoundError:
+        pass
+    return signal_path


### PR DESCRIPTION
## What does this PR do?

Adds a shared stop-marker mechanism for Forge do-work loops. Operators can now run:

- `./do-work.sh --stop` to stop all Forge workers for the current user
- `./do-work.sh --stop --branch <branch>` to stop only workers monitoring one Forge branch
- `./do-work.sh --clear-stop` or `./do-work.sh --clear-stop --branch <branch>` to resume future loops

Workers check the global marker and their branch-specific marker before cycles, between queue operations, and during sleep. The Python dispatcher reuses the existing interrupt cleanup path for active claimed issues and skips claiming new work once a stop marker applies.

Closes #4084

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/shutdown_signal.py`: reads, writes, and removes the global or branch-scoped stop marker under the user home directory by default.
- `forge/do_up_to_date_work.sh`: creates/clears stop marker files and checks them before cycles and during sleep.
- `forge/forge_metadata.py`: checks stop marker state while scheduling queues and active issue-processing futures.

## Testing

- `bash -n do_up_to_date_work.sh`
- `env -i bash do_up_to_date_work.sh --help`
- `python3 -m unittest tests.test_shutdown_signal tests.test_forge_metadata`
- Manual global and branch-scoped `--stop`/`--clear-stop` checks with temporary marker paths
