### PR TITLE
[GenAI] Add support for com.univocity:univocity-parsers:2.9.1 using gpt-5.5

### DIFF
--- a/metadata/com.univocity/univocity-parsers/2.9.1/reachability-metadata.json
+++ b/metadata/com.univocity/univocity-parsers/2.9.1/reachability-metadata.json
@@ -1,0 +1,197 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.BeanHelper"
+      },
+      "type" : "com.googlecode.openbeans.Introspector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com.univocity.parsers.annotations.Parsed"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.BeanConversionProcessor"
+      },
+      "type" : "com.univocity.parsers.conversions.IntegerConversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.BeanConversionProcessor"
+      },
+      "type" : "com.univocity.parsers.conversions.TrimConversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.BeanHelper"
+      },
+      "type" : "java.beans.BeanInfo",
+      "methods" : [
+        {
+          "name" : "getPropertyDescriptors",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.PropertyWrapper"
+      },
+      "type" : "java.beans.FeatureDescriptor",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.BeanHelper"
+      },
+      "type" : "java.beans.Introspector",
+      "methods" : [
+        {
+          "name" : "getBeanInfo",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.BeanHelper"
+      },
+      "type" : "java.beans.PropertyDescriptor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.PropertyWrapper"
+      },
+      "type" : "java.beans.PropertyDescriptor",
+      "methods" : [
+        {
+          "name" : "getWriteMethod",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.beans.PropertyWrapper"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationRegistry$AnnotationAttributes"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.ArgumentUtils"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormat",
+      "methods" : [
+        {
+          "name" : "setDecimalFormatSymbols",
+          "parameterTypes" : [
+            "java.text.DecimalFormatSymbols"
+          ]
+        },
+        {
+          "name" : "setMaximumIntegerDigits",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormatBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormatCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormatSymbols",
+      "methods" : [
+        {
+          "name" : "setDecimalSeparator",
+          "parameterTypes" : [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormatSymbolsBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.DecimalFormatSymbolsCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.Format"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.FormatBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.FormatCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.NumberFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.NumberFormatBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "java.text.NumberFormatCustomizer"
+    }
+  ]
+}

--- a/metadata/com.univocity/univocity-parsers/index.json
+++ b/metadata/com.univocity/univocity-parsers/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.9.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/univocity/univocity-parsers/2.9.1/univocity-parsers-2.9.1-sources.jar",
+    "repository-url" : "https://github.com/univocity/univocity-parsers",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/univocity/univocity-parsers/2.9.1/univocity-parsers-2.9.1-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/univocity/univocity-parsers/2.9.1/univocity-parsers-2.9.1-javadoc.jar",
+    "description" : "univocity-parsers provides fast, reliable Java parsers for delimited, fixed-width, and other text-based tabular formats through a consistent API. It also offers a framework for building new parsers and integrating parsed records into application data processing workflows.",
+    "tested-versions" : [
+      "2.9.1"
+    ],
+    "allowed-packages" : [
+      "com.univocity.parsers"
+    ]
+  }
+]

--- a/stats/com.univocity/univocity-parsers/2.9.1/execution-metrics.json
+++ b/stats/com.univocity/univocity-parsers/2.9.1/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T20:21:43.443001Z",
+    "library": "com.univocity:univocity-parsers:2.9.1",
+    "starting_commit": "cf86d51a6534bdf71e70afd054439e2e4902d377",
+    "ending_commit": "928218d5c6e625a1f39d8b9ddaab37b68e638786",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.9.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 32,
+            "totalCalls": 32
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9058,
+          "missed": 36030,
+          "ratio": 0.200896,
+          "total": 45088
+        },
+        "line": {
+          "covered": 2187,
+          "missed": 7491,
+          "ratio": 0.225976,
+          "total": 9678
+        },
+        "method": {
+          "covered": 442,
+          "missed": 1853,
+          "ratio": 0.192593,
+          "total": 2295
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 342262,
+      "cached_input_tokens_used": 3123712,
+      "output_tokens_used": 32270,
+      "iterations": 7,
+      "cost_usd": 2.53,
+      "generated_loc": 439,
+      "tested_library_loc": 2187,
+      "metadata_entries": 31,
+      "test_only_metadata_entries": 47,
+      "code_coverage_percent": 22.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/Univocity_parsersTest.java",
+      "metadata_file": "metadata/com.univocity/univocity-parsers/2.9.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.univocity/univocity-parsers/2.9.1/stats.json
+++ b/stats/com.univocity/univocity-parsers/2.9.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.9.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 32,
+          "totalCalls" : 32
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9058,
+        "missed" : 36030,
+        "ratio" : 0.200896,
+        "total" : 45088
+      },
+      "line" : {
+        "covered" : 2187,
+        "missed" : 7491,
+        "ratio" : 0.225976,
+        "total" : 9678
+      },
+      "method" : {
+        "covered" : 442,
+        "missed" : 1853,
+        "ratio" : 0.192593,
+        "total" : 2295
+      }
+    }
+  } ]
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/.gitignore
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/build.gradle
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.univocity:univocity-parsers:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/gradle.properties
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.univocity:univocity-parsers:2.9.1
+library.version = 2.9.1
+metadata.dir = com.univocity/univocity-parsers/2.9.1/

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/settings.gradle
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.univocity.univocity-parsers_tests'

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/AnnotationHelperTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/AnnotationHelperTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.annotations.Copy;
+import com.univocity.parsers.annotations.HeaderTransformer;
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.helpers.AnnotationHelper;
+import com.univocity.parsers.annotations.helpers.AnnotationRegistry;
+import com.univocity.parsers.annotations.helpers.MethodFilter;
+import com.univocity.parsers.common.beans.PropertyWrapper;
+import com.univocity.parsers.conversions.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AnnotationHelperTest {
+    @Test
+    public void createsConfiguredAndDefaultInstances() {
+        final PrefixHeaderTransformer transformer = AnnotationHelper.newInstance(
+                HeaderTransformer.class,
+                PrefixHeaderTransformer.class,
+                new String[] {"customer-"}
+        );
+        assertEquals("customer-name", transformer.transformName((Field) null, "name"));
+
+        final PassingValidator validator = AnnotationHelper.newInstance(
+                Validator.class,
+                PassingValidator.class,
+                new String[0]
+        );
+        assertNull(validator.validate("accepted"));
+    }
+
+    @Test
+    public void appliesFormatterSettingsThroughBeanProperties() {
+        final DecimalFormat formatter = new DecimalFormat("###0.###");
+
+        AnnotationHelper.applyFormatSettings(formatter, new String[] {
+                "maximumIntegerDigits=3",
+                "decimalSeparator=,"
+        });
+
+        assertEquals(3, formatter.getMaximumIntegerDigits());
+        assertEquals(',', formatter.getDecimalFormatSymbols().getDecimalSeparator());
+    }
+
+    @Test
+    public void discoversInheritedFieldsAndAnnotatedMethods() {
+        final Map<Field, PropertyWrapper> fields = AnnotationHelper.getAllFields(ChildRecord.class);
+        assertTrue(fields.keySet().stream().anyMatch(field -> "parentId".equals(field.getName())));
+        assertTrue(fields.keySet().stream().anyMatch(field -> "name".equals(field.getName())));
+
+        final List<Method> getters = AnnotationHelper.getAnnotatedMethods(ChildRecord.class, MethodFilter.ONLY_GETTERS);
+        assertEquals(1, getters.size());
+        assertEquals("getCategory", getters.get(0).getName());
+    }
+
+    @Test
+    public void copiesCustomAnnotationValuesIntoParsedAnnotation() {
+        AnnotationRegistry.reset();
+        final List<Field> fields = AnnotationHelper.getAnnotatedFields(ChildRecord.class, ParsedColumn.class);
+        assertFalse(fields.isEmpty());
+        final Field nameField = fields.stream()
+                .filter(field -> "name".equals(field.getName()))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        final Parsed parsed = AnnotationHelper.findAnnotation(nameField, Parsed.class);
+
+        assertNotNull(parsed);
+        assertArrayEquals(
+                new String[] {"customer_name"},
+                AnnotationRegistry.getValue(nameField, parsed, "field", parsed.field())
+        );
+        assertEquals(2, AnnotationRegistry.getValue(nameField, parsed, "index", parsed.index()));
+    }
+
+    @Parsed
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({FIELD, METHOD})
+    public @interface ParsedColumn {
+        @Copy(to = Parsed.class)
+        String field() default "";
+
+        @Copy(to = Parsed.class, property = "index")
+        int position() default -1;
+    }
+
+    public static class PrefixHeaderTransformer extends HeaderTransformer {
+        private final String prefix;
+
+        public PrefixHeaderTransformer(String[] arguments) {
+            prefix = arguments[0];
+        }
+
+        @Override
+        public String transformName(Field field, String name) {
+            return prefix + name;
+        }
+    }
+
+    public static class PassingValidator implements Validator<Object> {
+        @Override
+        public String validate(Object value) {
+            return null;
+        }
+    }
+
+    public static class ParentRecord {
+        private String parentId;
+
+        public String getParentId() {
+            return parentId;
+        }
+
+        public void setParentId(String parentId) {
+            this.parentId = parentId;
+        }
+    }
+
+    public static class ChildRecord extends ParentRecord {
+        @ParsedColumn(field = "customer_name", position = 2)
+        private String name;
+        private String category;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @ParsedColumn(field = "category")
+        public String getCategory() {
+            return category;
+        }
+
+        @ParsedColumn(field = "category")
+        public void setCategory(String category) {
+            this.category = category;
+        }
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/AnnotationRegistryInnerAnnotationAttributesTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/AnnotationRegistryInnerAnnotationAttributesTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.annotations.Copy;
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.helpers.AnnotationHelper;
+import com.univocity.parsers.annotations.helpers.AnnotationRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AnnotationRegistryInnerAnnotationAttributesTest {
+    @Test
+    public void promotesCopiedScalarAttributeToArrayWhenParentAnnotationRequiresArray() throws NoSuchFieldException {
+        AnnotationRegistry.reset();
+        final Field field = RecordWithForwardedName.class.getDeclaredField("accountId");
+
+        final Parsed parsed = AnnotationHelper.findAnnotation(field, Parsed.class);
+
+        assertNotNull(parsed);
+        assertArrayEquals(
+                new String[] {"account_id"},
+                AnnotationRegistry.getValue(field, parsed, "field", parsed.field())
+        );
+    }
+
+    @Parsed
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ANNOTATION_TYPE, FIELD, METHOD})
+    public @interface ParsedFieldBridge {
+        @Copy(to = Parsed.class, property = "field")
+        String[] bridgeFieldNames() default {"ignored_by_registry_promotion"};
+    }
+
+    @ParsedFieldBridge
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ANNOTATION_TYPE, FIELD, METHOD})
+    public @interface IntermediateParsedField {
+    }
+
+    @IntermediateParsedField
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({FIELD, METHOD})
+    public @interface ScalarParsedField {
+        @Copy(to = IntermediateParsedField.class, property = "field")
+        String field() default "";
+    }
+
+    public static class RecordWithForwardedName {
+        @ScalarParsedField(field = "account_id")
+        private String accountId;
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/ArgumentUtilsTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/ArgumentUtilsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.common.ArgumentUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArgumentUtilsTest {
+    @Test
+    public void findsDuplicatesWithArrayComponentTypePreserved() {
+        final String[] values = {"name", "code", "name", "status", "code", "code"};
+
+        final String[] duplicates = ArgumentUtils.findDuplicates(values);
+
+        assertArrayEquals(new String[] {"name", "code", "code"}, duplicates);
+        assertEquals(String[].class, duplicates.getClass());
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/BeanConversionProcessorTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/BeanConversionProcessorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.Trim;
+import com.univocity.parsers.csv.CsvParserSettings;
+import com.univocity.parsers.csv.CsvRoutines;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BeanConversionProcessorTest {
+    @Test
+    public void appliesAnnotatedConversionBeforeDefaultNumericConversion() {
+        final CsvParserSettings settings = new CsvParserSettings();
+        settings.setHeaderExtractionEnabled(true);
+
+        final CsvRoutines routines = new CsvRoutines(settings);
+        final List<InventoryRecord> records = routines.parseAll(
+                InventoryRecord.class,
+                new StringReader("quantity\n 42 \n")
+        );
+
+        assertEquals(1, records.size());
+        assertEquals(42, records.get(0).quantity);
+    }
+
+    public static class InventoryRecord {
+        @Trim
+        @Parsed(field = "quantity")
+        private int quantity;
+
+        public InventoryRecord() {
+        }
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/EnumConversionTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/EnumConversionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.conversions.EnumConversion;
+import com.univocity.parsers.conversions.EnumSelector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnumConversionTest {
+    @Test
+    public void convertsUsingCustomFieldValues() {
+        final EnumConversion<FieldBackedStatus> conversion = new EnumConversion<>(
+                FieldBackedStatus.class,
+                null,
+                null,
+                "wireValue",
+                EnumSelector.CUSTOM_FIELD
+        );
+
+        assertEquals(FieldBackedStatus.APPROVED, conversion.execute("approved"));
+        assertEquals("rejected", conversion.revert(FieldBackedStatus.REJECTED));
+    }
+
+    @Test
+    public void convertsUsingCustomInstanceMethodValues() {
+        final EnumConversion<MethodBackedStatus> conversion = new EnumConversion<>(
+                MethodBackedStatus.class,
+                null,
+                null,
+                "externalName",
+                EnumSelector.CUSTOM_METHOD
+        );
+
+        assertEquals(MethodBackedStatus.PAID, conversion.execute("paid-in-full"));
+        assertEquals("pending-payment", conversion.revert(MethodBackedStatus.PENDING));
+    }
+
+    @Test
+    public void convertsUsingCustomStaticLookupMethod() {
+        final EnumConversion<LookupBackedStatus> conversion = new EnumConversion<>(
+                LookupBackedStatus.class,
+                null,
+                null,
+                "fromExternalName",
+                EnumSelector.CUSTOM_METHOD
+        );
+
+        assertEquals(LookupBackedStatus.ACTIVE, conversion.execute("active-account"));
+        assertEquals(LookupBackedStatus.SUSPENDED, conversion.execute("suspended-account"));
+    }
+
+    public enum FieldBackedStatus {
+        APPROVED("approved"),
+        REJECTED("rejected");
+
+        private final String wireValue;
+
+        FieldBackedStatus(String wireValue) {
+            this.wireValue = wireValue;
+        }
+    }
+
+    public enum MethodBackedStatus {
+        PAID("paid-in-full"),
+        PENDING("pending-payment");
+
+        private final String label;
+
+        MethodBackedStatus(String label) {
+            this.label = label;
+        }
+
+        public String externalName() {
+            return label;
+        }
+    }
+
+    public enum LookupBackedStatus {
+        ACTIVE,
+        SUSPENDED;
+
+        public static LookupBackedStatus fromExternalName(String externalName) {
+            if ("active-account".equals(externalName)) {
+                return ACTIVE;
+            }
+            if ("suspended-account".equals(externalName)) {
+                return SUSPENDED;
+            }
+            throw new IllegalArgumentException("Unknown status: " + externalName);
+        }
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/FieldMappingTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/FieldMappingTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.csv.CsvParserSettings;
+import com.univocity.parsers.csv.CsvRoutines;
+import com.univocity.parsers.csv.CsvWriterSettings;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FieldMappingTest {
+    @Test
+    public void readsAndWritesAnnotatedFieldsDirectly() {
+        final CsvRoutines parser = new CsvRoutines(parserSettings());
+        final List<FieldMappedRecord> records = parser.parseAll(
+                FieldMappedRecord.class,
+                new StringReader("code\nfield-value\n")
+        );
+
+        assertEquals(1, records.size());
+        assertEquals("field-value", records.get(0).code);
+
+        final StringWriter output = new StringWriter();
+        final CsvRoutines writer = new CsvRoutines(writerSettings());
+        writer.writeAll(records, FieldMappedRecord.class, output, "code");
+
+        assertEquals("code\nfield-value\n", output.toString());
+    }
+
+    @Test
+    public void invokesAnnotatedSetterWhenParsingRows() {
+        final CsvRoutines parser = new CsvRoutines(parserSettings());
+        final List<SetterMappedRecord> records = parser.parseAll(
+                SetterMappedRecord.class,
+                new StringReader("code\nsetter-value\n")
+        );
+
+        assertEquals(1, records.size());
+        assertEquals("parsed:setter-value", records.get(0).value());
+    }
+
+    @Test
+    public void invokesAnnotatedGetterWhenWritingRows() {
+        final StringWriter output = new StringWriter();
+        final CsvRoutines writer = new CsvRoutines(writerSettings());
+        writer.writeAll(
+                Collections.singletonList(new GetterMappedRecord("getter-value")),
+                GetterMappedRecord.class,
+                output,
+                "code"
+        );
+
+        assertEquals("code\ngetter-value\n", output.toString());
+    }
+
+    private static CsvParserSettings parserSettings() {
+        final CsvParserSettings settings = new CsvParserSettings();
+        settings.setHeaderExtractionEnabled(true);
+        return settings;
+    }
+
+    private static CsvWriterSettings writerSettings() {
+        final CsvWriterSettings settings = new CsvWriterSettings();
+        settings.getFormat().setLineSeparator("\n");
+        return settings;
+    }
+
+    public static class FieldMappedRecord {
+        @Parsed(field = "code")
+        private String code;
+
+        public FieldMappedRecord() {
+        }
+    }
+
+    public static class SetterMappedRecord {
+        private String code;
+
+        public SetterMappedRecord() {
+        }
+
+        @Parsed(field = "code")
+        public void setCode(String code) {
+            this.code = "parsed:" + code;
+        }
+
+        public String value() {
+            return code;
+        }
+    }
+
+    public static class GetterMappedRecord {
+        private final String code;
+
+        public GetterMappedRecord(String code) {
+            this.code = code;
+        }
+
+        @Parsed(field = "code")
+        public String getCode() {
+            return code;
+        }
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/Univocity_parsersTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/Univocity_parsersTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_univocity.univocity_parsers;
+
+import org.junit.jupiter.api.Test;
+
+class Univocity_parsersTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/Univocity_parsersTest.java
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/java/com_univocity/univocity_parsers/Univocity_parsersTest.java
@@ -8,9 +8,9 @@ package com_univocity.univocity_parsers;
 
 import org.junit.jupiter.api.Test;
 
-class Univocity_parsersTest {
+public class Univocity_parsersTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    public void loadsLibrary() {
+        System.out.println("univocity-parsers is available");
     }
 }

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,287 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationHelperTest$ChildRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationHelperTest$ParentRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationHelperTest$ParsedColumn",
+      "methods" : [
+        {
+          "name" : "field",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "position",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationHelperTest$PassingValidator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationHelperTest$PrefixHeaderTransformer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationRegistryInnerAnnotationAttributesTest$IntermediateParsedField"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationRegistryInnerAnnotationAttributesTest$ParsedFieldBridge",
+      "methods" : [
+        {
+          "name" : "bridgeFieldNames",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.AnnotationRegistryInnerAnnotationAttributesTest$ScalarParsedField",
+      "methods" : [
+        {
+          "name" : "field",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.FieldMapping"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecord",
+      "fields" : [
+        {
+          "name" : "quantity"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.AbstractBeanProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.BeanConversionProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecord",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecordBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.BeanConversionProcessorTest$InventoryRecordCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.conversions.EnumConversion"
+      },
+      "type" : "com_univocity.univocity_parsers.EnumConversionTest$FieldBackedStatus",
+      "fields" : [
+        {
+          "name" : "wireValue"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.conversions.EnumConversion"
+      },
+      "type" : "com_univocity.univocity_parsers.EnumConversionTest$LookupBackedStatus",
+      "methods" : [
+        {
+          "name" : "fromExternalName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.conversions.EnumConversion"
+      },
+      "type" : "com_univocity.univocity_parsers.EnumConversionTest$MethodBackedStatus",
+      "methods" : [
+        {
+          "name" : "externalName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$FieldMappedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.FieldMapping"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$FieldMappedRecord",
+      "fields" : [
+        {
+          "name" : "code"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.BeanConversionProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$FieldMappedRecord",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$FieldMappedRecordBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$FieldMappedRecordCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$GetterMappedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.FieldMapping"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$GetterMappedRecord",
+      "methods" : [
+        {
+          "name" : "getCode",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.BeanWriterProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$GetterMappedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.FieldMapping"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecord",
+      "methods" : [
+        {
+          "name" : "setCode",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.AbstractBeanProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.common.processor.core.BeanConversionProcessor"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecord",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecordBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.univocity.parsers.annotations.helpers.AnnotationHelper"
+      },
+      "type" : "com_univocity.univocity_parsers.FieldMappingTest$SetterMappedRecordCustomizer"
+    }
+  ]
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/user-code-filter.json
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.univocity.parsers.**"
+    }
+  ]
+}

--- a/tests/src/com.univocity/univocity-parsers/2.9.1/user-code-filter.json
+++ b/tests/src/com.univocity/univocity-parsers/2.9.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.univocity.parsers.**"
+      "includeClasses" : "com.univocity.parsers.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2996

This PR introduces tests and metadata for com.univocity:univocity-parsers:2.9.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 342262
- Cached input tokens: 3123712
- Output tokens: 32270
- Metadata entries: 31
- Test-only metadata entries: 47
- Iterations: 7
- Library coverage percentage: 22.6
- Generated lines of code: 439
- Tested library lines of code: 2187

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `f4f0f9be0e5eced44cb1b5ea24941f18c06b9a4f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 32/32 covered calls (100.00%)
- Reflection: 32/32 covered calls (100.00%)

Library coverage:
- Instruction: 9058/45088 (20.09%)
- Line: 2187/9678 (22.60%)
- Method: 442/2295 (19.26%)
