### PR TITLE
[GenAI] Add support for xalan:xalan:2.7.0 using gpt-5.5

### DIFF
--- a/metadata/xalan/xalan/2.7.0/reachability-metadata.json
+++ b/metadata/xalan/xalan/2.7.0/reachability-metadata.json
@@ -1,0 +1,1087 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.lib.ExsltStrings$DocumentHolder"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.TransformerFactoryImpl"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.transformer.TransformerImpl"
+      },
+      "type": "java.io.StringWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Byte"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Character"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Double"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Float"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Long"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "java.lang.Short"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.dtm.SecuritySupport"
+      },
+      "type": "java.security.AccessController"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory"
+      },
+      "type": "java.security.AccessController"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.SecuritySupport"
+      },
+      "type": "java.security.AccessController"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorOutputElem"
+      },
+      "type": "org.apache.xalan.processor.ProcessorOutputElem",
+      "methods": [
+        {
+          "name": "setIndent",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setMethod",
+          "parameterTypes": [
+            "org.apache.xml.utils.QName"
+          ]
+        },
+        {
+          "name": "setOmitXmlDeclaration",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemApplyImport"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemApplyTemplates",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemApplyTemplates"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemAttribute"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemCallTemplate"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemChoose"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemComment"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemCopy"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemCopyOf"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemElement"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemExsltFuncResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemExsltFunction"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemExtensionDecl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemExtensionScript"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemFallback"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemForEach",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setSelect",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemForEach"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemIf"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorLRE"
+      },
+      "type": "org.apache.xalan.templates.ElemLiteralResult",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "addLiteralResultAttribute",
+          "parameterTypes": [
+            "org.apache.xalan.templates.AVT"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemLiteralResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemNumber"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemOtherwise"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemPI"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemParam",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemParam"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemSort",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setDataType",
+          "parameterTypes": [
+            "org.apache.xalan.templates.AVT"
+          ]
+        },
+        {
+          "name": "setOrder",
+          "parameterTypes": [
+            "org.apache.xalan.templates.AVT"
+          ]
+        },
+        {
+          "name": "setSelect",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTAttributeDef"
+      },
+      "type": "org.apache.xalan.templates.ElemSort",
+      "methods": [
+        {
+          "name": "setDataType",
+          "parameterTypes": [
+            "org.apache.xalan.templates.AVT"
+          ]
+        },
+        {
+          "name": "setOrder",
+          "parameterTypes": [
+            "org.apache.xalan.templates.AVT"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemSort"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemTemplate",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMatch",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemTemplate"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemText"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemTextLiteral"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemUnknown"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemValueOf",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setSelect",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemValueOf"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xalan.templates.ElemVariable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "org.apache.xml.utils.QName"
+          ]
+        },
+        {
+          "name": "setSelect",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemVariable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemWhen"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTSchema"
+      },
+      "type": "org.apache.xalan.templates.ElemWithParam"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.StylesheetHandler"
+      },
+      "type": "org.apache.xalan.templates.FuncDocument"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.axes.FilterExprWalker"
+      },
+      "type": "org.apache.xalan.templates.FuncDocument",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.StylesheetHandler"
+      },
+      "type": "org.apache.xalan.templates.FuncFormatNumb"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTAttributeDef"
+      },
+      "type": "org.apache.xalan.templates.FuncFormatNumb",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.templates.AVT"
+      },
+      "type": "org.apache.xalan.templates.FuncKey",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xalan.templates.FuncKey"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorKey"
+      },
+      "type": "org.apache.xalan.templates.KeyDeclaration",
+      "methods": [
+        {
+          "name": "setMatch",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        },
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "org.apache.xml.utils.QName"
+          ]
+        },
+        {
+          "name": "setUse",
+          "parameterTypes": [
+            "org.apache.xpath.XPath"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "org.apache.xalan.templates.Stylesheet",
+      "methods": [
+        {
+          "name": "setVersion",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorStylesheetElement"
+      },
+      "type": "org.apache.xalan.templates.StylesheetRoot"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.XPathContext"
+      },
+      "type": "org.apache.xalan.transformer.TransformerImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.dtm.ObjectFactory"
+      },
+      "type": "org.apache.xml.dtm.ObjectFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.dtm.ObjectFactory"
+      },
+      "type": "org.apache.xml.dtm.ref.DTMManagerDefault",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.ObjectFactory"
+      },
+      "type": "org.apache.xml.serializer.ObjectFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory$1"
+      },
+      "type": "org.apache.xml.serializer.OutputPropertiesFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.transformer.TransformerImpl"
+      },
+      "type": "org.apache.xml.serializer.ToTextStream"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.ObjectFactory"
+      },
+      "type": "org.apache.xml.serializer.ToXMLStream"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.SerializerFactory"
+      },
+      "type": "org.apache.xml.serializer.ToXMLStream",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.utils.ObjectPool"
+      },
+      "type": "org.apache.xml.utils.FastStringBuffer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.utils.StringBufferPool"
+      },
+      "type": "org.apache.xml.utils.FastStringBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.ProcessorTemplateElem"
+      },
+      "type": "org.apache.xpath.XPath"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncBoolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncCeiling"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncConcat"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncContains"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.templates.AVT"
+      },
+      "type": "org.apache.xpath.functions.FuncCount",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.Compiler"
+      },
+      "type": "org.apache.xpath.functions.FuncCount",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncCount"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncCurrent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncDoclocation"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncExtElementAvailable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncExtFunctionAvailable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncFalse"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncFloor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncGenerateId"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncId"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncLang"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncLast"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncLocalPart"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncNamespace"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTAttributeDef"
+      },
+      "type": "org.apache.xpath.functions.FuncNormalizeSpace",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncNormalizeSpace"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncNot"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.XSLTAttributeDef"
+      },
+      "type": "org.apache.xpath.functions.FuncNumber",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.Compiler"
+      },
+      "type": "org.apache.xpath.functions.FuncNumber",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncNumber"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncPosition"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncQname"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncRound"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncStartsWith"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.XPathAPI"
+      },
+      "type": "org.apache.xpath.functions.FuncString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncString"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.domapi.XPathEvaluatorImpl"
+      },
+      "type": "org.apache.xpath.functions.FuncString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.jaxp.XPathImpl"
+      },
+      "type": "org.apache.xpath.functions.FuncString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncStringLength"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncSubstring"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncSubstringAfter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncSubstringBefore"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncSum",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncSystemProperty"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncTranslate"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncTrue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xpath.compiler.FunctionTable"
+      },
+      "type": "org.apache.xpath.functions.FuncUnparsedEntityURI"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.transformer.NodeSortKey"
+      },
+      "type": "sun.text.resources.CollationData"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.CharInfo"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.lib.ExsltStrings$DocumentHolder"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.processor.TransformerFactoryImpl"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.dtm.SecuritySupport12$6"
+      },
+      "glob": "META-INF/services/org.apache.xml.dtm.DTMManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.utils.XMLReaderManager"
+      },
+      "glob": "META-INF/services/org.xml.sax.XMLReader"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.utils.XMLReaderManager"
+      },
+      "glob": "META-INF/services/org.xml.sax.driver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.SecuritySupport12$6"
+      },
+      "glob": "org/apache/xml/serializer/Encodings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.CharInfo"
+      },
+      "glob": "org/apache/xml/serializer/XMLEntities.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.CharInfo"
+      },
+      "glob": "org/apache/xml/serializer/XMLEntities_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.CharInfo"
+      },
+      "glob": "org/apache/xml/serializer/XMLEntities_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory"
+      },
+      "glob": "org/apache/xml/serializer/output_html.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory"
+      },
+      "glob": "org/apache/xml/serializer/output_text.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory"
+      },
+      "glob": "org/apache/xml/serializer/output_unknown.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.serializer.OutputPropertiesFactory"
+      },
+      "glob": "org/apache/xml/serializer/output_xml.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xalan.transformer.NodeSortKey"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xml.utils.XMLReaderManager"
+      },
+      "module": "java.xml",
+      "glob": "jdk/xml/internal/META-INF/services/org.xml.sax.driver"
+    },
+    {
+      "bundle": "org.apache.xml.res.XMLErrorResources"
+    },
+    {
+      "bundle": "org.apache.xml.serializer.XMLEntities"
+    },
+    {
+      "bundle": "org.apache.xml.serializer.utils.SerializerMessages"
+    }
+  ]
+}

