### PR TITLE
[GenAI] Add support for velocity:velocity-dep:1.4 using gpt-5.5

### DIFF
--- a/metadata/velocity/velocity-dep/1.4/reachability-metadata.json
+++ b/metadata/velocity/velocity-dep/1.4/reachability-metadata.json
@@ -1,0 +1,715 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.ASTMethod"
+      },
+      "type" : "Foo",
+      "methods" : [
+        {
+          "name" : "doIt",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.ClassloaderChangeTest"
+      },
+      "type" : "Foo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.MethodMap"
+      },
+      "type" : "java.lang.Byte"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.MethodMap"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.MethodMap"
+      },
+      "type" : "java.lang.Long"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "java.util.Collections$UnmodifiableMap",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.MethodMap"
+      },
+      "type" : "java.lang.Short"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log.output.net.SocketOutputTarget"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "java.util.HashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl$VelGetterImpl"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl$VelSetterImpl"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "put",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.util.Map",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.UberspectImpl"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase3"
+      },
+      "type" : "junit.framework.TestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.ParserTestCase"
+      },
+      "type" : "junit.framework.TestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log.output.net.SocketOutputTarget"
+      },
+      "type" : "org.apache.log.LogEvent",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log.format.ExtendedPatternFormatter"
+      },
+      "type" : "org.apache.log.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log.output.net.SocketOutputTarget"
+      },
+      "type" : "org.apache.log.Priority",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.GetExecutor"
+      },
+      "type" : "org.apache.velocity.VelocityContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.VelocityContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.Generator"
+      },
+      "type" : "org.apache.velocity.app.VelocityEngine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.GetExecutor"
+      },
+      "type" : "org.apache.velocity.context.AbstractContext",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.parser.node.PropertyExecutor"
+      },
+      "type" : "org.apache.velocity.context.AbstractContext",
+      "methods" : [
+        {
+          "name" : "getKeys",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.util.introspection.ClassMap"
+      },
+      "type" : "org.apache.velocity.context.InternalEventContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.app.FieldMethodizer"
+      },
+      "type" : "org.apache.velocity.runtime.RuntimeConstants",
+      "fields" : [
+        {
+          "name" : "INPUT_ENCODING"
+        },
+        {
+          "name" : "RESOURCE_LOADER"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.ParserTestCase"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Include",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Literal",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Macro",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.ParserTestCase"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Macro",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Parse",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.log.AvalonLogSystem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.log.LogManager"
+      },
+      "type" : "org.apache.velocity.runtime.log.NullLogSystem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.resource.ResourceManagerImpl"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceCacheImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceManagerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.resource.loader.ResourceLoaderFactory"
+      },
+      "type" : "org.apache.velocity.runtime.resource.loader.FileResourceLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.BaseTestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase3"
+      },
+      "type" : "org.apache.velocity.test.BaseTestCase"
+    },
+    {
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase$MethodProvider",
+      "methods" : [
+        {
+          "name" : "booleanMethod",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "byteMethod",
+          "parameterTypes" : [
+            "byte"
+          ]
+        },
+        {
+          "name" : "characterMethod",
+          "parameterTypes" : [
+            "char"
+          ]
+        },
+        {
+          "name" : "doubleMethod",
+          "parameterTypes" : [
+            "double"
+          ]
+        },
+        {
+          "name" : "floatMethod",
+          "parameterTypes" : [
+            "float"
+          ]
+        },
+        {
+          "name" : "integerMethod",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "longMethod",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "shortMethod",
+          "parameterTypes" : [
+            "short"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2$Tester",
+      "methods" : [
+        {
+          "name" : "find",
+          "parameterTypes" : [
+            "org.apache.velocity.test.IntrospectorTestCase2$Bar",
+            "org.apache.velocity.test.IntrospectorTestCase2$Bar"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2$Tester2"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase3"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase3",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase3"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase3$MethodProvider",
+      "methods" : [
+        {
+          "name" : "ii",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "lii",
+          "parameterTypes" : [
+            "java.util.List",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "ll",
+          "parameterTypes" : [
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "lll",
+          "parameterTypes" : [
+            "java.util.List",
+            "long"
+          ]
+        },
+        {
+          "name" : "lll",
+          "parameterTypes" : [
+            "java.util.List",
+            "long",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.ParserTestCase"
+      },
+      "type" : "org.apache.velocity.test.ParserTestCase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.Generator"
+      },
+      "type" : "org.apache.velocity.texen.util.FileUtil",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.Generator"
+      },
+      "type" : "org.apache.velocity.texen.util.PropertiesUtil",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.Generator"
+      },
+      "type" : "org.apache.velocity.util.StringUtils",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.util.introspection.UberspectImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log.output.net.SocketOutputTarget"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.log.VelocityFormatter"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.log.VelocityFormatter"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.log.VelocityFormatter"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/directive.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/velocity.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.Generator"
+      },
+      "glob" : "org/apache/velocity/texen/defaults/texen.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.texen.util.PropertiesUtil"
+      },
+      "glob" : "org/apache/velocity/texen/defaults/texen.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2$Bar.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2$Foo.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2$Tester.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2$Tester2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "glob" : "org/apache/velocity/test/IntrospectorTestCase2$Woogie.class"
+    }
+  ]
+}

--- a/metadata/velocity/velocity-dep/index.json
+++ b/metadata/velocity/velocity-dep/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/velocity/velocity-dep/1.4/velocity-dep-1.4-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/velocity/engine/",
+    "test-code-url" : "https://svn.apache.org/repos/asf/velocity/engine/tags/VEL_1_4/test/",
+    "documentation-url" : "https://svn.apache.org/repos/asf/velocity/engine/tags/VEL_1_4/docs/",
+    "description" : "Apache Velocity is a Java-based template engine for rendering text output from templates that reference objects supplied by application code. The velocity-dep artifact packages Velocity 1.4 together with its bundled runtime dependencies for convenient embedding in Java applications.",
+    "tested-versions" : [
+      "1.4"
+    ],
+    "allowed-packages" : [
+      "org.apache"
+    ]
+  }
+]

--- a/stats/velocity/velocity-dep/1.4/execution-metrics.json
+++ b/stats/velocity/velocity-dep/1.4/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T22:30:13.643422Z",
+    "library": "velocity:velocity-dep:1.4",
+    "starting_commit": "de8e512db821bb4b3f06cefd1f9dd87fca9fe524",
+    "ending_commit": "9954be7c0b8cabebb4a43abddb0b7f5983fbc65b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.886792,
+            "coveredCalls": 47,
+            "totalCalls": 53
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.896552,
+        "coveredCalls": 52,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18414,
+          "missed": 55080,
+          "ratio": 0.250551,
+          "total": 73494
+        },
+        "line": {
+          "covered": 3917,
+          "missed": 11832,
+          "ratio": 0.248714,
+          "total": 15749
+        },
+        "method": {
+          "covered": 702,
+          "missed": 1763,
+          "ratio": 0.284787,
+          "total": 2465
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 1115900,
+      "cached_input_tokens_used": 12650496,
+      "output_tokens_used": 147329,
+      "iterations": 32,
+      "cost_usd": 10.7451,
+      "generated_loc": 864,
+      "tested_library_loc": 3917,
+      "metadata_entries": 117,
+      "test_only_metadata_entries": 1,
+      "code_coverage_percent": 24.87
+    },
+    "artifacts": {
+      "test_file": "tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/UberspectImplTest.java",
+      "metadata_file": "metadata/velocity/velocity-dep/1.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/velocity/velocity-dep/1.4/stats.json
+++ b/stats/velocity/velocity-dep/1.4/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.886792,
+          "coveredCalls" : 47,
+          "totalCalls" : 53
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.896552,
+      "coveredCalls" : 52,
+      "totalCalls" : 58
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18414,
+        "missed" : 55080,
+        "ratio" : 0.250551,
+        "total" : 73494
+      },
+      "line" : {
+        "covered" : 3917,
+        "missed" : 11832,
+        "ratio" : 0.248714,
+        "total" : 15749
+      },
+      "method" : {
+        "covered" : 702,
+        "missed" : 1763,
+        "ratio" : 0.284787,
+        "total" : 2465
+      }
+    }
+  } ]
+}

