### PR TITLE
[GenAI] Add support for io.quarkus:quarkus-fs-util:1.3.0 using gpt-5.5

### DIFF
--- a/metadata/io.quarkus/quarkus-fs-util/1.3.0/reachability-metadata.json
+++ b/metadata/io.quarkus/quarkus-fs-util/1.3.0/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.quarkus.fs.util.FileSystemProviders"
+      },
+      "type": "jdk.internal.jrtfs.JrtFileSystemProvider"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.quarkus.fs.util.FileSystemProviders"
+      },
+      "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.fs.util.ZipUtils"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    }
+  ]
+}

--- a/metadata/io.quarkus/quarkus-fs-util/index.json
+++ b/metadata/io.quarkus/quarkus-fs-util/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-fs-util/1.3.0/quarkus-fs-util-1.3.0-sources.jar",
+    "repository-url" : "https://github.com/quarkusio/quarkus-fs-util",
+    "test-code-url" : "https://github.com/quarkusio/quarkus-fs-util/tree/1.3.0/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-fs-util/1.3.0/quarkus-fs-util-1.3.0-javadoc.jar",
+    "description" : "Quarkus FS Util provides helper classes for low-level filesystem operations in Java. It wraps and adapts Java NIO file system APIs to support efficient path, provider, and ZIP filesystem handling used by Quarkus tooling.",
+    "tested-versions" : [
+      "1.3.0"
+    ],
+    "allowed-packages" : [
+      "io.quarkus.fs.util"
+    ]
+  }
+]

--- a/stats/io.quarkus/quarkus-fs-util/1.3.0/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-fs-util/1.3.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T20:47:34.880774Z",
+    "library": "io.quarkus:quarkus-fs-util:1.3.0",
+    "starting_commit": "67247e76bcba824d37b2b81f64f8c3699892081d",
+    "ending_commit": "b4ecb69ad367e94b9345d21256492ef7edb89542",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.3.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 724,
+          "missed": 691,
+          "ratio": 0.511661,
+          "total": 1415
+        },
+        "line": {
+          "covered": 170,
+          "missed": 149,
+          "ratio": 0.532915,
+          "total": 319
+        },
+        "method": {
+          "covered": 45,
+          "missed": 90,
+          "ratio": 0.333333,
+          "total": 135
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 243617,
+      "cached_input_tokens_used": 1972736,
+      "output_tokens_used": 18759,
+      "iterations": 3,
+      "cost_usd": 1.5492,
+      "generated_loc": 227,
+      "tested_library_loc": 170,
+      "metadata_entries": 3,
+      "code_coverage_percent": 53.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java",
+      "metadata_file": "metadata/io.quarkus/quarkus-fs-util/1.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.quarkus/quarkus-fs-util/1.3.0/stats.json
+++ b/stats/io.quarkus/quarkus-fs-util/1.3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 724,
+        "missed" : 691,
+        "ratio" : 0.511661,
+        "total" : 1415
+      },
+      "line" : {
+        "covered" : 170,
+        "missed" : 149,
+        "ratio" : 0.532915,
+        "total" : 319
+      },
+      "method" : {
+        "covered" : 45,
+        "missed" : 90,
+        "ratio" : 0.333333,
+        "total" : 135
+      }
+    }
+  } ]
+}

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/.gitignore
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/build.gradle
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/build.gradle
@@ -24,4 +24,9 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        test {
+            buildArgs.add('--enable-url-protocols=jar')
+        }
+    }
 }

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/build.gradle
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.quarkus:quarkus-fs-util:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/gradle.properties
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.quarkus:quarkus-fs-util:1.3.0
+library.version = 1.3.0
+metadata.dir = io.quarkus/quarkus-fs-util/1.3.0/

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/settings.gradle
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.quarkus.quarkus-fs-util_tests'

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
@@ -8,11 +8,13 @@ package io_quarkus.quarkus_fs_util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import io.quarkus.fs.util.FileSystemHelper;
 import io.quarkus.fs.util.FileSystemProviders;
 import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.fs.util.sysfs.ConfigurableFileSystemProviderWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.net.URI;
@@ -20,12 +22,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessMode;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.junit.jupiter.api.Test;
@@ -86,6 +90,17 @@ public class Quarkus_fs_utilTest {
             assertThat(Files.readString(zipFileSystem.getPath("config/application.properties"), StandardCharsets.UTF_8))
                     .isEqualTo("key=value");
         }
