### PR TITLE
[GenAI] Test fix for org.jboss.logmanager:jboss-logmanager:1.4.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
@@ -1,0 +1,262 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "com.sun.jmx.trace.Trace"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "org.jboss.logmanager.AtomicArray",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "remove",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "clear",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "java.io.File",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.PojoConfigurationImpl"
+      },
+      "type" : "java.io.File",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.Enum",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.Level"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
+      },
+      "type" : "java.util.logging.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type" : "org.jboss.logmanager.FastCopyHashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogContext"
+      },
+      "type" : "org.jboss.logmanager.LogContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LoggerNode"
+      },
+      "type" : "org.jboss.logmanager.LoggerNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type" : "org.jboss.logmanager.formatters.Formatters$11$3",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logmanager.formatters.Formatters$11",
+            "java.lang.ClassLoader",
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "glob" : "java/lang/String.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$11.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$14.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters$JustifyingFormatStep.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/String.class"
+    }
+  ]
+}

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.4.1.Final",
+    "tested-versions" : [
+      "1.4.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.logmanager"
+    ]
+  },
+  {
     "metadata-version" : "1.2.1.GA",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.2.1.GA/jboss-logmanager-1.2.1.GA-sources.jar",
     "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.4.1.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.4.1.Final/jboss-logmanager-1.4.1.Final-sources.jar",
+    "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",
+    "test-code-url" : "https://github.com/jboss-logging/jboss-logmanager/tree/1.4.1.Final/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/1.4.1.Final/jboss-logmanager-1.4.1.Final-javadoc.jar",
+    "description" : "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
     "tested-versions" : [
       "1.4.1.Final"
     ],

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/execution-metrics.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-01": {
+    "timestamp": "2026-05-01T22:01:15.130757Z",
+    "library": "org.jboss.logmanager:jboss-logmanager:1.4.1.Final",
+    "starting_commit": "b4d3e7ddff94ced68ea4c3b88ec8e6e58e0fe538",
+    "ending_commit": "f76cab1b3b956c36aec481cbf31dd59005a1dfc7",
+    "previous_library": "org.jboss.logmanager:jboss-logmanager:1.2.1.GA",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 27,
+            "totalCalls": 27
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6346,
+          "missed": 17770,
+          "ratio": 0.263145,
+          "total": 24116
+        },
+        "line": {
+          "covered": 1422,
+          "missed": 4075,
+          "ratio": 0.258687,
+          "total": 5497
+        },
+        "method": {
+          "covered": 359,
+          "missed": 906,
+          "ratio": 0.283794,
+          "total": 1265
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.2.1.GA",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.9375,
+            "coveredCalls": 30,
+            "totalCalls": 32
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.945946,
+        "coveredCalls": 35,
+        "totalCalls": 37
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3668,
+          "missed": 10549,
+          "ratio": 0.258001,
+          "total": 14217
+        },
+        "line": {
+          "covered": 910,
+          "missed": 2571,
+          "ratio": 0.261419,
+          "total": 3481
+        },
+        "method": {
+          "covered": 185,
+          "missed": 601,
+          "ratio": 0.235369,
+          "total": 786
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 252526,
+      "cached_input_tokens_used": 2637824,
+      "output_tokens_used": 32866,
+      "iterations": 6,
+      "cost_usd": 2.3049,
+      "tested_library_loc": 1422,
+      "metadata_entries": 52,
+      "test_only_metadata_entries": 39,
+      "previous_library_metadata_entries": 20,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 25.87,
+      "previous_library_coverage_percent": 26.14
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java",
+      "metadata_file": "metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/stats.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.4.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 27,
+          "totalCalls" : 27
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6346,
+        "missed" : 17770,
+        "ratio" : 0.263145,
+        "total" : 24116
+      },
+      "line" : {
+        "covered" : 1422,
+        "missed" : 4075,
+        "ratio" : 0.258687,
+        "total" : 5497
+      },
+      "method" : {
+        "covered" : 359,
+        "missed" : 906,
+        "ratio" : 0.283794,
+        "total" : 1265
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/.gitignore
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/build.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.logmanager:jboss-logmanager:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/gradle.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.logmanager:jboss-logmanager:1.4.1.Final
+library.version = 1.4.1.Final
+metadata.dir = org.jboss.logmanager/jboss-logmanager/1.4.1.Final/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/settings.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.logmanager.jboss-logmanager_tests'

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous2Test {
+
+    @Test
+    void commitValidatesAndRunsAddedPostConfigurationMethod() {
+        LifecyclePojo.reset();
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "postConfiguredPojo";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(
+                    null,
+                    LifecyclePojo.class.getName(),
+                    pojoName
+            );
+
+            assertThat(pojo.addPostConfigurationMethod("markConfigured")).isTrue();
+
+            configuration.commit();
+
+            assertThat(pojo.getPostConfigurationMethods()).containsExactly("markConfigured");
+            assertThat(LifecyclePojo.getConstructorCalls()).isEqualTo(1);
+            assertThat(LifecyclePojo.getPostConfigurationCalls()).isEqualTo(1);
+        } finally {
+            configuration.forget();
+            LifecyclePojo.reset();
+        }
+    }
+
+    public static final class LifecyclePojo {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+        private static final AtomicInteger POST_CONFIGURATION_CALLS = new AtomicInteger();
+
+        public LifecyclePojo() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        public void markConfigured() {
+            POST_CONFIGURATION_CALLS.incrementAndGet();
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
+        }
+
+        static int getPostConfigurationCalls() {
+            return POST_CONFIGURATION_CALLS.get();
+        }
+
+        static void reset() {
+            CONSTRUCTOR_CALLS.set(0);
+            POST_CONFIGURATION_CALLS.set(0);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous3Test {
+
+    @Test
+    void commitValidatesAndRunsConfiguredPostConfigurationMethods() {
+        BatchConfiguredPojo.reset();
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "batchPostConfiguredPojo";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(
+                    null,
+                    BatchConfiguredPojo.class.getName(),
+                    pojoName
+            );
+
+            pojo.setPostConfigurationMethods("markStarted", "markFinished");
+
+            configuration.commit();
+
+            assertThat(pojo.getPostConfigurationMethods()).containsExactly("markStarted", "markFinished");
+            assertThat(BatchConfiguredPojo.getConstructorCalls()).isEqualTo(1);
+            assertThat(BatchConfiguredPojo.getStartedCalls()).isEqualTo(1);
+            assertThat(BatchConfiguredPojo.getFinishedCalls()).isEqualTo(1);
+        } finally {
+            configuration.forget();
+            BatchConfiguredPojo.reset();
+        }
+    }
+
+    public static final class BatchConfiguredPojo {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+        private static final AtomicInteger STARTED_CALLS = new AtomicInteger();
+        private static final AtomicInteger FINISHED_CALLS = new AtomicInteger();
+
+        public BatchConfiguredPojo() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        public void markStarted() {
+            STARTED_CALLS.incrementAndGet();
+        }
+
+        public void markFinished() {
+            FINISHED_CALLS.incrementAndGet();
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
+        }
+
+        static int getStartedCalls() {
+            return STARTED_CALLS.get();
+        }
+
+        static int getFinishedCalls() {
+            return FINISHED_CALLS.get();
+        }
+
+        static void reset() {
+            CONSTRUCTOR_CALLS.set(0);
+            STARTED_CALLS.set(0);
+            FINISHED_CALLS.set(0);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.File;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void commitPojoConfigurationUsesGetterToResolveConstructorPropertyType() {
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "constructorBackedFile";
+        final String path = "target/constructor-backed-file.log";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(null, File.class.getName(), pojoName, "path");
+            pojo.setPropertyValueString("path", path);
+
+            configuration.commit();
+
+            assertThat(configuration.getPojoNames()).contains(pojoName);
+            assertThat(configuration.getPojoConfiguration(pojoName).getClassName()).isEqualTo(File.class.getName());
+            assertThat(configuration.getPojoConfiguration(pojoName).getConstructorProperties()).containsExactly("path");
+            assertThat(configuration.getPojoConfiguration(pojoName).getPropertyValueString("path")).isEqualTo(path);
+        } finally {
+            configuration.forget();
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AtomicArrayTest {
+
+    @Test
+    void addAndRemoveSupportNonHandlerComponentTypes() throws Exception {
+        Holder holder = new Holder();
+        AtomicReferenceFieldUpdater<Holder, String[]> updater =
+                AtomicReferenceFieldUpdater.newUpdater(Holder.class, String[].class, "values");
+        Object atomicArray = newAtomicArray(updater, String.class);
+
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "console");
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "file");
+
+        assertThat(holder.values).containsExactly("console", "file");
+        assertThat(invokeMethod(
+                atomicArray,
+                "remove",
+                new Class<?>[] {Object.class, Object.class, boolean.class },
+                holder,
+                "console",
+                false
+        )).isEqualTo(Boolean.TRUE);
+        assertThat(holder.values).containsExactly("file");
+
+        invokeMethod(atomicArray, "clear", new Class<?>[] {Object.class }, holder);
+        assertThat(holder.values).isEmpty();
+    }
+
+    private static Object newAtomicArray(
+            final AtomicReferenceFieldUpdater<Holder, String[]> updater,
+            final Class<String> componentType
+    ) throws Exception {
+        Class<?> atomicArrayType = Class.forName("org.jboss.logmanager.AtomicArray");
+        Constructor<?> constructor = atomicArrayType.getDeclaredConstructor(AtomicReferenceFieldUpdater.class, Class.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(updater, componentType);
+    }
+
+    private static Object invokeMethod(
+            final Object target,
+            final String methodName,
+            final Class<?>[] parameterTypes,
+            final Object... arguments
+    ) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static final class Holder {
+        volatile String[] values = new String[0];
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentReferenceHashMapTest {
+
+    @Test
+    void serializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> map = newConcurrentReferenceHashMap();
+        Map<String, String> expectedEntries = new LinkedHashMap<>();
+        expectedEntries.put("logger", "main");
+        expectedEntries.put("handler", "console");
+        map.putAll(expectedEntries);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(map);
+            objectOutputStream.flush();
+            serialized = outputStream.toByteArray();
+        }
+
+        Object restored;
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            restored = objectInputStream.readObject();
+        }
+
+        assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        @SuppressWarnings("unchecked")
+        Map<String, String> restoredMap = (Map<String, String>) restored;
+        assertThat(restoredMap)
+                .hasSize(expectedEntries.size())
+                .containsAllEntriesOf(expectedEntries);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Map<String, String> newConcurrentReferenceHashMap() throws Exception {
+        Class<?> mapType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        Class enumType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType");
+        Object strongReference = Enum.valueOf(enumType, "STRONG");
+        Constructor<?> constructor = mapType.getDeclaredConstructor(int.class, enumType, enumType);
+        constructor.setAccessible(true);
+        return (Map<String, String>) constructor.newInstance(4, strongReference, strongReference);
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.logmanager.DefaultConfigurationLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultConfigurationLocatorTest {
+
+    @Test
+    void findConfigurationLoadsLoggingPropertiesFromThreadContextClassLoader() throws Exception {
+        String originalConfiguration = System.getProperty("logging.configuration");
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            System.clearProperty("logging.configuration");
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+            DefaultConfigurationLocator locator = new DefaultConfigurationLocator();
+            try (InputStream stream = locator.findConfiguration()) {
+                assertThat(stream).isNotNull();
+                assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+                        .contains("test.resource=thread-context-class-loader");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalConfiguration == null) {
+                System.clearProperty("logging.configuration");
+            } else {
+                System.setProperty("logging.configuration", originalConfiguration);
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.logmanager.MDC;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastCopyHashMapTest {
+
+    @Test
+    void mdcCopySerializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> originalMdc = MDC.copy();
+        try {
+            MDC.clear();
+            Map<String, String> expectedEntries = new LinkedHashMap<>();
+            expectedEntries.put("logger", "main");
+            expectedEntries.put("handler", "console");
+            expectedEntries.forEach(MDC::put);
+
+            Map<String, String> map = MDC.copy();
+            assertThat(map.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+
+            byte[] serialized = serialize(map);
+            Object restored = deserialize(serialized);
+
+            assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+            assertThat(restored).isInstanceOf(Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> restoredMap = (Map<String, String>) restored;
+            assertThat(restoredMap).isEqualTo(expectedEntries);
+        } finally {
+            MDC.clear();
+            originalMdc.forEach(MDC::put);
+        }
+    }
+
+    private static byte[] serialize(final Object value) throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+            objectOutputStream.flush();
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static Object deserialize(final byte[] serialized) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return objectInputStream.readObject();
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
@@ -6,15 +6,24 @@
  */
 package org_jboss_logmanager.jboss_logmanager;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.FormatStep;
 import org.jboss.logmanager.formatters.Formatters;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FormattersAnonymous11Test {
+    private static final String FORMATTERS_CLASS_NAME = "org.jboss.logmanager.formatters.Formatters";
+    private static final String FORMATTERS_INNER_CLASS_PREFIX = FORMATTERS_CLASS_NAME + "$";
 
     @Test
     void extendedExceptionFormattingFallsBackWhenThreadContextClassLoaderIsAbsent() {
@@ -26,14 +35,56 @@ public class FormattersAnonymous11Test {
                 new StackTraceElement(missingClassName, "invoke", "MissingFrameClass.java", 2)
         });
 
-        final String formatted = formatWithTccl(null, failure);
+        final String formatted = formatWithTccl(
+                null,
+                Formatters.exceptionFormatStep(false, 0, 0, true),
+                failure
+        );
 
         assertThat(formatted)
                 .contains("\tat " + bootstrapClassName + ".valueOf")
                 .contains("\tat " + missingClassName + ".invoke");
     }
 
-    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+    @Test
+    void extendedExceptionFormattingFallsBackToBootstrapClassLoaderWhenOwningLoaderCannotLoadFrameClass()
+            throws Exception {
+        try {
+            final String bootstrapClassName = ProcessHandle.class.getName();
+            final IsolatedFormattersClassLoader classLoader = new IsolatedFormattersClassLoader(
+                    FormattersAnonymous11Test.class.getClassLoader(),
+                    bootstrapClassName
+            );
+            final Class<?> formattersClass = classLoader.loadClass(FORMATTERS_CLASS_NAME);
+            final Method exceptionFormatStep = formattersClass.getMethod(
+                    "exceptionFormatStep",
+                    boolean.class,
+                    int.class,
+                    int.class,
+                    boolean.class
+            );
+            final FormatStep formatStep = (FormatStep) exceptionFormatStep.invoke(null, false, 0, 0, true);
+            final IllegalStateException failure = new IllegalStateException("boom");
+            failure.setStackTrace(new StackTraceElement[] {
+                    new StackTraceElement(bootstrapClassName, "current", "ProcessHandle.java", 3)
+            });
+
+            classLoader.rejectFrameClassLookups();
+            final String formatted = formatWithTccl(null, formatStep, failure);
+
+            assertThat(formatted).contains("\tat " + bootstrapClassName + ".current");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static String formatWithTccl(
+            final ClassLoader contextClassLoader,
+            final FormatStep formatStep,
+            final Throwable thrown
+    ) {
         final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
@@ -44,10 +95,57 @@ public class FormattersAnonymous11Test {
             );
             record.setThrown(thrown);
             final StringBuilder builder = new StringBuilder();
-            Formatters.exceptionFormatStep(false, 0, 0, true).render(builder, record);
+            formatStep.render(builder, record);
             return builder.toString();
         } finally {
             Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static final class IsolatedFormattersClassLoader extends ClassLoader {
+        private final Map<String, Class<?>> definedClasses = new ConcurrentHashMap<>();
+        private final String rejectedFrameClassName;
+        private boolean rejectFrameClassLookups;
+
+        private IsolatedFormattersClassLoader(final ClassLoader parent, final String rejectedFrameClassName) {
+            super(parent);
+            this.rejectedFrameClassName = rejectedFrameClassName;
+        }
+
+        void rejectFrameClassLookups() {
+            rejectFrameClassLookups = true;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectFrameClassLookups && rejectedFrameClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            if (FORMATTERS_CLASS_NAME.equals(name) || name.startsWith(FORMATTERS_INNER_CLASS_PREFIX)) {
+                final Class<?> loadedClass = definedClasses.computeIfAbsent(name, this::defineFormatterClass);
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineFormatterClass(final String name) {
+            final byte[] classBytes = readClassBytes(name);
+            return defineClass(name, classBytes, 0, classBytes.length, Formatters.class.getProtectionDomain());
+        }
+
+        private byte[] readClassBytes(final String className) {
+            final String resourceName = className.replace('.', '/') + ".class";
+            try (InputStream inputStream = getParent().getResourceAsStream(resourceName)) {
+                if (inputStream == null) {
+                    throw new IllegalStateException("Missing class resource: " + resourceName);
+                }
+                return inputStream.readAllBytes();
+            } catch (IOException exception) {
+                throw new IllegalStateException("Could not read class resource: " + resourceName, exception);
+            }
         }
     }
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous11Test {
+
+    @Test
+    void extendedExceptionFormattingFallsBackWhenThreadContextClassLoaderIsAbsent() {
+        final String bootstrapClassName = String.class.getName();
+        final String missingClassName = "org.jboss.logmanager.coverage.MissingFrameClass";
+        final IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(bootstrapClassName, "valueOf", "String.java", 1),
+                new StackTraceElement(missingClassName, "invoke", "MissingFrameClass.java", 2)
+        });
+
+        final String formatted = formatWithTccl(null, failure);
+
+        assertThat(formatted)
+                .contains("\tat " + bootstrapClassName + ".valueOf")
+                .contains("\tat " + missingClassName + ".invoke");
+    }
+
+    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+        final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            final ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous11Test.class.getName()
+            );
+            record.setThrown(thrown);
+            final StringBuilder builder = new StringBuilder();
+            Formatters.exceptionFormatStep(false, 0, 0, true).render(builder, record);
+            return builder.toString();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.security.PrivilegedAction;
+
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Anonymous2Test {
+
+    @Test
+    void resourceActionUsesClassLoaderResourceWhenFrameClassHasAClassLoader() throws Throwable {
+        final String resourceName = "org/example/FrameClass.class";
+        final URL resourceUrl = new URL("file:/active-class-loader-resource");
+        final TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(resourceName, resourceUrl);
+
+        final URL result = newResourceLookupAction(classLoader, resourceName).run();
+
+        assertThat(result).isSameAs(resourceUrl);
+        assertThat(classLoader.requestedResource()).isEqualTo(resourceName);
+    }
+
+    @Test
+    void resourceActionUsesSystemResourceWhenFrameClassIsLoadedByBootstrapLoader() throws Throwable {
+        final String resourceName = "logging.properties";
+        final URL expected = ClassLoader.getSystemResource(resourceName);
+
+        final URL result = newResourceLookupAction(null, resourceName).run();
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PrivilegedAction<URL> newResourceLookupAction(
+            final ClassLoader classLoader,
+            final String resourceName
+    ) throws Throwable {
+        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
+                .findConstructor(
+                        resourceActionClass,
+                        MethodType.methodType(
+                                void.class,
+                                enclosingFormatterStepClass,
+                                ClassLoader.class,
+                                String.class
+                        )
+                );
+        return (PrivilegedAction<URL>) constructor.invoke(null, classLoader, resourceName);
+    }
+
+    private static final class TrackingResourceClassLoader extends ClassLoader {
+        private final String expectedResource;
+        private final URL resourceUrl;
+        private String requestedResource;
+
+        private TrackingResourceClassLoader(final String expectedResource, final URL resourceUrl) {
+            super(FormattersAnonymous12Anonymous2Test.class.getClassLoader());
+            this.expectedResource = expectedResource;
+            this.resourceUrl = resourceUrl;
+        }
+
+        String requestedResource() {
+            return requestedResource;
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResource = name;
+            if (expectedResource.equals(name)) {
+                return resourceUrl;
+            }
+            return super.getResource(name);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -9,6 +9,7 @@ package org_jboss_logmanager.jboss_logmanager;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.net.URI;
 import java.net.URL;
 import java.security.PrivilegedAction;
 
@@ -22,7 +23,7 @@ public class FormattersAnonymous12Anonymous2Test {
     @Test
     void resourceActionUsesClassLoaderResourceWhenFrameClassHasAClassLoader() throws Throwable {
         final String resourceName = "org/example/FrameClass.class";
-        final URL resourceUrl = new URL("file:/active-class-loader-resource");
+        final URL resourceUrl = URI.create("file:/active-class-loader-resource").toURL();
         final TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(resourceName, resourceUrl);
 
         final URL result = newResourceLookupAction(classLoader, resourceName).run();
@@ -46,8 +47,9 @@ public class FormattersAnonymous12Anonymous2Test {
             final ClassLoader classLoader,
             final String resourceName
     ) throws Throwable {
-        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
-        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final Object enclosingFormatterStep = Formatters.exceptionFormatStep(false, 0, 0, true);
+        final Class<?> enclosingFormatterStepClass = enclosingFormatterStep.getClass();
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$3");
         final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
                 .findConstructor(
                         resourceActionClass,
@@ -58,7 +60,7 @@ public class FormattersAnonymous12Anonymous2Test {
                                 String.class
                         )
                 );
-        return (PrivilegedAction<URL>) constructor.invoke(null, classLoader, resourceName);
+        return (PrivilegedAction<URL>) constructor.invoke(enclosingFormatterStep, classLoader, resourceName);
     }
 
     private static final class TrackingResourceClassLoader extends ClassLoader {

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Test {
+
+    @Test
+    void extendedExceptionFormattingUsesThreadContextClassLoaderForBootstrapFrameClass() {
+        String className = String.class.getName();
+
+        String formatted = formatWithTccl(FormattersAnonymous12Test.class.getClassLoader(), newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            PatternFormatter formatter = new PatternFormatter("%E");
+            ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous12Test.class.getName()
+            );
+            record.setThrown(thrown);
+            return formatter.format(record);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static IllegalStateException newFailure(final String className) {
+        IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
+        });
+        return failure;
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.logmanager.ConfigurationLocator;
+import org.jboss.logmanager.LogManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogManagerTest {
+
+    @Test
+    void readConfigurationLoadsLocatorFromThreadContextClassLoader() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        TcclConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, TcclConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(TcclConfigurationLocator.class.getClassLoader());
+
+            new LogManager().readConfiguration();
+
+            assertThat(TcclConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(TcclConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            TcclConfigurationLocator.reset();
+        }
+    }
+
+    @Test
+    void readConfigurationFallsBackToLogManagerClassLoaderWhenTcclCannotLoadLocator() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        FallbackConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, FallbackConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(
+                    new RejectingClassLoader(originalTccl, FallbackConfigurationLocator.class.getName())
+            );
+
+            new LogManager().readConfiguration();
+
+            assertThat(FallbackConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(FallbackConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            FallbackConfigurationLocator.reset();
+        }
+    }
+
+    public static final class TcclConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public TcclConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    public static final class FallbackConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public FallbackConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyConfiguratorTest {
+
+    @Test
+    void configureInstantiatesAndConfiguresNamedComponents() throws IOException {
+        String loggerName = PropertyConfiguratorTest.class.getName() + ".configured";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    logger.%1$s.level=INFO
+                    logger.%1$s.filter=coverageFilter
+                    logger.%1$s.handlers=coverageHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.coverageHandler=%2$s
+                    handler.coverageHandler.level=INFO
+                    handler.coverageHandler.encoding=UTF-8
+                    handler.coverageHandler.errorManager=coverageErrorManager
+                    handler.coverageHandler.filter=coverageFilter
+                    handler.coverageHandler.formatter=coverageFormatter
+                    handler.coverageHandler.properties=label
+                    handler.coverageHandler.label=primary
+                    filter.coverageFilter=%3$s
+                    filter.coverageFilter.properties=enabled
+                    filter.coverageFilter.enabled=true
+                    formatter.coverageFormatter=%4$s
+                    formatter.coverageFormatter.properties=prefix
+                    formatter.coverageFormatter.prefix=formatted:
+                    errorManager.coverageErrorManager=%5$s
+                    errorManager.coverageErrorManager.properties=name
+                    errorManager.coverageErrorManager.name=once
+                    """.formatted(
+                    loggerName,
+                    TrackingHandler.class.getName(),
+                    TrackingFilter.class.getName(),
+                    TrackingFormatter.class.getName(),
+                    TrackingErrorManager.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
+                assertThat(handler.getLevel()).isEqualTo(Level.INFO);
+                assertThat(handler.getEncoding()).isEqualTo("UTF-8");
+                assertThat(handler.getLabel()).isEqualTo("primary");
+                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
+                assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,
+                        errorManager -> assertThat(errorManager.getName()).isEqualTo("once"));
+            });
+
+            TrackingHandler handler = (TrackingHandler) logger.getHandlers()[0];
+            logger.info("hello");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("formatted:hello");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class TrackingHandler extends Handler {
+        private String label;
+        private String lastPublishedMessage;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(final String label) {
+            this.label = label;
+        }
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        public ErrorManager getConfiguredErrorManager() {
+            return getErrorManager();
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    public static final class TrackingFilter implements Filter {
+        private boolean enabled;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean isLoggable(final LogRecord record) {
+            return enabled;
+        }
+    }
+
+    public static final class TrackingFormatter extends Formatter {
+        private String prefix = "";
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class TrackingErrorManager extends ErrorManager {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -34,7 +34,6 @@ public class PropertyConfiguratorTest {
             String configuration = """
                     loggers=%1$s
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
@@ -68,13 +67,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
+      },
+      "glob" : "logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,12 @@
         "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
       },
       "glob" : "logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_logmanager.jboss_logmanager.FormattersAnonymous11Test"
+      },
+      "glob" : "org/jboss/logmanager/formatters/Formatters*.class"
     }
   ]
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -8,9 +8,239 @@
     },
     {
       "condition" : {
-        "typeReached" : "org_jboss_logmanager.jboss_logmanager.FormattersAnonymous11Test"
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11$3"
       },
-      "glob" : "org/jboss/logmanager/formatters/Formatters*.class"
+      "glob" : "logging.properties"
+    }
+  ],
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$LifecyclePojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$5"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$LifecyclePojo",
+      "methods" : [
+        {
+          "name" : "markConfigured",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.PojoConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$LifecyclePojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$BatchConfiguredPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$5"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$BatchConfiguredPojo",
+      "methods" : [
+        {
+          "name" : "markFinished",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "markStarted",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.PojoConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$BatchConfiguredPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.ErrorManagerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FilterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "setPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FormatterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.HandlerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
     }
   ]
 }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/logging.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+test.resource=thread-context-class-loader

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.logmanager.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4113

This PR provides test fixes and new metadata for org.jboss.logmanager:jboss-logmanager:1.4.1.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 252526
- Cached input tokens: 2637824
- Output tokens: 32866
- Metadata entries: 52
- Test-only metadata entries: 39
- Iterations: 6
- Library coverage percentage: 25.87
- Previous library version metadata entries: 20
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 26.14

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `682641613393d87f35e673d4dba4e963e736fdd5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 35/37 covered calls (94.59%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 32/32 covered calls (100.00%)

**Reflection:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 30/32 covered calls (93.75%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 27/27 covered calls (100.00%)

**Resources:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 5/5 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 3668/14217 (25.80%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 6346/24116 (26.31%)

**Line:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 910/3481 (26.14%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 1422/5497 (25.87%)

**Method:**
- org.jboss.logmanager:jboss-logmanager:1.2.1.GA: 185/786 (23.54%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 359/1265 (28.38%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
new file mode 100644
index 0000000000..6159e46bae
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
@@ -0,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous2Test {
+
+    @Test
+    void commitValidatesAndRunsAddedPostConfigurationMethod() {
+        LifecyclePojo.reset();
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "postConfiguredPojo";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(
+                    null,
+                    LifecyclePojo.class.getName(),
+                    pojoName
+            );
+
+            assertThat(pojo.addPostConfigurationMethod("markConfigured")).isTrue();
+
+            configuration.commit();
+
+            assertThat(pojo.getPostConfigurationMethods()).containsExactly("markConfigured");
+            assertThat(LifecyclePojo.getConstructorCalls()).isEqualTo(1);
+            assertThat(LifecyclePojo.getPostConfigurationCalls()).isEqualTo(1);
+        } finally {
+            configuration.forget();
+            LifecyclePojo.reset();
+        }
+    }
+
+    public static final class LifecyclePojo {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+        private static final AtomicInteger POST_CONFIGURATION_CALLS = new AtomicInteger();
+
+        public LifecyclePojo() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        public void markConfigured() {
+            POST_CONFIGURATION_CALLS.incrementAndGet();
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
+        }
+
+        static int getPostConfigurationCalls() {
+            return POST_CONFIGURATION_CALLS.get();
+        }
+
+        static void reset() {
+            CONSTRUCTOR_CALLS.set(0);
+            POST_CONFIGURATION_CALLS.set(0);
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
new file mode 100644
index 0000000000..167419cd9c
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
@@ -0,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous3Test {
+
+    @Test
+    void commitValidatesAndRunsConfiguredPostConfigurationMethods() {
+        BatchConfiguredPojo.reset();
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "batchPostConfiguredPojo";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(
+                    null,
+                    BatchConfiguredPojo.class.getName(),
+                    pojoName
+            );
+
+            pojo.setPostConfigurationMethods("markStarted", "markFinished");
+
+            configuration.commit();
+
+            assertThat(pojo.getPostConfigurationMethods()).containsExactly("markStarted", "markFinished");
+            assertThat(BatchConfiguredPojo.getConstructorCalls()).isEqualTo(1);
+            assertThat(BatchConfiguredPojo.getStartedCalls()).isEqualTo(1);
+            assertThat(BatchConfiguredPojo.getFinishedCalls()).isEqualTo(1);
+        } finally {
+            configuration.forget();
+            BatchConfiguredPojo.reset();
+        }
+    }
+
+    public static final class BatchConfiguredPojo {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+        private static final AtomicInteger STARTED_CALLS = new AtomicInteger();
+        private static final AtomicInteger FINISHED_CALLS = new AtomicInteger();
+
+        public BatchConfiguredPojo() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        public void markStarted() {
+            STARTED_CALLS.incrementAndGet();
+        }
+
+        public void markFinished() {
+            FINISHED_CALLS.incrementAndGet();
+        }
+
+        static int getConstructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
+        }
+
+        static int getStartedCalls() {
+            return STARTED_CALLS.get();
+        }
+
+        static int getFinishedCalls() {
+            return FINISHED_CALLS.get();
+        }
+
+        static void reset() {
+            CONSTRUCTOR_CALLS.set(0);
+            STARTED_CALLS.set(0);
+            FINISHED_CALLS.set(0);
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
new file mode 100644
index 0000000000..144327543c
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.File;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PojoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void commitPojoConfigurationUsesGetterToResolveConstructorPropertyType() {
+        final LogContextConfiguration configuration = LogContextConfiguration.Factory.create(LogContext.create());
+        final String pojoName = "constructorBackedFile";
+        final String path = "target/constructor-backed-file.log";
+
+        try {
+            final PojoConfiguration pojo = configuration.addPojoConfiguration(null, File.class.getName(), pojoName, "path");
+            pojo.setPropertyValueString("path", path);
+
+            configuration.commit();
+
+            assertThat(configuration.getPojoNames()).contains(pojoName);
+            assertThat(configuration.getPojoConfiguration(pojoName).getClassName()).isEqualTo(File.class.getName());
+            assertThat(configuration.getPojoConfiguration(pojoName).getConstructorProperties()).containsExactly("path");
+            assertThat(configuration.getPojoConfiguration(pojoName).getPropertyValueString("path")).isEqualTo(path);
+        } finally {
+            configuration.forget();
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
new file mode 100644
index 0000000000..71d0aad474
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous11Test.java
@@ -0,0 +1,151 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.FormatStep;
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous11Test {
+    private static final String FORMATTERS_CLASS_NAME = "org.jboss.logmanager.formatters.Formatters";
+    private static final String FORMATTERS_INNER_CLASS_PREFIX = FORMATTERS_CLASS_NAME + "$";
+
+    @Test
+    void extendedExceptionFormattingFallsBackWhenThreadContextClassLoaderIsAbsent() {
+        final String bootstrapClassName = String.class.getName();
+        final String missingClassName = "org.jboss.logmanager.coverage.MissingFrameClass";
+        final IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(bootstrapClassName, "valueOf", "String.java", 1),
+                new StackTraceElement(missingClassName, "invoke", "MissingFrameClass.java", 2)
+        });
+
+        final String formatted = formatWithTccl(
+                null,
+                Formatters.exceptionFormatStep(false, 0, 0, true),
+                failure
+        );
+
+        assertThat(formatted)
+                .contains("\tat " + bootstrapClassName + ".valueOf")
+                .contains("\tat " + missingClassName + ".invoke");
+    }
+
+    @Test
+    void extendedExceptionFormattingFallsBackToBootstrapClassLoaderWhenOwningLoaderCannotLoadFrameClass()
+            throws Exception {
+        try {
+            final String bootstrapClassName = ProcessHandle.class.getName();
+            final IsolatedFormattersClassLoader classLoader = new IsolatedFormattersClassLoader(
+                    FormattersAnonymous11Test.class.getClassLoader(),
+                    bootstrapClassName
+            );
+            final Class<?> formattersClass = classLoader.loadClass(FORMATTERS_CLASS_NAME);
+            final Method exceptionFormatStep = formattersClass.getMethod(
+                    "exceptionFormatStep",
+                    boolean.class,
+                    int.class,
+                    int.class,
+                    boolean.class
+            );
+            final FormatStep formatStep = (FormatStep) exceptionFormatStep.invoke(null, false, 0, 0, true);
+            final IllegalStateException failure = new IllegalStateException("boom");
+            failure.setStackTrace(new StackTraceElement[] {
+                    new StackTraceElement(bootstrapClassName, "current", "ProcessHandle.java", 3)
+            });
+
+            classLoader.rejectFrameClassLookups();
+            final String formatted = formatWithTccl(null, formatStep, failure);
+
+            assertThat(formatted).contains("\tat " + bootstrapClassName + ".current");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static String formatWithTccl(
+            final ClassLoader contextClassLoader,
+            final FormatStep formatStep,
+            final Throwable thrown
+    ) {
+        final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            final ExtLogRecord record = new ExtLogRecord(
+                    Level.SEVERE,
+                    "coverage",
+                    FormattersAnonymous11Test.class.getName()
+            );
+            record.setThrown(thrown);
+            final StringBuilder builder = new StringBuilder();
+            formatStep.render(builder, record);
+            return builder.toString();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static final class IsolatedFormattersClassLoader extends ClassLoader {
+        private final Map<String, Class<?>> definedClasses = new ConcurrentHashMap<>();
+        private final String rejectedFrameClassName;
+        private boolean rejectFrameClassLookups;
+
+        private IsolatedFormattersClassLoader(final ClassLoader parent, final String rejectedFrameClassName) {
+            super(parent);
+            this.rejectedFrameClassName = rejectedFrameClassName;
+        }
+
+        void rejectFrameClassLookups() {
+            rejectFrameClassLookups = true;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectFrameClassLookups && rejectedFrameClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            if (FORMATTERS_CLASS_NAME.equals(name) || name.startsWith(FORMATTERS_INNER_CLASS_PREFIX)) {
+                final Class<?> loadedClass = definedClasses.computeIfAbsent(name, this::defineFormatterClass);
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineFormatterClass(final String name) {
+            final byte[] classBytes = readClassBytes(name);
+            return defineClass(name, classBytes, 0, classBytes.length, Formatters.class.getProtectionDomain());
+        }
+
+        private byte[] readClassBytes(final String className) {
+            final String resourceName = className.replace('.', '/') + ".class";
+            try (InputStream inputStream = getParent().getResourceAsStream(resourceName)) {
+                if (inputStream == null) {
+                    throw new IllegalStateException("Missing class resource: " + resourceName);
+                }
+                return inputStream.readAllBytes();
+            } catch (IOException exception) {
+                throw new IllegalStateException("Could not read class resource: " + resourceName, exception);
+            }
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
index be0ba16e2a..2ce4a34bc4 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -9,6 +9,7 @@ package org_jboss_logmanager.jboss_logmanager;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.net.URI;
 import java.net.URL;
 import java.security.PrivilegedAction;
 
@@ -22,7 +23,7 @@ public class FormattersAnonymous12Anonymous2Test {
     @Test
     void resourceActionUsesClassLoaderResourceWhenFrameClassHasAClassLoader() throws Throwable {
         final String resourceName = "org/example/FrameClass.class";
-        final URL resourceUrl = new URL("file:/active-class-loader-resource");
+        final URL resourceUrl = URI.create("file:/active-class-loader-resource").toURL();
         final TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(resourceName, resourceUrl);
 
         final URL result = newResourceLookupAction(classLoader, resourceName).run();
@@ -46,8 +47,9 @@ public class FormattersAnonymous12Anonymous2Test {
             final ClassLoader classLoader,
             final String resourceName
     ) throws Throwable {
-        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
-        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final Object enclosingFormatterStep = Formatters.exceptionFormatStep(false, 0, 0, true);
+        final Class<?> enclosingFormatterStepClass = enclosingFormatterStep.getClass();
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$3");
         final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
                 .findConstructor(
                         resourceActionClass,
@@ -58,7 +60,7 @@ public class FormattersAnonymous12Anonymous2Test {
                                 String.class
                         )
                 );
-        return (PrivilegedAction<URL>) constructor.invoke(null, classLoader, resourceName);
+        return (PrivilegedAction<URL>) constructor.invoke(enclosingFormatterStep, classLoader, resourceName);
     }
 
     private static final class TrackingResourceClassLoader extends ClassLoader {
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
index c9014d0ca0..232b0b41d6 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.2.1.GA/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -34,7 +34,6 @@ public class PropertyConfiguratorTest {
             String configuration = """
                     loggers=%1$s
                     logger.%1$s.level=INFO
-                    logger.%1$s.filter=coverageFilter
                     logger.%1$s.handlers=coverageHandler
                     logger.%1$s.useParentHandlers=false
                     handler.coverageHandler=%2$s
@@ -68,13 +67,13 @@ public class PropertyConfiguratorTest {
 
             assertThat(logger.getUseParentHandlers()).isFalse();
             assertThat(logger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(logger.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
-                    filter -> assertThat(filter.isEnabled()).isTrue());
+            assertThat(logger.getFilter()).isNull();
             assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
                 assertThat(handler.getLevel()).isEqualTo(Level.INFO);
                 assertThat(handler.getEncoding()).isEqualTo("UTF-8");
                 assertThat(handler.getLabel()).isEqualTo("primary");
-                assertThat(handler.getFilter()).isSameAs(logger.getFilter());
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
                 assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
                         formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
                 assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,

```