--- a/tests/src/velocity/velocity-dep/1.4/.gitignore
+++ b/tests/src/velocity/velocity-dep/1.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/velocity/velocity-dep/1.4/build.gradle
+++ b/tests/src/velocity/velocity-dep/1.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "velocity:velocity-dep:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/build.gradle
+++ b/tests/src/velocity/velocity-dep/1.4/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "velocity:velocity-dep:$libraryVersion"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/velocity/velocity-dep/1.4/gradle.properties
+++ b/tests/src/velocity/velocity-dep/1.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = velocity:velocity-dep:1.4
+library.version = 1.4
+metadata.dir = velocity/velocity-dep/1.4/

--- a/tests/src/velocity/velocity-dep/1.4/settings.gradle
+++ b/tests/src/velocity/velocity-dep/1.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'velocity.velocity-dep_tests'

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ASTDirectiveTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ASTDirectiveTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.StringWriter;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ASTDirectiveTest {
+    @Test
+    void initializesAndRendersBuiltInDirectiveFromParsedTemplate() throws Exception {
+        VelocityEngine velocityEngine = new VelocityEngine();
+        velocityEngine.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
+        velocityEngine.init();
+
+        VelocityContext context = new VelocityContext();
+        StringWriter writer = new StringWriter();
+
+        boolean rendered = velocityEngine.evaluate(
+                context,
+                writer,
+                "ast-directive-literal",
+                "#literal()$name is not interpolated#end");
+
+        assertTrue(rendered);
+        assertEquals("$name is not interpolated", writer.toString());
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassMapInnerMethodInfoTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassMapInnerMethodInfoTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.util.introspection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ClassMapInnerMethodInfoTest {
+    @Test
+    void upcastsMethodFromNonPublicImplementationToPublicInterface() throws Exception {
+        Map<String, String> values = new HashMap<>();
+        values.put("template", "merged");
+        Map<String, String> nonPublicMap = Collections.unmodifiableMap(values);
+        ClassMap classMap = new ClassMap(nonPublicMap.getClass());
+
+        Method method = classMap.findMethod("get", new Object[] { "template" });
+
+        assertNotNull(method);
+        assertEquals("get", method.getName());
+        assertEquals(Map.class, method.getDeclaringClass());
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassMapInnerMethodInfoTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassMapInnerMethodInfoTest.java
@@ -25,7 +25,7 @@ public class ClassMapInnerMethodInfoTest {
         Map<String, String> nonPublicMap = Collections.unmodifiableMap(values);
         ClassMap classMap = new ClassMap(nonPublicMap.getClass());
 
-        Method method = classMap.findMethod("get", new Object[] { "template" });
+        Method method = classMap.findMethod("get", new Object[] {"template" });
 
         assertNotNull(method);
         assertEquals("get", method.getName());

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassloaderChangeTestTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClassloaderChangeTestTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import org.apache.velocity.test.ClassloaderChangeTest;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ClassloaderChangeTestTest {
+    private static final byte[] FOO_CLASS_BYTES = Base64.getDecoder().decode(
+            "yv66vgAAADQAEQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+" +
+            "AQADKClWCAAIAQAOSGVsbG8gRnJvbSBGb28HAAoBAANGb28BAARDb2RlAQAPTGluZU51" +
+            "bWJlclRhYmxlAQAEZG9JdAEAFCgpTGphdmEvbGFuZy9TdHJpbmc7AQAKU291cmNlRmls" +
+            "ZQEACEZvby5qYXZhACEACQACAAAAAAACAAEABQAGAAEACwAAAB0AAQABAAAABSq3AAGx" +
+            "AAAAAQAMAAAABgABAAAAAQABAA0ADgABAAsAAAAbAAEAAQAAAAMSB7AAAAABAAwAAAAG" +
+            "AAEAAAADAAEADwAAAAIAEA=="
+    );
+
+    @Test
+    void reloadsEquivalentFooClassesFromSeparateClassLoaders() throws Exception {
+        writeFooClassForVelocityTestClassLoader();
+
+        try {
+            new ClassloaderChangeTest().runTest();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static void writeFooClassForVelocityTestClassLoader() throws IOException {
+        Path classFile = Path.of("..", "test", "classloader", "Foo.class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, FOO_CLASS_BYTES);
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClasspathResourceLoaderTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ClasspathResourceLoaderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ClasspathResourceLoaderTest {
+    private static final String TEMPLATE_RESOURCE = "velocity/velocity_dep/classpath-resource-loader-template.vm";
+
+    @Test
+    void opensTemplateResourceFromApplicationClasspath() throws Exception {
+        ClasspathResourceLoader loader = new ClasspathResourceLoader();
+
+        try (InputStream stream = loader.getResourceStream(TEMPLATE_RESOURCE)) {
+            assertNotNull(stream);
+            String template = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertEquals("Hello from the classpath resource loader.\n", template);
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ExtendedPatternFormatterTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ExtendedPatternFormatterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.ByteArrayOutputStream;
+
+import org.apache.log.ContextMap;
+import org.apache.log.Hierarchy;
+import org.apache.log.LogEvent;
+import org.apache.log.Logger;
+import org.apache.log.Priority;
+import org.apache.log.format.ExtendedPatternFormatter;
+import org.apache.log.output.io.StreamTarget;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ExtendedPatternFormatterTest {
+    @Test
+    @Order(1)
+    void formatsMethodPatternWhenEventHasNoMethodContext() {
+        ExtendedPatternFormatter formatter = new ExtendedPatternFormatter("method=%{method}");
+        LogEvent logEvent = new LogEvent();
+        logEvent.setContextMap(new ContextMap());
+
+        String formattedEvent = formatter.format(logEvent);
+
+        assertEquals("method=", formattedEvent);
+    }
+
+    @Test
+    @Order(2)
+    void formatsMethodPatternWhileProcessingLoggerEvent() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ExtendedPatternFormatter formatter = new ExtendedPatternFormatter("method=%{method} message=%{message}");
+        StreamTarget logTarget = new StreamTarget(outputStream, formatter);
+        Hierarchy hierarchy = new Hierarchy();
+        hierarchy.setDefaultLogTarget(logTarget);
+        hierarchy.setDefaultPriority(Priority.DEBUG);
+        Logger logger = hierarchy.getLoggerFor("dynamic.access.formatter");
+
+        logger.info("dynamic access formatter message");
+
+        String formattedEvent = outputStream.toString();
+        assertTrue(formattedEvent.startsWith("method="));
+        assertTrue(formattedEvent.contains("message=dynamic access formatter message"));
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/FieldMethodizerTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/FieldMethodizerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.apache.velocity.app.FieldMethodizer;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class FieldMethodizerTest {
+    @Test
+    void exposesPublicStaticFieldsFromClassName() throws Exception {
+        FieldMethodizer methodizer = new FieldMethodizer();
+
+        methodizer.addObject(RuntimeConstants.class.getName());
+
+        assertEquals(RuntimeConstants.INPUT_ENCODING, methodizer.get("INPUT_ENCODING"));
+        assertEquals(RuntimeConstants.RESOURCE_LOADER, methodizer.get("RESOURCE_LOADER"));
+        assertNull(methodizer.get("missingField"));
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GeneratorTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GeneratorTest.java
@@ -7,6 +7,9 @@
 package velocity.velocity_dep;
 
 import java.io.Writer;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -23,6 +26,16 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GeneratorTest {
+    @Test
+    void compilerGeneratedClassLookupResolvesVelocityEngineType() throws Throwable {
+        MethodHandle classLookup = MethodHandles.privateLookupIn(Generator.class, MethodHandles.lookup())
+                .findStatic(Generator.class, "class$", MethodType.methodType(Class.class, String.class));
+
+        Class<?> resolvedClass = (Class<?>) classLookup.invoke(VelocityEngine.class.getName());
+
+        assertEquals(VelocityEngine.class, resolvedClass);
+    }
+
     @Test
     void parsesControlTemplateWithDefaultTexenContextObjects() throws Exception {
         Generator generator = new Generator("missing-texen.properties");

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GeneratorTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.Writer;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.context.Context;
+import org.apache.velocity.texen.Generator;
+import org.apache.velocity.texen.util.FileUtil;
+import org.apache.velocity.texen.util.PropertiesUtil;
+import org.apache.velocity.util.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GeneratorTest {
+    @Test
+    void parsesControlTemplateWithDefaultTexenContextObjects() throws Exception {
+        Generator generator = new Generator("missing-texen.properties");
+        generator.setVelocityEngine(new ConstantTemplateVelocityEngine());
+        generator.setOutputPath("target/generated-texen");
+
+        VelocityContext context = new VelocityContext();
+        String rendered = generator.parse("control.vm", context);
+
+        assertEquals("texen template rendered", rendered);
+        assertSame(Generator.getInstance(), context.get("generator"));
+        assertEquals("target/generated-texen", context.get("outputDirectory"));
+        assertTrue(context.get("strings") instanceof StringUtils);
+        assertTrue(context.get("files") instanceof FileUtil);
+        assertTrue(context.get("properties") instanceof PropertiesUtil);
+    }
+}
+
+class ConstantTemplateVelocityEngine extends VelocityEngine {
+    @Override
+    public Template getTemplate(String name) {
+        return new ConstantTemplate();
+    }
+
+    @Override
+    public Template getTemplate(String name, String encoding) {
+        return getTemplate(name);
+    }
+}
+
+class ConstantTemplate extends Template {
+    @Override
+    public void merge(Context context, Writer writer) throws Exception {
+        writer.write("texen template rendered");
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GetExecutorTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/GetExecutorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.parser.node.GetExecutor;
+import org.apache.velocity.util.introspection.Introspector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GetExecutorTest {
+    @Test
+    void invokesVelocityContextGetThroughCurrentExecutor() throws Exception {
+        VelocityContext context = new VelocityContext();
+        context.put("message", "resolved through execute");
+        GetExecutor executor = createExecutor("message");
+
+        Object value = executor.execute(context);
+
+        assertEquals("resolved through execute", value);
+    }
+
+    @Test
+    void invokesVelocityContextGetThroughLegacyExecutor() throws Exception {
+        VelocityContext context = new VelocityContext();
+        context.put("message", "resolved through legacy execute");
+        GetExecutor executor = createExecutor("message");
+
+        Object value = executor.OLDexecute(context, null);
+
+        assertEquals("resolved through legacy execute", value);
+    }
+
+    private static GetExecutor createExecutor(String key) throws Exception {
+        RuntimeLogger logger = new NoOpRuntimeLogger();
+        Introspector introspector = new Introspector(logger);
+
+        return new GetExecutor(logger, introspector, VelocityContext.class, key);
+    }
+
+    private static class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(Object message) {
+        }
+
+        @Override
+        public void info(Object message) {
+        }
+
+        @Override
+        public void error(Object message) {
+        }
+
+        @Override
+        public void debug(Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.apache.velocity.test.IntrospectorTestCase2;
+import org.junit.jupiter.api.Test;
+
+public class IntrospectorTestCase2Test {
+    @Test
+    void resolvesMostSpecificMethodAndRejectsAmbiguousOverload() {
+        IntrospectorTestCase2 testCase = new IntrospectorTestCase2("IntrospectorTestCase2");
+
+        testCase.runTest();
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
@@ -6,14 +6,76 @@
  */
 package velocity.velocity_dep;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+
+import junit.framework.Test;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+
 import org.apache.velocity.test.IntrospectorTestCase2;
-import org.junit.jupiter.api.Test;
+import org.graalvm.internal.tck.NativeImageSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IntrospectorTestCase2Test {
-    @Test
+    private static final String TEST_CASE_CLASS_NAME = "org.apache.velocity.test.IntrospectorTestCase2";
+
+    @org.junit.jupiter.api.Test
     void resolvesMostSpecificMethodAndRejectsAmbiguousOverload() {
         IntrospectorTestCase2 testCase = new IntrospectorTestCase2("IntrospectorTestCase2");
 
         testCase.runTest();
+    }
+
+    @org.junit.jupiter.api.Test
+    void freshClassLoaderRunsWithEmptyCompilerClassCache() throws Exception {
+        try {
+            URL codeSource = IntrospectorTestCase2.class.getProtectionDomain().getCodeSource().getLocation();
+            try (URLClassLoader classLoader = new IsolatedIntrospectorTestCase2ClassLoader(
+                    new URL[] { codeSource },
+                    IntrospectorTestCase2.class.getClassLoader())) {
+                Class<?> testClass = classLoader.loadClass(TEST_CASE_CLASS_NAME);
+                Test test = TestSuite.createTest(testClass, "runTest");
+                TestResult result = new TestResult();
+
+                test.run(result);
+
+                assertEquals(0, result.errorCount(), Collections.list(result.errors()).toString());
+                assertEquals(0, result.failureCount(), Collections.list(result.failures()).toString());
+            }
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static final class IsolatedIntrospectorTestCase2ClassLoader extends URLClassLoader {
+        private IsolatedIntrospectorTestCase2ClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (isIntrospectorTestCase2Class(name)) {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> loadedClass = findLoadedClass(name);
+                    if (loadedClass == null) {
+                        loadedClass = findClass(name);
+                    }
+                    if (resolve) {
+                        resolveClass(loadedClass);
+                    }
+                    return loadedClass;
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private static boolean isIntrospectorTestCase2Class(String name) {
+            return name.equals(TEST_CASE_CLASS_NAME) || name.startsWith(TEST_CASE_CLASS_NAME + "$");
+        }
     }
 }

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase2Test.java
@@ -6,9 +6,17 @@
  */
 package velocity.velocity_dep;
 
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import junit.framework.Test;
 import junit.framework.TestResult;
@@ -21,6 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IntrospectorTestCase2Test {
     private static final String TEST_CASE_CLASS_NAME = "org.apache.velocity.test.IntrospectorTestCase2";
+    private static final String[] TEST_CASE_CLASS_RESOURCES = {
+            "org/apache/velocity/test/IntrospectorTestCase2.class",
+            "org/apache/velocity/test/IntrospectorTestCase2$Bar.class",
+            "org/apache/velocity/test/IntrospectorTestCase2$Foo.class",
+            "org/apache/velocity/test/IntrospectorTestCase2$Tester.class",
+            "org/apache/velocity/test/IntrospectorTestCase2$Tester2.class",
+            "org/apache/velocity/test/IntrospectorTestCase2$Woogie.class"
+    };
 
     @org.junit.jupiter.api.Test
     void resolvesMostSpecificMethodAndRejectsAmbiguousOverload() {
@@ -32,9 +48,8 @@ public class IntrospectorTestCase2Test {
     @org.junit.jupiter.api.Test
     void freshClassLoaderRunsWithEmptyCompilerClassCache() throws Exception {
         try {
-            URL codeSource = IntrospectorTestCase2.class.getProtectionDomain().getCodeSource().getLocation();
             try (URLClassLoader classLoader = new IsolatedIntrospectorTestCase2ClassLoader(
-                    new URL[] { codeSource },
+                    new URL[] {materializeIntrospectorTestCase2Classes().toUri().toURL() },
                     IntrospectorTestCase2.class.getClassLoader())) {
                 Class<?> testClass = classLoader.loadClass(TEST_CASE_CLASS_NAME);
                 Test test = TestSuite.createTest(testClass, "runTest");
@@ -50,6 +65,75 @@ public class IntrospectorTestCase2Test {
                 throw error;
             }
         }
+    }
+
+    private static Path materializeIntrospectorTestCase2Classes() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("velocity-introspector-testcase2-");
+        Path velocityDepJar = null;
+
+        for (String resourceName : TEST_CASE_CLASS_RESOURCES) {
+            Path target = tempDirectory.resolve(resourceName);
+            Files.createDirectories(target.getParent());
+
+            InputStream classBytes = IntrospectorTestCase2.class.getClassLoader().getResourceAsStream(resourceName);
+            if (classBytes == null) {
+                if (velocityDepJar == null) {
+                    velocityDepJar = findVelocityDepJar();
+                }
+                classBytes = openClassBytesFromJar(velocityDepJar, resourceName);
+            }
+
+            try (InputStream input = classBytes) {
+                if (classBytes == null) {
+                    throw new IOException("Missing class resource " + resourceName);
+                }
+                Files.copy(input, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+
+        return tempDirectory;
+    }
+
+    private static Path findVelocityDepJar() throws IOException {
+        Path cacheRoot = Path.of(System.getProperty("user.home"),
+                ".gradle",
+                "caches",
+                "modules-2",
+                "files-2.1",
+                "velocity",
+                "velocity-dep",
+                "1.4");
+        if (!Files.isDirectory(cacheRoot)) {
+            throw new IOException("Cannot locate Gradle cache directory " + cacheRoot);
+        }
+
+        try (java.util.stream.Stream<Path> paths = Files.walk(cacheRoot)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".jar"))
+                    .findFirst()
+                    .orElseThrow(() -> new IOException("Cannot locate velocity-dep 1.4 jar under " + cacheRoot));
+        }
+    }
+
+    private static InputStream openClassBytesFromJar(Path jarPath, String resourceName) throws IOException {
+        ZipFile zipFile = new ZipFile(jarPath.toFile());
+        ZipEntry zipEntry = zipFile.getEntry(resourceName);
+        if (zipEntry == null) {
+            zipFile.close();
+            throw new IOException("Missing " + resourceName + " in " + jarPath);
+        }
+
+        return new FilterInputStream(zipFile.getInputStream(zipEntry)) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    zipFile.close();
+                }
+            }
+        };
     }
 
     private static final class IsolatedIntrospectorTestCase2ClassLoader extends URLClassLoader {

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase3Test.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase3Test.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import org.apache.velocity.test.IntrospectorTestCase3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class IntrospectorTestCase3Test {
+    @org.junit.jupiter.api.Test
+    void suiteBuildsFromCompiledTestClass() {
+        Test suite = IntrospectorTestCase3.suite();
+
+        assertInstanceOf(TestSuite.class, suite);
+        assertEquals(1, suite.countTestCases());
+    }
+
+    @org.junit.jupiter.api.Test
+    void resolvesAndInvokesOverloadedPrimitiveMethods() throws Exception {
+        IntrospectorTestCase3 testCase = new IntrospectorTestCase3("testSimple");
+
+        testCase.testSimple();
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase3Test.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCase3Test.java
@@ -6,6 +6,9 @@
  */
 package velocity.velocity_dep;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
@@ -16,7 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class IntrospectorTestCase3Test {
     @org.junit.jupiter.api.Test
-    void suiteBuildsFromCompiledTestClass() {
+    void suiteBuildsFromCompiledTestClass() throws Throwable {
+        clearCachedClass("class$org$apache$velocity$test$IntrospectorTestCase3");
+
         Test suite = IntrospectorTestCase3.suite();
 
         assertInstanceOf(TestSuite.class, suite);
@@ -24,9 +29,19 @@ public class IntrospectorTestCase3Test {
     }
 
     @org.junit.jupiter.api.Test
-    void resolvesAndInvokesOverloadedPrimitiveMethods() throws Exception {
+    void resolvesAndInvokesOverloadedPrimitiveMethods() throws Throwable {
+        clearCachedClass("class$org$apache$velocity$test$IntrospectorTestCase3$MethodProvider");
         IntrospectorTestCase3 testCase = new IntrospectorTestCase3("testSimple");
 
         testCase.testSimple();
+    }
+
+    private static void clearCachedClass(String fieldName) throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                IntrospectorTestCase3.class,
+                MethodHandles.lookup());
+        VarHandle cachedClass = lookup.findStaticVarHandle(IntrospectorTestCase3.class, fieldName, Class.class);
+
+        cachedClass.set(null);
     }
 }

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCaseTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCaseTest.java
@@ -6,11 +6,14 @@
  */
 package velocity.velocity_dep;
 
+import org.apache.velocity.test.IntrospectorTestCase;
 import org.junit.jupiter.api.Test;
 
-class Velocity_depTest {
+public class IntrospectorTestCaseTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void runUpstreamPrimitiveIntrospectionTest() {
+        IntrospectorTestCase testCase = new IntrospectorTestCase("IntrospectorTestCase");
+
+        testCase.runTest();
     }
 }

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCaseTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/IntrospectorTestCaseTest.java
@@ -6,8 +6,14 @@
  */
 package velocity.velocity_dep;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
 import org.apache.velocity.test.IntrospectorTestCase;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class IntrospectorTestCaseTest {
     @Test
@@ -15,5 +21,21 @@ public class IntrospectorTestCaseTest {
         IntrospectorTestCase testCase = new IntrospectorTestCase("IntrospectorTestCase");
 
         testCase.runTest();
+    }
+
+    @Test
+    void compilerCompatibilityHelperLoadsMethodProviderClass() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                IntrospectorTestCase.class,
+                MethodHandles.lookup());
+        MethodHandle classLoaderHelper = lookup.findStatic(
+                IntrospectorTestCase.class,
+                "class$",
+                MethodType.methodType(Class.class, String.class));
+
+        Class<?> loadedClass = (Class<?>) classLoaderHelper.invoke(
+                "org.apache.velocity.test.IntrospectorTestCase$MethodProvider");
+
+        assertSame(IntrospectorTestCase.MethodProvider.class, loadedClass);
     }
 }

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/LogManagerTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/LogManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.log.LogManager;
+import org.apache.velocity.runtime.log.LogSystem;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LogManagerTest {
+    @Test
+    void createsConfiguredLogSystemClassByName() throws Exception {
+        RuntimeInstance runtimeServices = new ConfiguredRuntimeServices(NullLogSystem.class.getName());
+
+        LogSystem logSystem = LogManager.createLogSystem(runtimeServices);
+
+        assertTrue(logSystem instanceof NullLogSystem);
+    }
+
+    private static final class ConfiguredRuntimeServices extends RuntimeInstance {
+        private final String logSystemClassName;
+
+        private ConfiguredRuntimeServices(String logSystemClassName) {
+            this.logSystemClassName = logSystemClassName;
+        }
+
+        @Override
+        public Object getProperty(String key) {
+            if (RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS.equals(key)) {
+                return logSystemClassName;
+            }
+            return null;
+        }
+
+        @Override
+        public void info(Object message) {
+        }
+
+        @Override
+        public void debug(Object message) {
+        }
+
+        @Override
+        public void error(Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ParserTestCaseTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/ParserTestCaseTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import junit.framework.TestSuite;
+import org.apache.velocity.test.ParserTestCase;
+import org.apache.velocity.util.EnumerationIterator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ParserTestCaseTest {
+    @Test
+    void exposesJUnit3SuiteForParserTests() throws Throwable {
+        clearCachedTestClass();
+
+        Object suite = ParserTestCase.suite();
+
+        assertTrue(suite instanceof TestSuite);
+        assertEquals(3, ((TestSuite) suite).countTestCases());
+    }
+
+    @Test
+    void compilerCompatibilityHelperLoadsNamedClass() throws Throwable {
+        MethodHandle classLoaderHelper = lookupForParserTestCase().findStatic(
+                ParserTestCase.class,
+                "class$",
+                MethodType.methodType(Class.class, String.class));
+
+        Class<?> loadedClass = (Class<?>) classLoaderHelper.invoke("org.apache.velocity.util.EnumerationIterator");
+
+        assertEquals(EnumerationIterator.class, loadedClass);
+    }
+
+    @Test
+    void runsUpstreamParserValidationScenarios() throws Exception {
+        ParserTestCase testCase = new ParserTestCase("ParserTestCase");
+
+        testCase.testEquals();
+        testCase.testMacro();
+        testCase.testArgs();
+    }
+
+    private static void clearCachedTestClass() throws Throwable {
+        VarHandle cachedClass = lookupForParserTestCase().findStaticVarHandle(
+                ParserTestCase.class,
+                "class$org$apache$velocity$test$ParserTestCase",
+                Class.class);
+
+        cachedClass.set(null);
+    }
+
+    private static MethodHandles.Lookup lookupForParserTestCase() throws IllegalAccessException {
+        return MethodHandles.privateLookupIn(ParserTestCase.class, MethodHandles.lookup());
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertiesUtilTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertiesUtilTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.util.Properties;
+
+import org.apache.velocity.texen.util.PropertiesUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class PropertiesUtilTest {
+    private static final String TEXEN_DEFAULTS = "org/apache/velocity/texen/defaults/texen.properties";
+
+    @Test
+    void loadsPropertiesResourceFromClasspath() {
+        PropertiesUtil propertiesUtil = new PropertiesUtil();
+
+        Properties properties = propertiesUtil.load(TEXEN_DEFAULTS);
+
+        assertNotNull(properties);
+        assertEquals("org.apache.velocity.texen.util.PropertiesUtil", properties.getProperty("context.objects.properties"));
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertyExecutorTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertyExecutorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.parser.node.PropertyExecutor;
+import org.apache.velocity.util.introspection.Introspector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class PropertyExecutorTest {
+    @Test
+    void invokesResolvedGetterThroughPropertyExecutor() throws Exception {
+        VelocityContext context = new VelocityContext();
+        context.put("message", "resolved through property executor");
+        PropertyExecutor executor = createExecutor("keys");
+
+        Object value = executor.execute(context);
+
+        assertArrayEquals(new Object[] { "message" }, (Object[]) value);
+    }
+
+    private static PropertyExecutor createExecutor(String property) throws Exception {
+        RuntimeLogger logger = new NoOpRuntimeLogger();
+        Introspector introspector = new Introspector(logger);
+
+        return new PropertyExecutor(logger, introspector, VelocityContext.class, property);
+    }
+
+    private static class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(Object message) {
+        }
+
+        @Override
+        public void info(Object message) {
+        }
+
+        @Override
+        public void error(Object message) {
+        }
+
+        @Override
+        public void debug(Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertyExecutorTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/PropertyExecutorTest.java
@@ -23,7 +23,7 @@ public class PropertyExecutorTest {
 
         Object value = executor.execute(context);
 
-        assertArrayEquals(new Object[] { "message" }, (Object[]) value);
+        assertArrayEquals(new Object[] {"message" }, (Object[]) value);
     }
 
     private static PropertyExecutor createExecutor(String property) throws Exception {

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/RuntimeInstanceTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/RuntimeInstanceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.StringReader;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.apache.velocity.runtime.parser.node.SimpleNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class RuntimeInstanceTest {
+    @Test
+    void initializesRuntimeComponentsFromDefaultResources() throws Exception {
+        RuntimeInstance runtime = newRuntimeInstance();
+
+        assertEquals("ISO-8859-1", runtime.getString(RuntimeConstants.INPUT_ENCODING));
+        assertNotNull(runtime.getUberspect());
+    }
+
+    @Test
+    void parsesTemplateWithRuntimeLoadedDirectives() throws Exception {
+        RuntimeInstance runtime = newRuntimeInstance();
+        SimpleNode syntaxTree = runtime.parse(
+                new StringReader("#foreach($name in $names)$name#end"),
+                "runtime-instance-directives.vm");
+
+        assertNotNull(syntaxTree);
+    }
+
+    private static RuntimeInstance newRuntimeInstance() throws Exception {
+        RuntimeInstance runtime = new RuntimeInstance();
+        runtime.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
+
+        runtime.init();
+        return runtime;
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/SocketOutputTargetTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/SocketOutputTargetTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log.LogEvent;
+import org.apache.log.Priority;
+import org.apache.log.output.net.SocketOutputTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class SocketOutputTargetTest {
+    private static final int SOCKET_TIMEOUT_MILLIS = 5_000;
+
+    @Test
+    void serializesLogEventToSocketOutputStream() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = createLoopbackServerSocket()) {
+            CompletableFuture<LogEvent> receivedEvent = CompletableFuture.supplyAsync(
+                    () -> readSerializedEvent(serverSocket), executorService);
+            SocketOutputTarget target = new SocketOutputTarget(
+                    InetAddress.getLoopbackAddress(), serverSocket.getLocalPort());
+            try {
+                target.setErrorHandler((message, throwable, event) -> fail(message, throwable));
+
+                target.processEvent(createLogEvent());
+
+                LogEvent logEvent = receivedEvent.get(SOCKET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                assertEquals("dynamic.access.socket", logEvent.getCategory());
+                assertEquals("serialized socket output target event", logEvent.getMessage());
+                assertSame(Priority.INFO, logEvent.getPriority());
+            } finally {
+                target.close();
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private static ServerSocket createLoopbackServerSocket() throws IOException {
+        ServerSocket serverSocket = new ServerSocket();
+        serverSocket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+        serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        return serverSocket;
+    }
+
+    private static LogEvent createLogEvent() {
+        LogEvent logEvent = new LogEvent();
+        logEvent.setCategory("dynamic.access.socket");
+        logEvent.setMessage("serialized socket output target event");
+        logEvent.setPriority(Priority.INFO);
+        logEvent.setTime(System.currentTimeMillis());
+        return logEvent;
+    }
+
+    private static LogEvent readSerializedEvent(ServerSocket serverSocket) {
+        try (Socket socket = serverSocket.accept()) {
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+            try (ObjectInputStream inputStream = new ObjectInputStream(socket.getInputStream())) {
+                Object value = inputStream.readObject();
+                if (value instanceof LogEvent) {
+                    return (LogEvent) value;
+                }
+                throw new AssertionError("Expected serialized LogEvent but received " + value);
+            }
+        } catch (ClassNotFoundException | IOException e) {
+            throw new AssertionError("Failed to read serialized LogEvent", e);
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/UberspectImplTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/UberspectImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.apache.velocity.util.introspection.Info;
+import org.apache.velocity.util.introspection.UberspectImpl;
+import org.apache.velocity.util.introspection.VelPropertySet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UberspectImplTest {
+    @Test
+    void templateMapPropertyAssignmentUsesUberspectMapSetterFallback() throws Exception {
+        VelocityEngine engine = new VelocityEngine();
+        engine.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
+        engine.init();
+        Map<String, Object> values = new HashMap<>();
+        VelocityContext context = new VelocityContext();
+        context.put("values", values);
+        StringWriter writer = new StringWriter();
+
+        boolean rendered = engine.evaluate(
+                context,
+                writer,
+                "uberspect-map-property-assignment.vm",
+                "#set($values.answer = \"forty-two\")$values.answer");
+
+        assertTrue(rendered);
+        assertEquals("forty-two", writer.toString());
+        assertEquals("forty-two", values.get("answer"));
+    }
+
+    @Test
+    void mapPropertySetterUsesPutWhenBeanSetterIsUnavailable() throws Exception {
+        UberspectImpl uberspect = new UberspectImpl();
+        uberspect.setRuntimeLogger(new NoOpRuntimeLogger());
+        Map<String, Object> values = new HashMap<>();
+        Info info = new Info("map-property-setter", 1, 1);
+
+        VelPropertySet setter = uberspect.getPropertySet(values, "answer", "initial", info);
+
+        assertNotNull(setter);
+        assertEquals("put", setter.getMethodName());
+        assertNull(setter.invoke(values, "forty-two"));
+        assertEquals("forty-two", values.get("answer"));
+        assertEquals("forty-two", setter.invoke(values, "forty-three"));
+        assertEquals("forty-three", values.get("answer"));
+    }
+
+    private static class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(Object message) {
+        }
+
+        @Override
+        public void info(Object message) {
+        }
+
+        @Override
+        public void error(Object message) {
+        }
+
+        @Override
+        public void debug(Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/Velocity_depTest.java
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/java/velocity/velocity_dep/Velocity_depTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity_dep;
+
+import org.junit.jupiter.api.Test;
+
+class Velocity_depTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader"
+      },
+      "glob" : "velocity/velocity_dep/classpath-resource-loader-template.vm"
+    }
+  ]
+}

--- a/tests/src/velocity/velocity-dep/1.4/src/test/resources/velocity/velocity_dep/classpath-resource-loader-template.vm
+++ b/tests/src/velocity/velocity-dep/1.4/src/test/resources/velocity/velocity_dep/classpath-resource-loader-template.vm
@@ -1,0 +1,1 @@
+Hello from the classpath resource loader.

--- a/tests/src/velocity/velocity-dep/1.4/user-code-filter.json
+++ b/tests/src/velocity/velocity-dep/1.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2397

This PR introduces tests and metadata for velocity:velocity-dep:1.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 1115900
- Cached input tokens: 12650496
- Output tokens: 147329
- Metadata entries: 117
- Test-only metadata entries: 1
- Iterations: 32
- Library coverage percentage: 24.87
- Generated lines of code: 864
- Tested library lines of code: 3917

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7ffb2ecdea4a46bf9d7affb82628bd6768aeffb8`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 52/58 covered calls (89.66%)
- Reflection: 47/53 covered calls (88.68%)
- Resources: 5/5 covered calls (100.00%)

Library coverage:
- Instruction: 18414/73494 (25.06%)
- Line: 3917/15749 (24.87%)
- Method: 702/2465 (28.48%)
