### PR TITLE
[GenAI] Add support for com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/index.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.13.5",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.13.5/jackson-datatype-jdk8-2.13.5-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-modules-java8",
+    "test-code-url" : "https://github.com/FasterXML/jackson-modules-java8/tree/jackson-modules-java8-2.13.5/datatypes/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.13.5/jackson-datatype-jdk8-2.13.5-javadoc.jar",
+    "description" : "Jackson Datatype JDK8 is an add-on module for Jackson Databind that adds serialization and deserialization support for Java 8 types such as Optional, OptionalInt, OptionalLong, and OptionalDouble. It lets ObjectMapper handle those JDK 8 container types through Jackson's standard module registration mechanism.",
+    "tested-versions" : [
+      "2.13.5"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.datatype.jdk8"
+    ]
+  }
+]

--- a/stats/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T23:13:23.508382Z",
+    "library": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5",
+    "starting_commit": "96859903e7d3fc0eed10f04b895b4ef477fee3c2",
+    "ending_commit": "a7c82597ba9fae13f84380d45bbf7c4f22761294",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.13.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 587,
+          "missed": 524,
+          "ratio": 0.528353,
+          "total": 1111
+        },
+        "line": {
+          "covered": 168,
+          "missed": 136,
+          "ratio": 0.552632,
+          "total": 304
+        },
+        "method": {
+          "covered": 60,
+          "missed": 30,
+          "ratio": 0.666667,
+          "total": 90
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 102151,
+      "cached_input_tokens_used": 532992,
+      "output_tokens_used": 14283,
+      "iterations": 3,
+      "cost_usd": 0.695,
+      "generated_loc": 356,
+      "tested_library_loc": 168,
+      "metadata_entries": 2,
+      "code_coverage_percent": 55.26
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/stats.json
+++ b/stats/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.13.5",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 587,
+        "missed" : 524,
+        "ratio" : 0.528353,
+        "total" : 1111
+      },
+      "line" : {
+        "covered" : 168,
+        "missed" : 136,
+        "ratio" : 0.552632,
+        "total" : 304
+      },
+      "method" : {
+        "covered" : 60,
+        "missed" : 30,
+        "ratio" : 0.666667,
+        "total" : 90
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/.gitignore
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/build.gradle
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5
+library.version = 2.13.5
+metadata.dir = com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.datatype.jackson-datatype-jdk8_tests'

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_datatype.jackson_datatype_jdk8;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_datatype_jdk8Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -197,6 +198,26 @@ public class Jackson_datatype_jdk8Test {
     }
 
     @Test
+    void serializesUnwrappedOptionalBeanProperties() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        UnwrappedOptionalAddress present = new UnwrappedOptionalAddress(
+                "office", Optional.of(new Address("Vienna", "1010")));
+        UnwrappedOptionalAddress absent = new UnwrappedOptionalAddress("remote", Optional.empty());
+
+        JsonNode presentTree = mapper.readTree(mapper.writeValueAsString(present));
+        JsonNode absentTree = mapper.readTree(mapper.writeValueAsString(absent));
+
+        assertThat(presentTree.get("id").asText()).isEqualTo("office");
+        assertThat(presentTree.get("address_city").asText()).isEqualTo("Vienna");
+        assertThat(presentTree.get("address_postalCode").asText()).isEqualTo("1010");
+        assertThat(presentTree.has("address")).isFalse();
+        assertThat(absentTree.get("id").asText()).isEqualTo("remote");
+        assertThat(absentTree.has("address_city")).isFalse();
+        assertThat(absentTree.has("address_postalCode")).isFalse();
+        assertThat(absentTree.has("address")).isFalse();
+    }
+
+    @Test
     void supportsObjectMapperModuleAutoDiscovery() throws Exception {
         ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
         Optional<String> value = Optional.of("auto-discovered");
@@ -313,6 +334,18 @@ public class Jackson_datatype_jdk8Test {
         public GenericContainers(List<Optional<String>> labels, Map<String, Optional<Address>> offices) {
             this.labels = labels;
             this.offices = offices;
+        }
+    }
+
+    public static final class UnwrappedOptionalAddress {
+        public String id;
+
+        @JsonUnwrapped(prefix = "address_")
+        public Optional<Address> address;
+
+        public UnwrappedOptionalAddress(String id, Optional<Address> address) {
+            this.id = id;
+            this.address = address;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
@@ -6,11 +6,350 @@
  */
 package com_fasterxml_jackson_datatype.jackson_datatype_jdk8;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 
-class Jackson_datatype_jdk8Test {
+public class Jackson_datatype_jdk8Test {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void serializesAndDeserializesPresentOptionalProperties() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        OptionalValues values = OptionalValues.presentSample();
+
+        String json = mapper.writeValueAsString(values);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.get("name").asText()).isEqualTo("Ada");
+        assertThat(tree.get("score").asInt()).isEqualTo(42);
+        assertThat(tree.get("visits").asLong()).isEqualTo(1_234_567_890_123L);
+        assertThat(tree.get("ratio").asDouble()).isEqualTo(0.625D);
+        assertThat(tree.at("/address/city").asText()).isEqualTo("London");
+
+        OptionalValues restored = mapper.readValue(json, OptionalValues.class);
+
+        assertThat(restored.name).contains("Ada");
+        assertThat(restored.score).hasValue(42);
+        assertThat(restored.visits).hasValue(1_234_567_890_123L);
+        assertThat(restored.ratio).hasValue(0.625D);
+        assertThat(restored.address).contains(new Address("London", "SW1A"));
+    }
+
+    @Test
+    void representsEmptyOptionalValuesAsJsonNullsAndReadsJsonNullAsEmpty() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        OptionalValues values = OptionalValues.emptySample();
+
+        String json = mapper.writeValueAsString(values);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.get("name").isNull()).isTrue();
+        assertThat(tree.get("score").isNull()).isTrue();
+        assertThat(tree.get("visits").isNull()).isTrue();
+        assertThat(tree.get("ratio").isNull()).isTrue();
+        assertThat(tree.get("address").isNull()).isTrue();
+
+        OptionalValues restored = mapper.readValue(
+                "{\"name\":null,\"score\":null,\"visits\":null,\"ratio\":null,\"address\":null}",
+                OptionalValues.class);
+
+        assertThat(restored.name).isEmpty();
+        assertThat(restored.score).isEmpty();
+        assertThat(restored.visits).isEmpty();
+        assertThat(restored.ratio).isEmpty();
+        assertThat(restored.address).isEmpty();
+    }
+
+    @Test
+    void writesAndReadsRootOptionalValues() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        TypeReference<Optional<Address>> optionalAddressType = new TypeReference<Optional<Address>>() { };
+
+        String presentJson = mapper.writeValueAsString(Optional.of(new Address("Paris", "75001")));
+        String emptyJson = mapper.writeValueAsString(Optional.empty());
+
+        assertThat(mapper.readTree(presentJson).get("city").asText()).isEqualTo("Paris");
+        assertThat(emptyJson).isEqualTo("null");
+        assertThat(mapper.readValue(presentJson, optionalAddressType)).contains(new Address("Paris", "75001"));
+        assertThat(mapper.readValue(emptyJson, optionalAddressType)).isEmpty();
+    }
+
+    @Test
+    void excludesAbsentValuesWhenUsingNonAbsentInclusion() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        NonAbsentValues values = new NonAbsentValues();
+        values.title = Optional.of("visible");
+        values.missingTitle = Optional.empty();
+        values.count = OptionalInt.of(7);
+        values.missingCount = OptionalInt.empty();
+        values.directNull = null;
+
+        String json = mapper.writeValueAsString(values);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.has("title")).isTrue();
+        assertThat(tree.get("title").asText()).isEqualTo("visible");
+        assertThat(tree.has("count")).isTrue();
+        assertThat(tree.get("count").asInt()).isEqualTo(7);
+        assertThat(tree.has("missingTitle")).isFalse();
+        assertThat(tree.has("missingCount")).isFalse();
+        assertThat(tree.has("directNull")).isFalse();
+    }
+
+    @Test
+    void supportsOptionalValuesInsideGenericCollectionsAndMaps() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        LinkedHashMap<String, Optional<Address>> offices = new LinkedHashMap<>();
+        offices.put("primary", Optional.of(new Address("Prague", "11000")));
+        offices.put("secondary", Optional.empty());
+        GenericContainers containers = new GenericContainers(
+                Arrays.asList(Optional.of("alpha"), Optional.empty(), Optional.of("omega")), offices);
+
+        String json = mapper.writeValueAsString(containers);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.at("/labels/0").asText()).isEqualTo("alpha");
+        assertThat(tree.at("/labels/1").isNull()).isTrue();
+        assertThat(tree.at("/offices/primary/city").asText()).isEqualTo("Prague");
+        assertThat(tree.at("/offices/secondary").isNull()).isTrue();
+
+        GenericContainers restored = mapper.readValue(json, GenericContainers.class);
+
+        assertThat(restored.labels).containsExactly(Optional.of("alpha"), Optional.empty(), Optional.of("omega"));
+        assertThat(restored.offices).containsExactlyEntriesOf(offices);
+    }
+
+    @Test
+    void supportsDeeplyNestedParameterizedOptionalContent() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        TypeReference<Optional<List<Optional<Address>>>> nestedType =
+                new TypeReference<Optional<List<Optional<Address>>>>() { };
+        Optional<List<Optional<Address>>> nested = Optional.of(Arrays.asList(
+                Optional.of(new Address("Berlin", "10115")),
+                Optional.empty(),
+                Optional.of(new Address("Rome", "00100"))));
+
+        String json = mapper.writeValueAsString(nested);
+
+        assertThat(mapper.readTree(json).at("/0/city").asText()).isEqualTo("Berlin");
+        assertThat(mapper.readTree(json).at("/1").isNull()).isTrue();
+        assertThat(mapper.readValue(json, nestedType)).isEqualTo(nested);
+    }
+
+    @Test
+    void supportsCreatorParametersWithOptionalValues() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        CreatorBackedValue original = new CreatorBackedValue(
+                Optional.of("created"), OptionalInt.of(5), OptionalLong.of(55L), OptionalDouble.of(5.5D));
+
+        String json = mapper.writeValueAsString(original);
+        CreatorBackedValue restored = mapper.readValue(json, CreatorBackedValue.class);
+        CreatorBackedValue nullRestored = mapper.readValue(
+                "{\"name\":null,\"retries\":null,\"duration\":null,\"ratio\":null}",
+                CreatorBackedValue.class);
+
+        assertThat(restored.name).contains("created");
+        assertThat(restored.retries).hasValue(5);
+        assertThat(restored.duration).hasValue(55L);
+        assertThat(restored.ratio).hasValue(5.5D);
+        assertThat(nullRestored.name).isEmpty();
+        assertThat(nullRestored.retries).isEmpty();
+        assertThat(nullRestored.duration).isEmpty();
+        assertThat(nullRestored.ratio).isEmpty();
+    }
+
+    @Test
+    void supportsPolymorphicContentInsideOptionalValues() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        OptionalPetHolder holder = new OptionalPetHolder(Optional.of(new Dog("Rex", 8)), Optional.empty());
+
+        String json = mapper.writeValueAsString(holder);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.at("/pet/type").asText()).isEqualTo("dog");
+        assertThat(tree.at("/pet/name").asText()).isEqualTo("Rex");
+        assertThat(tree.at("/missingPet").isNull()).isTrue();
+
+        OptionalPetHolder restored = mapper.readValue(json, OptionalPetHolder.class);
+
+        assertThat(restored.pet).contains(new Dog("Rex", 8));
+        assertThat(restored.missingPet).isEmpty();
+    }
+
+    @Test
+    void supportsObjectMapperModuleAutoDiscovery() throws Exception {
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        Optional<String> value = Optional.of("auto-discovered");
+        TypeReference<Optional<String>> optionalStringType = new TypeReference<Optional<String>>() { };
+
+        String json = mapper.writeValueAsString(value);
+
+        assertThat(json).isEqualTo("\"auto-discovered\"");
+        assertThat(mapper.readValue(json, optionalStringType)).contains("auto-discovered");
+        assertThat(mapper.readValue("null", optionalStringType)).isEmpty();
+    }
+
+    private static ObjectMapper jdk8Mapper() {
+        return new ObjectMapper().registerModule(new Jdk8Module());
+    }
+
+    public static final class OptionalValues {
+        public Optional<String> name;
+        public OptionalInt score;
+        public OptionalLong visits;
+        public OptionalDouble ratio;
+        public Optional<Address> address;
+
+        public OptionalValues() { }
+
+        static OptionalValues presentSample() {
+            OptionalValues values = new OptionalValues();
+            values.name = Optional.of("Ada");
+            values.score = OptionalInt.of(42);
+            values.visits = OptionalLong.of(1_234_567_890_123L);
+            values.ratio = OptionalDouble.of(0.625D);
+            values.address = Optional.of(new Address("London", "SW1A"));
+            return values;
+        }
+
+        static OptionalValues emptySample() {
+            OptionalValues values = new OptionalValues();
+            values.name = Optional.empty();
+            values.score = OptionalInt.empty();
+            values.visits = OptionalLong.empty();
+            values.ratio = OptionalDouble.empty();
+            values.address = Optional.empty();
+            return values;
+        }
+    }
+
+    public static final class Address {
+        public String city;
+        public String postalCode;
+
+        public Address() { }
+
+        public Address(String city, String postalCode) {
+            this.city = city;
+            this.postalCode = postalCode;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Address)) {
+                return false;
+            }
+            Address address = (Address) other;
+            return city.equals(address.city) && postalCode.equals(address.postalCode);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * city.hashCode() + postalCode.hashCode();
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public static final class NonAbsentValues {
+        public Optional<String> title;
+        public Optional<String> missingTitle;
+        public OptionalInt count;
+        public OptionalInt missingCount;
+        public String directNull;
+    }
+
+    public static final class GenericContainers {
+        public List<Optional<String>> labels;
+        public Map<String, Optional<Address>> offices;
+
+        public GenericContainers() { }
+
+        public GenericContainers(List<Optional<String>> labels, Map<String, Optional<Address>> offices) {
+            this.labels = labels;
+            this.offices = offices;
+        }
+    }
+
+    public static final class CreatorBackedValue {
+        public final Optional<String> name;
+        public final OptionalInt retries;
+        public final OptionalLong duration;
+        public final OptionalDouble ratio;
+
+        @JsonCreator
+        public CreatorBackedValue(
+                @JsonProperty("name") Optional<String> name,
+                @JsonProperty("retries") OptionalInt retries,
+                @JsonProperty("duration") OptionalLong duration,
+                @JsonProperty("ratio") OptionalDouble ratio) {
+            this.name = name;
+            this.retries = retries;
+            this.duration = duration;
+            this.ratio = ratio;
+        }
+    }
+
+    public static final class OptionalPetHolder {
+        public Optional<Pet> pet;
+        public Optional<Pet> missingPet;
+
+        public OptionalPetHolder() { }
+
+        public OptionalPetHolder(Optional<Pet> pet, Optional<Pet> missingPet) {
+            this.pet = pet;
+            this.missingPet = missingPet;
+        }
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(@JsonSubTypes.Type(value = Dog.class, name = "dog"))
+    public interface Pet { }
+
+    public static final class Dog implements Pet {
+        public String name;
+        public int barkVolume;
+
+        public Dog() { }
+
+        public Dog(String name, int barkVolume) {
+            this.name = name;
+            this.barkVolume = barkVolume;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Dog)) {
+                return false;
+            }
+            Dog dog = (Dog) other;
+            return barkVolume == dog.barkVolume && name.equals(dog.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * name.hashCode() + barkVolume;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/src/test/java/com_fasterxml_jackson_datatype/jackson_datatype_jdk8/Jackson_datatype_jdk8Test.java
@@ -25,6 +25,10 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 public class Jackson_datatype_jdk8Test {
@@ -205,6 +209,29 @@ public class Jackson_datatype_jdk8Test {
         assertThat(mapper.readValue("null", optionalStringType)).isEmpty();
     }
 
+    @Test
+    void serializesJdk8StreamsAsJsonArrays() throws Exception {
+        ObjectMapper mapper = jdk8Mapper();
+        StreamValues values = new StreamValues(
+                Stream.of("north", "south"),
+                IntStream.of(1, 2, 3),
+                LongStream.of(10L, 20L),
+                DoubleStream.of(0.25D, 0.5D));
+
+        String json = mapper.writeValueAsString(values);
+
+        JsonNode tree = mapper.readTree(json);
+        assertThat(tree.withArray("names").get(0).asText()).isEqualTo("north");
+        assertThat(tree.withArray("names").get(1).asText()).isEqualTo("south");
+        assertThat(tree.withArray("counts").get(0).asInt()).isEqualTo(1);
+        assertThat(tree.withArray("counts").get(1).asInt()).isEqualTo(2);
+        assertThat(tree.withArray("counts").get(2).asInt()).isEqualTo(3);
+        assertThat(tree.withArray("sizes").get(0).asLong()).isEqualTo(10L);
+        assertThat(tree.withArray("sizes").get(1).asLong()).isEqualTo(20L);
+        assertThat(tree.withArray("ratios").get(0).asDouble()).isEqualTo(0.25D);
+        assertThat(tree.withArray("ratios").get(1).asDouble()).isEqualTo(0.5D);
+    }
+
     private static ObjectMapper jdk8Mapper() {
         return new ObjectMapper().registerModule(new Jdk8Module());
     }
@@ -286,6 +313,20 @@ public class Jackson_datatype_jdk8Test {
         public GenericContainers(List<Optional<String>> labels, Map<String, Optional<Address>> offices) {
             this.labels = labels;
             this.offices = offices;
+        }
+    }
+
+    public static final class StreamValues {
+        public Stream<String> names;
+        public IntStream counts;
+        public LongStream sizes;
+        public DoubleStream ratios;
+
+        public StreamValues(Stream<String> names, IntStream counts, LongStream sizes, DoubleStream ratios) {
+            this.names = names;
+            this.counts = counts;
+            this.sizes = sizes;
+            this.ratios = ratios;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.fasterxml.jackson.datatype.jdk8.**"
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.fasterxml.jackson.datatype.jdk8.**"
+      "includeClasses" : "com.fasterxml.jackson.datatype.jdk8.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2253

This PR introduces tests and metadata for com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 102151
- Cached input tokens: 532992
- Output tokens: 14283
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 55.26
- Generated lines of code: 356
- Tested library lines of code: 168

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `ec97da8fc1d2703e96c5eee75bec7e73ebd22527`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 587/1111 (52.84%)
- Line: 168/304 (55.26%)
- Method: 60/90 (66.67%)