--- a/metadata/xalan/xalan/index.json
+++ b/metadata/xalan/xalan/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.7.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/xalan/xalan/2.7.0/xalan-2.7.0-sources.jar",
+    "repository-url" : "https://github.com/apache/xalan-java",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/apache/xalan-java/tree/xalan-j_2_7_0/xdocs",
+    "description" : "Xalan-Java is an XSLT processor for transforming XML documents into HTML, text, or other XML document types. It includes XPath support and Java APIs, including JAXP/TRAX integration, for applying stylesheets and running transformations.",
+    "tested-versions" : [
+      "2.7.0"
+    ],
+    "allowed-packages" : [
+      "java_cup.runtime",
+      "org.apache"
+    ]
+  }
+]

--- a/stats/xalan/xalan/2.7.0/execution-metrics.json
+++ b/stats/xalan/xalan/2.7.0/execution-metrics.json
@@ -1,0 +1,50 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T19:28:47.897504Z",
+    "library": "xalan:xalan:2.7.0",
+    "starting_commit": "92ff807e9e61858bb481b4d2198d0907795451b1",
+    "ending_commit": "08102711e597d40c917065fb1708a5e300714919",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.7.0",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 33910,
+          "missed": 401615,
+          "ratio": 0.07786,
+          "total": 435525
+        },
+        "line": {
+          "covered": 7942,
+          "missed": 51246,
+          "ratio": 0.134183,
+          "total": 59188
+        },
+        "method": {
+          "covered": 1575,
+          "missed": 8768,
+          "ratio": 0.152277,
+          "total": 10343
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 401737,
+      "cached_input_tokens_used": 7405056,
+      "output_tokens_used": 35704,
+      "iterations": 4,
+      "cost_usd": 4.7736,
+      "generated_loc": 348,
+      "tested_library_loc": 7942,
+      "metadata_entries": 182,
+      "code_coverage_percent": 13.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java",
+      "metadata_file": "metadata/xalan/xalan/2.7.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/xalan/xalan/2.7.0/stats.json
+++ b/stats/xalan/xalan/2.7.0/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "2.7.0",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 33910,
+        "missed" : 401615,
+        "ratio" : 0.07786,
+        "total" : 435525
+      },
+      "line" : {
+        "covered" : 7942,
+        "missed" : 51246,
+        "ratio" : 0.134183,
+        "total" : 59188
+      },
+      "method" : {
+        "covered" : 1575,
+        "missed" : 8768,
+        "ratio" : 0.152277,
+        "total" : 10343
+      }
+    }
+  } ]
+}