+    }
+
+    @Test
+    void configurableFileSystemProviderAllowsOnlyConfiguredAccessModes() {
+        Path missing = tempDir.resolve("missing-executable");
+        ConfigurableFileSystemProviderWrapper provider = new ConfigurableFileSystemProviderWrapper(
+                missing.getFileSystem().provider(), Set.of(AccessMode.EXECUTE));
+
+        assertThatCode(() -> provider.checkAccess(missing, AccessMode.EXECUTE)).doesNotThrowAnyException();
+        assertThatExceptionOfType(NoSuchFileException.class)
+                .isThrownBy(() -> provider.checkAccess(missing, AccessMode.READ));
     }
 
     @Test

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
@@ -6,11 +6,222 @@
  */
 package io_quarkus.quarkus_fs_util;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-class Quarkus_fs_utilTest {
+import io.quarkus.fs.util.FileSystemHelper;
+import io.quarkus.fs.util.FileSystemProviders;
+import io.quarkus.fs.util.ZipUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessMode;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Quarkus_fs_utilTest {
+    @TempDir
+    Path tempDir;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void zipAndUnzipDirectoryPreservesNestedContents() throws Exception {
+        Path source = tempDir.resolve("source");
+        Files.createDirectories(source.resolve("nested/deeper"));
+        Files.writeString(source.resolve("alpha.txt"), "alpha", StandardCharsets.UTF_8);
+        Files.writeString(source.resolve("nested/beta.txt"), "beta", StandardCharsets.UTF_8);
+        Files.writeString(source.resolve("nested/deeper/gamma.txt"), "gamma", StandardCharsets.UTF_8);
+
+        Path zip = tempDir.resolve("archive.zip");
+        ZipUtils.zip(source, zip);
+
+        Path target = tempDir.resolve("target");
+        ZipUtils.unzip(zip, target);
+
+        assertThat(Files.readString(target.resolve("alpha.txt"), StandardCharsets.UTF_8)).isEqualTo("alpha");
+        assertThat(Files.readString(target.resolve("nested/beta.txt"), StandardCharsets.UTF_8)).isEqualTo("beta");
+        assertThat(Files.readString(target.resolve("nested/deeper/gamma.txt"), StandardCharsets.UTF_8))
+                .isEqualTo("gamma");
+    }
+
+    @Test
+    void zipSingleFileStoresItUnderOriginalFileName() throws Exception {
+        Path source = tempDir.resolve("note.txt");
+        Files.writeString(source, "single file payload", StandardCharsets.UTF_8);
+
+        Path zip = tempDir.resolve("single-file.zip");
+        ZipUtils.zip(source, zip);
+
+        try (FileSystem zipFileSystem = ZipUtils.newFileSystem(zip)) {
+            Path entry = zipFileSystem.getPath("note.txt");
+
+            assertThat(Files.isRegularFile(entry)).isTrue();
+            assertThat(Files.readString(entry, StandardCharsets.UTF_8)).isEqualTo("single file payload");
+        }
+    }
+
+    @Test
+    void newZipCreatesMissingParentDirectoriesAndCanBeReadBack() throws Exception {
+        Path zip = tempDir.resolve("missing/parents/created.zip");
+
+        try (FileSystem zipFileSystem = ZipUtils.newZip(zip)) {
+            Files.createDirectories(zipFileSystem.getPath("config"));
+            Files.writeString(
+                    zipFileSystem.getPath("config/application.properties"), "key=value", StandardCharsets.UTF_8);
+        }
+
+        assertThat(Files.isDirectory(zip.getParent())).isTrue();
+        try (FileSystem zipFileSystem = ZipUtils.newFileSystem(zip)) {
+            assertThat(Files.readString(zipFileSystem.getPath("config/application.properties"), StandardCharsets.UTF_8))
+                    .isEqualTo("key=value");
+        }
+    }
+
+    @Test
+    void copyFromZipCopiesOnlySelectedSubtree() throws Exception {
+        Path zip = tempDir.resolve("subtree.zip");
+        try (FileSystem zipFileSystem = ZipUtils.newZip(zip)) {
+            Files.createDirectories(zipFileSystem.getPath("root/child"));
+            Files.writeString(zipFileSystem.getPath("root/child/data.txt"), "copied", StandardCharsets.UTF_8);
+            Files.createDirectories(zipFileSystem.getPath("other"));
+            Files.writeString(zipFileSystem.getPath("other/ignored.txt"), "ignored", StandardCharsets.UTF_8);
+        }
+
+        Path target = tempDir.resolve("subtree-target");
+        Files.createDirectories(target);
+        try (FileSystem zipFileSystem = ZipUtils.newFileSystem(zip)) {
+            ZipUtils.copyFromZip(zipFileSystem.getPath("root"), target);
+        }
+
+        assertThat(Files.readString(target.resolve("child/data.txt"), StandardCharsets.UTF_8)).isEqualTo("copied");
+        assertThat(target.resolve("ignored.txt")).doesNotExist();
+    }
+
+    @Test
+    void zipReproduciblyCreatesStableArchiveBytesAndReadableEntries() throws Exception {
+        Path sourceA = tempDir.resolve("source-a");
+        Path sourceB = tempDir.resolve("source-b");
+        createSameTreeInNaturalOrder(sourceA);
+        createSameTreeInReverseOrder(sourceB);
+
+        Instant entryTime = Instant.parse("2020-01-02T03:04:05Z");
+        Path zipA = tempDir.resolve("reproducible-a.zip");
+        Path zipB = tempDir.resolve("reproducible-b.zip");
+
+        ZipUtils.zipReproducibly(sourceA, zipA, entryTime);
+        ZipUtils.zipReproducibly(sourceB, zipB, entryTime);
+
+        assertThat(Files.readAllBytes(zipA)).isEqualTo(Files.readAllBytes(zipB));
+        assertThat(zipEntryNames(zipA)).contains("alpha.txt", "nested/beta.txt", "nested/gamma.txt");
+
+        Path unpacked = tempDir.resolve("reproducible-unpacked");
+        ZipUtils.unzip(zipA, unpacked);
+        assertThat(Files.readString(unpacked.resolve("alpha.txt"), StandardCharsets.UTF_8)).isEqualTo("alpha");
+        assertThat(Files.readString(unpacked.resolve("nested/beta.txt"), StandardCharsets.UTF_8)).isEqualTo("beta");
+        assertThat(Files.readString(unpacked.resolve("nested/gamma.txt"), StandardCharsets.UTF_8)).isEqualTo("gamma");
+    }
+
+    @Test
+    void createNewReproducibleZipFileSystemRejectsExistingTargetAndWritesEntries() throws Exception {
+        Path existing = tempDir.resolve("existing.zip");
+        Files.writeString(existing, "already here", StandardCharsets.UTF_8);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> ZipUtils.createNewReproducibleZipFileSystem(existing, Instant.EPOCH))
+                .withMessageContaining(existing.toString());
+
+        Path zip = tempDir.resolve("new-reproducible.zip");
+        try (FileSystem zipFileSystem = ZipUtils.createNewReproducibleZipFileSystem(zip, Instant.EPOCH)) {
+            Files.createDirectories(zipFileSystem.getPath("META-INF"));
+            Files.writeString(zipFileSystem.getPath("META-INF/example.txt"), "created", StandardCharsets.UTF_8);
+        }
+
+        try (FileSystem zipFileSystem = ZipUtils.newFileSystem(zip)) {
+            assertThat(Files.readString(zipFileSystem.getPath("META-INF/example.txt"), StandardCharsets.UTF_8))
+                    .isEqualTo("created");
+        }
+    }
+
+    @Test
+    void fileSystemHelperOpensZipFilesAndEscapesBangCharactersInUris() throws Exception {
+        Path directoryWithBang = tempDir.resolve("bang!");
+        Path zip = directoryWithBang.resolve("archive.zip");
+        try (FileSystem zipFileSystem = ZipUtils.newZip(zip)) {
+            Files.writeString(zipFileSystem.getPath("entry.txt"), "from zip", StandardCharsets.UTF_8);
+        }
+
+        URI zipUri = ZipUtils.toZipUri(zip);
+
+        assertThat(zipUri.getScheme()).isEqualTo("jar");
+        assertThat(zipUri.toASCIIString()).contains("bang%21/archive.zip!/");
+        try (FileSystem zipFileSystem = FileSystemHelper.openFS(zip, Map.of(), getClass().getClassLoader())) {
+            assertThat(Files.readString(zipFileSystem.getPath("entry.txt"), StandardCharsets.UTF_8))
+                    .isEqualTo("from zip");
+        }
+    }
+
+    @Test
+    void ignoreFileWriteabilityKeepsPathOperationsUsableWhileAllowingWriteAccessChecks() throws Exception {
+        Path file = tempDir.resolve("readonly-check.txt");
+        Files.writeString(file, "initial", StandardCharsets.UTF_8);
+
+        Path wrapped = FileSystemHelper.ignoreFileWriteability(file);
+
+        assertThat(wrapped.getFileSystem()).isNotSameAs(file.getFileSystem());
+        assertThat(wrapped.getFileSystem().provider()).isNotSameAs(file.getFileSystem().provider());
+        assertThat(Files.exists(wrapped)).isTrue();
+        assertThat(Files.readString(wrapped, StandardCharsets.UTF_8)).isEqualTo("initial");
+        assertThatCode(() -> wrapped.getFileSystem().provider().checkAccess(wrapped, AccessMode.WRITE))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void exposesUsableJarFileSystemProviderAndOutputStreamWrapperIsTransparent() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputStream wrapped = ZipUtils.wrapForJDK8232879(outputStream);
+
+        wrapped.write("payload".getBytes(StandardCharsets.UTF_8));
+        wrapped.flush();
+
+        assertThat(FileSystemProviders.ZIP_PROVIDER.getScheme()).isEqualTo("jar");
+        assertThat(wrapped).isSameAs(outputStream);
+        assertThat(outputStream.toString(StandardCharsets.UTF_8)).isEqualTo("payload");
+    }
+
+    private static void createSameTreeInNaturalOrder(Path root) throws Exception {
+        Files.createDirectories(root.resolve("nested"));
+        Files.writeString(root.resolve("alpha.txt"), "alpha", StandardCharsets.UTF_8);
+        Files.writeString(root.resolve("nested/beta.txt"), "beta", StandardCharsets.UTF_8);
+        Files.writeString(root.resolve("nested/gamma.txt"), "gamma", StandardCharsets.UTF_8);
+    }
+
+    private static void createSameTreeInReverseOrder(Path root) throws Exception {
+        Files.createDirectories(root.resolve("nested"));
+        Files.writeString(root.resolve("nested/gamma.txt"), "gamma", StandardCharsets.UTF_8);
+        Files.writeString(root.resolve("nested/beta.txt"), "beta", StandardCharsets.UTF_8);
+        Files.writeString(root.resolve("alpha.txt"), "alpha", StandardCharsets.UTF_8);
+    }
+
+    private static List<String> zipEntryNames(Path zip) throws Exception {
+        List<String> names = new ArrayList<>();
+        try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(zip))) {
+            ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                names.add(entry.getName());
+            }
+        }
+        Collections.sort(names);
+        return names;
     }
 }

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_quarkus.quarkus_fs_util;
+
+import org.junit.jupiter.api.Test;
+
+class Quarkus_fs_utilTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/src/test/java/io_quarkus/quarkus_fs_util/Quarkus_fs_utilTest.java
@@ -24,6 +24,9 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -165,6 +168,32 @@ public class Quarkus_fs_utilTest {
         try (FileSystem zipFileSystem = ZipUtils.newFileSystem(zip)) {
             assertThat(Files.readString(zipFileSystem.getPath("META-INF/example.txt"), StandardCharsets.UTF_8))
                     .isEqualTo("created");
+        }
+    }
+
+    @Test
+    void reproducibleZipFileSystemNormalizesEntryTimestampsAndUnixPermissions() throws Exception {
+        Instant entryTime = Instant.parse("2021-04-05T06:07:08Z");
+        Path zip = tempDir.resolve("normalized-attributes.zip");
+
+        try (FileSystem zipFileSystem = ZipUtils.createNewReproducibleZipFileSystem(zip, entryTime)) {
+            Files.createDirectories(zipFileSystem.getPath("assets"));
+            Files.writeString(zipFileSystem.getPath("assets/data.txt"), "normalized", StandardCharsets.UTF_8);
+        }
+
+        FileTime expectedTime = FileTime.fromMillis(entryTime.toEpochMilli());
+        Set<PosixFilePermission> expectedDirectoryPermissions = PosixFilePermissions.fromString("rwxr-xr-x");
+        Set<PosixFilePermission> expectedFilePermissions = PosixFilePermissions.fromString("rw-r--r--");
+        try (FileSystem zipFileSystem = ZipUtils.newFileSystem(
+                ZipUtils.toZipUri(zip), Map.of("enablePosixFileAttributes", "true"))) {
+            Path directory = zipFileSystem.getPath("assets");
+            Path file = zipFileSystem.getPath("assets/data.txt");
+
+            assertThat(Files.getLastModifiedTime(directory)).isEqualTo(expectedTime);
+            assertThat(Files.getLastModifiedTime(file)).isEqualTo(expectedTime);
+            assertThat(Files.getPosixFilePermissions(directory)).isEqualTo(expectedDirectoryPermissions);
+            assertThat(Files.getPosixFilePermissions(file)).isEqualTo(expectedFilePermissions);
+            assertThat(Files.readString(file, StandardCharsets.UTF_8)).isEqualTo("normalized");
         }
     }
 

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.quarkus.fs.util.**"
+    }
+  ]
+}

--- a/tests/src/io.quarkus/quarkus-fs-util/1.3.0/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-fs-util/1.3.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.quarkus.fs.util.**"
+      "includeClasses" : "io.quarkus.fs.util.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3730

This PR introduces tests and metadata for io.quarkus:quarkus-fs-util:1.3.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 243617
- Cached input tokens: 1972736
- Output tokens: 18759
- Metadata entries: 3
- Iterations: 3
- Library coverage percentage: 53.29
- Generated lines of code: 227
- Tested library lines of code: 170

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 724/1415 (51.17%)
- Line: 170/319 (53.29%)
- Method: 45/135 (33.33%)
