### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt.core.compiler:ecj:4.6.1

### DIFF
--- a/metadata/org.eclipse.jdt.core.compiler/ecj/4.6.1/reachability-metadata.json
+++ b/metadata/org.eclipse.jdt.core.compiler/ecj/4.6.1/reachability-metadata.json
@@ -1,0 +1,3084 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ReadManager"
+      },
+      "type" : "java.lang.Runtime",
+      "methods" : [
+        {
+          "name" : "availableProcessors",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$Logger"
+      },
+      "type" : "org.eclipse.jdt.core.compiler.IProblem",
+      "fields" : [
+        {
+          "name" : "AbstractMethodCannotBeOverridden"
+        },
+        {
+          "name" : "AbstractMethodInAbstractClass"
+        },
+        {
+          "name" : "AbstractMethodInEnum"
+        },
+        {
+          "name" : "AbstractMethodMustBeImplemented"
+        },
+        {
+          "name" : "AbstractMethodMustBeImplementedOverConcreteMethod"
+        },
+        {
+          "name" : "AbstractMethodsInConcreteClass"
+        },
+        {
+          "name" : "AmbiguousConstructor"
+        },
+        {
+          "name" : "AmbiguousConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "AmbiguousConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "AmbiguousField"
+        },
+        {
+          "name" : "AmbiguousMethod"
+        },
+        {
+          "name" : "AmbiguousType"
+        },
+        {
+          "name" : "AnnotationCannotOverrideMethod"
+        },
+        {
+          "name" : "AnnotationCircularity"
+        },
+        {
+          "name" : "AnnotationCircularitySelfReference"
+        },
+        {
+          "name" : "AnnotationFieldNeedConstantInitialization"
+        },
+        {
+          "name" : "AnnotationMembersCannotHaveParameters"
+        },
+        {
+          "name" : "AnnotationMembersCannotHaveTypeParameters"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveConstructor"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveSuperclass"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveSuperinterfaces"
+        },
+        {
+          "name" : "AnnotationTypeUsedAsSuperInterface"
+        },
+        {
+          "name" : "AnnotationValueMustBeAnEnumConstant"
+        },
+        {
+          "name" : "AnnotationValueMustBeAnnotation"
+        },
+        {
+          "name" : "AnnotationValueMustBeArrayInitializer"
+        },
+        {
+          "name" : "AnnotationValueMustBeClassLiteral"
+        },
+        {
+          "name" : "AnnotationValueMustBeConstant"
+        },
+        {
+          "name" : "AnonymousClassCannotExtendFinalClass"
+        },
+        {
+          "name" : "ApplicableMethodOverriddenByInapplicable"
+        },
+        {
+          "name" : "ArgumentHidingField"
+        },
+        {
+          "name" : "ArgumentHidingLocalVariable"
+        },
+        {
+          "name" : "ArgumentIsNeverUsed"
+        },
+        {
+          "name" : "ArgumentTypeAmbiguous"
+        },
+        {
+          "name" : "ArgumentTypeCannotBeVoid"
+        },
+        {
+          "name" : "ArgumentTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "ArgumentTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ArgumentTypeInternalNameProvided"
+        },
+        {
+          "name" : "ArgumentTypeNotFound"
+        },
+        {
+          "name" : "ArgumentTypeNotVisible"
+        },
+        {
+          "name" : "ArrayConstantsOnlyInArrayInitializers"
+        },
+        {
+          "name" : "ArrayReferencePotentialNullReference"
+        },
+        {
+          "name" : "ArrayReferenceRequired"
+        },
+        {
+          "name" : "AssignmentHasNoEffect"
+        },
+        {
+          "name" : "AssignmentToMultiCatchParameter"
+        },
+        {
+          "name" : "AssignmentToResource"
+        },
+        {
+          "name" : "AutoManagedResourceNotBelow17"
+        },
+        {
+          "name" : "BinaryLiteralNotBelow17"
+        },
+        {
+          "name" : "BodyForAbstractMethod"
+        },
+        {
+          "name" : "BodyForNativeMethod"
+        },
+        {
+          "name" : "BoundCannotBeArray"
+        },
+        {
+          "name" : "BoundHasConflictingArguments"
+        },
+        {
+          "name" : "BoundMustBeAnInterface"
+        },
+        {
+          "name" : "BoxingConversion"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimit"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimitForClinit"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimitForConstructor"
+        },
+        {
+          "name" : "CannotAllocateVoidArray"
+        },
+        {
+          "name" : "CannotDeclareEnumSpecialMethod"
+        },
+        {
+          "name" : "CannotDefineAnnotationInLocalType"
+        },
+        {
+          "name" : "CannotDefineDimensionExpressionsWithInit"
+        },
+        {
+          "name" : "CannotDefineEnumInLocalType"
+        },
+        {
+          "name" : "CannotDefineInterfaceInLocalType"
+        },
+        {
+          "name" : "CannotDefineStaticInitializerInLocalType"
+        },
+        {
+          "name" : "CannotExtendEnum"
+        },
+        {
+          "name" : "CannotHideAnInstanceMethodWithAStaticMethod"
+        },
+        {
+          "name" : "CannotImplementIncompatibleNullness"
+        },
+        {
+          "name" : "CannotImportPackage"
+        },
+        {
+          "name" : "CannotInferElidedTypes"
+        },
+        {
+          "name" : "CannotInferInvocationType"
+        },
+        {
+          "name" : "CannotInvokeSuperConstructorInEnum"
+        },
+        {
+          "name" : "CannotOverrideAStaticMethodWithAnInstanceMethod"
+        },
+        {
+          "name" : "CannotReadSource"
+        },
+        {
+          "name" : "CannotReturnInInitializer"
+        },
+        {
+          "name" : "CannotThrowNull"
+        },
+        {
+          "name" : "CannotThrowType"
+        },
+        {
+          "name" : "CannotUseDiamondWithAnonymousClasses"
+        },
+        {
+          "name" : "CannotUseDiamondWithExplicitTypeArguments"
+        },
+        {
+          "name" : "CannotUseSuperInCodeSnippet"
+        },
+        {
+          "name" : "ClassExtendFinalClass"
+        },
+        {
+          "name" : "CodeCannotBeReached"
+        },
+        {
+          "name" : "CodeSnippetMissingClass"
+        },
+        {
+          "name" : "CodeSnippetMissingMethod"
+        },
+        {
+          "name" : "ComparingIdentical"
+        },
+        {
+          "name" : "ConflictingImport"
+        },
+        {
+          "name" : "ConflictingInheritedNullAnnotations"
+        },
+        {
+          "name" : "ConflictingNullAnnotations"
+        },
+        {
+          "name" : "ConstructedArrayIncompatible"
+        },
+        {
+          "name" : "ConstructionTypeMismatch"
+        },
+        {
+          "name" : "ConstructorReferenceNotBelow18"
+        },
+        {
+          "name" : "ConstructorRelated"
+        },
+        {
+          "name" : "ConstructorVarargsArgumentNeedCast"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasNonDefaultMembers"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasShorterRetention"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasWrongValueType"
+        },
+        {
+          "name" : "ContainerAnnotationTypeMustHaveValue"
+        },
+        {
+          "name" : "ContradictoryNullAnnotations"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsInferred"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsInferredFunctionType"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsOnBound"
+        },
+        {
+          "name" : "CorruptedSignature"
+        },
+        {
+          "name" : "DanglingReference"
+        },
+        {
+          "name" : "DeadCode"
+        },
+        {
+          "name" : "DefaultMethodNotBelow18"
+        },
+        {
+          "name" : "DefaultMethodOverridesObjectMethod"
+        },
+        {
+          "name" : "DereferencingNullableExpression"
+        },
+        {
+          "name" : "DiamondNotBelow17"
+        },
+        {
+          "name" : "DirectInvocationOfAbstractMethod"
+        },
+        {
+          "name" : "DisallowedExplicitThisParameter"
+        },
+        {
+          "name" : "DisallowedTargetForAnnotation"
+        },
+        {
+          "name" : "DisallowedTargetForContainerAnnotationType"
+        },
+        {
+          "name" : "DiscouragedReference"
+        },
+        {
+          "name" : "DuplicateAnnotation"
+        },
+        {
+          "name" : "DuplicateAnnotationMember"
+        },
+        {
+          "name" : "DuplicateAnnotationNotMarkedRepeatable"
+        },
+        {
+          "name" : "DuplicateBlankFinalFieldInitialization"
+        },
+        {
+          "name" : "DuplicateBoundInIntersectionCast"
+        },
+        {
+          "name" : "DuplicateBounds"
+        },
+        {
+          "name" : "DuplicateCase"
+        },
+        {
+          "name" : "DuplicateDefaultCase"
+        },
+        {
+          "name" : "DuplicateField"
+        },
+        {
+          "name" : "DuplicateFinalLocalInitialization"
+        },
+        {
+          "name" : "DuplicateImport"
+        },
+        {
+          "name" : "DuplicateInheritedDefaultMethods"
+        },
+        {
+          "name" : "DuplicateInheritedMethods"
+        },
+        {
+          "name" : "DuplicateLabel"
+        },
+        {
+          "name" : "DuplicateMethod"
+        },
+        {
+          "name" : "DuplicateMethodErasure"
+        },
+        {
+          "name" : "DuplicateModifierForArgument"
+        },
+        {
+          "name" : "DuplicateModifierForField"
+        },
+        {
+          "name" : "DuplicateModifierForMethod"
+        },
+        {
+          "name" : "DuplicateModifierForType"
+        },
+        {
+          "name" : "DuplicateModifierForVariable"
+        },
+        {
+          "name" : "DuplicateNestedType"
+        },
+        {
+          "name" : "DuplicateParameterizedMethods"
+        },
+        {
+          "name" : "DuplicateSuperInterface"
+        },
+        {
+          "name" : "DuplicateTargetInTargetAnnotation"
+        },
+        {
+          "name" : "DuplicateTypeVariable"
+        },
+        {
+          "name" : "DuplicateTypes"
+        },
+        {
+          "name" : "EmptyControlFlowStatement"
+        },
+        {
+          "name" : "EnclosingInstanceInConstructorCall"
+        },
+        {
+          "name" : "EndOfSource"
+        },
+        {
+          "name" : "EnumAbstractMethodMustBeImplemented"
+        },
+        {
+          "name" : "EnumConstantCannotDefineAbstractMethod"
+        },
+        {
+          "name" : "EnumConstantMustImplementAbstractMethod"
+        },
+        {
+          "name" : "EnumConstantsCannotBeSurroundedByParenthesis"
+        },
+        {
+          "name" : "EnumStaticFieldInInInitializerContext"
+        },
+        {
+          "name" : "EnumSwitchCannotTargetField"
+        },
+        {
+          "name" : "ExceptionTypeAmbiguous"
+        },
+        {
+          "name" : "ExceptionTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ExceptionTypeInternalNameProvided"
+        },
+        {
+          "name" : "ExceptionTypeNotFound"
+        },
+        {
+          "name" : "ExceptionTypeNotVisible"
+        },
+        {
+          "name" : "ExceptionParameterIsNeverUsed"
+        },
+        {
+          "name" : "ExplicitAnnotationTargetRequired"
+        },
+        {
+          "name" : "ExplicitThisParameterNotBelow18"
+        },
+        {
+          "name" : "ExplicitThisParameterNotInLambda"
+        },
+        {
+          "name" : "ExplicitlyClosedAutoCloseable"
+        },
+        {
+          "name" : "ExpressionShouldBeAVariable"
+        },
+        {
+          "name" : "ExternalProblemFixable"
+        },
+        {
+          "name" : "ExternalProblemNotFixable"
+        },
+        {
+          "name" : "FallthroughCase"
+        },
+        {
+          "name" : "FieldComparisonYieldsFalse"
+        },
+        {
+          "name" : "FieldHidingField"
+        },
+        {
+          "name" : "FieldHidingLocalVariable"
+        },
+        {
+          "name" : "FieldMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "FieldRelated"
+        },
+        {
+          "name" : "FieldTypeAmbiguous"
+        },
+        {
+          "name" : "FieldTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "FieldTypeInternalNameProvided"
+        },
+        {
+          "name" : "FieldTypeNotFound"
+        },
+        {
+          "name" : "FieldTypeNotVisible"
+        },
+        {
+          "name" : "FinalBoundForTypeVariable"
+        },
+        {
+          "name" : "FinalFieldAssignment"
+        },
+        {
+          "name" : "FinalMethodCannotBeOverridden"
+        },
+        {
+          "name" : "FinalOuterLocalAssignment"
+        },
+        {
+          "name" : "FinallyMustCompleteNormally"
+        },
+        {
+          "name" : "ForbiddenReference"
+        },
+        {
+          "name" : "GenericConstructorTypeArgumentMismatch"
+        },
+        {
+          "name" : "GenericInferenceError"
+        },
+        {
+          "name" : "GenericMethodTypeArgumentMismatch"
+        },
+        {
+          "name" : "GenericTypeCannotExtendThrowable"
+        },
+        {
+          "name" : "HidingEnclosingType"
+        },
+        {
+          "name" : "HierarchyCircularity"
+        },
+        {
+          "name" : "HierarchyCircularitySelfReference"
+        },
+        {
+          "name" : "HierarchyHasProblems"
+        },
+        {
+          "name" : "IgnoreCategoriesMask"
+        },
+        {
+          "name" : "IllegalAbstractModifierCombinationForMethod"
+        },
+        {
+          "name" : "IllegalAccessFromTypeVariable"
+        },
+        {
+          "name" : "IllegalAnnotationForBaseType"
+        },
+        {
+          "name" : "IllegalArrayOfUnionType"
+        },
+        {
+          "name" : "IllegalArrayTypeInIntersectionCast"
+        },
+        {
+          "name" : "IllegalBasetypeInIntersectionCast"
+        },
+        {
+          "name" : "IllegalCast"
+        },
+        {
+          "name" : "IllegalClassLiteralForTypeVariable"
+        },
+        {
+          "name" : "IllegalDeclarationOfThisParameter"
+        },
+        {
+          "name" : "IllegalDefaultModifierSpecification"
+        },
+        {
+          "name" : "IllegalDefinitionToNonNullParameter"
+        },
+        {
+          "name" : "IllegalDimension"
+        },
+        {
+          "name" : "IllegalEnclosingInstanceSpecification"
+        },
+        {
+          "name" : "IllegalExtendedDimensions"
+        },
+        {
+          "name" : "IllegalExtendedDimensionsForVarArgs"
+        },
+        {
+          "name" : "IllegalGenericArray"
+        },
+        {
+          "name" : "IllegalHexaLiteral"
+        },
+        {
+          "name" : "IllegalInstanceofParameterizedType"
+        },
+        {
+          "name" : "IllegalInstanceofTypeParameter"
+        },
+        {
+          "name" : "IllegalModifierCombinationFinalAbstractForClass"
+        },
+        {
+          "name" : "IllegalModifierCombinationFinalVolatileForField"
+        },
+        {
+          "name" : "IllegalModifierCombinationForInterfaceMethod"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationField"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationMemberType"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationMethod"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationType"
+        },
+        {
+          "name" : "IllegalModifierForArgument"
+        },
+        {
+          "name" : "IllegalModifierForClass"
+        },
+        {
+          "name" : "IllegalModifierForConstructor"
+        },
+        {
+          "name" : "IllegalModifierForEnum"
+        },
+        {
+          "name" : "IllegalModifierForEnumConstant"
+        },
+        {
+          "name" : "IllegalModifierForEnumConstructor"
+        },
+        {
+          "name" : "IllegalModifierForField"
+        },
+        {
+          "name" : "IllegalModifierForInterface"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceField"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceMethod"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceMethod18"
+        },
+        {
+          "name" : "IllegalModifierForLocalClass"
+        },
+        {
+          "name" : "IllegalModifierForLocalEnum"
+        },
+        {
+          "name" : "IllegalModifierForMemberClass"
+        },
+        {
+          "name" : "IllegalModifierForMemberEnum"
+        },
+        {
+          "name" : "IllegalModifierForMemberInterface"
+        },
+        {
+          "name" : "IllegalModifierForMethod"
+        },
+        {
+          "name" : "IllegalModifierForVariable"
+        },
+        {
+          "name" : "IllegalModifiers"
+        },
+        {
+          "name" : "IllegalModifiersForElidedType"
+        },
+        {
+          "name" : "IllegalParameterNullityRedefinition"
+        },
+        {
+          "name" : "IllegalPrimitiveOrArrayTypeForEnclosingInstance"
+        },
+        {
+          "name" : "IllegalQualifiedEnumConstantLabel"
+        },
+        {
+          "name" : "IllegalQualifiedParameterizedTypeAllocation"
+        },
+        {
+          "name" : "IllegalQualifierForExplicitThis"
+        },
+        {
+          "name" : "IllegalQualifierForExplicitThis2"
+        },
+        {
+          "name" : "IllegalRedefinitionOfTypeVariable"
+        },
+        {
+          "name" : "IllegalRedefinitionToNonNullParameter"
+        },
+        {
+          "name" : "IllegalReturnNullityRedefinition"
+        },
+        {
+          "name" : "IllegalReturnNullityRedefinitionFreeTypeVariable"
+        },
+        {
+          "name" : "IllegalStaticModifierForMemberType"
+        },
+        {
+          "name" : "IllegalStrictfpForAbstractInterfaceMethod"
+        },
+        {
+          "name" : "IllegalTypeAnnotationsInStaticMemberAccess"
+        },
+        {
+          "name" : "IllegalTypeArgumentsInRawConstructorReference"
+        },
+        {
+          "name" : "IllegalTypeForExplicitThis"
+        },
+        {
+          "name" : "IllegalTypeVariableSuperReference"
+        },
+        {
+          "name" : "IllegalUnderscorePosition"
+        },
+        {
+          "name" : "IllegalUsageOfQualifiedTypeReference"
+        },
+        {
+          "name" : "IllegalUsageOfTypeAnnotations"
+        },
+        {
+          "name" : "IllegalUseOfUnderscoreAsAnIdentifier"
+        },
+        {
+          "name" : "IllegalVararg"
+        },
+        {
+          "name" : "IllegalVarargInLambda"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForField"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForMemberType"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForMethod"
+        },
+        {
+          "name" : "IllegalVisibilityModifierForInterfaceMemberType"
+        },
+        {
+          "name" : "ImplicitObjectBoundNoNullDefault"
+        },
+        {
+          "name" : "ImportAmbiguous"
+        },
+        {
+          "name" : "ImportInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ImportInternalNameProvided"
+        },
+        {
+          "name" : "ImportNotFound"
+        },
+        {
+          "name" : "ImportNotVisible"
+        },
+        {
+          "name" : "ImportRelated"
+        },
+        {
+          "name" : "IncompatibleExceptionInInheritedMethodThrowsClause"
+        },
+        {
+          "name" : "IncompatibleExceptionInThrowsClause"
+        },
+        {
+          "name" : "IncompatibleExceptionInThrowsClauseForNonInheritedInterfaceMethod"
+        },
+        {
+          "name" : "IncompatibleLambdaParameterType"
+        },
+        {
+          "name" : "IncompatibleMethodReference"
+        },
+        {
+          "name" : "IncompatibleReturnType"
+        },
+        {
+          "name" : "IncompatibleReturnTypeForNonInheritedInterfaceMethod"
+        },
+        {
+          "name" : "IncompatibleTypesInConditionalOperator"
+        },
+        {
+          "name" : "IncompatibleTypesInEqualityOperator"
+        },
+        {
+          "name" : "IncompatibleTypesInForeach"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedConstructor"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedMethod"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedType"
+        },
+        {
+          "name" : "IncorrectEnclosingInstanceReference"
+        },
+        {
+          "name" : "IncorrectSwitchType"
+        },
+        {
+          "name" : "IncorrectSwitchType17"
+        },
+        {
+          "name" : "IndirectAccessToStaticField"
+        },
+        {
+          "name" : "IndirectAccessToStaticMethod"
+        },
+        {
+          "name" : "IndirectAccessToStaticType"
+        },
+        {
+          "name" : "InheritedDefaultMethodConflictsWithOtherInherited"
+        },
+        {
+          "name" : "InheritedFieldHidesEnclosingName"
+        },
+        {
+          "name" : "InheritedIncompatibleReturnType"
+        },
+        {
+          "name" : "InheritedMethodHidesEnclosingName"
+        },
+        {
+          "name" : "InheritedMethodReducesVisibility"
+        },
+        {
+          "name" : "InheritedTypeHidesEnclosingName"
+        },
+        {
+          "name" : "InitializerMustCompleteNormally"
+        },
+        {
+          "name" : "InstanceFieldDuringConstructorInvocation"
+        },
+        {
+          "name" : "InstanceMethodDuringConstructorInvocation"
+        },
+        {
+          "name" : "InterfaceAmbiguous"
+        },
+        {
+          "name" : "InterfaceCannotHaveConstructors"
+        },
+        {
+          "name" : "InterfaceCannotHaveInitializers"
+        },
+        {
+          "name" : "InterfaceInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "InterfaceInternalNameProvided"
+        },
+        {
+          "name" : "InterfaceNotFound"
+        },
+        {
+          "name" : "InterfaceNotFunctionalInterface"
+        },
+        {
+          "name" : "InterfaceNotVisible"
+        },
+        {
+          "name" : "InterfaceStaticMethodInvocationNotBelow18"
+        },
+        {
+          "name" : "InterfaceSuperInvocationNotBelow18"
+        },
+        {
+          "name" : "Internal"
+        },
+        {
+          "name" : "InternalTypeNameProvided"
+        },
+        {
+          "name" : "IntersectionCastNotBelow18"
+        },
+        {
+          "name" : "InvalidAnnotationMemberType"
+        },
+        {
+          "name" : "InvalidArrayConstructorReference"
+        },
+        {
+          "name" : "InvalidBinary"
+        },
+        {
+          "name" : "InvalidBreak"
+        },
+        {
+          "name" : "InvalidCatchBlockSequence"
+        },
+        {
+          "name" : "InvalidCharacterConstant"
+        },
+        {
+          "name" : "InvalidClassInstantiation"
+        },
+        {
+          "name" : "InvalidContinue"
+        },
+        {
+          "name" : "InvalidDigit"
+        },
+        {
+          "name" : "InvalidEncoding"
+        },
+        {
+          "name" : "InvalidEscape"
+        },
+        {
+          "name" : "InvalidExplicitConstructorCall"
+        },
+        {
+          "name" : "InvalidExpressionAsStatement"
+        },
+        {
+          "name" : "InvalidFileNameForPackageAnnotations"
+        },
+        {
+          "name" : "InvalidFloat"
+        },
+        {
+          "name" : "InvalidHexa"
+        },
+        {
+          "name" : "InvalidHighSurrogate"
+        },
+        {
+          "name" : "InvalidInput"
+        },
+        {
+          "name" : "InvalidLowSurrogate"
+        },
+        {
+          "name" : "InvalidNullToSynchronized"
+        },
+        {
+          "name" : "InvalidOctal"
+        },
+        {
+          "name" : "InvalidOperator"
+        },
+        {
+          "name" : "InvalidParameterizedExceptionType"
+        },
+        {
+          "name" : "InvalidParenthesizedExpression"
+        },
+        {
+          "name" : "InvalidTypeArguments"
+        },
+        {
+          "name" : "InvalidTypeExpression"
+        },
+        {
+          "name" : "InvalidTypeForCollection"
+        },
+        {
+          "name" : "InvalidTypeForCollectionTarget14"
+        },
+        {
+          "name" : "InvalidTypeForStaticImport"
+        },
+        {
+          "name" : "InvalidTypeToSynchronized"
+        },
+        {
+          "name" : "InvalidTypeVariableExceptionType"
+        },
+        {
+          "name" : "InvalidUnaryExpression"
+        },
+        {
+          "name" : "InvalidUnicodeEscape"
+        },
+        {
+          "name" : "InvalidUnionTypeReferenceSequence"
+        },
+        {
+          "name" : "InvalidUsageOfAnnotationDeclarations"
+        },
+        {
+          "name" : "InvalidUsageOfAnnotations"
+        },
+        {
+          "name" : "InvalidUsageOfEnumDeclarations"
+        },
+        {
+          "name" : "InvalidUsageOfForeachStatements"
+        },
+        {
+          "name" : "InvalidUsageOfStaticImports"
+        },
+        {
+          "name" : "InvalidUsageOfTypeAnnotations"
+        },
+        {
+          "name" : "InvalidUsageOfTypeArguments"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParameters"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParametersForAnnotationDeclaration"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParametersForEnumDeclaration"
+        },
+        {
+          "name" : "InvalidUsageOfVarargs"
+        },
+        {
+          "name" : "InvalidUsageOfWildcard"
+        },
+        {
+          "name" : "InvalidVoidExpression"
+        },
+        {
+          "name" : "IsClassPathCorrect"
+        },
+        {
+          "name" : "Javadoc"
+        },
+        {
+          "name" : "JavadocAmbiguousConstructor"
+        },
+        {
+          "name" : "JavadocAmbiguousField"
+        },
+        {
+          "name" : "JavadocAmbiguousMethod"
+        },
+        {
+          "name" : "JavadocAmbiguousMethodReference"
+        },
+        {
+          "name" : "JavadocAmbiguousType"
+        },
+        {
+          "name" : "JavadocDuplicateParamName"
+        },
+        {
+          "name" : "JavadocDuplicateReturnTag"
+        },
+        {
+          "name" : "JavadocDuplicateTag"
+        },
+        {
+          "name" : "JavadocDuplicateThrowsClassName"
+        },
+        {
+          "name" : "JavadocEmptyReturnTag"
+        },
+        {
+          "name" : "JavadocGenericConstructorTypeArgumentMismatch"
+        },
+        {
+          "name" : "JavadocGenericMethodTypeArgumentMismatch"
+        },
+        {
+          "name" : "JavadocHiddenReference"
+        },
+        {
+          "name" : "JavadocIncorrectArityForParameterizedConstructor"
+        },
+        {
+          "name" : "JavadocIncorrectArityForParameterizedMethod"
+        },
+        {
+          "name" : "JavadocInheritedFieldHidesEnclosingName"
+        },
+        {
+          "name" : "JavadocInheritedMethodHidesEnclosingName"
+        },
+        {
+          "name" : "JavadocInheritedNameHidesEnclosingTypeName"
+        },
+        {
+          "name" : "JavadocInternalTypeNameProvided"
+        },
+        {
+          "name" : "JavadocInvalidMemberTypeQualification"
+        },
+        {
+          "name" : "JavadocInvalidParamName"
+        },
+        {
+          "name" : "JavadocInvalidParamTagName"
+        },
+        {
+          "name" : "JavadocInvalidParamTagTypeParameter"
+        },
+        {
+          "name" : "JavadocInvalidSeeArgs"
+        },
+        {
+          "name" : "JavadocInvalidSeeHref"
+        },
+        {
+          "name" : "JavadocInvalidSeeReference"
+        },
+        {
+          "name" : "JavadocInvalidSeeUrlReference"
+        },
+        {
+          "name" : "JavadocInvalidTag"
+        },
+        {
+          "name" : "JavadocInvalidThrowsClass"
+        },
+        {
+          "name" : "JavadocInvalidThrowsClassName"
+        },
+        {
+          "name" : "JavadocInvalidValueReference"
+        },
+        {
+          "name" : "JavadocMalformedSeeReference"
+        },
+        {
+          "name" : "JavadocMessagePrefix"
+        },
+        {
+          "name" : "JavadocMissing"
+        },
+        {
+          "name" : "JavadocMissingHashCharacter"
+        },
+        {
+          "name" : "JavadocMissingIdentifier"
+        },
+        {
+          "name" : "JavadocMissingParamName"
+        },
+        {
+          "name" : "JavadocMissingParamTag"
+        },
+        {
+          "name" : "JavadocMissingReturnTag"
+        },
+        {
+          "name" : "JavadocMissingSeeReference"
+        },
+        {
+          "name" : "JavadocMissingTagDescription"
+        },
+        {
+          "name" : "JavadocMissingThrowsClassName"
+        },
+        {
+          "name" : "JavadocMissingThrowsTag"
+        },
+        {
+          "name" : "JavadocNoMessageSendOnArrayType"
+        },
+        {
+          "name" : "JavadocNoMessageSendOnBaseType"
+        },
+        {
+          "name" : "JavadocNonGenericConstructor"
+        },
+        {
+          "name" : "JavadocNonGenericMethod"
+        },
+        {
+          "name" : "JavadocNonStaticTypeFromStaticInvocation"
+        },
+        {
+          "name" : "JavadocNotVisibleConstructor"
+        },
+        {
+          "name" : "JavadocNotVisibleField"
+        },
+        {
+          "name" : "JavadocNotVisibleMethod"
+        },
+        {
+          "name" : "JavadocNotVisibleType"
+        },
+        {
+          "name" : "JavadocParameterMismatch"
+        },
+        {
+          "name" : "JavadocParameterizedConstructorArgumentTypeMismatch"
+        },
+        {
+          "name" : "JavadocParameterizedMethodArgumentTypeMismatch"
+        },
+        {
+          "name" : "JavadocTypeArgumentsForRawGenericConstructor"
+        },
+        {
+          "name" : "JavadocTypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "JavadocUndefinedConstructor"
+        },
+        {
+          "name" : "JavadocUndefinedField"
+        },
+        {
+          "name" : "JavadocUndefinedMethod"
+        },
+        {
+          "name" : "JavadocUndefinedType"
+        },
+        {
+          "name" : "JavadocUnexpectedTag"
+        },
+        {
+          "name" : "JavadocUnexpectedText"
+        },
+        {
+          "name" : "JavadocUnterminatedInlineTag"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedConstructor"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedField"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedMethod"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedType"
+        },
+        {
+          "name" : "LambdaDescriptorMentionsUnmentionable"
+        },
+        {
+          "name" : "LambdaExpressionNotBelow18"
+        },
+        {
+          "name" : "LambdaRedeclaresArgument"
+        },
+        {
+          "name" : "LambdaRedeclaresLocal"
+        },
+        {
+          "name" : "LambdaShapeComputationError"
+        },
+        {
+          "name" : "LocalVariableCanOnlyBeNull"
+        },
+        {
+          "name" : "LocalVariableCannotBeNull"
+        },
+        {
+          "name" : "LocalVariableHidingField"
+        },
+        {
+          "name" : "LocalVariableHidingLocalVariable"
+        },
+        {
+          "name" : "LocalVariableIsNeverUsed"
+        },
+        {
+          "name" : "LocalVariableMayBeNull"
+        },
+        {
+          "name" : "MaskedCatch"
+        },
+        {
+          "name" : "MethodButWithConstructorName"
+        },
+        {
+          "name" : "MethodCanBePotentiallyStatic"
+        },
+        {
+          "name" : "MethodCanBeStatic"
+        },
+        {
+          "name" : "MethodMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "MethodMustOverride"
+        },
+        {
+          "name" : "MethodMustOverrideOrImplement"
+        },
+        {
+          "name" : "MethodNameClash"
+        },
+        {
+          "name" : "MethodNameClashHidden"
+        },
+        {
+          "name" : "MethodReducesVisibility"
+        },
+        {
+          "name" : "MethodReferenceNotBelow18"
+        },
+        {
+          "name" : "MethodReferenceSwingsBothWays"
+        },
+        {
+          "name" : "MethodRelated"
+        },
+        {
+          "name" : "MethodRequiresBody"
+        },
+        {
+          "name" : "MethodReturnsVoid"
+        },
+        {
+          "name" : "MethodVarargsArgumentNeedCast"
+        },
+        {
+          "name" : "MisplacedTypeAnnotations"
+        },
+        {
+          "name" : "MissingArgumentsForParameterizedMemberType"
+        },
+        {
+          "name" : "MissingDefaultCase"
+        },
+        {
+          "name" : "MissingEnclosingInstance"
+        },
+        {
+          "name" : "MissingEnclosingInstanceForConstructorCall"
+        },
+        {
+          "name" : "MissingEnumConstantCase"
+        },
+        {
+          "name" : "MissingEnumConstantCaseDespiteDefault"
+        },
+        {
+          "name" : "MissingEnumDefaultCase"
+        },
+        {
+          "name" : "MissingNonNullByDefaultAnnotationOnPackage"
+        },
+        {
+          "name" : "MissingNonNullByDefaultAnnotationOnType"
+        },
+        {
+          "name" : "MissingOverrideAnnotation"
+        },
+        {
+          "name" : "MissingOverrideAnnotationForInterfaceMethodImplementation"
+        },
+        {
+          "name" : "MissingReturnType"
+        },
+        {
+          "name" : "MissingSemiColon"
+        },
+        {
+          "name" : "MissingSerialVersion"
+        },
+        {
+          "name" : "MissingSynchronizedModifierInInheritedMethod"
+        },
+        {
+          "name" : "MissingTypeInConstructor"
+        },
+        {
+          "name" : "MissingTypeInLambda"
+        },
+        {
+          "name" : "MissingTypeInMethod"
+        },
+        {
+          "name" : "MissingValueForAnnotationMember"
+        },
+        {
+          "name" : "MultiCatchNotBelow17"
+        },
+        {
+          "name" : "MultipleFunctionalInterfaces"
+        },
+        {
+          "name" : "MustDefineEitherDimensionExpressionsOrInitializer"
+        },
+        {
+          "name" : "MustSpecifyPackage"
+        },
+        {
+          "name" : "NativeMethodsCannotBeStrictfp"
+        },
+        {
+          "name" : "NeedToEmulateConstructorAccess"
+        },
+        {
+          "name" : "NeedToEmulateFieldReadAccess"
+        },
+        {
+          "name" : "NeedToEmulateFieldWriteAccess"
+        },
+        {
+          "name" : "NeedToEmulateMethodAccess"
+        },
+        {
+          "name" : "NoAdditionalBoundAfterTypeVariable"
+        },
+        {
+          "name" : "NoFieldOnBaseType"
+        },
+        {
+          "name" : "NoGenericLambda"
+        },
+        {
+          "name" : "NoImplicitStringConversionForCharArrayExpression"
+        },
+        {
+          "name" : "NoMessageSendOnArrayType"
+        },
+        {
+          "name" : "NoMessageSendOnBaseType"
+        },
+        {
+          "name" : "NoSuperInInterfaceContext"
+        },
+        {
+          "name" : "NonBlankFinalLocalAssignment"
+        },
+        {
+          "name" : "NonConstantExpression"
+        },
+        {
+          "name" : "NonExternalizedStringLiteral"
+        },
+        {
+          "name" : "NonGenericConstructor"
+        },
+        {
+          "name" : "NonGenericMethod"
+        },
+        {
+          "name" : "NonGenericType"
+        },
+        {
+          "name" : "NonNullDefaultDetailIsNotEvaluated"
+        },
+        {
+          "name" : "NonNullExpressionComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullMessageSendComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullMethodTypeVariableFromLegacyMethod"
+        },
+        {
+          "name" : "NonNullSpecdFieldComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullTypeVariableFromLegacyMethod"
+        },
+        {
+          "name" : "NonStaticAccessToStaticField"
+        },
+        {
+          "name" : "NonStaticAccessToStaticMethod"
+        },
+        {
+          "name" : "NonStaticContextForEnumMemberType"
+        },
+        {
+          "name" : "NonStaticFieldFromStaticInvocation"
+        },
+        {
+          "name" : "NonStaticOrAlienTypeReceiver"
+        },
+        {
+          "name" : "NonStaticTypeFromStaticInvocation"
+        },
+        {
+          "name" : "NotAnnotationType"
+        },
+        {
+          "name" : "NotVisibleConstructor"
+        },
+        {
+          "name" : "NotVisibleConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "NotVisibleConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "NotVisibleField"
+        },
+        {
+          "name" : "NotVisibleMethod"
+        },
+        {
+          "name" : "NotVisibleType"
+        },
+        {
+          "name" : "NullAnnotationUnsupportedLocation"
+        },
+        {
+          "name" : "NullAnnotationUnsupportedLocationAtType"
+        },
+        {
+          "name" : "NullExpressionReference"
+        },
+        {
+          "name" : "NullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "NullLocalVariableInstanceofYieldsFalse"
+        },
+        {
+          "name" : "NullLocalVariableReference"
+        },
+        {
+          "name" : "NullNotCompatibleToFreeTypeVariable"
+        },
+        {
+          "name" : "NullSourceString"
+        },
+        {
+          "name" : "NullUnboxing"
+        },
+        {
+          "name" : "NullableFieldReference"
+        },
+        {
+          "name" : "NullityMismatchAgainstFreeTypeVariable"
+        },
+        {
+          "name" : "NullityMismatchTypeArgument"
+        },
+        {
+          "name" : "NullityMismatchingTypeAnnotation"
+        },
+        {
+          "name" : "NullityMismatchingTypeAnnotationSuperHint"
+        },
+        {
+          "name" : "NullityUncheckedTypeAnnotationDetail"
+        },
+        {
+          "name" : "NullityUncheckedTypeAnnotationDetailSuperHint"
+        },
+        {
+          "name" : "NumericValueOutOfRange"
+        },
+        {
+          "name" : "ObjectCannotBeGeneric"
+        },
+        {
+          "name" : "ObjectCannotHaveSuperTypes"
+        },
+        {
+          "name" : "ObjectHasNoSuperclass"
+        },
+        {
+          "name" : "ObjectMustBeClass"
+        },
+        {
+          "name" : "OuterLocalMustBeEffectivelyFinal"
+        },
+        {
+          "name" : "OuterLocalMustBeFinal"
+        },
+        {
+          "name" : "OverridingDeprecatedMethod"
+        },
+        {
+          "name" : "OverridingMethodWithoutSuperInvocation"
+        },
+        {
+          "name" : "OverridingNonVisibleMethod"
+        },
+        {
+          "name" : "PackageCollidesWithType"
+        },
+        {
+          "name" : "PackageIsNotExpectedPackage"
+        },
+        {
+          "name" : "ParameterAssignment"
+        },
+        {
+          "name" : "ParameterLackingNonNullAnnotation"
+        },
+        {
+          "name" : "ParameterLackingNullableAnnotation"
+        },
+        {
+          "name" : "ParameterMismatch"
+        },
+        {
+          "name" : "ParameterizedConstructorArgumentTypeMismatch"
+        },
+        {
+          "name" : "ParameterizedMethodArgumentTypeMismatch"
+        },
+        {
+          "name" : "ParsingError"
+        },
+        {
+          "name" : "ParsingErrorDeleteToken"
+        },
+        {
+          "name" : "ParsingErrorDeleteTokens"
+        },
+        {
+          "name" : "ParsingErrorInsertToComplete"
+        },
+        {
+          "name" : "ParsingErrorInsertToCompletePhrase"
+        },
+        {
+          "name" : "ParsingErrorInsertToCompleteScope"
+        },
+        {
+          "name" : "ParsingErrorInsertTokenAfter"
+        },
+        {
+          "name" : "ParsingErrorInsertTokenBefore"
+        },
+        {
+          "name" : "ParsingErrorInvalidToken"
+        },
+        {
+          "name" : "ParsingErrorMergeTokens"
+        },
+        {
+          "name" : "ParsingErrorMisplacedConstruct"
+        },
+        {
+          "name" : "ParsingErrorNoSuggestion"
+        },
+        {
+          "name" : "ParsingErrorNoSuggestionForTokens"
+        },
+        {
+          "name" : "ParsingErrorOnKeyword"
+        },
+        {
+          "name" : "ParsingErrorOnKeywordNoSuggestion"
+        },
+        {
+          "name" : "ParsingErrorReplaceTokens"
+        },
+        {
+          "name" : "ParsingErrorUnexpectedEOF"
+        },
+        {
+          "name" : "PolymorphicMethodNotBelow17"
+        },
+        {
+          "name" : "PossibleAccidentalBooleanAssignment"
+        },
+        {
+          "name" : "PotentialHeapPollutionFromVararg"
+        },
+        {
+          "name" : "PotentialNullExpressionReference"
+        },
+        {
+          "name" : "PotentialNullLocalVariableReference"
+        },
+        {
+          "name" : "PotentialNullMessageSendReference"
+        },
+        {
+          "name" : "PotentialNullUnboxing"
+        },
+        {
+          "name" : "PotentiallyUnclosedCloseable"
+        },
+        {
+          "name" : "PotentiallyUnclosedCloseableAtExit"
+        },
+        {
+          "name" : "PublicClassMustMatchFileName"
+        },
+        {
+          "name" : "RawMemberTypeCannotBeParameterized"
+        },
+        {
+          "name" : "RawTypeReference"
+        },
+        {
+          "name" : "RecursiveConstructorInvocation"
+        },
+        {
+          "name" : "RedefinedArgument"
+        },
+        {
+          "name" : "RedefinedLocal"
+        },
+        {
+          "name" : "RedundantLocalVariableNullAssignment"
+        },
+        {
+          "name" : "RedundantNullAnnotation"
+        },
+        {
+          "name" : "RedundantNullCheckAgainstNonNullType"
+        },
+        {
+          "name" : "RedundantNullCheckOnField"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullExpression"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullMessageSend"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullSpecdField"
+        },
+        {
+          "name" : "RedundantNullCheckOnNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullCheckOnSpecdNonNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotation"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationMethod"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationPackage"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationType"
+        },
+        {
+          "name" : "RedundantSpecificationOfTypeArguments"
+        },
+        {
+          "name" : "RedundantSuperinterface"
+        },
+        {
+          "name" : "ReferenceExpressionParameterNullityMismatch"
+        },
+        {
+          "name" : "ReferenceExpressionParameterNullityUnchecked"
+        },
+        {
+          "name" : "ReferenceExpressionReturnNullRedef"
+        },
+        {
+          "name" : "ReferenceExpressionReturnNullRedefUnchecked"
+        },
+        {
+          "name" : "ReferenceToForwardField"
+        },
+        {
+          "name" : "ReferenceToForwardTypeVariable"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeIsDocumented"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeIsInherited"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeTargetMismatch"
+        },
+        {
+          "name" : "RepeatableAnnotationWithRepeatingContainerAnnotation"
+        },
+        {
+          "name" : "RepeatedAnnotationWithContainerAnnotation"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedFreeTypeVariable"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedNull"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedPotentialNull"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedSpecdNullable"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedUnknown"
+        },
+        {
+          "name" : "ResourceHasToImplementAutoCloseable"
+        },
+        {
+          "name" : "ReturnTypeAmbiguous"
+        },
+        {
+          "name" : "ReturnTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "ReturnTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ReturnTypeInternalNameProvided"
+        },
+        {
+          "name" : "ReturnTypeMismatch"
+        },
+        {
+          "name" : "ReturnTypeNotFound"
+        },
+        {
+          "name" : "ReturnTypeNotVisible"
+        },
+        {
+          "name" : "SafeVarargsOnFixedArityMethod"
+        },
+        {
+          "name" : "SafeVarargsOnNonFinalInstanceMethod"
+        },
+        {
+          "name" : "ShouldImplementHashcode"
+        },
+        {
+          "name" : "ShouldReturnValue"
+        },
+        {
+          "name" : "ShouldReturnValueHintMissingDefault"
+        },
+        {
+          "name" : "SpecdNonNullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "StaticInheritedMethodConflicts"
+        },
+        {
+          "name" : "StaticInterfaceMethodNotBelow18"
+        },
+        {
+          "name" : "StaticMemberOfParameterizedType"
+        },
+        {
+          "name" : "StaticMethodRequested"
+        },
+        {
+          "name" : "StaticMethodShouldBeAccessedStatically"
+        },
+        {
+          "name" : "StringConstantIsExceedingUtf8Limit"
+        },
+        {
+          "name" : "SuperAccessCannotBypassDirectSuper"
+        },
+        {
+          "name" : "SuperCallCannotBypassOverride"
+        },
+        {
+          "name" : "SuperInterfaceMustBeAnInterface"
+        },
+        {
+          "name" : "SuperInterfacesCollide"
+        },
+        {
+          "name" : "SuperTypeUsingWildcard"
+        },
+        {
+          "name" : "SuperclassAmbiguous"
+        },
+        {
+          "name" : "SuperclassInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "SuperclassInternalNameProvided"
+        },
+        {
+          "name" : "SuperclassMustBeAClass"
+        },
+        {
+          "name" : "SuperclassNotFound"
+        },
+        {
+          "name" : "SuperclassNotVisible"
+        },
+        {
+          "name" : "SuperfluousSemicolon"
+        },
+        {
+          "name" : "SwitchOnEnumNotBelow15"
+        },
+        {
+          "name" : "SwitchOnStringsNotBelow17"
+        },
+        {
+          "name" : "Syntax"
+        },
+        {
+          "name" : "TargetTypeNotAFunctionalInterface"
+        },
+        {
+          "name" : "Task"
+        },
+        {
+          "name" : "ThisInStaticContext"
+        },
+        {
+          "name" : "ThisSuperDuringConstructorInvocation"
+        },
+        {
+          "name" : "ToleratedMisplacedTypeAnnotations"
+        },
+        {
+          "name" : "TooManyArgumentSlots"
+        },
+        {
+          "name" : "TooManyArrayDimensions"
+        },
+        {
+          "name" : "TooManyBytesForStringConstant"
+        },
+        {
+          "name" : "TooManyConstantsInConstantPool"
+        },
+        {
+          "name" : "TooManyFields"
+        },
+        {
+          "name" : "TooManyLocalVariableSlots"
+        },
+        {
+          "name" : "TooManyMethods"
+        },
+        {
+          "name" : "TooManyParametersForSyntheticMethod"
+        },
+        {
+          "name" : "TooManySyntheticArgumentSlots"
+        },
+        {
+          "name" : "TypeArgumentMismatch"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericConstructor"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "TypeCollidesWithPackage"
+        },
+        {
+          "name" : "TypeHidingType"
+        },
+        {
+          "name" : "TypeHidingTypeParameterFromMethod"
+        },
+        {
+          "name" : "TypeHidingTypeParameterFromType"
+        },
+        {
+          "name" : "TypeMismatch"
+        },
+        {
+          "name" : "TypeMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "TypeParameterHidingType"
+        },
+        {
+          "name" : "TypeRelated"
+        },
+        {
+          "name" : "UnboxingConversion"
+        },
+        {
+          "name" : "UncheckedAccessOfValueOfFreeTypeVariable"
+        },
+        {
+          "name" : "Unclassified"
+        },
+        {
+          "name" : "UnclosedCloseable"
+        },
+        {
+          "name" : "UnclosedCloseableAtExit"
+        },
+        {
+          "name" : "UndefinedAnnotationMember"
+        },
+        {
+          "name" : "UndefinedConstructor"
+        },
+        {
+          "name" : "UndefinedConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "UndefinedConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "UndefinedField"
+        },
+        {
+          "name" : "UndefinedLabel"
+        },
+        {
+          "name" : "UndefinedMethod"
+        },
+        {
+          "name" : "UndefinedName"
+        },
+        {
+          "name" : "UndefinedType"
+        },
+        {
+          "name" : "UndefinedTypeVariable"
+        },
+        {
+          "name" : "UnderscoresInLiteralsNotBelow17"
+        },
+        {
+          "name" : "UndocumentedEmptyBlock"
+        },
+        {
+          "name" : "UnexpectedStaticModifierForField"
+        },
+        {
+          "name" : "UnexpectedStaticModifierForMethod"
+        },
+        {
+          "name" : "UnhandledException"
+        },
+        {
+          "name" : "UnhandledExceptionInDefaultConstructor"
+        },
+        {
+          "name" : "UnhandledExceptionInImplicitConstructorCall"
+        },
+        {
+          "name" : "UnhandledExceptionOnAutoClose"
+        },
+        {
+          "name" : "UnhandledWarningToken"
+        },
+        {
+          "name" : "UninitializedBlankFinalField"
+        },
+        {
+          "name" : "UninitializedBlankFinalFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedFreeTypeVariableField"
+        },
+        {
+          "name" : "UninitializedFreeTypeVariableFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedLocalVariable"
+        },
+        {
+          "name" : "UninitializedLocalVariableHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedNonNullField"
+        },
+        {
+          "name" : "UninitializedNonNullFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninternedIdentityComparison"
+        },
+        {
+          "name" : "UnmatchedBracket"
+        },
+        {
+          "name" : "UnnecessaryArgumentCast"
+        },
+        {
+          "name" : "UnnecessaryCast"
+        },
+        {
+          "name" : "UnnecessaryElse"
+        },
+        {
+          "name" : "UnnecessaryInstanceof"
+        },
+        {
+          "name" : "UnnecessaryNLSTag"
+        },
+        {
+          "name" : "UnqualifiedFieldAccess"
+        },
+        {
+          "name" : "UnreachableCatch"
+        },
+        {
+          "name" : "UnresolvedVariable"
+        },
+        {
+          "name" : "UnsafeElementTypeConversion"
+        },
+        {
+          "name" : "UnsafeGenericArrayForVarargs"
+        },
+        {
+          "name" : "UnsafeGenericCast"
+        },
+        {
+          "name" : "UnsafeNullnessCast"
+        },
+        {
+          "name" : "UnsafeRawConstructorInvocation"
+        },
+        {
+          "name" : "UnsafeRawFieldAssignment"
+        },
+        {
+          "name" : "UnsafeRawGenericConstructorInvocation"
+        },
+        {
+          "name" : "UnsafeRawGenericMethodInvocation"
+        },
+        {
+          "name" : "UnsafeRawMethodInvocation"
+        },
+        {
+          "name" : "UnsafeReturnTypeOverride"
+        },
+        {
+          "name" : "UnsafeTypeConversion"
+        },
+        {
+          "name" : "UnterminatedComment"
+        },
+        {
+          "name" : "UnterminatedString"
+        },
+        {
+          "name" : "UnusedConstructorDeclaredThrownException"
+        },
+        {
+          "name" : "UnusedImport"
+        },
+        {
+          "name" : "UnusedLabel"
+        },
+        {
+          "name" : "UnusedMethodDeclaredThrownException"
+        },
+        {
+          "name" : "UnusedObjectAllocation"
+        },
+        {
+          "name" : "UnusedPrivateConstructor"
+        },
+        {
+          "name" : "UnusedPrivateField"
+        },
+        {
+          "name" : "UnusedPrivateMethod"
+        },
+        {
+          "name" : "UnusedPrivateType"
+        },
+        {
+          "name" : "UnusedTypeArgumentsForConstructorInvocation"
+        },
+        {
+          "name" : "UnusedTypeArgumentsForMethodInvocation"
+        },
+        {
+          "name" : "UnusedTypeParameter"
+        },
+        {
+          "name" : "UnusedWarningToken"
+        },
+        {
+          "name" : "UseAssertAsAnIdentifier"
+        },
+        {
+          "name" : "UseEnumAsAnIdentifier"
+        },
+        {
+          "name" : "UsingDeprecatedConstructor"
+        },
+        {
+          "name" : "UsingDeprecatedField"
+        },
+        {
+          "name" : "UsingDeprecatedMethod"
+        },
+        {
+          "name" : "UsingDeprecatedType"
+        },
+        {
+          "name" : "VarargsConflict"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisible"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisibleForConstructor"
+        },
+        {
+          "name" : "VariableTypeCannotBeVoid"
+        },
+        {
+          "name" : "VariableTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "VoidMethodReturnsValue"
+        },
+        {
+          "name" : "WildcardConstructorInvocation"
+        },
+        {
+          "name" : "WildcardFieldAssignment"
+        },
+        {
+          "name" : "WildcardMethodInvocation"
+        },
+        {
+          "name" : "illFormedParameterizationOfFunctionalInterface"
+        },
+        {
+          "name" : "lambdaParameterTypeMismatched"
+        },
+        {
+          "name" : "lambdaSignatureMismatched"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.impl.IntConstant[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.AnnotationBinding[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.FieldBinding[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.ProblemReasons",
+      "fields" : [
+        {
+          "name" : "Ambiguous"
+        },
+        {
+          "name" : "ApplicableMethodOverriddenByInapplicable"
+        },
+        {
+          "name" : "AttemptToBypassDirectSuper"
+        },
+        {
+          "name" : "ContradictoryNullAnnotations"
+        },
+        {
+          "name" : "DefectiveContainerAnnotationType"
+        },
+        {
+          "name" : "IllegalSuperTypeVariable"
+        },
+        {
+          "name" : "InferredApplicableMethodInapplicable"
+        },
+        {
+          "name" : "InheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "InternalNameProvided"
+        },
+        {
+          "name" : "InterfaceMethodInvocationNotBelow18"
+        },
+        {
+          "name" : "IntersectionHasMultipleFunctionalInterfaces"
+        },
+        {
+          "name" : "InvalidTypeForAutoManagedResource"
+        },
+        {
+          "name" : "InvalidTypeForStaticImport"
+        },
+        {
+          "name" : "InvocationTypeInferenceFailure"
+        },
+        {
+          "name" : "NoError"
+        },
+        {
+          "name" : "NoProperEnclosingInstance"
+        },
+        {
+          "name" : "NoSuchMethodOnArray"
+        },
+        {
+          "name" : "NoSuchSingleAbstractMethod"
+        },
+        {
+          "name" : "NonStaticOrAlienTypeReceiver"
+        },
+        {
+          "name" : "NonStaticReferenceInConstructorInvocation"
+        },
+        {
+          "name" : "NonStaticReferenceInStaticContext"
+        },
+        {
+          "name" : "NotAWellFormedParameterizedType"
+        },
+        {
+          "name" : "NotFound"
+        },
+        {
+          "name" : "NotVisible"
+        },
+        {
+          "name" : "ParameterBoundMismatch"
+        },
+        {
+          "name" : "ParameterizedMethodExpectedTypeProblem"
+        },
+        {
+          "name" : "ParameterizedMethodTypeMismatch"
+        },
+        {
+          "name" : "ReceiverTypeNotVisible"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "TypeParameterArityMismatch"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisible"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchProcessingEnvImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.tool.EclipseCompilerImpl",
+      "fields" : [
+        {
+          "name" : "fileManager"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.util.Messages",
+      "fields" : [
+        {
+          "name" : "abort_againstSourceModel"
+        },
+        {
+          "name" : "abort_externaAnnotationFile"
+        },
+        {
+          "name" : "abort_invalidAttribute"
+        },
+        {
+          "name" : "abort_invalidExceptionAttribute"
+        },
+        {
+          "name" : "abort_invalidOpcode"
+        },
+        {
+          "name" : "abort_missingCode"
+        },
+        {
+          "name" : "accept_cannot"
+        },
+        {
+          "name" : "ast_missingCode"
+        },
+        {
+          "name" : "compilation_beginningToCompile"
+        },
+        {
+          "name" : "compilation_done"
+        },
+        {
+          "name" : "compilation_internalError"
+        },
+        {
+          "name" : "compilation_loadBinary"
+        },
+        {
+          "name" : "compilation_process"
+        },
+        {
+          "name" : "compilation_processing"
+        },
+        {
+          "name" : "compilation_request"
+        },
+        {
+          "name" : "compilation_unit"
+        },
+        {
+          "name" : "compilation_units"
+        },
+        {
+          "name" : "compilation_unresolvedProblem"
+        },
+        {
+          "name" : "compilation_unresolvedProblems"
+        },
+        {
+          "name" : "compilation_write"
+        },
+        {
+          "name" : "constant_cannotCastedInto"
+        },
+        {
+          "name" : "constant_cannotConvertedTo"
+        },
+        {
+          "name" : "output_isFile"
+        },
+        {
+          "name" : "output_notValid"
+        },
+        {
+          "name" : "output_notValidAll"
+        },
+        {
+          "name" : "parser_corruptedFile"
+        },
+        {
+          "name" : "parser_endOfConstructor"
+        },
+        {
+          "name" : "parser_endOfFile"
+        },
+        {
+          "name" : "parser_endOfInitializer"
+        },
+        {
+          "name" : "parser_endOfMethod"
+        },
+        {
+          "name" : "parser_incorrectPath"
+        },
+        {
+          "name" : "parser_missingFile"
+        },
+        {
+          "name" : "parser_moveFiles"
+        },
+        {
+          "name" : "parser_regularParse"
+        },
+        {
+          "name" : "parser_syntaxRecovery"
+        },
+        {
+          "name" : "problem_atLine"
+        },
+        {
+          "name" : "problem_noSourceInformation"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages$MessagesProperties"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.util.Messages",
+      "fields" : [
+        {
+          "name" : "abort_againstSourceModel"
+        },
+        {
+          "name" : "abort_externaAnnotationFile"
+        },
+        {
+          "name" : "abort_invalidAttribute"
+        },
+        {
+          "name" : "abort_invalidExceptionAttribute"
+        },
+        {
+          "name" : "abort_invalidOpcode"
+        },
+        {
+          "name" : "abort_missingCode"
+        },
+        {
+          "name" : "accept_cannot"
+        },
+        {
+          "name" : "ast_missingCode"
+        },
+        {
+          "name" : "compilation_beginningToCompile"
+        },
+        {
+          "name" : "compilation_done"
+        },
+        {
+          "name" : "compilation_internalError"
+        },
+        {
+          "name" : "compilation_loadBinary"
+        },
+        {
+          "name" : "compilation_process"
+        },
+        {
+          "name" : "compilation_processing"
+        },
+        {
+          "name" : "compilation_request"
+        },
+        {
+          "name" : "compilation_unit"
+        },
+        {
+          "name" : "compilation_units"
+        },
+        {
+          "name" : "compilation_unresolvedProblem"
+        },
+        {
+          "name" : "compilation_unresolvedProblems"
+        },
+        {
+          "name" : "compilation_write"
+        },
+        {
+          "name" : "constant_cannotCastedInto"
+        },
+        {
+          "name" : "constant_cannotConvertedTo"
+        },
+        {
+          "name" : "output_isFile"
+        },
+        {
+          "name" : "output_notValid"
+        },
+        {
+          "name" : "output_notValidAll"
+        },
+        {
+          "name" : "parser_corruptedFile"
+        },
+        {
+          "name" : "parser_endOfConstructor"
+        },
+        {
+          "name" : "parser_endOfFile"
+        },
+        {
+          "name" : "parser_endOfInitializer"
+        },
+        {
+          "name" : "parser_endOfMethod"
+        },
+        {
+          "name" : "parser_incorrectPath"
+        },
+        {
+          "name" : "parser_missingFile"
+        },
+        {
+          "name" : "parser_moveFiles"
+        },
+        {
+          "name" : "parser_regularParse"
+        },
+        {
+          "name" : "parser_syntaxRecovery"
+        },
+        {
+          "name" : "problem_atLine"
+        },
+        {
+          "name" : "problem_noSourceInformation"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "glob" : "META-INF/services/javax.annotation.processing.Processor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser10.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser11.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser12.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser13.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser15.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser16.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser17.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser18.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser19.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser20.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser21.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser22.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser23.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser24.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser3.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser4.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser5.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser6.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser7.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser8.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser9.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/readableNames.props"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "glob" : "org_eclipse_jdt_core_compiler/ecj/BatchAnnotationProcessorManagerTest$ServiceDiscoveredProcessor.class"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.antadapter.messages"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.compiler.batch.messages"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.compiler.problem.messages"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jdt.core.compiler/ecj/index.json
+++ b/metadata/org.eclipse.jdt.core.compiler/ecj/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.6.1",
+    "test-version" : "4.4.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jdt/core/compiler/ecj/4.6.1/ecj-4.6.1-sources.jar",
+    "repository-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core",
+    "test-code-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core/tree/R4_6_1/org.eclipse.jdt.core.tests.compiler/src",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jdt/core/compiler/ecj/4.6.1/ecj-4.6.1-javadoc.jar",
+    "description" : "Eclipse ECJ is the Eclipse JDT Core batch compiler, a standalone Java compiler used to compile Java source code outside the Eclipse IDE. It provides compiler APIs and command-line batch compilation support for parsing, type checking, diagnostics, and bytecode generation.",
+    "tested-versions" : [
+      "4.6.1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jdt"
+    ]
+  },
+  {
     "metadata-version" : "4.4.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jdt/core/compiler/ecj/4.4.2/ecj-4.4.2-sources.jar",
     "repository-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core",

--- a/stats/org.eclipse.jdt.core.compiler/ecj/4.6.1/stats.json
+++ b/stats/org.eclipse.jdt.core.compiler/ecj/4.6.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.6.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 29,
+          "totalCalls" : 29
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 17,
+          "totalCalls" : 17
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 46,
+      "totalCalls" : 46
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 46794,
+        "missed" : 401461,
+        "ratio" : 0.104391,
+        "total" : 448255
+      },
+      "line" : {
+        "covered" : 10905,
+        "missed" : 90992,
+        "ratio" : 0.10702,
+        "total" : 101897
+      },
+      "method" : {
+        "covered" : 1339,
+        "missed" : 7158,
+        "ratio" : 0.157585,
+        "total" : 8497
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4110

This PR provides new metadata needed for the org.eclipse.jdt.core.compiler:ecj:4.6.1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt.core.compiler:ecj:4.4.2`): 921
- Test-only metadata entries (previous `org.eclipse.jdt.core.compiler:ecj:4.4.2`): 17
- Metadata entries (new `org.eclipse.jdt.core.compiler:ecj:4.6.1`): 944
- Test-only metadata entries (new `org.eclipse.jdt.core.compiler:ecj:4.6.1`): 17
- Library coverage (previous): 11.04%
- Library coverage (new): 10.70%

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `master`
- Forge commit hash: `8d8858cbcb09d19c5c153c5f991c8d6cf2223267`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt.core.compiler:ecj:4.4.2: 46/46 covered calls (100.00%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 46/46 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt.core.compiler:ecj:4.4.2: 29/29 covered calls (100.00%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 29/29 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt.core.compiler:ecj:4.4.2: 17/17 covered calls (100.00%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 17/17 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt.core.compiler:ecj:4.4.2: 46460/431814 (10.76%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 46794/448255 (10.44%)

**Line:**
- org.eclipse.jdt.core.compiler:ecj:4.4.2: 10885/98609 (11.04%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 10905/101897 (10.70%)

**Method:**
- org.eclipse.jdt.core.compiler:ecj:4.4.2: 1340/8079 (16.59%)
- org.eclipse.jdt.core.compiler:ecj:4.6.1: 1339/8497 (15.76%)