--- a/tests/src/xalan/xalan/2.7.0/.gitignore
+++ b/tests/src/xalan/xalan/2.7.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/xalan/xalan/2.7.0/build.gradle
+++ b/tests/src/xalan/xalan/2.7.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "xalan:xalan:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/xalan/xalan/2.7.0/gradle.properties
+++ b/tests/src/xalan/xalan/2.7.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = xalan:xalan:2.7.0
+library.version = 2.7.0
+metadata.dir = xalan/xalan/2.7.0/

--- a/tests/src/xalan/xalan/2.7.0/settings.gradle
+++ b/tests/src/xalan/xalan/2.7.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'xalan.xalan_tests'

--- a/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
+++ b/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
@@ -32,9 +32,11 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import org.apache.xalan.lib.ExsltMath;
+import org.apache.xalan.lib.ExsltSets;
 import org.apache.xalan.lib.ExsltStrings;
 import org.apache.xalan.processor.TransformerFactoryImpl;
 import org.apache.xpath.CachedXPathAPI;
+import org.apache.xpath.NodeSet;
 import org.apache.xpath.XPathAPI;
 import org.apache.xpath.jaxp.XPathFactoryImpl;
 import org.apache.xpath.objects.XObject;
@@ -243,6 +245,27 @@ public class XalanTest {
         assertThat(ExsltStrings.concat(titles)).isEqualTo("KindredEarthseaParable");
     }
 
