### PR TITLE
[GenAI] Add support for com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/index.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.13.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.13.1/jackson-datatype-jsr310-2.13.1-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-modules-java8",
+    "test-code-url" : "https://github.com/FasterXML/jackson-modules-java8/tree/jackson-modules-java8-2.13.1/datetime/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.13.1/jackson-datatype-jsr310-2.13.1-javadoc.jar",
+    "description" : "Jackson Datatype JSR310 is an add-on module for Jackson that adds serialization and deserialization support for Java 8 Date and Time API types. It lets ObjectMapper handle java.time classes such as LocalDate, LocalDateTime, OffsetDateTime, and Instant using Jackson's standard module registration mechanism.",
+    "tested-versions" : [
+      "2.13.1"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.datatype.jsr310"
+    ]
+  }
+]

--- a/stats/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T20:37:16.669245Z",
+    "library": "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1",
+    "starting_commit": "a2a8e9309acba17a56d515d34f7fcf5cee9d5044",
+    "ending_commit": "a1eb09f443c2dd205cab3797b552730b335423d4",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.13.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2758,
+          "missed": 3770,
+          "ratio": 0.422488,
+          "total": 6528
+        },
+        "line": {
+          "covered": 714,
+          "missed": 810,
+          "ratio": 0.468504,
+          "total": 1524
+        },
+        "method": {
+          "covered": 218,
+          "missed": 137,
+          "ratio": 0.614085,
+          "total": 355
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 96752,
+      "cached_input_tokens_used": 531456,
+      "output_tokens_used": 13826,
+      "iterations": 3,
+      "cost_usd": 0.6805,
+      "generated_loc": 228,
+      "tested_library_loc": 714,
+      "metadata_entries": 4,
+      "code_coverage_percent": 46.85
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/stats.json
+++ b/stats/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.13.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2758,
+        "missed" : 3770,
+        "ratio" : 0.422488,
+        "total" : 6528
+      },
+      "line" : {
+        "covered" : 714,
+        "missed" : 810,
+        "ratio" : 0.468504,
+        "total" : 1524
+      },
+      "method" : {
+        "covered" : 218,
+        "missed" : 137,
+        "ratio" : 0.614085,
+        "total" : 355
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/.gitignore
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/build.gradle
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1
+library.version = 2.13.1
+metadata.dir = com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.datatype.jackson-datatype-jsr310_tests'

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
@@ -155,6 +155,23 @@ public class Jackson_datatype_jsr310Test {
         assertThat(mapper.readValue(durationJson, Duration.class)).isEqualTo(duration);
     }
 
+    @Test
+    void honorsDurationJsonFormatUnitPatterns() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+        DurationUnits values = new DurationUnits(Duration.ofMinutes(90), Duration.ofHours(5));
+
+        String json = mapper.writeValueAsString(values);
+
+        assertThat(json).contains("\"minutes\":90").contains("\"hours\":5");
+
+        DurationUnits restored = mapper.readValue("{\"minutes\":45,\"hours\":3}", DurationUnits.class);
+
+        assertThat(restored.minutes).isEqualTo(Duration.ofMinutes(45));
+        assertThat(restored.hours).isEqualTo(Duration.ofHours(3));
+    }
+
     private static ObjectMapper isoMapper() {
         return new ObjectMapper()
                 .registerModule(new JavaTimeModule())
@@ -236,6 +253,21 @@ public class Jackson_datatype_jsr310Test {
             this.meetingTime = meetingTime;
             this.compactDate = compactDate;
             this.billingMonth = billingMonth;
+        }
+    }
+
+    public static final class DurationUnits {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT, pattern = "MINUTES")
+        public Duration minutes;
+
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT, pattern = "HOURS")
+        public Duration hours;
+
+        public DurationUnits() {}
+
+        DurationUnits(Duration minutes, Duration hours) {
+            this.minutes = minutes;
+            this.hours = hours;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
@@ -102,6 +102,19 @@ public class Jackson_datatype_jsr310Test {
     }
 
     @Test
+    void supportsObjectMapperModuleAutoDiscovery() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .findAndRegisterModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        MonthDay leapDay = MonthDay.of(2, 29);
+
+        String json = mapper.writeValueAsString(leapDay);
+
+        assertThat(json).isEqualTo("\"--02-29\"");
+        assertThat(mapper.readValue(json, MonthDay.class)).isEqualTo(leapDay);
+    }
+
+    @Test
     void supportsArrayAndNumericTimestampRepresentations() throws Exception {
         ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         LocalDate date = LocalDate.of(2020, 2, 29);

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
@@ -6,11 +6,223 @@
  */
 package com_fasterxml_jackson_datatype.jackson_datatype_jsr310;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class Jackson_datatype_jsr310Test {
+public class Jackson_datatype_jsr310Test {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void serializesAndDeserializesIsoStringsForSupportedJavaTimeValues() throws Exception {
+        ObjectMapper mapper = isoMapper();
+        DateTimeValues values = DateTimeValues.sample();
+
+        String json = mapper.writeValueAsString(values);
+
+        assertThat(json)
+                .contains("\"localDate\":\"2020-02-29\"")
+                .contains("\"localTime\":\"13:45:59.123456789\"")
+                .contains("\"localDateTime\":\"2020-02-29T13:45:59.123456789\"")
+                .contains("\"offsetTime\":\"13:45:59.123456789+05:30\"")
+                .contains("\"offsetDateTime\":\"2020-02-29T13:45:59.123456789+05:30\"")
+                .contains("\"instant\":\"2020-02-29T08:15:30.123456789Z\"")
+                .contains("\"yearMonth\":\"2020-02\"")
+                .contains("\"monthDay\":\"--02-29\"")
+                .contains("\"period\":\"P1Y2M3D\"")
+                .contains("\"duration\":\"PT1H2M3.000000004S\"")
+                .contains("\"zoneId\":\"Europe/Paris\"")
+                .contains("\"zoneOffset\":\"+05:30\"");
+
+        DateTimeValues restored = mapper.readValue(json, DateTimeValues.class);
+
+        assertDateTimeValues(restored, values);
+    }
+
+    @Test
+    void honorsContextualJsonFormatPatternsOnJavaTimeProperties() throws Exception {
+        ObjectMapper mapper = isoMapper();
+        FormattedValues values = new FormattedValues(
+                LocalDateTime.of(2022, 10, 5, 14, 30, 15),
+                LocalDate.of(2022, 10, 5),
+                YearMonth.of(2022, 10));
+
+        String json = mapper.writeValueAsString(values);
+
+        assertThat(json)
+                .contains("\"meetingTime\":\"2022/10/05 14:30:15\"")
+                .contains("\"compactDate\":\"20221005\"")
+                .contains("\"billingMonth\":\"2022-10\"");
+
+        FormattedValues restored = mapper.readValue(json, FormattedValues.class);
+
+        assertThat(restored.meetingTime).isEqualTo(values.meetingTime);
+        assertThat(restored.compactDate).isEqualTo(values.compactDate);
+        assertThat(restored.billingMonth).isEqualTo(values.billingMonth);
+    }
+
+    @Test
+    void supportsTemporalValuesAsMapKeysAndValues() throws Exception {
+        ObjectMapper mapper = isoMapper();
+        Map<LocalDate, OffsetDateTime> deadlines = new LinkedHashMap<>();
+        deadlines.put(LocalDate.of(2024, 1, 31), OffsetDateTime.parse("2024-01-31T23:45:07+01:00"));
+        deadlines.put(LocalDate.of(2024, 2, 29), OffsetDateTime.parse("2024-02-29T10:15:30-05:00"));
+
+        String json = mapper.writeValueAsString(deadlines);
+
+        assertThat(json)
+                .contains("\"2024-01-31\":\"2024-01-31T23:45:07+01:00\"")
+                .contains("\"2024-02-29\":\"2024-02-29T10:15:30-05:00\"");
+
+        TypeReference<LinkedHashMap<LocalDate, OffsetDateTime>> type =
+                new TypeReference<LinkedHashMap<LocalDate, OffsetDateTime>>() {};
+        LinkedHashMap<LocalDate, OffsetDateTime> restored = mapper.readValue(json, type);
+
+        assertThat(restored).containsExactlyEntriesOf(deadlines);
+    }
+
+    @Test
+    void supportsArrayAndNumericTimestampRepresentations() throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        LocalDate date = LocalDate.of(2020, 2, 29);
+        LocalTime time = LocalTime.of(1, 2, 3, 4);
+        LocalDateTime dateTime = LocalDateTime.of(date, time);
+        Instant instant = Instant.parse("2022-01-01T00:00:00.123456789Z");
+
+        String dateJson = mapper.writeValueAsString(date);
+        String timeJson = mapper.writeValueAsString(time);
+        String dateTimeJson = mapper.writeValueAsString(dateTime);
+        String instantJson = mapper.writeValueAsString(instant);
+
+        assertThat(dateJson).isEqualTo("[2020,2,29]");
+        assertThat(dateTimeJson).startsWith("[2020,2,29,1,2,3");
+        assertThat(instantJson).doesNotStartWith("\"");
+        assertThat(mapper.readValue(dateJson, LocalDate.class)).isEqualTo(date);
+        assertThat(mapper.readValue(timeJson, LocalTime.class)).isEqualTo(time);
+        assertThat(mapper.readValue(dateTimeJson, LocalDateTime.class)).isEqualTo(dateTime);
+        assertThat(mapper.readValue(instantJson, Instant.class)).isEqualTo(instant);
+    }
+
+    @Test
+    void supportsMillisecondTimestampConfigurationForInstantsAndDurations() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
+        Instant instant = Instant.ofEpochMilli(1_640_995_200_123L);
+        Duration duration = Duration.ofMillis(3_723_004L);
+
+        String instantJson = mapper.writeValueAsString(instant);
+        String durationJson = mapper.writeValueAsString(duration);
+
+        assertThat(instantJson).isEqualTo("1640995200123");
+        assertThat(durationJson).isEqualTo("\"PT1H2M3.004S\"");
+        assertThat(mapper.readValue(instantJson, Instant.class)).isEqualTo(instant);
+        assertThat(mapper.readValue(durationJson, Duration.class)).isEqualTo(duration);
+    }
+
+    private static ObjectMapper isoMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID);
+    }
+
+    private static void assertDateTimeValues(DateTimeValues actual, DateTimeValues expected) {
+        assertThat(actual.localDate).isEqualTo(expected.localDate);
+        assertThat(actual.localTime).isEqualTo(expected.localTime);
+        assertThat(actual.localDateTime).isEqualTo(expected.localDateTime);
+        assertThat(actual.offsetTime).isEqualTo(expected.offsetTime);
+        assertThat(actual.offsetDateTime).isEqualTo(expected.offsetDateTime);
+        assertThat(actual.zonedDateTime).isEqualTo(expected.zonedDateTime);
+        assertThat(actual.instant).isEqualTo(expected.instant);
+        assertThat(actual.year).isEqualTo(expected.year);
+        assertThat(actual.yearMonth).isEqualTo(expected.yearMonth);
+        assertThat(actual.monthDay).isEqualTo(expected.monthDay);
+        assertThat(actual.period).isEqualTo(expected.period);
+        assertThat(actual.duration).isEqualTo(expected.duration);
+        assertThat(actual.zoneId).isEqualTo(expected.zoneId);
+        assertThat(actual.zoneOffset).isEqualTo(expected.zoneOffset);
+    }
+
+    public static final class DateTimeValues {
+        public LocalDate localDate;
+        public LocalTime localTime;
+        public LocalDateTime localDateTime;
+        public OffsetTime offsetTime;
+        public OffsetDateTime offsetDateTime;
+        public ZonedDateTime zonedDateTime;
+        public Instant instant;
+        public Year year;
+        public YearMonth yearMonth;
+        public MonthDay monthDay;
+        public Period period;
+        public Duration duration;
+        public ZoneId zoneId;
+        public ZoneOffset zoneOffset;
+
+        public DateTimeValues() {}
+
+        static DateTimeValues sample() {
+            DateTimeValues values = new DateTimeValues();
+            values.localDate = LocalDate.of(2020, 2, 29);
+            values.localTime = LocalTime.of(13, 45, 59, 123_456_789);
+            values.localDateTime = LocalDateTime.of(values.localDate, values.localTime);
+            values.offsetTime = OffsetTime.of(values.localTime, ZoneOffset.ofHoursMinutes(5, 30));
+            values.offsetDateTime = OffsetDateTime.of(values.localDateTime, ZoneOffset.ofHoursMinutes(5, 30));
+            values.zonedDateTime = ZonedDateTime.of(
+                    LocalDateTime.of(2020, 2, 29, 9, 15, 30, 123_456_789), ZoneId.of("Europe/Paris"));
+            values.instant = Instant.parse("2020-02-29T08:15:30.123456789Z");
+            values.year = Year.of(2020);
+            values.yearMonth = YearMonth.of(2020, 2);
+            values.monthDay = MonthDay.of(2, 29);
+            values.period = Period.of(1, 2, 3);
+            values.duration = Duration.ofHours(1).plusMinutes(2).plusSeconds(3).plusNanos(4);
+            values.zoneId = ZoneId.of("Europe/Paris");
+            values.zoneOffset = ZoneOffset.ofHoursMinutes(5, 30);
+            return values;
+        }
+    }
+
+    public static final class FormattedValues {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu/MM/dd HH:mm:ss")
+        public LocalDateTime meetingTime;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuuMMdd")
+        public LocalDate compactDate;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM")
+        public YearMonth billingMonth;
+
+        public FormattedValues() {}
+
+        FormattedValues(LocalDateTime meetingTime, LocalDate compactDate, YearMonth billingMonth) {
+            this.meetingTime = meetingTime;
+            this.compactDate = compactDate;
+            this.billingMonth = billingMonth;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_datatype.jackson_datatype_jsr310;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_datatype_jsr310Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jsr310/Jackson_datatype_jsr310Test.java
@@ -214,7 +214,7 @@ public class Jackson_datatype_jsr310Test {
         public ZoneId zoneId;
         public ZoneOffset zoneOffset;
 
-        public DateTimeValues() {}
+        public DateTimeValues() { }
 
         static DateTimeValues sample() {
             DateTimeValues values = new DateTimeValues();
@@ -247,7 +247,7 @@ public class Jackson_datatype_jsr310Test {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM")
         public YearMonth billingMonth;
 
-        public FormattedValues() {}
+        public FormattedValues() { }
 
         FormattedValues(LocalDateTime meetingTime, LocalDate compactDate, YearMonth billingMonth) {
             this.meetingTime = meetingTime;
@@ -263,7 +263,7 @@ public class Jackson_datatype_jsr310Test {
         @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT, pattern = "HOURS")
         public Duration hours;
 
-        public DurationUnits() {}
+        public DurationUnits() { }
 
         DurationUnits(Duration minutes, Duration hours) {
             this.minutes = minutes;

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.fasterxml.jackson.datatype.jsr310.**"
+      "includeClasses" : "com.fasterxml.jackson.datatype.jsr310.**"
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.fasterxml.jackson.datatype.jsr310.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1308

This PR introduces tests and metadata for com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 96752
- Cached input tokens: 531456
- Output tokens: 13826
- Metadata entries: 4
- Iterations: 3
- Library coverage percentage: 46.85
- Generated lines of code: 228
- Tested library lines of code: 714

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `master`
- Forge commit hash: `2122abd53937dc9507f8d8a98cc4c7046c40d254`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2758/6528 (42.25%)
- Line: 714/1524 (46.85%)
- Method: 218/355 (61.41%)
