### PR TITLE
[GenAI] Add support for org.glassfish.jaxb:xsom:4.0.6 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.jaxb/xsom/4.0.6/reachability-metadata.json
+++ b/metadata/org.glassfish.jaxb/xsom/4.0.6/reachability-metadata.json
@@ -1,0 +1,57 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.util.DomAnnotationParserFactory$1"
+      },
+      "type": "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.impl.parser.ParserContext"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.util.DomAnnotationParserFactory$1"
+      },
+      "glob": "META-INF/services/javax.xml.transform.TransformerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.impl.parser.ParserContext"
+      },
+      "glob": "com/sun/xml/xsom/impl/parser/Messages.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.impl.parser.ParserContext"
+      },
+      "glob": "com/sun/xml/xsom/impl/parser/Messages_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.impl.parser.ParserContext"
+      },
+      "glob": "com/sun/xml/xsom/impl/parser/Messages_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.xml.xsom.impl.parser.ParserContext"
+      },
+      "glob": "com/sun/xml/xsom/impl/parser/datatypes.xsd"
+    },
+    {
+      "bundle": "com.sun.xml.xsom.impl.parser.Messages"
+    }
+  ]
+}

--- a/metadata/org.glassfish.jaxb/xsom/index.json
+++ b/metadata/org.glassfish.jaxb/xsom/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jaxb/xsom/4.0.6/xsom-4.0.6-sources.jar",
+    "repository-url" : "https://github.com/eclipse-ee4j/jaxb-ri",
+    "test-code-url" : "https://github.com/eclipse-ee4j/jaxb-ri/tree/4.0.6-RI/jaxb-ri/xsom/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jaxb/xsom/4.0.6/xsom-4.0.6-javadoc.jar",
+    "description" : "XSOM is a Java library for parsing XML Schema documents into an object model that applications can inspect programmatically. It is useful for tools and frameworks that need to read schema definitions, types, elements, and constraints as input.",
+    "tested-versions" : [
+      "4.0.6"
+    ],
+    "allowed-packages" : [
+      "com.sun.xml.xsom"
+    ]
+  }
+]

