### PR TITLE
[GenAI] Add support for io.netty:netty-transport-classes-kqueue:4.1.74.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-classes-kqueue/4.1.74.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/4.1.74.Final/reachability-metadata.json
@@ -1,0 +1,186 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "io.netty.channel.DefaultFileRegion"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoop"
+      },
+      "type": "io.netty.channel.kqueue.KQueueEventLoop"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueDomainSocketChannel"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "io.netty.channel.unix.PeerCredentials"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.io.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "java.nio.channels.FileChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.Native"
+      },
+      "type": "sun.misc.VM"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-classes-kqueue/index.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.74.Final/netty-transport-classes-kqueue-4.1.74.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://github.com/netty/netty/tree/netty-4.1.74.Final/transport-native-kqueue/src/test/java/io/netty/channel/kqueue",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.74.Final/netty-transport-classes-kqueue-4.1.74.Final-javadoc.jar",
+    "description" : "Netty Transport Classes KQueue provides the Java classes that implement Netty's kqueue-based transport integration on BSD-derived operating systems such as macOS. It enables Netty applications to use the native kqueue event notification mechanism for high-performance asynchronous network I/O when paired with the matching native transport artifacts.",
+    "tested-versions" : [
+      "4.1.74.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.kqueue"
+    ]
+  }
+]

