### PR TITLE
[GenAI] Add support for io.netty:netty-codec-smtp:4.1.74.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-codec-smtp/4.1.74.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-smtp/4.1.74.Final/reachability-metadata.json
@@ -1,0 +1,177 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.misc.VM"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-smtp/index.json
+++ b/metadata/io.netty/netty-codec-smtp/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/4.1.74.Final/netty-codec-smtp-4.1.74.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/4.1.74.Final/netty-codec-smtp-4.1.74.Final-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/4.1.74.Final/netty-codec-smtp-4.1.74.Final-javadoc.jar",
+    "description" : "Netty Codec SMTP provides SMTP protocol support for Netty by modeling SMTP commands, requests, responses, and message content. It includes an SMTP request encoder and response decoder for implementing asynchronous SMTP clients on Netty's channel pipeline.",
+    "tested-versions" : [
+      "4.1.74.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec.smtp"
+    ]
+  }
+]

--- a/stats/io.netty/netty-codec-smtp/4.1.74.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec-smtp/4.1.74.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-01": {
+    "timestamp": "2026-05-01T23:33:53.904464Z",
+    "library": "io.netty:netty-codec-smtp:4.1.74.Final",
+    "starting_commit": "38ebb16da6235d4f3e915e7393c022b76c5e3595",
+    "ending_commit": "e21660acd28f5ca331f99e6efccf594729a6d8da",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 980,
+          "missed": 181,
+          "ratio": 0.8441,
+          "total": 1161
+        },
+        "line": {
+          "covered": 209,
+          "missed": 42,
+          "ratio": 0.832669,
+          "total": 251
+        },
+        "method": {
+          "covered": 62,
+          "missed": 21,
+          "ratio": 0.746988,
+          "total": 83
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 223538,
+      "cached_input_tokens_used": 1710592,
+      "output_tokens_used": 16590,
+      "iterations": 4,
+      "cost_usd": 1.353,
+      "generated_loc": 319,
+      "tested_library_loc": 209,
+      "metadata_entries": 34,
+      "code_coverage_percent": 83.27
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java",
+      "metadata_file": "metadata/io.netty/netty-codec-smtp/4.1.74.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-codec-smtp/4.1.74.Final/stats.json
+++ b/stats/io.netty/netty-codec-smtp/4.1.74.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.74.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 980,
+        "missed" : 181,
+        "ratio" : 0.8441,
+        "total" : 1161
+      },
+      "line" : {
+        "covered" : 209,
+        "missed" : 42,
+        "ratio" : 0.832669,
+        "total" : 251
+      },
+      "method" : {
+        "covered" : 62,
+        "missed" : 21,
+        "ratio" : 0.746988,
+        "total" : 83
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/.gitignore
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-codec-smtp:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/gradle.properties
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-codec-smtp:4.1.74.Final
+library.version = 4.1.74.Final
+metadata.dir = io.netty/netty-codec-smtp/4.1.74.Final/

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/settings.gradle
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-codec-smtp_tests'

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_codec_smtp;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_codec_smtpTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
@@ -201,6 +201,25 @@ public class Netty_codec_smtpTest {
     }
 
     @Test
+    void responseDecoderAccumulatesMultiLineResponsesAcrossInboundWrites() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpResponseDecoder(128));
+        try {
+            assertThat(channel.writeInbound(copiedBuffer("250-mail.example.org\r\n"))).isFalse();
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+            assertThat(channel.writeInbound(copiedBuffer("250-ENHANCEDSTATUSCODES\r\n"))).isFalse();
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+            assertThat(channel.writeInbound(copiedBuffer("250 HELP\r\n"))).isTrue();
+
+            SmtpResponse response = channel.readInbound();
+            assertThat(response.code()).isEqualTo(250);
+            assertThat(response.details()).containsExactly("mail.example.org", "ENHANCEDSTATUSCODES", "HELP");
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
     void responseDecoderWaitsForCompleteLinesAndRejectsMalformedLines() {
         EmbeddedChannel partialChannel = new EmbeddedChannel(new SmtpResponseDecoder(128));
         try {

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
@@ -15,6 +15,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.smtp.DefaultLastSmtpContent;
 import io.netty.handler.codec.smtp.DefaultSmtpContent;
 import io.netty.handler.codec.smtp.DefaultSmtpRequest;
@@ -220,6 +221,19 @@ public class Netty_codec_smtpTest {
                     .hasMessageContaining("Received invalid line");
         } finally {
             invalidChannel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void responseDecoderRejectsLinesLongerThanConfiguredMaximum() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpResponseDecoder(10));
+        try {
+            assertThatThrownBy(() -> channel.writeInbound(copiedBuffer("250 response text exceeds limit\r\n")))
+                    .isInstanceOf(TooLongFrameException.class)
+                    .hasMessageContaining("frame length");
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+        } finally {
+            channel.finishAndReleaseAll();
         }
     }
 

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/src/test/java/io_netty/netty_codec_smtp/Netty_codec_smtpTest.java
@@ -6,11 +6,315 @@
  */
 package io_netty.netty_codec_smtp;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.smtp.DefaultLastSmtpContent;
+import io.netty.handler.codec.smtp.DefaultSmtpContent;
+import io.netty.handler.codec.smtp.DefaultSmtpRequest;
+import io.netty.handler.codec.smtp.DefaultSmtpResponse;
+import io.netty.handler.codec.smtp.LastSmtpContent;
+import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpContent;
+import io.netty.handler.codec.smtp.SmtpRequest;
+import io.netty.handler.codec.smtp.SmtpRequestEncoder;
+import io.netty.handler.codec.smtp.SmtpRequests;
+import io.netty.handler.codec.smtp.SmtpResponse;
+import io.netty.handler.codec.smtp.SmtpResponseDecoder;
+import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-class Netty_codec_smtpTest {
+public class Netty_codec_smtpTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void smtpCommandValueOfReusesKnownCommandsAndKeepsCustomNames() {
+        SmtpCommand canonicalMail = SmtpCommand.valueOf("MAIL");
+        SmtpCommand lowerCaseMail = SmtpCommand.valueOf("mail");
+        SmtpCommand customCommand = SmtpCommand.valueOf("XCLIENT");
+
+        assertThat(canonicalMail).isSameAs(SmtpCommand.MAIL);
+        assertThat(lowerCaseMail).isEqualTo(SmtpCommand.MAIL);
+        assertThat(lowerCaseMail.name().toString()).isEqualTo("mail");
+        assertThat(customCommand.name().toString()).isEqualTo("XCLIENT");
+        assertThat(customCommand).isEqualTo(SmtpCommand.valueOf("xclient"));
+        assertThat(customCommand.toString()).contains("XCLIENT");
+    }
+
+    @Test
+    void requestFactoryCreatesProtocolSpecificCommandsAndImmutableParameters() {
+        SmtpRequest ehlo = SmtpRequests.ehlo("client.example.org");
+        SmtpRequest mail = SmtpRequests.mail("sender@example.org", "BODY=8BITMIME", "SMTPUTF8");
+        SmtpRequest nullReversePath = SmtpRequests.mail(null);
+        SmtpRequest recipient = SmtpRequests.rcpt("recipient@example.org", "NOTIFY=SUCCESS,FAILURE");
+        SmtpRequest auth = SmtpRequests.auth("PLAIN", "AHVzZXIAc2VjcmV0");
+        SmtpRequest empty = SmtpRequests.empty("comment", "ignored-by-server");
+
+        assertThat(ehlo.command()).isSameAs(SmtpCommand.EHLO);
+        assertThat(ehlo.parameters()).containsExactly("client.example.org");
+        assertThat(mail.command()).isSameAs(SmtpCommand.MAIL);
+        assertThat(mail.parameters()).containsExactly("FROM:<sender@example.org>", "BODY=8BITMIME", "SMTPUTF8");
+        assertThat(nullReversePath.parameters()).extracting(CharSequence::toString).containsExactly("FROM:<>");
+        assertThat(recipient.command()).isSameAs(SmtpCommand.RCPT);
+        assertThat(recipient.parameters()).containsExactly("TO:<recipient@example.org>", "NOTIFY=SUCCESS,FAILURE");
+        assertThat(auth.command()).isSameAs(SmtpCommand.AUTH);
+        assertThat(auth.parameters()).containsExactly("PLAIN", "AHVzZXIAc2VjcmV0");
+        assertThat(empty.command()).isSameAs(SmtpCommand.EMPTY);
+        assertThat(empty.parameters()).containsExactly("comment", "ignored-by-server");
+        assertThat(SmtpRequests.noop()).isSameAs(SmtpRequests.noop());
+        assertThat(SmtpRequests.data()).isSameAs(SmtpRequests.data());
+        assertThat(SmtpRequests.help(null)).isSameAs(SmtpRequests.help(null));
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> mail.parameters().add("SIZE=123"));
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> SmtpRequests.rcpt(null));
+    }
+
+    @Test
+    void defaultMessagesValidateCodesAndImplementValueSemantics() {
+        DefaultSmtpRequest request = new DefaultSmtpRequest("xforward", "NAME=client", "ADDR=127.0.0.1");
+        DefaultSmtpRequest equalRequest = new DefaultSmtpRequest("xforward", "NAME=client", "ADDR=127.0.0.1");
+        DefaultSmtpResponse response = new DefaultSmtpResponse(250, "PIPELINING", "SIZE 4096");
+        DefaultSmtpResponse equalResponse = new DefaultSmtpResponse(250, "PIPELINING", "SIZE 4096");
+
+        assertThat(request.command()).isEqualTo(SmtpCommand.valueOf("XFORWARD"));
+        assertThat(request.command().name().toString()).isEqualTo("xforward");
+        assertThat(request.parameters()).containsExactly("NAME=client", "ADDR=127.0.0.1");
+        assertThat(request).isEqualTo(equalRequest);
+        assertThat(request.hashCode()).isEqualTo(equalRequest.hashCode());
+        assertThat(request.toString()).contains("xforward", "NAME=client");
+        assertThat(response.code()).isEqualTo(250);
+        assertThat(response.details()).containsExactly("PIPELINING", "SIZE 4096");
+        assertThat(response).isEqualTo(equalResponse);
+        assertThat(response.hashCode()).isEqualTo(equalResponse.hashCode());
+        assertThat(response.toString()).contains("250", "PIPELINING");
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> response.details().add("STARTTLS"));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new DefaultSmtpResponse(99));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new DefaultSmtpResponse(600));
+    }
+
+    @Test
+    void requestEncoderWritesCommandsWithArgumentsAndEmptyCommandLines() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
+        try {
+            assertThat(channel.writeOutbound(SmtpRequests.ehlo("client.example.org"))).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.mail(
+                    "sender@example.org", "BODY=8BITMIME", "SMTPUTF8"))).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.rcpt(
+                    "recipient@example.org", "NOTIFY=SUCCESS,FAILURE"))).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.auth("PLAIN", "AHVzZXIAc2VjcmV0"))).isTrue();
+            assertThat(channel.writeOutbound(new DefaultSmtpRequest(
+                    "XCLIENT", "ADDR=192.0.2.10", "NAME=mail.example.org"))).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.empty("raw server extension"))).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.quit())).isTrue();
+
+            assertThat(readOutboundText(channel)).isEqualTo("EHLO client.example.org\r\n");
+            assertThat(readOutboundText(channel))
+                    .isEqualTo("MAIL FROM:<sender@example.org> BODY=8BITMIME SMTPUTF8\r\n");
+            assertThat(readOutboundText(channel))
+                    .isEqualTo("RCPT TO:<recipient@example.org> NOTIFY=SUCCESS,FAILURE\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("AUTH PLAIN AHVzZXIAc2VjcmV0\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("XCLIENT ADDR=192.0.2.10 NAME=mail.example.org\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("raw server extension\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("QUIT\r\n");
+            assertThat(channel.<ByteBuf>readOutbound()).isNull();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void requestEncoderStreamsDataContentAndTerminatesLastContent() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
+        try {
+            SmtpContent firstChunk = new DefaultSmtpContent(copiedBuffer("Subject: test\r\n\r\nHello "));
+            LastSmtpContent lastChunk = new DefaultLastSmtpContent(copiedBuffer("world\r\n"));
+
+            assertThat(channel.writeOutbound(SmtpRequests.data())).isTrue();
+            assertThat(channel.writeOutbound(firstChunk)).isTrue();
+            assertThat(channel.writeOutbound(lastChunk)).isTrue();
+
+            assertThat(readOutboundText(channel)).isEqualTo("DATA\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("Subject: test\r\n\r\nHello ");
+            assertThat(readOutboundText(channel)).isEqualTo("world\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo(".\r\n");
+            assertThat(channel.<ByteBuf>readOutbound()).isNull();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void requestEncoderEnforcesDataStateAndAllowsRsetToAbortMailBody() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
+        try {
+            assertThatThrownBy(() -> channel.writeOutbound(new DefaultSmtpContent(copiedBuffer("orphan"))))
+                    .satisfies(Netty_codec_smtpTest::assertNoContentExpectedFailure);
+
+            assertThat(channel.writeOutbound(SmtpRequests.data())).isTrue();
+            assertThat(readOutboundText(channel)).isEqualTo("DATA\r\n");
+            assertThatThrownBy(() -> channel.writeOutbound(SmtpRequests.mail("sender@example.org")))
+                    .satisfies(Netty_codec_smtpTest::assertContentExpectedFailure);
+
+            assertThat(channel.writeOutbound(SmtpRequests.rset())).isTrue();
+            assertThat(channel.writeOutbound(SmtpRequests.mail("sender@example.org"))).isTrue();
+            assertThat(readOutboundText(channel)).isEqualTo("RSET\r\n");
+            assertThat(readOutboundText(channel)).isEqualTo("MAIL FROM:<sender@example.org>\r\n");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void responseDecoderParsesSingleLineAndMultiLineResponses() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SmtpResponseDecoder(128));
+        try {
+            assertThat(channel.writeInbound(copiedBuffer("220 smtp.example.org ESMTP ready\r\n"))).isTrue();
+            SmtpResponse greeting = channel.readInbound();
+            assertThat(greeting.code()).isEqualTo(220);
+            assertThat(greeting.details()).containsExactly("smtp.example.org ESMTP ready");
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+
+            String capabilitiesLines = "250-mail.example.org\r\n"
+                    + "250-PIPELINING\r\n"
+                    + "250-SIZE 4096\r\n"
+                    + "250 SMTPUTF8\r\n";
+            assertThat(channel.writeInbound(copiedBuffer(capabilitiesLines))).isTrue();
+            SmtpResponse capabilities = channel.readInbound();
+            assertThat(capabilities.code()).isEqualTo(250);
+            assertThat(capabilities.details())
+                    .containsExactly("mail.example.org", "PIPELINING", "SIZE 4096", "SMTPUTF8");
+            assertThat(channel.<SmtpResponse>readInbound()).isNull();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void responseDecoderWaitsForCompleteLinesAndRejectsMalformedLines() {
+        EmbeddedChannel partialChannel = new EmbeddedChannel(new SmtpResponseDecoder(128));
+        try {
+            assertThat(partialChannel.writeInbound(copiedBuffer("354 Start mail input"))).isFalse();
+            assertThat(partialChannel.<SmtpResponse>readInbound()).isNull();
+            assertThat(partialChannel.writeInbound(copiedBuffer("\r\n"))).isTrue();
+            SmtpResponse response = partialChannel.readInbound();
+            assertThat(response.code()).isEqualTo(354);
+            assertThat(response.details()).containsExactly("Start mail input");
+        } finally {
+            partialChannel.finishAndReleaseAll();
+        }
+
+        EmbeddedChannel invalidChannel = new EmbeddedChannel(new SmtpResponseDecoder(128));
+        try {
+            assertThatThrownBy(() -> invalidChannel.writeInbound(copiedBuffer("OK not an SMTP response\r\n")))
+                    .isInstanceOf(DecoderException.class)
+                    .hasMessageContaining("Received invalid line");
+        } finally {
+            invalidChannel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void smtpContentPreservesConcreteTypesAcrossCopyDuplicateAndReplace() {
+        DefaultSmtpContent content = new DefaultSmtpContent(copiedBuffer("payload"));
+        DefaultLastSmtpContent lastContent = new DefaultLastSmtpContent(copiedBuffer("final"));
+        SmtpContent copied = null;
+        SmtpContent duplicate = null;
+        SmtpContent retainedDuplicate = null;
+        SmtpContent replaced = null;
+        LastSmtpContent lastCopy = null;
+        LastSmtpContent lastDuplicate = null;
+        LastSmtpContent lastReplacement = null;
+        try {
+            copied = content.copy();
+            duplicate = content.duplicate();
+            retainedDuplicate = content.retainedDuplicate();
+            replaced = content.replace(copiedBuffer("replacement"));
+            lastCopy = lastContent.copy();
+            lastDuplicate = lastContent.retainedDuplicate();
+            lastReplacement = lastContent.replace(copiedBuffer("new-final"));
+
+            assertThat(copied).isInstanceOf(DefaultSmtpContent.class);
+            assertThat(duplicate).isInstanceOf(DefaultSmtpContent.class);
+            assertThat(retainedDuplicate).isInstanceOf(DefaultSmtpContent.class);
+            assertThat(replaced).isInstanceOf(DefaultSmtpContent.class);
+            assertThat(copied.content().toString(CharsetUtil.US_ASCII)).isEqualTo("payload");
+            assertThat(duplicate.content().toString(CharsetUtil.US_ASCII)).isEqualTo("payload");
+            assertThat(replaced.content().toString(CharsetUtil.US_ASCII)).isEqualTo("replacement");
+            int referenceCount = content.refCnt();
+            assertThat(content.retain().touch("hint")).isSameAs(content);
+            assertThat(content.refCnt()).isEqualTo(referenceCount + 1);
+            assertThat(content.release()).isFalse();
+            assertThat(content.refCnt()).isEqualTo(referenceCount);
+
+            assertThat(lastCopy).isInstanceOf(DefaultLastSmtpContent.class);
+            assertThat(lastDuplicate).isInstanceOf(DefaultLastSmtpContent.class);
+            assertThat(lastReplacement).isInstanceOf(DefaultLastSmtpContent.class);
+            assertThat(lastCopy.content().toString(CharsetUtil.US_ASCII)).isEqualTo("final");
+            assertThat(lastReplacement.content().toString(CharsetUtil.US_ASCII)).isEqualTo("new-final");
+            assertThat(LastSmtpContent.EMPTY_LAST_CONTENT.content().readableBytes()).isZero();
+        } finally {
+            releaseIfAccessible(lastReplacement);
+            releaseIfAccessible(lastDuplicate);
+            releaseIfAccessible(lastCopy);
+            releaseIfAccessible(replaced);
+            releaseIfAccessible(retainedDuplicate);
+            releaseIfAccessible(duplicate);
+            releaseIfAccessible(copied);
+            releaseIfAccessible(lastContent);
+            releaseIfAccessible(content);
+        }
+    }
+
+    private static ByteBuf copiedBuffer(String text) {
+        return Unpooled.copiedBuffer(text, CharsetUtil.US_ASCII);
+    }
+
+    private static String readOutboundText(EmbeddedChannel channel) {
+        ByteBuf buffer = channel.readOutbound();
+        assertThat(buffer).isNotNull();
+        try {
+            return buffer.toString(CharsetUtil.US_ASCII);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static void assertNoContentExpectedFailure(Throwable throwable) {
+        assertThat(rootCause(throwable))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No SmtpContent expected");
+    }
+
+    private static void assertContentExpectedFailure(Throwable throwable) {
+        assertThat(rootCause(throwable))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("SmtpContent expected");
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        if (throwable instanceof EncoderException && throwable.getCause() != null) {
+            return throwable.getCause();
+        }
+        return current;
+    }
+
+    private static void releaseIfAccessible(SmtpContent content) {
+        if (content != null && content.refCnt() > 0) {
+            content.release(content.refCnt());
+        }
     }
 }

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.handler.codec.smtp.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.handler.codec.smtp.**"
+      "includeClasses" : "io.netty.handler.codec.smtp.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3167

This PR introduces tests and metadata for io.netty:netty-codec-smtp:4.1.74.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 223538
- Cached input tokens: 1710592
- Output tokens: 16590
- Metadata entries: 34
- Iterations: 4
- Library coverage percentage: 83.27
- Generated lines of code: 319
- Tested library lines of code: 209

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 980/1161 (84.41%)
- Line: 209/251 (83.27%)
- Method: 62/83 (74.70%)