--- a/stats/org.glassfish.jaxb/xsom/4.0.6/execution-metrics.json
+++ b/stats/org.glassfish.jaxb/xsom/4.0.6/execution-metrics.json
@@ -1,0 +1,50 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T19:56:41.115377Z",
+    "library": "org.glassfish.jaxb:xsom:4.0.6",
+    "starting_commit": "d05bee2cb4e7b7bf24efba65cb2831d3cb7e5783",
+    "ending_commit": "3d2b543a25fc6b93c358b6c59a5355c8678df8ee",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.6",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 20183,
+          "missed": 37622,
+          "ratio": 0.349157,
+          "total": 57805
+        },
+        "line": {
+          "covered": 4121,
+          "missed": 7574,
+          "ratio": 0.352373,
+          "total": 11695
+        },
+        "method": {
+          "covered": 756,
+          "missed": 987,
+          "ratio": 0.433735,
+          "total": 1743
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 375922,
+      "cached_input_tokens_used": 4514304,
+      "output_tokens_used": 32658,
+      "iterations": 5,
+      "cost_usd": 3.2369,
+      "generated_loc": 499,
+      "tested_library_loc": 4121,
+      "metadata_entries": 9,
+      "code_coverage_percent": 35.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java",
+      "metadata_file": "metadata/org.glassfish.jaxb/xsom/4.0.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.jaxb/xsom/4.0.6/stats.json
+++ b/stats/org.glassfish.jaxb/xsom/4.0.6/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "4.0.6",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 20183,
+        "missed" : 37622,
+        "ratio" : 0.349157,
+        "total" : 57805
+      },
+      "line" : {
+        "covered" : 4121,
+        "missed" : 7574,
+        "ratio" : 0.352373,
+        "total" : 11695
+      },
+      "method" : {
+        "covered" : 756,
+        "missed" : 987,
+        "ratio" : 0.433735,
+        "total" : 1743
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/.gitignore
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/build.gradle
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.jaxb:xsom:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/gradle.properties
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.jaxb:xsom:4.0.6
+library.version = 4.0.6
+metadata.dir = org.glassfish.jaxb/xsom/4.0.6/

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/settings.gradle
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.jaxb.xsom_tests'

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_jaxb.xsom;
+
+import org.junit.jupiter.api.Test;
+
+class XsomTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
@@ -10,15 +10,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sun.xml.xsom.ForeignAttributes;
+import com.sun.xml.xsom.SCD;
 import com.sun.xml.xsom.XSAnnotation;
+import com.sun.xml.xsom.XSAttributeDecl;
 import com.sun.xml.xsom.XSAttributeUse;
 import com.sun.xml.xsom.XSComplexType;
+import com.sun.xml.xsom.XSComponent;
 import com.sun.xml.xsom.XSElementDecl;
 import com.sun.xml.xsom.XSFacet;
 import com.sun.xml.xsom.XSIdentityConstraint;
 import com.sun.xml.xsom.XSListSimpleType;
 import com.sun.xml.xsom.XSModelGroup;
 import com.sun.xml.xsom.XSModelGroupDecl;
+import com.sun.xml.xsom.XSNotation;
 import com.sun.xml.xsom.XSParticle;
 import com.sun.xml.xsom.XSRestrictionSimpleType;
 import com.sun.xml.xsom.XSSchema;
@@ -34,10 +38,14 @@ import com.sun.xml.xsom.parser.XSOMParser;
 import com.sun.xml.xsom.util.DomAnnotationParserFactory;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.SAXParserFactory;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
@@ -329,6 +337,54 @@ public class XsomTest {
     }
 
     @Test
+    void resolvesSchemaComponentDesignatorsAndNotations() throws Exception {
+        XSSchemaSet schemaSet = parseSingleSchema("memory:/assets.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:notation name="png" public="image/png" system="viewer:png"/>
+                  <xs:complexType name="ImageType">
+                    <xs:sequence>
+                      <xs:element name="title" type="xs:string"/>
+                      <xs:element name="caption" type="xs:string" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attribute name="format" type="xs:string" use="required"/>
+                  </xs:complexType>
+                  <xs:element name="image" type="tns:ImageType"/>
+                </xs:schema>
+                """);
+        NamespaceContext namespaces = namespaceContext(Map.of(
+                "shop", SHOP_NS,
+                "xs", XML_SCHEMA_NS));
+
+        XSSchema schema = schemaSet.getSchema(SHOP_NS);
+        XSNotation png = schema.getNotation("png");
+        assertThat(png.isGlobal()).isTrue();
+        assertThat(png.getPublicId()).isEqualTo("image/png");
+        assertThat(png.getSystemId()).isEqualTo("viewer:png");
+        assertThat(schemaSet.iterateNotations()).toIterable().contains(png);
+
+        XSComponent imageType = schemaSet.selectSingle("x-schema::shop/type::shop:ImageType", namespaces);
+        assertThat(imageType).isSameAs(schema.getComplexType("ImageType"));
+        XSComponent selectedNotation = SCD.create("x-schema::shop/notation::shop:png", namespaces).selectSingle(schemaSet);
+        assertThat(selectedNotation).isSameAs(png);
+
+        XSComponent titleComponent = schemaSet.selectSingle(
+                "x-schema::shop/type::shop:ImageType/model::sequence/element::shop:title", namespaces);
+        assertThat(titleComponent).isInstanceOf(XSElementDecl.class);
+        XSElementDecl title = (XSElementDecl) titleComponent;
+        assertThat(title.isLocal()).isTrue();
+        assertThat(title.getType()).isSameAs(schemaSet.getSimpleType(XML_SCHEMA_NS, "string"));
+
+        XSComponent formatComponent = imageType.selectSingle("@format", namespaces);
+        assertThat(formatComponent).isInstanceOf(XSAttributeDecl.class);
+        XSAttributeDecl format = (XSAttributeDecl) formatComponent;
+        assertThat(format.getName()).isEqualTo("format");
+        assertThat(format.isLocal()).isTrue();
+    }
+
+    @Test
     void parsesDomAnnotationsForeignAttributesAndXmlStringValues() throws Exception {
         XSOMParser parser = newParser();
         parser.setAnnotationParser(new DomAnnotationParserFactory());
@@ -357,10 +413,12 @@ public class XsomTest {
         assertThat(foreignAttributes.getValue(APP_NS, "version")).isEqualTo("1.2");
         assertThat(foreignAttributes.getLocator().getLineNumber()).isPositive();
 
-        XSAnnotation annotation = annotated.getAnnotation();
+        XSElementDecl annotatedAnnotationAccess = annotated;
+        XSAnnotation annotation = annotatedAnnotationAccess.getAnnotation();
         assertThat(annotation.getLocator().getLineNumber()).isPositive();
-        assertThat(annotation.getAnnotation()).isInstanceOf(Element.class);
-        Element annotationElement = (Element) annotation.getAnnotation();
+        XSAnnotation xsAnnotationAccess = annotation;
+        assertThat(xsAnnotationAccess.getAnnotation()).isInstanceOf(Element.class);
+        Element annotationElement = (Element) xsAnnotationAccess.getAnnotation();
         assertThat(annotationElement.getLocalName()).isEqualTo("annotation");
         assertThat(annotationElement.getElementsByTagNameNS("urn:metadata", "display-name").item(0).getTextContent())
                 .isEqualTo("Annotated value");
@@ -419,6 +477,36 @@ public class XsomTest {
             InputSource source = inputSource(schema, systemId);
             source.setPublicId(publicId);
             return source;
+        };
+    }
+
+    private static NamespaceContext namespaceContext(Map<String, String> namespaces) {
+        return new NamespaceContext() {
+            @Override
+            public String getNamespaceURI(String prefix) {
+                if (prefix == null) {
+                    throw new IllegalArgumentException("prefix");
+                }
+                return namespaces.getOrDefault(prefix, XMLConstants.NULL_NS_URI);
+            }
+
+            @Override
+            public String getPrefix(String namespaceURI) {
+                return namespaces.entrySet().stream()
+                        .filter(entry -> entry.getValue().equals(namespaceURI))
+                        .map(Map.Entry::getKey)
+                        .findFirst()
+                        .orElse(null);
+            }
+
+            @Override
+            public Iterator<String> getPrefixes(String namespaceURI) {
+                String prefix = getPrefix(namespaceURI);
+                if (prefix == null) {
+                    return Collections.emptyIterator();
+                }
+                return Collections.singleton(prefix).iterator();
+            }
         };
     }
 

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
@@ -25,6 +25,7 @@ import com.sun.xml.xsom.XSSchema;
 import com.sun.xml.xsom.XSSchemaSet;
 import com.sun.xml.xsom.XSSimpleType;
 import com.sun.xml.xsom.XSTerm;
+import com.sun.xml.xsom.XSType;
 import com.sun.xml.xsom.XSUnionSimpleType;
 import com.sun.xml.xsom.XSWildcard;
 import com.sun.xml.xsom.XmlString;
@@ -261,6 +262,70 @@ public class XsomTest {
         XSElementDecl importedAddress = shippingChildren.getChild(1).getTerm().asElementDecl();
         assertThat(importedAddress.getTargetNamespace()).isEqualTo(EXTERNAL_NS);
         assertThat(importedAddress.getName()).isEqualTo("address");
+    }
+
+    @Test
+    void exposesSubstitutionGroupsAndDerivedComplexTypes() throws Exception {
+        XSSchemaSet schemaSet = parseSingleSchema("memory:/animals.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:complexType name="AnimalType">
+                    <xs:sequence>
+                      <xs:element name="name" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                  <xs:complexType name="DogType">
+                    <xs:complexContent>
+                      <xs:extension base="tns:AnimalType">
+                        <xs:sequence>
+                          <xs:element name="barkVolume" type="xs:int"/>
+                        </xs:sequence>
+                        <xs:attribute name="breed" type="xs:string"/>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+                  <xs:complexType name="CatType">
+                    <xs:complexContent>
+                      <xs:extension base="tns:AnimalType">
+                        <xs:sequence>
+                          <xs:element name="lives" type="xs:int"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+                  <xs:element name="animal" type="tns:AnimalType" abstract="true"/>
+                  <xs:element name="dog" type="tns:DogType" substitutionGroup="tns:animal"/>
+                  <xs:element name="cat" type="tns:CatType" substitutionGroup="tns:animal"/>
+                </xs:schema>
+                """);
+
+        XSElementDecl animal = schemaSet.getElementDecl(SHOP_NS, "animal");
+        XSElementDecl dog = schemaSet.getElementDecl(SHOP_NS, "dog");
+        XSElementDecl cat = schemaSet.getElementDecl(SHOP_NS, "cat");
+        assertThat(animal.isAbstract()).isTrue();
+        assertThat(animal.getSubstAffiliation()).isNull();
+        assertThat(dog.getSubstAffiliation()).isSameAs(animal);
+        assertThat(cat.getSubstAffiliation()).isSameAs(animal);
+        assertThat(animal.canBeSubstitutedBy(dog)).isTrue();
+        assertThat(animal.canBeSubstitutedBy(cat)).isTrue();
+        assertThat(dog.canBeSubstitutedBy(animal)).isFalse();
+        assertThat(animal.listSubstitutables()).contains(animal, dog, cat);
+        assertThat(animal.getSubstitutables())
+                .extracting(XSElementDecl::getName)
+                .contains("animal", "dog", "cat");
+
+        XSComplexType animalType = schemaSet.getComplexType(SHOP_NS, "AnimalType");
+        XSComplexType dogType = schemaSet.getComplexType(SHOP_NS, "DogType");
+        XSComplexType catType = schemaSet.getComplexType(SHOP_NS, "CatType");
+        assertThat(dogType.getBaseType()).isSameAs(animalType);
+        assertThat(dogType.getDerivationMethod()).isEqualTo(XSType.EXTENSION);
+        assertThat(dogType.isDerivedFrom(animalType)).isTrue();
+        assertThat(catType.isDerivedFrom(animalType)).isTrue();
+        assertThat(animalType.getSubtypes()).contains(dogType, catType);
+        assertThat(dogType.getElementDecls()).contains(dog);
+        assertThat(catType.getElementDecls()).contains(cat);
     }
 
     @Test

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/src/test/java/org_glassfish_jaxb/xsom/XsomTest.java
@@ -6,11 +6,387 @@
  */
 package org_glassfish_jaxb.xsom;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class XsomTest {
+import com.sun.xml.xsom.ForeignAttributes;
+import com.sun.xml.xsom.XSAnnotation;
+import com.sun.xml.xsom.XSAttributeUse;
+import com.sun.xml.xsom.XSComplexType;
+import com.sun.xml.xsom.XSElementDecl;
+import com.sun.xml.xsom.XSFacet;
+import com.sun.xml.xsom.XSIdentityConstraint;
+import com.sun.xml.xsom.XSListSimpleType;
+import com.sun.xml.xsom.XSModelGroup;
+import com.sun.xml.xsom.XSModelGroupDecl;
+import com.sun.xml.xsom.XSParticle;
+import com.sun.xml.xsom.XSRestrictionSimpleType;
+import com.sun.xml.xsom.XSSchema;
+import com.sun.xml.xsom.XSSchemaSet;
+import com.sun.xml.xsom.XSSimpleType;
+import com.sun.xml.xsom.XSTerm;
+import com.sun.xml.xsom.XSUnionSimpleType;
+import com.sun.xml.xsom.XSWildcard;
+import com.sun.xml.xsom.XmlString;
+import com.sun.xml.xsom.parser.SchemaDocument;
+import com.sun.xml.xsom.parser.XSOMParser;
+import com.sun.xml.xsom.util.DomAnnotationParserFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.xml.parsers.SAXParserFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class XsomTest {
+    private static final String XML_SCHEMA_NS = "http://www.w3.org/2001/XMLSchema";
+    private static final String SHOP_NS = "urn:shop";
+    private static final String EXTERNAL_NS = "urn:external";
+    private static final String APP_NS = "urn:app";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void parsesSchemaAndNavigatesTypesParticlesAttributesAndIdentityConstraints() throws Exception {
+        XSSchemaSet schemaSet = parseSingleSchema("memory:/shop.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:simpleType name="SkuCode">
+                    <xs:restriction base="xs:string">
+                      <xs:pattern value="[A-Z]{3}-\\d{3}"/>
+                      <xs:enumeration value="ABC-123"/>
+                      <xs:enumeration value="XYZ-999"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType name="SkuList">
+                    <xs:list itemType="tns:SkuCode"/>
+                  </xs:simpleType>
+                  <xs:simpleType name="CodeOrQuantity">
+                    <xs:union memberTypes="tns:SkuCode xs:positiveInteger"/>
+                  </xs:simpleType>
+                  <xs:attribute name="currency" type="xs:string" default="USD"/>
+                  <xs:complexType name="LineItemType">
+                    <xs:sequence>
+                      <xs:element name="sku" type="tns:SkuCode"/>
+                      <xs:element name="quantity" type="xs:int" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:attribute ref="tns:currency" use="optional"/>
+                    <xs:attribute name="status" type="tns:CodeOrQuantity" use="required" fixed="ABC-123"/>
+                  </xs:complexType>
+                  <xs:complexType name="OrderType">
+                    <xs:sequence>
+                      <xs:element name="line" type="tns:LineItemType" maxOccurs="unbounded"/>
+                      <xs:choice minOccurs="0">
+                        <xs:element name="note" type="xs:string"/>
+                        <xs:any namespace="##other" processContents="lax"/>
+                      </xs:choice>
+                    </xs:sequence>
+                    <xs:attribute name="priority" type="xs:boolean" default="false"/>
+                  </xs:complexType>
+                  <xs:element name="order" type="tns:OrderType" nillable="true">
+                    <xs:key name="lineSkuKey">
+                      <xs:selector xpath="tns:line"/>
+                      <xs:field xpath="tns:sku"/>
+                    </xs:key>
+                  </xs:element>
+                </xs:schema>
+                """);
+
+        XSSchema schema = schemaSet.getSchema(SHOP_NS);
+        assertThat(schema.getTargetNamespace()).isEqualTo(SHOP_NS);
+        assertThat(schema.getRoot()).isSameAs(schemaSet);
+        assertThat(schemaSet.getSchema(XML_SCHEMA_NS)).isNotNull();
+
+        XSSimpleType skuCode = schemaSet.getSimpleType(SHOP_NS, "SkuCode");
+        assertThat(skuCode.isSimpleType()).isTrue();
+        assertThat(skuCode.isRestriction()).isTrue();
+        XSRestrictionSimpleType skuRestriction = skuCode.asRestriction();
+        XSFacet pattern = skuRestriction.getDeclaredFacet(XSFacet.FACET_PATTERN);
+        assertThat(pattern.getValue().value).isEqualTo("[A-Z]{3}-\\d{3}");
+        assertThat(skuRestriction.getDeclaredFacets(XSFacet.FACET_ENUMERATION))
+                .extracting(facet -> facet.getValue().value)
+                .containsExactly("ABC-123", "XYZ-999");
+
+        XSSimpleType skuListType = schema.getSimpleType("SkuList");
+        assertThat(skuListType.isList()).isTrue();
+        XSListSimpleType skuList = skuListType.asList();
+        assertThat(skuList.getItemType().getName()).isEqualTo("SkuCode");
+
+        XSSimpleType codeOrQuantityType = schema.getSimpleType("CodeOrQuantity");
+        assertThat(codeOrQuantityType.isUnion()).isTrue();
+        XSUnionSimpleType codeOrQuantity = codeOrQuantityType.asUnion();
+        assertThat(codeOrQuantity.getMemberSize()).isEqualTo(2);
+        assertThat(codeOrQuantity.getMember(0).getName()).isEqualTo("SkuCode");
+        assertThat(codeOrQuantity.getMember(1).getTargetNamespace()).isEqualTo(XML_SCHEMA_NS);
+
+        XSComplexType lineItemType = schemaSet.getComplexType(SHOP_NS, "LineItemType");
+        assertThat(lineItemType.isComplexType()).isTrue();
+        assertThat(lineItemType.getBaseType()).isSameAs(schemaSet.getAnyType());
+        XSAttributeUse currency = attributeUse(lineItemType, "currency");
+        assertThat(currency.isRequired()).isFalse();
+        assertThat(currency.getDecl().getTargetNamespace()).isEqualTo(SHOP_NS);
+        assertThat(currency.getDecl().getDefaultValue().value).isEqualTo("USD");
+        XSAttributeUse status = lineItemType.getAttributeUse("", "status");
+        assertThat(status.isRequired()).isTrue();
+        assertThat(status.getFixedValue().value).isEqualTo("ABC-123");
+
+        XSModelGroup lineItemChildren = lineItemType.getContentType().asParticle().getTerm().asModelGroup();
+        assertThat(lineItemChildren.getCompositor()).isSameAs(XSModelGroup.SEQUENCE);
+        assertThat(lineItemChildren.getSize()).isEqualTo(2);
+        assertThat(lineItemChildren.getChild(0).getTerm().asElementDecl().getName()).isEqualTo("sku");
+        XSParticle quantityParticle = lineItemChildren.getChild(1);
+        assertThat(quantityParticle.getTerm().asElementDecl().getName()).isEqualTo("quantity");
+        assertThat(quantityParticle.isRepeated()).isTrue();
+
+        XSElementDecl order = schema.getElementDecl("order");
+        assertThat(order.isGlobal()).isTrue();
+        assertThat(order.isNillable()).isTrue();
+        assertThat(order.getType().getName()).isEqualTo("OrderType");
+        assertThat(order.getIdentityConstraints()).hasSize(1);
+        XSIdentityConstraint key = order.getIdentityConstraints().get(0);
+        assertThat(key.getCategory()).isEqualTo(XSIdentityConstraint.KEY);
+        assertThat(key.getName()).isEqualTo("lineSkuKey");
+        assertThat(key.getSelector().getXPath().value).isEqualTo("tns:line");
+        assertThat(key.getFields()).extracting(field -> field.getXPath().value).containsExactly("tns:sku");
+
+        XSComplexType orderType = order.getType().asComplexType();
+        XSModelGroup orderChildren = orderType.getContentType().asParticle().getTerm().asModelGroup();
+        assertThat(orderChildren.getChild(0).getTerm().asElementDecl().getName()).isEqualTo("line");
+        XSTerm choiceTerm = orderChildren.getChild(1).getTerm();
+        assertThat(choiceTerm.isModelGroup()).isTrue();
+        XSModelGroup choice = choiceTerm.asModelGroup();
+        assertThat(choice.getCompositor()).isSameAs(XSModelGroup.CHOICE);
+        assertThat(choice.getChild(0).getTerm().asElementDecl().getName()).isEqualTo("note");
+        XSWildcard wildcard = choice.getChild(1).getTerm().asWildcard();
+        assertThat(wildcard.getMode()).isEqualTo(XSWildcard.LAX);
+        assertThat(wildcard.acceptsNamespace(EXTERNAL_NS)).isTrue();
+        assertThat(wildcard.acceptsNamespace(SHOP_NS)).isFalse();
+    }
+
+    @Test
+    void resolvesIncludesImportsModelGroupsAttributeGroupsAndSchemaDocuments() throws Exception {
+        Map<String, String> schemas = new HashMap<>();
+        schemas.put("memory:/common.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:attributeGroup name="auditAttributes">
+                    <xs:attribute name="createdBy" type="xs:string" use="required"/>
+                    <xs:attribute name="revision" type="xs:int" default="1"/>
+                  </xs:attributeGroup>
+                  <xs:group name="personName">
+                    <xs:sequence>
+                      <xs:element name="firstName" type="xs:string"/>
+                      <xs:element name="lastName" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:group>
+                </xs:schema>
+                """);
+        schemas.put("memory:/external.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:ext="urn:external"
+                           targetNamespace="urn:external"
+                           elementFormDefault="qualified">
+                  <xs:element name="address" type="xs:string"/>
+                </xs:schema>
+                """);
+        schemas.put("memory:/main.xsd", """
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           xmlns:ext="urn:external"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:include schemaLocation="memory:/common.xsd"/>
+                  <xs:import namespace="urn:external" schemaLocation="memory:/external.xsd"/>
+                  <xs:complexType name="ShippingType">
+                    <xs:sequence>
+                      <xs:group ref="tns:personName"/>
+                      <xs:element ref="ext:address" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="tns:auditAttributes"/>
+                    <xs:anyAttribute namespace="##other" processContents="lax"/>
+                  </xs:complexType>
+                  <xs:element name="shipment" type="tns:ShippingType"/>
+                </xs:schema>
+                """);
+
+        XSOMParser parser = newParser();
+        parser.setEntityResolver(memoryResolver(schemas));
+        parser.parse(inputSource(schemas.get("memory:/main.xsd"), "memory:/main.xsd"));
+        XSSchemaSet schemaSet = parser.getResult();
+
+        Set<String> documentIds = parser.getDocuments().stream()
+                .map(SchemaDocument::getSystemId)
+                .collect(Collectors.toSet());
+        assertThat(documentIds).contains("memory:/main.xsd", "memory:/common.xsd", "memory:/external.xsd");
+
+        SchemaDocument mainDocument = documentWithSystemId(parser.getDocuments(), "memory:/main.xsd");
+        Set<String> referencedIds = mainDocument.getReferencedDocuments().stream()
+                .map(SchemaDocument::getSystemId)
+                .collect(Collectors.toSet());
+        assertThat(referencedIds).contains("memory:/common.xsd", "memory:/external.xsd");
+        assertThat(mainDocument.getIncludedDocuments())
+                .extracting(SchemaDocument::getSystemId)
+                .contains("memory:/common.xsd");
+        assertThat(mainDocument.getImportedDocuments(EXTERNAL_NS))
+                .extracting(SchemaDocument::getSystemId)
+                .contains("memory:/external.xsd");
+
+        XSSchema shopSchema = schemaSet.getSchema(SHOP_NS);
+        XSSchema externalSchema = schemaSet.getSchema(EXTERNAL_NS);
+        assertThat(shopSchema.getAttGroupDecl("auditAttributes")).isNotNull();
+        XSModelGroupDecl personName = shopSchema.getModelGroupDecl("personName");
+        assertThat(personName.getModelGroup().getSize()).isEqualTo(2);
+        assertThat(externalSchema.getElementDecl("address").getType().getTargetNamespace()).isEqualTo(XML_SCHEMA_NS);
+
+        XSComplexType shippingType = shopSchema.getComplexType("ShippingType");
+        assertThat(shippingType.getAttributeUse("", "createdBy").isRequired()).isTrue();
+        assertThat(shippingType.getAttributeUse("", "revision").getDecl().getDefaultValue().value).isEqualTo("1");
+        assertThat(shippingType.getAttributeWildcard().acceptsNamespace(EXTERNAL_NS)).isTrue();
+        assertThat(shippingType.getAttributeWildcard().acceptsNamespace(SHOP_NS)).isFalse();
+
+        XSModelGroup shippingChildren = shippingType.getContentType().asParticle().getTerm().asModelGroup();
+        XSTerm groupReference = shippingChildren.getChild(0).getTerm();
+        assertThat(groupReference.isModelGroupDecl()).isTrue();
+        assertThat(groupReference.asModelGroupDecl().getName()).isEqualTo("personName");
+        XSElementDecl importedAddress = shippingChildren.getChild(1).getTerm().asElementDecl();
+        assertThat(importedAddress.getTargetNamespace()).isEqualTo(EXTERNAL_NS);
+        assertThat(importedAddress.getName()).isEqualTo("address");
+    }
+
+    @Test
+    void parsesDomAnnotationsForeignAttributesAndXmlStringValues() throws Exception {
+        XSOMParser parser = newParser();
+        parser.setAnnotationParser(new DomAnnotationParserFactory());
+        parser.parse(new StringReader("""
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:app="urn:app"
+                           xmlns:meta="urn:metadata"
+                           targetNamespace="urn:shop"
+                           elementFormDefault="qualified">
+                  <xs:element name="annotated" type="xs:string" app:version="1.2">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <meta:display-name>Annotated value</meta:display-name>
+                      </xs:appinfo>
+                      <xs:documentation xml:lang="en">A documented element.</xs:documentation>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:schema>
+                """));
+        XSSchemaSet schemaSet = parser.getResult();
+
+        XSElementDecl annotated = schemaSet.getElementDecl(SHOP_NS, "annotated");
+        assertThat(annotated.getForeignAttribute(APP_NS, "version")).isEqualTo("1.2");
+        assertThat(annotated.getForeignAttributes()).hasSize(1);
+        ForeignAttributes foreignAttributes = annotated.getForeignAttributes().get(0);
+        assertThat(foreignAttributes.getValue(APP_NS, "version")).isEqualTo("1.2");
+        assertThat(foreignAttributes.getLocator().getLineNumber()).isPositive();
+
+        XSAnnotation annotation = annotated.getAnnotation();
+        assertThat(annotation.getLocator().getLineNumber()).isPositive();
+        assertThat(annotation.getAnnotation()).isInstanceOf(Element.class);
+        Element annotationElement = (Element) annotation.getAnnotation();
+        assertThat(annotationElement.getLocalName()).isEqualTo("annotation");
+        assertThat(annotationElement.getElementsByTagNameNS("urn:metadata", "display-name").item(0).getTextContent())
+                .isEqualTo("Annotated value");
+        assertThat(annotationElement.getElementsByTagNameNS(XML_SCHEMA_NS, "documentation").item(0).getTextContent())
+                .contains("documented element");
+
+        XmlString xmlString = new XmlString("literal-value");
+        assertThat(xmlString.value).isEqualTo("literal-value");
+        assertThat(xmlString.toString()).isEqualTo("literal-value");
+        assertThat(xmlString.resolvePrefix("unused")).isNull();
+    }
+
+    @Test
+    void reportsSchemaErrorsThroughConfiguredErrorHandler() throws Exception {
+        XSOMParser parser = newParser();
+        RecordingErrorHandler errorHandler = new RecordingErrorHandler();
+        parser.setErrorHandler(errorHandler);
+        parser.parse(inputSource("""
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="urn:shop"
+                           targetNamespace="urn:shop">
+                  <xs:element name="broken" type="tns:MissingType"/>
+                </xs:schema>
+                """, "memory:/broken.xsd"));
+
+        assertThatThrownBy(parser::getResult)
+                .isInstanceOf(InternalError.class)
+                .hasMessageContaining("unresolved reference");
+        assertThat(errorHandler.errorCount()).isGreaterThan(0);
+    }
+
+    private static XSSchemaSet parseSingleSchema(String systemId, String schema) throws SAXException, IOException {
+        XSOMParser parser = newParser();
+        parser.parse(inputSource(schema, systemId));
+        return parser.getResult();
+    }
+
+    private static XSOMParser newParser() {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        return new XSOMParser(factory);
+    }
+
+    private static InputSource inputSource(String xml, String systemId) {
+        InputSource inputSource = new InputSource(new StringReader(xml));
+        inputSource.setSystemId(systemId);
+        return inputSource;
+    }
+
+    private static EntityResolver memoryResolver(Map<String, String> schemas) {
+        return (publicId, systemId) -> {
+            String schema = schemas.get(systemId);
+            if (schema == null) {
+                return null;
+            }
+            InputSource source = inputSource(schema, systemId);
+            source.setPublicId(publicId);
+            return source;
+        };
+    }
+
+    private static XSAttributeUse attributeUse(XSComplexType complexType, String name) {
+        return complexType.getAttributeUses().stream()
+                .filter(attribute -> name.equals(attribute.getDecl().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing attribute use " + name));
+    }
+
+    private static SchemaDocument documentWithSystemId(Set<SchemaDocument> documents, String systemId) {
+        return documents.stream()
+                .filter(document -> systemId.equals(document.getSystemId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing schema document " + systemId));
+    }
+
+    private static final class RecordingErrorHandler extends DefaultHandler {
+        private int errorCount;
+
+        @Override
+        public void error(SAXParseException exception) {
+            errorCount++;
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            errorCount++;
+            throw exception;
+        }
+
+        int errorCount() {
+            return errorCount;
+        }
     }
 }

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/user-code-filter.json
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.sun.xml.xsom.**"
+      "includeClasses" : "com.sun.xml.xsom.**"
     }
   ]
 }

--- a/tests/src/org.glassfish.jaxb/xsom/4.0.6/user-code-filter.json
+++ b/tests/src/org.glassfish.jaxb/xsom/4.0.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.sun.xml.xsom.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3286

This PR introduces tests and metadata for org.glassfish.jaxb:xsom:4.0.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 375922
- Cached input tokens: 4514304
- Output tokens: 32658
- Metadata entries: 9
- Iterations: 5
- Library coverage percentage: 35.24
- Generated lines of code: 499
- Tested library lines of code: 4121

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 20183/57805 (34.92%)
- Line: 4121/11695 (35.24%)
- Method: 756/1743 (43.37%)