+    @Test
+    public void exsltSetFunctionsComputeRelationshipsBetweenNodeLists() throws Exception {
+        Document document = parseXml(CATALOG_XML);
+        NodeList books = document.getElementsByTagName("book");
+        NodeSet allBooks = new NodeSet(books);
+        NodeSet fictionBooks = nodeSet(books.item(0), books.item(2));
+        NodeSet costlyBooks = nodeSet(books.item(1), books.item(2));
+
+        assertThat(attributes(ExsltSets.intersection(fictionBooks, costlyBooks), "id")).containsExactly("b3");
+        assertThat(attributes(ExsltSets.difference(allBooks, fictionBooks), "id")).containsExactly("b2");
+        assertThat(attributes(ExsltSets.leading(allBooks, costlyBooks), "id")).containsExactly("b1");
+        assertThat(attributes(ExsltSets.trailing(allBooks, costlyBooks), "id")).containsExactly("b3");
+        assertThat(ExsltSets.hasSameNode(fictionBooks, costlyBooks)).isTrue();
+
+        NodeSet categories = nodeSet(
+                ((Element) books.item(0)).getAttributeNode("category"),
+                ((Element) books.item(1)).getAttributeNode("category"),
+                ((Element) books.item(2)).getAttributeNode("category"));
+        assertThat(texts(ExsltSets.distinct(categories))).containsExactly("fiction", "fantasy");
+    }
+
     private TransformerFactoryImpl newTransformerFactory() {
         TransformerFactoryImpl factory = new TransformerFactoryImpl();
         assertThat(factory.getFeature(StreamSource.FEATURE)).isTrue();
@@ -286,6 +309,23 @@ public class XalanTest {
 
     private static String textOf(Element element, String tagName) {
         return element.getElementsByTagName(tagName).item(0).getTextContent();
+    }
+
+    private static NodeSet nodeSet(Node... nodes) {
+        NodeSet nodeSet = new NodeSet();
+        for (Node node : nodes) {
+            nodeSet.addNode(node);
+        }
+        return nodeSet;
+    }
+
+    private static List<String> attributes(NodeList nodes, String attributeName) {
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Element element = (Element) nodes.item(i);
+            values.add(element.getAttribute(attributeName));
+        }
+        return values;
     }
 
     private static List<String> texts(NodeList nodes) {

--- a/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
+++ b/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
@@ -6,11 +6,311 @@
  */
 package xalan.xalan;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
-class XalanTest {
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.apache.xalan.lib.ExsltMath;
+import org.apache.xalan.lib.ExsltStrings;
+import org.apache.xalan.processor.TransformerFactoryImpl;
+import org.apache.xpath.CachedXPathAPI;
+import org.apache.xpath.XPathAPI;
+import org.apache.xpath.jaxp.XPathFactoryImpl;
+import org.apache.xpath.objects.XObject;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+public class XalanTest {
+    private static final String CATALOG_XML = """
+            <?xml version="1.0"?>
+            <catalog>
+                <book id="b1" category="fiction" author="Octavia Butler">
+                    <title>Kindred</title>
+                    <price>8.99</price>
+                </book>
+                <book id="b2" category="fantasy" author="Ursula Le Guin">
+                    <title>Earthsea</title>
+                    <price>12.50</price>
+                </book>
+                <book id="b3" category="fiction" author="Octavia Butler">
+                    <title>Parable</title>
+                    <price>15.00</price>
+                </book>
+            </catalog>
+            """;
+
+    private static final String AUTHORS_XML = """
+            <?xml version="1.0"?>
+            <authors>
+                <author name="Octavia Butler" country="US"/>
+                <author name="Ursula Le Guin" country="US"/>
+            </authors>
+            """;
+
+    private static final String SUMMARY_STYLESHEET = """
+            <?xml version="1.0"?>
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:output method="xml" omit-xml-declaration="yes" indent="no"/>
+                <xsl:param name="minimumPrice" select="0"/>
+                <xsl:key name="books-by-author" match="book" use="@author"/>
+                <xsl:variable name="authors" select="document('authors.xml')/authors/author"/>
+
+                <xsl:template match="/catalog">
+                    <summary count="{count(book[number(price) &gt;= $minimumPrice])}">
+                        <xsl:for-each select="book[number(price) &gt;= $minimumPrice]">
+                            <xsl:sort select="number(price)" data-type="number" order="descending"/>
+                            <xsl:variable name="authorName" select="@author"/>
+                            <book id="{@id}" category="{@category}" author="{@author}"
+                                  peer-count="{count(key('books-by-author', @author))}">
+                                <title><xsl:value-of select="normalize-space(title)"/></title>
+                                <author-country>
+                                    <xsl:value-of select="$authors[@name = $authorName]/@country"/>
+                                </author-country>
+                                <formatted-price><xsl:value-of select="format-number(price, '0.00')"/></formatted-price>
+                            </book>
+                        </xsl:for-each>
+                    </summary>
+                </xsl:template>
+            </xsl:stylesheet>
+            """;
+
+    private static final String TITLES_STYLESHEET = """
+            <?xml version="1.0"?>
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:output method="xml" omit-xml-declaration="yes" indent="no"/>
+                <xsl:template match="/catalog">
+                    <titles>
+                        <xsl:apply-templates select="book">
+                            <xsl:sort select="title"/>
+                        </xsl:apply-templates>
+                    </titles>
+                </xsl:template>
+                <xsl:template match="book">
+                    <title category="{@category}"><xsl:value-of select="normalize-space(title)"/></title>
+                </xsl:template>
+            </xsl:stylesheet>
+            """;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    public void compiledTemplatesApplyParametersKeysAndUriResolvedDocuments() throws Exception {
+        TransformerFactoryImpl factory = newTransformerFactory();
+        InMemoryUriResolver uriResolver = new InMemoryUriResolver(Map.of("authors.xml", AUTHORS_XML));
+        factory.setURIResolver(uriResolver);
+        Templates templates = factory.newTemplates(streamSource(SUMMARY_STYLESHEET, "memory:summary.xsl"));
+
+        Transformer transformer = templates.newTransformer();
+        transformer.setURIResolver(uriResolver);
+        transformer.setParameter("minimumPrice", "10");
+        String output = transformToString(transformer, streamSource(CATALOG_XML, "memory:catalog.xml"));
+
+        Document result = parseXml(output);
+        Element summary = result.getDocumentElement();
+        assertThat(summary.getNodeName()).isEqualTo("summary");
+        assertThat(summary.getAttribute("count")).isEqualTo("2");
+
+        NodeList books = summary.getElementsByTagName("book");
+        assertThat(books.getLength()).isEqualTo(2);
+        Element first = (Element) books.item(0);
+        assertThat(first.getAttribute("id")).isEqualTo("b3");
+        assertThat(first.getAttribute("author")).isEqualTo("Octavia Butler");
+        assertThat(first.getAttribute("peer-count")).isEqualTo("2");
+        assertThat(textOf(first, "title")).isEqualTo("Parable");
+        assertThat(textOf(first, "author-country")).isEqualTo("US");
+        assertThat(textOf(first, "formatted-price")).isEqualTo("15.00");
+
+        Element second = (Element) books.item(1);
+        assertThat(second.getAttribute("id")).isEqualTo("b2");
+        assertThat(second.getAttribute("peer-count")).isEqualTo("1");
+        assertThat(textOf(second, "title")).isEqualTo("Earthsea");
+    }
+
+    @Test
+    public void saxTransformerHandlerTransformsParserEvents() throws Exception {
+        TransformerFactoryImpl factory = newTransformerFactory();
+        Templates templates = factory.newTemplates(streamSource(TITLES_STYLESHEET, "memory:titles.xsl"));
+        TransformerHandler handler = factory.newTransformerHandler(templates);
+        StringWriter writer = new StringWriter();
+        handler.setResult(new StreamResult(writer));
+
+        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        parserFactory.setNamespaceAware(true);
+        XMLReader reader = parserFactory.newSAXParser().getXMLReader();
+        reader.setContentHandler(handler);
+        reader.parse(inputSource(CATALOG_XML, "memory:catalog.xml"));
+
+        Document result = parseXml(writer.toString());
+        NodeList titleElements = result.getDocumentElement().getElementsByTagName("title");
+        assertThat(texts(titleElements)).containsExactly("Earthsea", "Kindred", "Parable");
+        assertThat(((Element) titleElements.item(0)).getAttribute("category")).isEqualTo("fantasy");
+    }
+
+    @Test
+    public void identityTransformerCopiesDomAndHonorsOutputProperties() throws Exception {
+        TransformerFactoryImpl factory = newTransformerFactory();
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.setOutputProperty(OutputKeys.INDENT, "no");
+
+        Document source = parseXml(CATALOG_XML);
+        Document copied = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        DOMResult domResult = new DOMResult(copied);
+        transformer.transform(new DOMSource(source), domResult);
+        assertThat(copied.getDocumentElement().getNodeName()).isEqualTo("catalog");
+        assertThat(copied.getElementsByTagName("book").getLength()).isEqualTo(3);
+        assertThat(textOf((Element) copied.getElementsByTagName("book").item(1), "title")).isEqualTo("Earthsea");
+
+        String serialized = transformToString(transformer, new DOMSource(copied));
+        assertThat(serialized).doesNotStartWith("<?xml");
+        assertThat(serialized).contains("<catalog>");
+    }
+
+    @Test
+    public void jaxpXPathFactoryEvaluatesVariablesAndNodeSets() throws Exception {
+        XPathFactoryImpl factory = new XPathFactoryImpl();
+        assertThat(factory.isObjectModelSupported(XPathFactory.DEFAULT_OBJECT_MODEL_URI)).isTrue();
+
+        XPath xpath = factory.newXPath();
+        xpath.setXPathVariableResolver(this::resolveXPathVariable);
+        Document document = parseXml(CATALOG_XML);
+
+        Double total = (Double) xpath.evaluate(
+                "sum(/catalog/book[@category = $category]/price)", document, XPathConstants.NUMBER);
+        assertThat(total).isCloseTo(23.99, within(0.0001));
+
+        NodeList expensiveTitles = (NodeList) xpath.evaluate(
+                "/catalog/book[number(price) >= $minimumPrice]/title", document, XPathConstants.NODESET);
+        assertThat(texts(expensiveTitles)).containsExactly("Earthsea", "Parable");
+
+        String selectedAuthor = xpath.evaluate("string(/catalog/book[@id = 'b3']/@author)", document);
+        assertThat(selectedAuthor).isEqualTo("Octavia Butler");
+    }
+
+    @Test
+    public void xalanXPathApiAndCachedXPathApiEvaluateAgainstDom() throws Exception {
+        Document document = parseXml(CATALOG_XML);
+        CachedXPathAPI cachedXPath = new CachedXPathAPI();
+
+        NodeList butlerBooks = cachedXPath.selectNodeList(document, "/catalog/book[@author = 'Octavia Butler']");
+        assertThat(butlerBooks.getLength()).isEqualTo(2);
+        assertThat(texts(cachedXPath.selectNodeList(document, "/catalog/book[@category = 'fiction']/title")))
+                .containsExactly("Kindred", "Parable");
+
+        XObject firstFantasyTitle = XPathAPI.eval(document, "string(/catalog/book[@category = 'fantasy']/title)");
+        assertThat(firstFantasyTitle.str()).isEqualTo("Earthsea");
+
+        XObject hasTwoCostlyBooks = cachedXPath.eval(document, "count(/catalog/book[number(price) >= 10]) = 2");
+        assertThat(hasTwoCostlyBooks.bool()).isTrue();
+    }
+
+    @Test
+    public void exsltUtilityFunctionsOperateOnNodeSetsAndStrings() throws Exception {
+        NodeList tokens = ExsltStrings.tokenize("alpha,beta,gamma", ",");
+        assertThat(texts(tokens)).containsExactly("alpha", "beta", "gamma");
+        assertThat(ExsltStrings.padding(5, "ab")).isEqualTo("ababa");
+
+        Document document = parseXml(CATALOG_XML);
+        NodeList prices = XPathAPI.selectNodeList(document, "/catalog/book/price");
+        assertThat(ExsltMath.max(prices)).isEqualTo(15.0);
+        assertThat(ExsltMath.min(prices)).isCloseTo(8.99, within(0.0001));
+
+        NodeList titles = XPathAPI.selectNodeList(document, "/catalog/book/title");
+        assertThat(ExsltStrings.concat(titles)).isEqualTo("KindredEarthseaParable");
+    }
+
+    private TransformerFactoryImpl newTransformerFactory() {
+        TransformerFactoryImpl factory = new TransformerFactoryImpl();
+        assertThat(factory.getFeature(StreamSource.FEATURE)).isTrue();
+        assertThat(factory.getFeature(StreamResult.FEATURE)).isTrue();
+        assertThat(factory.getFeature(DOMSource.FEATURE)).isTrue();
+        assertThat(factory.getFeature(DOMResult.FEATURE)).isTrue();
+        return factory;
+    }
+
+    private Object resolveXPathVariable(QName variableName) {
+        return switch (variableName.getLocalPart()) {
+            case "category" -> "fiction";
+            case "minimumPrice" -> 10;
+            default -> throw new IllegalArgumentException("Unexpected XPath variable: " + variableName);
+        };
+    }
+
+    private static String transformToString(Transformer transformer, Source source) throws TransformerException {
+        StringWriter writer = new StringWriter();
+        transformer.transform(source, new StreamResult(writer));
+        return writer.toString();
+    }
+
+    private static Document parseXml(String xml) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        return factory.newDocumentBuilder().parse(inputSource(xml, "memory:document.xml"));
+    }
+
+    private static StreamSource streamSource(String xml, String systemId) {
+        StreamSource source = new StreamSource(new StringReader(xml));
+        source.setSystemId(systemId);
+        return source;
+    }
+
+    private static InputSource inputSource(String xml, String systemId) {
+        InputSource source = new InputSource(new StringReader(xml));
+        source.setSystemId(systemId);
+        return source;
+    }
+
+    private static String textOf(Element element, String tagName) {
+        return element.getElementsByTagName(tagName).item(0).getTextContent();
+    }
+
+    private static List<String> texts(NodeList nodes) {
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            values.add(node.getTextContent());
+        }
+        return values;
+    }
+
+    private static final class InMemoryUriResolver implements URIResolver {
+        private final Map<String, String> resources;
+
+        private InMemoryUriResolver(Map<String, String> resources) {
+            this.resources = resources;
+        }
+
+        @Override
+        public Source resolve(String href, String base) throws TransformerException {
+            String xml = resources.get(href);
+            if (xml == null) {
+                throw new TransformerException("Unexpected URI requested by stylesheet: " + href);
+            }
+            return streamSource(xml, "memory:" + href);
+        }
     }
 }

--- a/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
+++ b/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
@@ -38,6 +38,7 @@ import org.apache.xalan.processor.TransformerFactoryImpl;
 import org.apache.xpath.CachedXPathAPI;
 import org.apache.xpath.NodeSet;
 import org.apache.xpath.XPathAPI;
+import org.apache.xpath.domapi.XPathEvaluatorImpl;
 import org.apache.xpath.jaxp.XPathFactoryImpl;
 import org.apache.xpath.objects.XObject;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.w3c.dom.xpath.XPathExpression;
+import org.w3c.dom.xpath.XPathNSResolver;
+import org.w3c.dom.xpath.XPathResult;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
@@ -73,6 +77,21 @@ public class XalanTest {
                 <author name="Octavia Butler" country="US"/>
                 <author name="Ursula Le Guin" country="US"/>
             </authors>
+            """;
+
+    private static final String NAMESPACED_CATALOG_XML = """
+            <?xml version="1.0"?>
+            <lib:catalog xmlns:lib="urn:library" xmlns:meta="urn:metadata">
+                <lib:book meta:id="b1" meta:category="fiction">
+                    <lib:title>Kindred</lib:title>
+                </lib:book>
+                <lib:book meta:id="b2" meta:category="fantasy">
+                    <lib:title>Earthsea</lib:title>
+                </lib:book>
+                <lib:book meta:id="b3" meta:category="fiction">
+                    <lib:title>Parable</lib:title>
+                </lib:book>
+            </lib:catalog>
             """;
 
     private static final String SUMMARY_STYLESHEET = """
@@ -228,6 +247,30 @@ public class XalanTest {
 
         XObject hasTwoCostlyBooks = cachedXPath.eval(document, "count(/catalog/book[number(price) >= 10]) = 2");
         assertThat(hasTwoCostlyBooks.bool()).isTrue();
+    }
+
+    @Test
+    public void domLevelXPathEvaluatorUsesNamespaceResolversAndSnapshotResults() throws Exception {
+        Document document = parseXml(NAMESPACED_CATALOG_XML);
+        XPathEvaluatorImpl evaluator = new XPathEvaluatorImpl(document);
+        XPathNSResolver resolver = evaluator.createNSResolver(document.getDocumentElement());
+
+        XPathExpression fictionTitlesExpression = evaluator.createExpression(
+                "/lib:catalog/lib:book[@meta:category = 'fiction']/lib:title", resolver);
+        XPathResult fictionTitles = (XPathResult) fictionTitlesExpression.evaluate(
+                document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+
+        assertThat(fictionTitles.getSnapshotLength()).isEqualTo(2);
+        assertThat(fictionTitles.snapshotItem(0).getTextContent()).isEqualTo("Kindred");
+        assertThat(fictionTitles.snapshotItem(1).getTextContent()).isEqualTo("Parable");
+
+        XPathResult fantasyTitle = (XPathResult) evaluator.evaluate(
+                "string(/lib:catalog/lib:book[@meta:id = 'b2']/lib:title)",
+                document,
+                resolver,
+                XPathResult.STRING_TYPE,
+                null);
+        assertThat(fantasyTitle.getStringValue()).isEqualTo("Earthsea");
     }
 
     @Test

--- a/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
+++ b/tests/src/xalan/xalan/2.7.0/src/test/java/xalan/xalan/XalanTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package xalan.xalan;
+
+import org.junit.jupiter.api.Test;
+
+class XalanTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/xalan/xalan/2.7.0/user-code-filter.json
+++ b/tests/src/xalan/xalan/2.7.0/user-code-filter.json
@@ -1,13 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "java_cup.runtime.**"
+      "includeClasses" : "java_cup.runtime.**"
     },
     {
-      "includeClasses": "org.apache.**"
+      "includeClasses" : "org.apache.**"
     }
   ]
 }

--- a/tests/src/xalan/xalan/2.7.0/user-code-filter.json
+++ b/tests/src/xalan/xalan/2.7.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "java_cup.runtime.**"
+    },
+    {
+      "includeClasses": "org.apache.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2865

This PR introduces tests and metadata for xalan:xalan:2.7.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 401737
- Cached input tokens: 7405056
- Output tokens: 35704
- Metadata entries: 182
- Iterations: 4
- Library coverage percentage: 13.42
- Generated lines of code: 348
- Tested library lines of code: 7942

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `e9a9e26cb06e38e24c7dd07bfc1c5ae87599cda5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 33910/435525 (7.79%)
- Line: 7942/59188 (13.42%)
- Method: 1575/10343 (15.23%)