--- a/stats/io.netty/netty-transport-classes-kqueue/4.1.74.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-classes-kqueue/4.1.74.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T23:14:33.429097Z",
+    "library": "io.netty:netty-transport-classes-kqueue:4.1.74.Final",
+    "starting_commit": "ca48c36f9367ed3951c73a4a9d1cab97bcf6e37d",
+    "ending_commit": "6c3fdc10a4aea49096f4b120f8de88c918438ccd",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 334,
+          "missed": 8143,
+          "ratio": 0.039401,
+          "total": 8477
+        },
+        "line": {
+          "covered": 75,
+          "missed": 2042,
+          "ratio": 0.035427,
+          "total": 2117
+        },
+        "method": {
+          "covered": 26,
+          "missed": 521,
+          "ratio": 0.047532,
+          "total": 547
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 194983,
+      "cached_input_tokens_used": 1711616,
+      "output_tokens_used": 16883,
+      "iterations": 4,
+      "cost_usd": 1.3623,
+      "generated_loc": 193,
+      "tested_library_loc": 75,
+      "metadata_entries": 35,
+      "code_coverage_percent": 3.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-classes-kqueue/4.1.74.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-classes-kqueue/4.1.74.Final/stats.json
+++ b/stats/io.netty/netty-transport-classes-kqueue/4.1.74.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.74.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 334,
+        "missed" : 8143,
+        "ratio" : 0.039401,
+        "total" : 8477
+      },
+      "line" : {
+        "covered" : 75,
+        "missed" : 2042,
+        "ratio" : 0.035427,
+        "total" : 2117
+      },
+      "method" : {
+        "covered" : 26,
+        "missed" : 521,
+        "ratio" : 0.047532,
+        "total" : 547
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-classes-kqueue:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-classes-kqueue:4.1.74.Final
+library.version = 4.1.74.Final
+metadata.dir = io.netty/netty-transport-classes-kqueue/4.1.74.Final/

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-classes-kqueue_tests'

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_classes_kqueue;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_classes_kqueueTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -20,10 +20,12 @@ import io.netty.channel.kqueue.KQueueChannelOption;
 import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannelConfig;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.unix.DomainSocketReadMode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -112,6 +114,33 @@ public class Netty_transport_classes_kqueueTest {
     @Test
     void eventLoopGroupConstructorRespectsTransportAvailability() {
         assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+    }
+
+    @Test
+    void domainSocketChannelConfigControlsReadModeAndHalfClosure() {
+        if (KQueue.isAvailable()) {
+            KQueueDomainSocketChannel channel = new KQueueDomainSocketChannel();
+            try {
+                KQueueDomainSocketChannelConfig config = channel.config();
+
+                assertThat(config.getReadMode()).isEqualTo(DomainSocketReadMode.BYTES);
+                assertThat(config.setReadMode(DomainSocketReadMode.FILE_DESCRIPTORS)).isSameAs(config);
+                assertThat(config.getReadMode()).isEqualTo(DomainSocketReadMode.FILE_DESCRIPTORS);
+
+                assertThat(config.isAllowHalfClosure()).isFalse();
+                assertThat(config.setAllowHalfClosure(true)).isSameAs(config);
+                assertThat(config.isAllowHalfClosure()).isTrue();
+
+                assertThatThrownBy(() -> config.setReadMode(null))
+                        .isInstanceOf(NullPointerException.class)
+                        .hasMessageContaining("mode");
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(KQueueDomainSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
     }
 
     private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 import org.junit.jupiter.api.Test;
 
@@ -114,6 +115,31 @@ public class Netty_transport_classes_kqueueTest {
     @Test
     void eventLoopGroupConstructorRespectsTransportAvailability() {
         assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+    }
+
+    @Test
+    void socketChannelConfigControlsTcpNoPushOption() {
+        if (KQueue.isAvailable()) {
+            KQueueSocketChannel channel = new KQueueSocketChannel();
+            try {
+                KQueueSocketChannelConfig config = channel.config();
+
+                assertThat(config.getOptions()).containsKey(KQueueChannelOption.TCP_NOPUSH);
+
+                config.setTcpNoPush(true);
+                assertThat(config.isTcpNoPush()).isTrue();
+                assertThat(config.getOption(KQueueChannelOption.TCP_NOPUSH)).isTrue();
+
+                assertThat(config.setOption(KQueueChannelOption.TCP_NOPUSH, false)).isTrue();
+                assertThat(config.isTcpNoPush()).isFalse();
+                assertThat(config.getOption(KQueueChannelOption.TCP_NOPUSH)).isFalse();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(KQueueSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
     }
 
     @Test

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -6,11 +6,166 @@
  */
 package io_netty.netty_transport_classes_kqueue;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.AcceptFilter;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueChannelConfig;
+import io.netty.channel.kqueue.KQueueChannelOption;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
 import org.junit.jupiter.api.Test;
 
-class Netty_transport_classes_kqueueTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_transport_classes_kqueueTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void kqueueAvailabilityContractIsSelfConsistent() {
+        boolean available = KQueue.isAvailable();
+        Throwable cause = KQueue.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(KQueue::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(KQueue.isTcpFastOpenClientSideAvailable()).isFalse();
+        assertThat(KQueue.isTcpFastOpenServerSideAvailable()).isFalse();
+
+        Throwable thrown = catchThrowable(KQueue::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+        assertThat(rootCauseMessage(thrown)).isNotBlank();
+    }
+
+    @Test
+    void acceptFilterExposesImmutableValueSemantics() {
+        AcceptFilter httpReady = new AcceptFilter("httpready", "GET");
+        AcceptFilter sameFilter = new AcceptFilter("httpready", "GET");
+        AcceptFilter differentName = new AcceptFilter("dataready", "GET");
+        AcceptFilter differentArgs = new AcceptFilter("httpready", "POST");
+
+        assertThat(httpReady.filterName()).isEqualTo("httpready");
+        assertThat(httpReady.filterArgs()).isEqualTo("GET");
+        assertThat(httpReady).isEqualTo(httpReady);
+        assertThat(httpReady).isEqualTo(sameFilter).hasSameHashCodeAs(sameFilter);
+        assertThat(httpReady).isNotEqualTo(differentName);
+        assertThat(httpReady).isNotEqualTo(differentArgs);
+        assertThat(httpReady).isNotEqualTo("httpready, GET");
+        assertThat(httpReady).hasToString("httpready, GET");
+    }
+
+    @Test
+    void acceptFilterRejectsNullComponents() {
+        assertThatThrownBy(() -> new AcceptFilter(null, "args"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filterName");
+        assertThatThrownBy(() -> new AcceptFilter("name", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filterArgs");
+    }
+
+    @Test
+    void kqueueChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                KQueueChannelOption.SO_SNDLOWAT,
+                KQueueChannelOption.TCP_NOPUSH,
+                KQueueChannelOption.SO_ACCEPTFILTER,
+                KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void publicChannelConstructorsRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(KQueueSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDatagramChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDomainDatagramChannel::new);
+    }
+
+    @Test
+    void eventLoopGroupConstructorRespectsTransportAvailability() {
+        assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (KQueue.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+                assertThat(channel.config()).isInstanceOf(KQueueChannelConfig.class);
+                assertTransportProvidesGuessOptionRoundTrips((KQueueChannelConfig) channel.config());
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertTransportProvidesGuessOptionRoundTrips(KQueueChannelConfig config) {
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isFalse();
+
+        assertThat(config.setOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true)).isTrue();
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isTrue();
+        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isTrue();
+
+        assertThat(config.setRcvAllocTransportProvidesGuess(false)).isSameAs(config);
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(
+            Supplier<? extends EventLoopGroup> constructor) {
+        if (KQueue.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+                ((KQueueEventLoopGroup) group).setIoRatio(25);
+                assertThatThrownBy(() -> ((KQueueEventLoopGroup) group).setIoRatio(0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("ioRatio");
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage() == null ? current.getClass().getName() : current.getMessage();
     }
 }

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.channel.kqueue.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.channel.kqueue.**"
+      "includeClasses" : "io.netty.channel.kqueue.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1499

This PR introduces tests and metadata for io.netty:netty-transport-classes-kqueue:4.1.74.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 194983
- Cached input tokens: 1711616
- Output tokens: 16883
- Metadata entries: 35
- Iterations: 4
- Library coverage percentage: 3.54
- Generated lines of code: 193
- Tested library lines of code: 75

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 334/8477 (3.94%)
- Line: 75/2117 (3.54%)
- Method: 26/547 (4.75%)
