### PR TITLE
[GenAI] Add support for io.netty:netty-transport-native-kqueue:4.1.60.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-native-kqueue/4.1.60.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-native-kqueue/4.1.60.Final/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoop"
+      },
+      "type": "io.netty.channel.kqueue.KQueueEventLoop"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueSocketChannel"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-native-kqueue/index.json
+++ b/metadata/io.netty/netty-transport-native-kqueue/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.60.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-kqueue/4.1.60.Final/netty-transport-native-kqueue-4.1.60.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-kqueue/4.1.60.Final/netty-transport-native-kqueue-4.1.60.Final-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-kqueue/4.1.60.Final/netty-transport-native-kqueue-4.1.60.Final-javadoc.jar",
+    "description" : "Netty Transport Native KQueue provides Netty's native kqueue-based transport implementation for macOS, FreeBSD, and OpenBSD. It packages JNI/native code and Java channel and event-loop classes so Netty applications can use the operating system's kqueue event notification API for high-performance asynchronous networking.",
+    "tested-versions" : [
+      "4.1.60.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.kqueue"
+    ]
+  }
+]

--- a/stats/io.netty/netty-transport-native-kqueue/4.1.60.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-native-kqueue/4.1.60.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T00:17:48.836460Z",
+    "library": "io.netty:netty-transport-native-kqueue:4.1.60.Final",
+    "starting_commit": "13f2cafd786383484d7bc2b8e11493da9a812aeb",
+    "ending_commit": "42c822cc4e9e02211365ebaf0272d66f405d4397",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.60.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 254,
+          "missed": 6974,
+          "ratio": 0.035141,
+          "total": 7228
+        },
+        "line": {
+          "covered": 57,
+          "missed": 1753,
+          "ratio": 0.031492,
+          "total": 1810
+        },
+        "method": {
+          "covered": 22,
+          "missed": 464,
+          "ratio": 0.045267,
+          "total": 486
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 150038,
+      "cached_input_tokens_used": 713216,
+      "output_tokens_used": 17053,
+      "iterations": 4,
+      "cost_usd": 0.8682,
+      "generated_loc": 368,
+      "tested_library_loc": 57,
+      "metadata_entries": 4,
+      "code_coverage_percent": 3.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-native-kqueue/4.1.60.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-native-kqueue/4.1.60.Final/stats.json
+++ b/stats/io.netty/netty-transport-native-kqueue/4.1.60.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.60.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 254,
+        "missed" : 6974,
+        "ratio" : 0.035141,
+        "total" : 7228
+      },
+      "line" : {
+        "covered" : 57,
+        "missed" : 1753,
+        "ratio" : 0.031492,
+        "total" : 1810
+      },
+      "method" : {
+        "covered" : 22,
+        "missed" : 464,
+        "ratio" : 0.045267,
+        "total" : 486
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-native-kqueue:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-native-kqueue:4.1.60.Final
+library.version = 4.1.60.Final
+metadata.dir = io.netty/netty-transport-native-kqueue/4.1.60.Final/

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-native-kqueue_tests'

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
@@ -7,6 +7,8 @@
 package io_netty.netty_transport_native_kqueue;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +40,7 @@ import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -181,6 +184,54 @@ public class Netty_transport_native_kqueueTest {
             clientGroup.shutdownGracefully().syncUninterruptibly();
             workerGroup.shutdownGracefully().syncUninterruptibly();
             bossGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void kqueueDomainSocketChannelsCanExchangeBytesWhenAvailable() throws Exception {
+        if (!KQueue.isAvailable()) {
+            assertThatThrownBy(KQueueEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        Path socketPath = Files.createTempFile("netty-kqueue-domain-", ".sock");
+        Files.deleteIfExists(socketPath);
+        DomainSocketAddress socketAddress = new DomainSocketAddress(socketPath.toFile());
+        EventLoopGroup serverGroup = new KQueueEventLoopGroup(1);
+        EventLoopGroup clientGroup = new KQueueEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(serverGroup)
+                    .channel(KQueueServerDomainSocketChannel.class)
+                    .childHandler(new EchoServerInitializer(failure));
+            serverChannel = serverBootstrap.bind(socketAddress).syncUninterruptibly().channel();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(KQueueDomainSocketChannel.class)
+                    .handler(new EchoClientInitializer(response, responseReceived, failure));
+            clientChannel = clientBootstrap.connect(socketAddress).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(Unpooled.copiedBuffer("domain", CharsetUtil.UTF_8)).syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("echo:domain");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            serverGroup.shutdownGracefully().syncUninterruptibly();
+            Files.deleteIfExists(socketPath);
         }
     }
 

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
@@ -6,11 +6,272 @@
  */
 package io_netty.netty_transport_native_kqueue;
 
+import java.net.InetSocketAddress;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.kqueue.AcceptFilter;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueChannelOption;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannelConfig;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannelConfig;
+import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-class Netty_transport_native_kqueueTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_transport_native_kqueueTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void kqueueAvailabilityContractIsSelfConsistent() {
+        boolean available = KQueue.isAvailable();
+        Throwable cause = KQueue.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(KQueue::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        Throwable thrown = catchThrowable(KQueue::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void kqueuePublicTypesRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(KQueueSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDatagramChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerDomainSocketChannel::new);
+        assertEventLoopGroupConstructorMatchesAvailability(KQueueEventLoopGroup::new);
+    }
+
+    @Test
+    void kqueueChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                KQueueChannelOption.SO_SNDLOWAT,
+                KQueueChannelOption.TCP_NOPUSH,
+                KQueueChannelOption.SO_ACCEPTFILTER,
+                KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void acceptFilterExposesStableValueSemantics() {
+        AcceptFilter filter = new AcceptFilter("httpready", "data=hello");
+        AcceptFilter sameFilter = new AcceptFilter("httpready", "data=hello");
+        AcceptFilter differentFilter = new AcceptFilter("dataready", "data=hello");
+
+        assertThat(filter.filterName()).isEqualTo("httpready");
+        assertThat(filter.filterArgs()).isEqualTo("data=hello");
+        assertThat(filter).isEqualTo(sameFilter).hasSameHashCodeAs(sameFilter);
+        assertThat(filter).isNotEqualTo(differentFilter);
+        assertThat(filter).hasToString("httpready, data=hello");
+        assertThatThrownBy(() -> new AcceptFilter(null, "args")).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new AcceptFilter("name", null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void kqueueChannelConfigurationRoundTripsPortableOptionsWhenAvailable() {
+        if (!KQueue.isAvailable()) {
+            assertThatThrownBy(KQueueSocketChannel::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        KQueueSocketChannel socketChannel = new KQueueSocketChannel();
+        KQueueDomainSocketChannel domainSocketChannel = new KQueueDomainSocketChannel();
+        try {
+            KQueueSocketChannelConfig socketConfig = socketChannel.config();
+            assertThat(socketConfig.getOptions()).containsKey(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS);
+
+            socketConfig.setRcvAllocTransportProvidesGuess(true);
+            assertThat(socketConfig.getRcvAllocTransportProvidesGuess()).isTrue();
+            assertThat(socketConfig.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isTrue();
+
+            socketConfig.setOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, false);
+            assertThat(socketConfig.getRcvAllocTransportProvidesGuess()).isFalse();
+            assertThat(socketConfig.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isFalse();
+
+            KQueueDomainSocketChannelConfig domainConfig = domainSocketChannel.config();
+            domainConfig.setReadMode(DomainSocketReadMode.FILE_DESCRIPTORS);
+            assertThat(domainConfig.getReadMode()).isSameAs(DomainSocketReadMode.FILE_DESCRIPTORS);
+            domainConfig.setReadMode(DomainSocketReadMode.BYTES);
+            assertThat(domainConfig.getReadMode()).isSameAs(DomainSocketReadMode.BYTES);
+        } finally {
+            domainSocketChannel.close().syncUninterruptibly();
+            socketChannel.close().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void kqueueTcpChannelsCanExchangeBytesWhenAvailable() throws Exception {
+        if (!KQueue.isAvailable()) {
+            assertThatThrownBy(KQueueEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EventLoopGroup bossGroup = new KQueueEventLoopGroup(1);
+        EventLoopGroup workerGroup = new KQueueEventLoopGroup(1);
+        EventLoopGroup clientGroup = new KQueueEventLoopGroup(1);
+        Channel serverChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(bossGroup, workerGroup)
+                    .channel(KQueueServerSocketChannel.class)
+                    .childHandler(new EchoServerInitializer(failure));
+            serverChannel = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(KQueueSocketChannel.class)
+                    .handler(new EchoClientInitializer(response, responseReceived, failure));
+            Channel clientChannel = clientBootstrap.connect("127.0.0.1", port).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(Unpooled.copiedBuffer("ping", CharsetUtil.UTF_8)).syncUninterruptibly();
+            clientChannel.closeFuture().syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("echo:ping");
+        } finally {
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            workerGroup.shutdownGracefully().syncUninterruptibly();
+            bossGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (KQueue.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(LinkageError.class);
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(Supplier<? extends EventLoopGroup> constructor) {
+        if (KQueue.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(LinkageError.class);
+    }
+
+    private static final class EchoServerInitializer extends ChannelInitializer<Channel> {
+        private final AtomicReference<Throwable> failure;
+
+        private EchoServerInitializer(AtomicReference<Throwable> failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        protected void initChannel(Channel channel) {
+            channel.pipeline().addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                    String request = msg.toString(CharsetUtil.UTF_8);
+                    ctx.writeAndFlush(Unpooled.copiedBuffer("echo:" + request, CharsetUtil.UTF_8))
+                            .addListener(ChannelFutureListener.CLOSE);
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    failure.compareAndSet(null, cause);
+                    ctx.close();
+                }
+            });
+        }
+    }
+
+    private static final class EchoClientInitializer extends ChannelInitializer<Channel> {
+        private final AtomicReference<String> response;
+
+        private final CountDownLatch responseReceived;
+
+        private final AtomicReference<Throwable> failure;
+
+        private EchoClientInitializer(
+                AtomicReference<String> response,
+                CountDownLatch responseReceived,
+                AtomicReference<Throwable> failure
+        ) {
+            this.response = response;
+            this.responseReceived = responseReceived;
+            this.failure = failure;
+        }
+
+        @Override
+        protected void initChannel(Channel channel) {
+            ChannelPipeline pipeline = channel.pipeline();
+            pipeline.addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                    response.set(msg.toString(CharsetUtil.UTF_8));
+                    responseReceived.countDown();
+                    ctx.close();
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    failure.compareAndSet(null, cause);
+                    responseReceived.countDown();
+                    ctx.close();
+                }
+            });
+        }
     }
 }

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
@@ -37,6 +37,7 @@ import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannelConfig;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -180,6 +181,93 @@ public class Netty_transport_native_kqueueTest {
             clientGroup.shutdownGracefully().syncUninterruptibly();
             workerGroup.shutdownGracefully().syncUninterruptibly();
             bossGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void kqueueDatagramChannelsCanExchangePacketsWhenAvailable() throws Exception {
+        if (!KQueue.isAvailable()) {
+            assertThatThrownBy(KQueueEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EventLoopGroup serverGroup = new KQueueEventLoopGroup(1);
+        EventLoopGroup clientGroup = new KQueueEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            Bootstrap serverBootstrap = new Bootstrap()
+                    .group(serverGroup)
+                    .channel(KQueueDatagramChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                                    String request = packet.content().toString(CharsetUtil.UTF_8);
+                                    ctx.writeAndFlush(new DatagramPacket(
+                                            Unpooled.copiedBuffer("datagram:" + request, CharsetUtil.UTF_8),
+                                            packet.sender()
+                                    ));
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            serverChannel = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            InetSocketAddress serverAddress = (InetSocketAddress) serverChannel.localAddress();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(KQueueDatagramChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                                    response.set(packet.content().toString(CharsetUtil.UTF_8));
+                                    responseReceived.countDown();
+                                    ctx.close();
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    responseReceived.countDown();
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            clientChannel = clientBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer("ping", CharsetUtil.UTF_8),
+                    serverAddress
+            )).syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("datagram:ping");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            serverGroup.shutdownGracefully().syncUninterruptibly();
         }
     }
 

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/src/test/java/io_netty/netty_transport_native_kqueue/Netty_transport_native_kqueueTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_native_kqueue;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_native_kqueueTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.channel.kqueue.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-kqueue/4.1.60.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.channel.kqueue.**"
+      "includeClasses" : "io.netty.channel.kqueue.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1501

This PR introduces tests and metadata for io.netty:netty-transport-native-kqueue:4.1.60.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 150038
- Cached input tokens: 713216
- Output tokens: 17053
- Metadata entries: 4
- Iterations: 4
- Library coverage percentage: 3.15
- Generated lines of code: 368
- Tested library lines of code: 57

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `f4f0f9be0e5eced44cb1b5ea24941f18c06b9a4f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 254/7228 (3.51%)
- Line: 57/1810 (3.15%)
- Method: 22/486 (4.53%)
