### PR TITLE
[Automation] Generated metadata for org.eclipse.jetty:jetty-http:10.0.0

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-http/10.0.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-http/10.0.0/reachability-metadata.json
@@ -1,0 +1,209 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getUptime",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "org.eclipse.jetty.util.log.Slf4jLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Boolean",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Byte",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Double",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Float",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Integer",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Long",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Short",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging-linux.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "jetty-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime.properties"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "10.0.0",
+    "test-version" : "9.4.1.v20170120",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/10.0.0/jetty-http-10.0.0-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-10.0.0/jetty-http/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/10.0.0/jetty-http-10.0.0-javadoc.jar",
+    "description" : "Jetty HTTP provides core HTTP utilities for Eclipse Jetty, including request and response metadata, headers, cookies, MIME types, and URI handling. It is used by Jetty server and client components to parse, represent, and generate HTTP protocol data.",
+    "tested-versions" : [
+      "10.0.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.http"
+    ]
+  },
+  {
     "metadata-version" : "9.4.1.v20170120",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.1.v20170120/jetty-http-9.4.1.v20170120-sources.jar",
     "repository-url" : "https://github.com/eclipse/jetty.project",

--- a/stats/org.eclipse.jetty/jetty-http/10.0.0/stats.json
+++ b/stats/org.eclipse.jetty/jetty-http/10.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "10.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2114,
+        "missed" : 22346,
+        "ratio" : 0.086427,
+        "total" : 24460
+      },
+      "line" : {
+        "covered" : 369,
+        "missed" : 4920,
+        "ratio" : 0.069767,
+        "total" : 5289
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 805,
+        "ratio" : 0.048463,
+        "total" : 846
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4111

This PR provides new metadata needed for the org.eclipse.jetty:jetty-http:10.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jetty:jetty-http:9.4.1.v20170120`): 22
- Metadata entries (new `org.eclipse.jetty:jetty-http:10.0.0`): 36
- Library coverage (previous): 8.21%
- Library coverage (new): 6.98%

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:10.0.0: 0/0 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:10.0.0: N/A

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2123/20876 (10.17%)
- org.eclipse.jetty:jetty-http:10.0.0: 2114/24460 (8.64%)

**Line:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 343/4178 (8.21%)
- org.eclipse.jetty:jetty-http:10.0.0: 369/5289 (6.98%)

**Method:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 39/598 (6.52%)
- org.eclipse.jetty:jetty-http:10.0.0: 41/846 (4.85%)
