### PR TITLE
[GenAI] Add support for io.netty:netty-transport-native-unix-common:4.1.42.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-native-unix-common/4.1.42.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/4.1.42.Final/reachability-metadata.json
@@ -1,0 +1,149 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.PreferredDirectByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.FileDescriptor"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent0$5"
+      },
+      "type": "java.nio.Bits",
+      "fields": [
+        {
+          "name": "UNALIGNED"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Buffer"
+      },
+      "type": "sun.misc.VM"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-native-unix-common/index.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.42.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.42.Final/netty-transport-native-unix-common-tests-4.1.42.Final-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-javadoc.jar",
+    "description" : "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
+    "tested-versions" : [
+      "4.1.42.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.unix"
+    ]
+  }
+]

--- a/metadata/io.netty/netty-transport-native-unix-common/index.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.1.42.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.42.Final/netty-transport-native-unix-common-tests-4.1.42.Final-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-javadoc.jar",
-    "description" : "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.1.42.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.42.Final/netty-transport-native-unix-common-tests-4.1.42.Final-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-javadoc.jar",
+    "description": "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
+    "tested-versions": [
       "4.1.42.Final"
     ],
-    "allowed-packages" : [
-      "io.netty.channel.unix"
+    "allowed-packages": [
+      "io.netty.channel.unix",
+      "io.netty.util.internal"
     ]
   }
 ]

