### PR TITLE
[GenAI] Add support for org.jboss:jboss-common-core:2.0.5.GA using gpt-5.5

### DIFF
--- a/metadata/org.jboss/jboss-common-core/2.0.5.GA/reachability-metadata.json
+++ b/metadata/org.jboss/jboss-common-core/2.0.5.GA/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.logging.Logger"
+      },
+      "type": "org.jboss.logging.NullLoggerPlugin",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logging.Logger"
+      },
+      "type": "org.jboss.logging.log4j.Log4jLoggerPlugin"
+    }
+  ]
+}

--- a/metadata/org.jboss/jboss-common-core/index.json
+++ b/metadata/org.jboss/jboss-common-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.5.GA",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/jboss-common-core/2.0.5.GA/jboss-common-core-2.0.5.GA-sources.jar",
+    "repository-url" : "https://github.com/jboss/jboss-common-core",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "JBoss Common Core provides utility classes shared across JBoss projects. It includes support code for collections, URL protocols, sockets, property handling, XML utilities, threading, and related infrastructure.",
+    "tested-versions" : [
+      "2.0.5.GA"
+    ],
+    "allowed-packages" : [
+      "org.jboss"
+    ]
+  }
+]

--- a/stats/org.jboss/jboss-common-core/2.0.5.GA/execution-metrics.json
+++ b/stats/org.jboss/jboss-common-core/2.0.5.GA/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T19:58:06.741164Z",
+    "library": "org.jboss:jboss-common-core:2.0.5.GA",
+    "starting_commit": "88eddafb6309c01b0617a366ac4497506132a6e8",
+    "ending_commit": "9731322c6f81f6a90bc119d6514a838e9042f134",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.5.GA",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 69
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 79
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2548,
+          "missed": 41090,
+          "ratio": 0.058389,
+          "total": 43638
+        },
+        "line": {
+          "covered": 390,
+          "missed": 10221,
+          "ratio": 0.036754,
+          "total": 10611
+        },
+        "method": {
+          "covered": 84,
+          "missed": 2125,
+          "ratio": 0.038026,
+          "total": 2209
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 345919,
+      "cached_input_tokens_used": 6631424,
+      "output_tokens_used": 32300,
+      "iterations": 10,
+      "cost_usd": 4.2847,
+      "generated_loc": 136,
+      "tested_library_loc": 390,
+      "metadata_entries": 3,
+      "code_coverage_percent": 3.68
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java",
+      "metadata_file": "metadata/org.jboss/jboss-common-core/2.0.5.GA/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss/jboss-common-core/2.0.5.GA/stats.json
+++ b/stats/org.jboss/jboss-common-core/2.0.5.GA/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.0.5.GA",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 69
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 10
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 79
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2548,
+        "missed" : 41090,
+        "ratio" : 0.058389,
+        "total" : 43638
+      },
+      "line" : {
+        "covered" : 390,
+        "missed" : 10221,
+        "ratio" : 0.036754,
+        "total" : 10611
+      },
+      "method" : {
+        "covered" : 84,
+        "missed" : 2125,
+        "ratio" : 0.038026,
+        "total" : 2209
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/.gitignore
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/build.gradle
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss:jboss-common-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/build.gradle
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/build.gradle
@@ -11,7 +11,14 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.jboss:jboss-common-core:$libraryVersion"
+    testImplementation("org.jboss:jboss-common-core:$libraryVersion") {
+        exclude group: "apache-httpclient", module: "commons-httpclient"
+        exclude group: "apache-slide", module: "webdavlib"
+        exclude group: "apache-xerces", module: "xml-apis"
+        exclude group: "jboss", module: "jboss-common-logging-spi"
+        exclude group: "oswego-concurrent", module: "concurrent"
+    }
+    testRuntimeOnly "org.jboss.logging:jboss-logging-spi:2.0.5.GA"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/gradle.properties
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss:jboss-common-core:2.0.5.GA
+library.version = 2.0.5.GA
+metadata.dir = org.jboss/jboss-common-core/2.0.5.GA/

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/settings.gradle
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.jboss-common-core_tests'

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jboss_common_core;
+
+import org.junit.jupiter.api.Test;
+
+class Jboss_common_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
@@ -6,11 +6,95 @@
  */
 package org_jboss.jboss_common_core;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Jboss_common_coreTest {
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.jboss.util.Heap;
+import org.jboss.util.JBossStringBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Jboss_common_coreTest {
+    @TempDir
+    private Path temporaryDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void jbossStringBuilderSupportsMutableCharSequenceOperations() {
+        JBossStringBuilder builder = new JBossStringBuilder("common");
+
+        builder.insert(0, "jboss-")
+                .append('-')
+                .append(2)
+                .append('.')
+                .append(0);
+        assertThat(builder.toString()).isEqualTo("jboss-common-2.0");
+        assertThat(builder.length()).isEqualTo(16);
+        assertThat(builder.charAt(6)).isEqualTo('c');
+        assertThat(builder.indexOf("common")).isEqualTo(6);
+        assertThat(builder.lastIndexOf("-")).isEqualTo(12);
+        assertThat(builder.substring(6, 12)).isEqualTo("common");
+        assertThat(builder.subSequence(0, 5).toString()).isEqualTo("jboss");
+
+        char[] copied = new char[6];
+        builder.getChars(6, 12, copied, 0);
+        assertThat(copied).containsExactly('c', 'o', 'm', 'm', 'o', 'n');
+
+        builder.replace(6, 12, "core");
+        assertThat(builder.toString()).isEqualTo("jboss-core-2.0");
+        builder.delete(10, 14).deleteCharAt(0).setCharAt(0, 'B');
+        assertThat(builder.toString()).isEqualTo("Boss-core");
+        builder.reverse();
+        assertThat(builder.toString()).isEqualTo("eroc-ssoB");
+    }
+
+    @Test
+    void heapOrdersNaturalAndComparatorBackedValues() {
+        Heap naturalHeap = new Heap();
+        naturalHeap.insert(5);
+        naturalHeap.insert(1);
+        naturalHeap.insert(3);
+        assertThat(naturalHeap.peek()).isEqualTo(1);
+        assertThat(naturalHeap.extract()).isEqualTo(1);
+        assertThat(naturalHeap.extract()).isEqualTo(3);
+        assertThat(naturalHeap.extract()).isEqualTo(5);
+        assertThat(naturalHeap.extract()).isNull();
+
+        Heap lengthHeap = new Heap(
+                (left, right) -> Integer.compare(((String) left).length(), ((String) right).length()));
+        lengthHeap.insert("longest");
+        lengthHeap.insert("mid");
+        lengthHeap.insert("s");
+        assertThat(lengthHeap.extract()).isEqualTo("s");
+        assertThat(lengthHeap.extract()).isEqualTo("mid");
+        lengthHeap.clear();
+        assertThat(lengthHeap.peek()).isNull();
+    }
+
+    @Test
+    void fileUtilitiesCopyEncodeDecodeAndDeleteTrees() throws Exception {
+        Path source = temporaryDirectory.resolve("source.txt");
+        Path copied = temporaryDirectory.resolve("nested").resolve("copied.txt");
+        java.nio.file.Files.write(source, "JBoss file utility copy".getBytes(StandardCharsets.UTF_8));
+
+        org.jboss.util.file.Files.copy(source.toUri().toURL(), copied.toFile());
+        assertThat(java.nio.file.Files.readString(copied)).isEqualTo("JBoss file utility copy");
+
+        Path copiedAgain = temporaryDirectory.resolve("copied-again.txt");
+        org.jboss.util.file.Files.copy(copied.toFile(), copiedAgain.toFile(), 4);
+        assertThat(java.nio.file.Files.readAllBytes(copiedAgain))
+                .isEqualTo(java.nio.file.Files.readAllBytes(source));
+
+        String originalName = "module:org.jboss/common core";
+        String encodedName = org.jboss.util.file.Files.encodeFileName(originalName, '#');
+        assertThat(encodedName).doesNotContain(":", "/", " ");
+        assertThat(org.jboss.util.file.Files.decodeFileName(encodedName, '#')).isEqualTo(originalName);
+
+        Path tree = temporaryDirectory.resolve("tree");
+        java.nio.file.Files.createDirectories(tree.resolve("child"));
+        java.nio.file.Files.writeString(tree.resolve("child").resolve("leaf.txt"), "leaf");
+        assertThat(org.jboss.util.file.Files.delete(tree.toFile())).isTrue();
+        assertThat(tree).doesNotExist();
     }
 }

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import org.jboss.util.Base64;
 import org.jboss.util.Heap;
 import org.jboss.util.JBossStringBuilder;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,25 @@ public class Jboss_common_coreTest {
         assertThat(lengthHeap.extract()).isEqualTo("mid");
         lengthHeap.clear();
         assertThat(lengthHeap.peek()).isNull();
+    }
+
+    @Test
+    void base64EncodesAndDecodesByteRanges() {
+        String message = "JBoss common core utilities";
+        byte[] messageBytes = message.getBytes(StandardCharsets.UTF_8);
+        byte[] prefixBytes = "prefix:".getBytes(StandardCharsets.UTF_8);
+        String source = "prefix:" + message + ":suffix";
+        byte[] sourceBytes = source.getBytes(StandardCharsets.UTF_8);
+
+        String encoded = Base64.encodeBytes(
+                sourceBytes,
+                prefixBytes.length,
+                messageBytes.length,
+                Base64.DONT_BREAK_LINES);
+
+        assertThat(encoded).doesNotContain("\n", "\r");
+        assertThat(encoded).isEqualTo(java.util.Base64.getEncoder().encodeToString(messageBytes));
+        assertThat(Base64.decode(encoded)).isEqualTo(messageBytes);
     }
 
     @Test

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/src/test/java/org_jboss/jboss_common_core/Jboss_common_coreTest.java
@@ -10,10 +10,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.util.Base64;
 import org.jboss.util.Heap;
 import org.jboss.util.JBossStringBuilder;
+import org.jboss.util.graph.Edge;
+import org.jboss.util.graph.Graph;
+import org.jboss.util.graph.Vertex;
+import org.jboss.util.graph.Visitor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -71,6 +77,40 @@ public class Jboss_common_coreTest {
         assertThat(lengthHeap.extract()).isEqualTo("mid");
         lengthHeap.clear();
         assertThat(lengthHeap.peek()).isNull();
+    }
+
+    @Test
+    void graphSupportsWeightedEdgesTraversalAndCycleDetection() {
+        Graph<String> graph = new Graph<>();
+        Vertex<String> compile = new Vertex<>("compile", "compile-sources");
+        Vertex<String> test = new Vertex<>("test", "run-tests");
+        Vertex<String> packageArchive = new Vertex<>("package", "create-archive");
+
+        assertThat(graph.addVertex(compile)).isTrue();
+        assertThat(graph.addVertex(test)).isTrue();
+        assertThat(graph.addVertex(packageArchive)).isTrue();
+        assertThat(graph.addEdge(compile, test, 2)).isTrue();
+        assertThat(graph.addEdge(test, packageArchive, 3)).isTrue();
+
+        List<String> depthFirstNames = new ArrayList<>();
+        graph.depthFirstSearch(compile, (Visitor<String>) (visitedGraph, vertex) -> depthFirstNames.add(vertex.getName()));
+        assertThat(depthFirstNames).containsExactly("compile", "test", "package");
+
+        graph.clearMark();
+        List<String> breadthFirstNames = new ArrayList<>();
+        graph.breadthFirstSearch(compile, (Visitor<String>) (visitedGraph, vertex) -> breadthFirstNames.add(vertex.getName()));
+        assertThat(breadthFirstNames).containsExactly("compile", "test", "package");
+
+        assertThat(compile.cost(test)).isEqualTo(2);
+        assertThat(graph.findVertexByName("package")).isSameAs(packageArchive);
+        assertThat(graph.findCycles()).isEmpty();
+
+        assertThat(graph.addEdge(packageArchive, compile, 5)).isTrue();
+        Edge<String>[] cycles = graph.findCycles();
+        assertThat(cycles).hasSize(1);
+        assertThat(cycles[0].getFrom()).isSameAs(packageArchive);
+        assertThat(cycles[0].getTo()).isSameAs(compile);
+        assertThat(cycles[0].getCost()).isEqualTo(5);
     }
 
     @Test

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/user-code-filter.json
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss/jboss-common-core/2.0.5.GA/user-code-filter.json
+++ b/tests/src/org.jboss/jboss-common-core/2.0.5.GA/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.**"
+      "includeClasses" : "org.jboss.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2860

This PR introduces tests and metadata for org.jboss:jboss-common-core:2.0.5.GA, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 345919
- Cached input tokens: 6631424
- Output tokens: 32300
- Metadata entries: 3
- Iterations: 10
- Library coverage percentage: 3.68
- Generated lines of code: 136
- Tested library lines of code: 390

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `e9a9e26cb06e38e24c7dd07bfc1c5ae87599cda5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/79 covered calls (0.00%)
- Reflection: 0/69 covered calls (0.00%)
- Resources: 0/10 covered calls (0.00%)

Library coverage:
- Instruction: 2548/43638 (5.84%)
- Line: 390/10611 (3.68%)
- Method: 84/2209 (3.80%)