--- a/stats/io.netty/netty-transport-native-unix-common/4.1.42.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-native-unix-common/4.1.42.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T21:29:23.822108Z",
+    "library": "io.netty:netty-transport-native-unix-common:4.1.42.Final",
+    "starting_commit": "cc99e1f41b904fa5273ff60cbbcec0ad61f619c1",
+    "ending_commit": "c995df466e88861eade0681d861bb4a354745a96",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.42.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 425,
+          "missed": 1817,
+          "ratio": 0.189563,
+          "total": 2242
+        },
+        "line": {
+          "covered": 87,
+          "missed": 443,
+          "ratio": 0.164151,
+          "total": 530
+        },
+        "method": {
+          "covered": 40,
+          "missed": 123,
+          "ratio": 0.245399,
+          "total": 163
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 219589,
+      "cached_input_tokens_used": 2181632,
+      "output_tokens_used": 29808,
+      "iterations": 3,
+      "cost_usd": 1.985,
+      "generated_loc": 224,
+      "tested_library_loc": 87,
+      "metadata_entries": 29,
+      "code_coverage_percent": 16.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-native-unix-common/4.1.42.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-native-unix-common/4.1.42.Final/stats.json
+++ b/stats/io.netty/netty-transport-native-unix-common/4.1.42.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.42.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 425,
+        "missed" : 1817,
+        "ratio" : 0.189563,
+        "total" : 2242
+      },
+      "line" : {
+        "covered" : 87,
+        "missed" : 443,
+        "ratio" : 0.164151,
+        "total" : 530
+      },
+      "method" : {
+        "covered" : 40,
+        "missed" : 123,
+        "ratio" : 0.245399,
+        "total" : 163
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-native-unix-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-native-unix-common:4.1.42.Final
+library.version = 4.1.42.Final
+metadata.dir = io.netty/netty-transport-native-unix-common/4.1.42.Final/

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-native-unix-common_tests'

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_native_unix_common;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_native_unix_commonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -6,11 +6,230 @@
  */
 package io_netty.netty_transport_native_unix_common;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.unix.Buffer;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.NativeInetAddress;
+import io.netty.channel.unix.PreferredDirectByteBufAllocator;
+import io.netty.channel.unix.UnixChannelOption;
+import io.netty.channel.unix.UnixChannelUtil;
+import java.io.File;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
-class Netty_transport_native_unix_commonTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Netty_transport_native_unix_commonTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void domainSocketAddressExposesPathAndValueSemantics() {
+        DomainSocketAddress stringAddress = new DomainSocketAddress("/tmp/netty-test.sock");
+        DomainSocketAddress equalAddress = new DomainSocketAddress(new File("/tmp/netty-test.sock"));
+        DomainSocketAddress otherAddress = new DomainSocketAddress("/tmp/netty-other.sock");
+
+        assertThat(stringAddress.path()).isEqualTo("/tmp/netty-test.sock");
+        assertThat(stringAddress.toString()).isEqualTo("/tmp/netty-test.sock");
+        assertThat(stringAddress).isEqualTo(equalAddress);
+        assertThat(stringAddress.hashCode()).isEqualTo(equalAddress.hashCode());
+        assertThat(stringAddress).isNotEqualTo(otherAddress);
+        assertThat(stringAddress).isNotEqualTo("/tmp/netty-test.sock");
+        assertThatNullPointerException()
+                .isThrownBy(() -> new DomainSocketAddress((String) null));
+    }
+
+    @Test
+    void nativeInetAddressMapsIpv4AddressToIpv4MappedIpv6Bytes() throws Exception {
+        InetAddress loopback = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+        NativeInetAddress nativeAddress = NativeInetAddress.newInstance(loopback);
+        byte[] expected = new byte[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, (byte) 0xff, (byte) 0xff,
+                127, 0, 0, 1
+        };
+
+        assertThat(nativeAddress.address()).containsExactly(expected);
+        assertThat(nativeAddress.scopeId()).isZero();
+        assertThat(NativeInetAddress.ipv4MappedIpv6Address(loopback.getAddress())).containsExactly(expected);
+
+        byte[] copied = new byte[16];
+        NativeInetAddress.copyIpv4MappedIpv6Address(new byte[] {10, 20, 30, 40}, copied);
+        assertThat(copied).containsExactly(
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, (byte) 0xff, (byte) 0xff,
+                10, 20, 30, 40);
+    }
+
+    @Test
+    void nativeInetAddressPreservesIpv6BytesAndScope() throws Exception {
+        byte[] ipv6Bytes = new byte[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 1
+        };
+        Inet6Address loopback = Inet6Address.getByAddress(null, ipv6Bytes, 0);
+        NativeInetAddress nativeAddress = NativeInetAddress.newInstance(loopback);
+
+        assertThat(nativeAddress.address()).containsExactly(ipv6Bytes);
+        assertThat(nativeAddress.scopeId()).isEqualTo(loopback.getScopeId());
+
+        NativeInetAddress explicitScope = new NativeInetAddress(ipv6Bytes, 7);
+        assertThat(explicitScope.address()).containsExactly(ipv6Bytes);
+        assertThat(explicitScope.scopeId()).isEqualTo(7);
+    }
+
+    @Test
+    void nativeInetAddressDecodesIpv4SocketAddressWithOffset() throws Exception {
+        byte[] encoded = new byte[12];
+        int offset = 2;
+        encoded[offset] = (byte) 192;
+        encoded[offset + 1] = (byte) 168;
+        encoded[offset + 2] = 1;
+        encoded[offset + 3] = 25;
+        encodeInt(encoded, offset + 4, 8080);
+
+        InetSocketAddress socketAddress = NativeInetAddress.address(encoded, offset, 8);
+
+        assertThat(socketAddress.getAddress().getAddress()).containsExactly((byte) 192, (byte) 168, 1, 25);
+        assertThat(socketAddress.getPort()).isEqualTo(8080);
+    }
+
+    @Test
+    void nativeInetAddressDecodesIpv6SocketAddressWithScopeAndOffset() throws Exception {
+        byte[] encoded = new byte[30];
+        int offset = 3;
+        byte[] ipv6Bytes = new byte[] {
+                0x20, 0x01, 0x0d, (byte) 0xb8,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 5
+        };
+        System.arraycopy(ipv6Bytes, 0, encoded, offset, ipv6Bytes.length);
+        encodeInt(encoded, offset + 16, 9);
+        encodeInt(encoded, offset + 20, 443);
+
+        InetSocketAddress socketAddress = NativeInetAddress.address(encoded, offset, 24);
+
+        assertThat(socketAddress.getAddress()).isInstanceOf(Inet6Address.class);
+        assertThat(socketAddress.getAddress().getAddress()).containsExactly(ipv6Bytes);
+        assertThat(((Inet6Address) socketAddress.getAddress()).getScopeId()).isEqualTo(9);
+        assertThat(socketAddress.getPort()).isEqualTo(443);
+    }
+
+    @Test
+    void bufferAllocatesDirectByteBufferUsingNativeByteOrder() {
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(32);
+
+        assertThat(buffer.isDirect()).isTrue();
+        assertThat(buffer.capacity()).isEqualTo(32);
+        assertThat(buffer.order()).isEqualTo(ByteOrder.nativeOrder());
+    }
+
+    @Test
+    void preferredAllocatorDelegatesToDirectBuffersForGenericAndIoAllocations() {
+        PreferredDirectByteBufAllocator allocator = new PreferredDirectByteBufAllocator();
+        allocator.updateAllocator(UnpooledByteBufAllocator.DEFAULT);
+        ByteBuf buffer = allocator.buffer(16, 64);
+        ByteBuf ioBuffer = allocator.ioBuffer(8);
+        ByteBuf directBuffer = allocator.directBuffer(4);
+        ByteBuf heapBuffer = allocator.heapBuffer(4);
+        CompositeByteBuf compositeBuffer = allocator.compositeBuffer(2);
+        CompositeByteBuf compositeHeapBuffer = allocator.compositeHeapBuffer(2);
+        CompositeByteBuf compositeDirectBuffer = allocator.compositeDirectBuffer(2);
+        compositeBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.directBuffer(1).writeByte(1));
+        compositeHeapBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.heapBuffer(1).writeByte(2));
+        compositeDirectBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.directBuffer(1).writeByte(3));
+
+        try {
+            assertThat(buffer.isDirect()).isTrue();
+            assertThat(buffer.capacity()).isEqualTo(16);
+            assertThat(buffer.maxCapacity()).isEqualTo(64);
+            assertThat(ioBuffer.isDirect()).isTrue();
+            assertThat(directBuffer.isDirect()).isTrue();
+            assertThat(heapBuffer.isDirect()).isFalse();
+            assertThat(compositeBuffer.isDirect()).isTrue();
+            assertThat(compositeHeapBuffer.isDirect()).isFalse();
+            assertThat(compositeDirectBuffer.isDirect()).isTrue();
+            assertThat(allocator.isDirectBufferPooled())
+                    .isEqualTo(UnpooledByteBufAllocator.DEFAULT.isDirectBufferPooled());
+            assertThat(allocator.calculateNewCapacity(33, 128))
+                    .isEqualTo(UnpooledByteBufAllocator.DEFAULT.calculateNewCapacity(33, 128));
+        } finally {
+            buffer.release();
+            ioBuffer.release();
+            directBuffer.release();
+            heapBuffer.release();
+            compositeBuffer.release();
+            compositeHeapBuffer.release();
+            compositeDirectBuffer.release();
+        }
+    }
+
+    @Test
+    void unixChannelUtilKeepsRequestedHostNameWhenOsAddressIsAvailable() throws Exception {
+        InetSocketAddress requested = InetSocketAddress.createUnresolved("requested.example", 1111);
+        InetSocketAddress operatingSystemAddress = new InetSocketAddress(
+                InetAddress.getByAddress(new byte[] {10, 11, 12, 13}), 2222);
+
+        InetSocketAddress computed = UnixChannelUtil.computeRemoteAddr(requested, operatingSystemAddress);
+
+        assertThat(computed.getHostString()).isEqualTo("requested.example");
+        assertThat(computed.getAddress().getAddress()).containsExactly(10, 11, 12, 13);
+        assertThat(computed.getPort()).isEqualTo(2222);
+        assertThat(UnixChannelUtil.computeRemoteAddr(requested, null)).isSameAs(requested);
+    }
+
+    @Test
+    void unixChannelOptionsExposeTypedConstantsAndValidation() {
+        ChannelOption<Boolean> reusePort = UnixChannelOption.SO_REUSEPORT;
+        ChannelOption<DomainSocketReadMode> readMode = UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
+
+        assertThat(reusePort).isSameAs(ChannelOption.valueOf(UnixChannelOption.class, "SO_REUSEPORT"));
+        assertThat(readMode).isSameAs(ChannelOption.valueOf(UnixChannelOption.class, "DOMAIN_SOCKET_READ_MODE"));
+        assertThat(reusePort.name()).endsWith("SO_REUSEPORT");
+        assertThat(readMode.name()).endsWith("DOMAIN_SOCKET_READ_MODE");
+        reusePort.validate(Boolean.TRUE);
+        readMode.validate(DomainSocketReadMode.BYTES);
+        assertThatNullPointerException().isThrownBy(() -> readMode.validate(null));
+    }
+
+    @Test
+    void domainSocketReadModeSupportsStableEnumLookup() {
+        assertThat(DomainSocketReadMode.values()).containsExactly(
+                DomainSocketReadMode.BYTES,
+                DomainSocketReadMode.FILE_DESCRIPTORS);
+        assertThat(DomainSocketReadMode.valueOf("BYTES")).isSameAs(DomainSocketReadMode.BYTES);
+        assertThat(DomainSocketReadMode.valueOf("FILE_DESCRIPTORS"))
+                .isSameAs(DomainSocketReadMode.FILE_DESCRIPTORS);
+    }
+
+    @Test
+    void fileDescriptorWrapsIntegerDescriptorWithValueSemanticsWithoutClosingIt() {
+        FileDescriptor descriptor = new FileDescriptor(7);
+        FileDescriptor equalDescriptor = new FileDescriptor(7);
+        FileDescriptor otherDescriptor = new FileDescriptor(8);
+
+        assertThat(descriptor.intValue()).isEqualTo(7);
+        assertThat(descriptor.isOpen()).isTrue();
+        assertThat(descriptor).isEqualTo(equalDescriptor);
+        assertThat(descriptor.hashCode()).isEqualTo(equalDescriptor.hashCode());
+        assertThat(descriptor).isNotEqualTo(otherDescriptor);
+        assertThat(descriptor.toString()).isEqualTo("FileDescriptor{fd=7}");
+        assertThatThrownBy(() -> new FileDescriptor(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void encodeInt(byte[] target, int index, int value) {
+        target[index] = (byte) (value >>> 24);
+        target[index + 1] = (byte) (value >>> 16);
+        target[index + 2] = (byte) (value >>> 8);
+        target[index + 3] = (byte) value;
     }
 }

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -174,6 +174,14 @@ public class Netty_transport_native_unix_commonTest {
     }
 
     @Test
+    void nativeInetAddressRejectsUnsupportedSocketAddressPayloadLength() {
+        byte[] encoded = new byte[16];
+
+        assertThatThrownBy(() -> NativeInetAddress.address(encoded, 0, 12))
+                .isInstanceOf(Error.class);
+    }
+
+    @Test
     void unixChannelUtilKeepsRequestedHostNameWhenOsAddressIsAvailable() throws Exception {
         InetSocketAddress requested = InetSocketAddress.createUnresolved("requested.example", 1111);
         InetSocketAddress operatingSystemAddress = new InetSocketAddress(

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -174,6 +174,20 @@ public class Netty_transport_native_unix_commonTest {
     }
 
     @Test
+    void nativeInetAddressConstructsFromEncodedBytesWithDefaultScope() {
+        byte[] addressBytes = new byte[] {
+                0x20, 0x01, 0x0d, (byte) 0xb8,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 9
+        };
+        NativeInetAddress nativeAddress = new NativeInetAddress(addressBytes);
+
+        assertThat(nativeAddress.address()).containsExactly(addressBytes);
+        assertThat(nativeAddress.scopeId()).isZero();
+    }
+
+    @Test
     void nativeInetAddressRejectsUnsupportedSocketAddressPayloadLength() {
         byte[] encoded = new byte[16];
 

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.channel.unix.**"
+      "includeClasses" : "io.netty.channel.unix.**"
     }
   ]
 }

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.channel.unix.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1386

This PR introduces tests and metadata for io.netty:netty-transport-native-unix-common:4.1.42.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 219589
- Cached input tokens: 2181632
- Output tokens: 29808
- Metadata entries: 29
- Iterations: 3
- Library coverage percentage: 16.42
- Generated lines of code: 224
- Tested library lines of code: 87

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `682641613393d87f35e673d4dba4e963e736fdd5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 425/2242 (18.96%)
- Line: 87/530 (16.42%)
- Method: 40/163 (24.54%)
