### PR TITLE
[GenAI] Add support for io.netty:netty-codec-mqtt:4.1.74.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-codec-mqtt/4.1.74.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-mqtt/4.1.74.Final/reachability-metadata.json
@@ -1,0 +1,43 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttCodecUtil"
+      },
+      "type": "io.netty.util.DefaultAttributeMap$DefaultAttribute"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-mqtt/index.json
+++ b/metadata/io.netty/netty-codec-mqtt/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-javadoc.jar",
+    "description" : "Netty Codec MQTT provides encoder, decoder, message, and property classes for handling MQTT protocol traffic within Netty pipelines. It lets Netty applications parse and generate MQTT packets for brokers, clients, and other asynchronous network components.",
+    "tested-versions" : [
+      "4.1.74.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec.mqtt"
+    ]
+  }
+]

--- a/stats/io.netty/netty-codec-mqtt/4.1.74.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec-mqtt/4.1.74.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T00:54:24.922398Z",
+    "library": "io.netty:netty-codec-mqtt:4.1.74.Final",
+    "starting_commit": "d02b2fbbe458bee016d33980ece58cb8e8434ff8",
+    "ending_commit": "0337ad6f2709add6d0bcfd1cb6c46ed6b8394921",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6007,
+          "missed": 2132,
+          "ratio": 0.738051,
+          "total": 8139
+        },
+        "line": {
+          "covered": 1387,
+          "missed": 403,
+          "ratio": 0.77486,
+          "total": 1790
+        },
+        "method": {
+          "covered": 296,
+          "missed": 88,
+          "ratio": 0.770833,
+          "total": 384
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 224686,
+      "cached_input_tokens_used": 2087424,
+      "output_tokens_used": 29832,
+      "iterations": 6,
+      "cost_usd": 1.9387,
+      "generated_loc": 451,
+      "tested_library_loc": 1387,
+      "metadata_entries": 7,
+      "code_coverage_percent": 77.49
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java",
+      "metadata_file": "metadata/io.netty/netty-codec-mqtt/4.1.74.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-codec-mqtt/4.1.74.Final/stats.json
+++ b/stats/io.netty/netty-codec-mqtt/4.1.74.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.74.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6007,
+        "missed" : 2132,
+        "ratio" : 0.738051,
+        "total" : 8139
+      },
+      "line" : {
+        "covered" : 1387,
+        "missed" : 403,
+        "ratio" : 0.77486,
+        "total" : 1790
+      },
+      "method" : {
+        "covered" : 296,
+        "missed" : 88,
+        "ratio" : 0.770833,
+        "total" : 384
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/.gitignore
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-codec-mqtt:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/gradle.properties
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-codec-mqtt:4.1.74.Final
+library.version = 4.1.74.Final
+metadata.dir = io.netty/netty-codec-mqtt/4.1.74.Final/

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/settings.gradle
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-codec-mqtt_tests'

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
@@ -146,6 +146,49 @@ public class Netty_codec_mqttTest {
     }
 
     @Test
+    void decoderBuffersFragmentedPublishFrameUntilCompleteMultiByteRemainingLengthFrameArrives() {
+        byte[] payloadBytes = new byte[180];
+        for (int i = 0; i < payloadBytes.length; i++) {
+            payloadBytes[i] = (byte) ('a' + i % 26);
+        }
+        MqttPublishMessage message = MqttMessageBuilders.publish()
+                .topicName("fragments/large-payload")
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .payload(Unpooled.wrappedBuffer(payloadBytes))
+                .build();
+
+        ByteBuf encoded = encode(message, false);
+        assertThat(encoded.getUnsignedByte(1) & 0x80).isNotZero();
+        EmbeddedChannel decoder = new EmbeddedChannel(new MqttDecoder(MAX_MESSAGE_SIZE));
+        try {
+            assertThat(decoder.writeInbound(encoded.readRetainedSlice(1))).isFalse();
+            Object incompleteHeader = decoder.readInbound();
+            assertThat(incompleteHeader).isNull();
+            assertThat(decoder.writeInbound(encoded.readRetainedSlice(2))).isFalse();
+            Object incompletePayload = decoder.readInbound();
+            assertThat(incompletePayload).isNull();
+            assertThat(decoder.writeInbound(encoded.readRetainedSlice(encoded.readableBytes()))).isTrue();
+
+            MqttPublishMessage decoded = (MqttPublishMessage) decoder.readInbound();
+            try {
+                assertThat(decoded.decoderResult().isSuccess()).isTrue();
+                assertThat(decoded.fixedHeader().messageType()).isEqualTo(MqttMessageType.PUBLISH);
+                assertThat(decoded.variableHeader().topicName()).isEqualTo("fragments/large-payload");
+                byte[] decodedBytes = new byte[decoded.payload().readableBytes()];
+                decoded.payload().getBytes(decoded.payload().readerIndex(), decodedBytes);
+                assertThat(decodedBytes).containsExactly(payloadBytes);
+                Object unexpectedMessage = decoder.readInbound();
+                assertThat(unexpectedMessage).isNull();
+            } finally {
+                decoded.release();
+            }
+        } finally {
+            encoded.release();
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
     void subscribeAndUnsubscribeMessagesPreservePacketIdsOptionsAndFilters() {
         MqttProperties subscribeProperties = new MqttProperties();
         subscribeProperties.add(new IntegerProperty(MqttPropertyType.SUBSCRIPTION_IDENTIFIER.value(), 1234));

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
@@ -16,6 +16,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
@@ -184,6 +185,31 @@ public class Netty_codec_mqttTest {
             }
         } finally {
             encoded.release();
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void decoderReportsFailureWhenFrameExceedsConfiguredMaxMessageSize() {
+        ByteBuf payload = Unpooled.copiedBuffer("payload that is larger than the configured decoder limit",
+                StandardCharsets.UTF_8);
+        MqttPublishMessage message = MqttMessageBuilders.publish()
+                .topicName("limits/max-message-size")
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .payload(payload)
+                .build();
+
+        ByteBuf encoded = encode(message, false);
+        EmbeddedChannel decoder = new EmbeddedChannel(new MqttDecoder(8));
+        try {
+            assertThat(decoder.writeInbound(encoded)).isTrue();
+            MqttMessage decoded = decoder.readInbound();
+            assertThat(decoded).isNotNull();
+            assertThat(decoded.decoderResult().isFailure()).isTrue();
+            assertThat(decoded.decoderResult().cause()).isInstanceOf(TooLongFrameException.class);
+            Object unexpectedMessage = decoder.readInbound();
+            assertThat(unexpectedMessage).isNull();
+        } finally {
             decoder.finishAndReleaseAll();
         }
     }

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
@@ -115,7 +115,7 @@ public class Netty_codec_mqttTest {
         MqttProperties properties = new MqttProperties();
         properties.add(new IntegerProperty(MqttPropertyType.PAYLOAD_FORMAT_INDICATOR.value(), 1));
         properties.add(new StringProperty(MqttPropertyType.CONTENT_TYPE.value(), "application/json"));
-        properties.add(new BinaryProperty(MqttPropertyType.CORRELATION_DATA.value(), new byte[] { 1, 2, 3, 5, 8 }));
+        properties.add(new BinaryProperty(MqttPropertyType.CORRELATION_DATA.value(), new byte[] {1, 2, 3, 5, 8 }));
 
         ByteBuf payload = Unpooled.copiedBuffer("{\"temperature\":21.5}", StandardCharsets.UTF_8);
         MqttPublishMessage message = MqttMessageBuilders.publish()

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
@@ -6,11 +6,427 @@
  */
 package io_netty.netty_codec_mqtt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.netty.handler.codec.mqtt.MqttDecoder;
+import io.netty.handler.codec.mqtt.MqttEncoder;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttIdentifierRejectedException;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttMessageIdAndPropertiesVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttProperties.BinaryProperty;
+import io.netty.handler.codec.mqtt.MqttProperties.IntegerProperty;
+import io.netty.handler.codec.mqtt.MqttProperties.MqttProperty;
+import io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType;
+import io.netty.handler.codec.mqtt.MqttProperties.StringPair;
+import io.netty.handler.codec.mqtt.MqttProperties.StringProperty;
+import io.netty.handler.codec.mqtt.MqttProperties.UserProperties;
+import io.netty.handler.codec.mqtt.MqttPubReplyMessageVariableHeader;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttReasonCodeAndPropertiesVariableHeader;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption.RetainedHandlingPolicy;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import io.netty.handler.codec.mqtt.MqttUnacceptableProtocolVersionException;
+import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttVersion;
 import org.junit.jupiter.api.Test;
 
-class Netty_codec_mqttTest {
+public class Netty_codec_mqttTest {
+    private static final int MAX_MESSAGE_SIZE = 8 * 1024;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void connectMessageRoundTripsMqtt5FlagsPayloadAndProperties() {
+        MqttProperties connectProperties = new MqttProperties();
+        connectProperties.add(new IntegerProperty(MqttPropertyType.SESSION_EXPIRY_INTERVAL.value(), 120));
+        connectProperties.add(new IntegerProperty(MqttPropertyType.RECEIVE_MAXIMUM.value(), 10));
+
+        MqttProperties willProperties = new MqttProperties();
+        willProperties.add(new IntegerProperty(MqttPropertyType.WILL_DELAY_INTERVAL.value(), 5));
+        willProperties.add(new StringProperty(MqttPropertyType.CONTENT_TYPE.value(), "text/plain"));
+
+        MqttConnectMessage message = MqttMessageBuilders.connect()
+                .protocolVersion(MqttVersion.MQTT_5)
+                .clientId("client-native-image")
+                .cleanSession(false)
+                .keepAlive(45)
+                .willFlag(true)
+                .willQoS(MqttQoS.AT_LEAST_ONCE)
+                .willTopic("clients/status")
+                .willMessage("offline".getBytes(StandardCharsets.UTF_8))
+                .willRetain(true)
+                .willProperties(willProperties)
+                .hasUser(true)
+                .username("mqtt-user")
+                .hasPassword(true)
+                .password("s3cr3t".getBytes(StandardCharsets.UTF_8))
+                .properties(connectProperties)
+                .build();
+
+        MqttConnectMessage decoded = (MqttConnectMessage) roundTrip(message);
+
+        assertThat(decoded.fixedHeader().messageType()).isEqualTo(MqttMessageType.CONNECT);
+        assertThat(decoded.variableHeader().name()).isEqualTo("MQTT");
+        assertThat(decoded.variableHeader().version()).isEqualTo(MqttVersion.MQTT_5.protocolLevel());
+        assertThat(decoded.variableHeader().hasUserName()).isTrue();
+        assertThat(decoded.variableHeader().hasPassword()).isTrue();
+        assertThat(decoded.variableHeader().isWillFlag()).isTrue();
+        assertThat(decoded.variableHeader().willQos()).isEqualTo(MqttQoS.AT_LEAST_ONCE.value());
+        assertThat(decoded.variableHeader().isWillRetain()).isTrue();
+        assertThat(decoded.variableHeader().isCleanSession()).isFalse();
+        assertThat(decoded.variableHeader().keepAliveTimeSeconds()).isEqualTo(45);
+        assertThat(propertyValue(decoded.variableHeader().properties(), MqttPropertyType.SESSION_EXPIRY_INTERVAL))
+                .isEqualTo(120);
+        assertThat(propertyValue(decoded.variableHeader().properties(), MqttPropertyType.RECEIVE_MAXIMUM))
+                .isEqualTo(10);
+        assertThat(decoded.payload().clientIdentifier()).isEqualTo("client-native-image");
+        assertThat(decoded.payload().willTopic()).isEqualTo("clients/status");
+        assertThat(decoded.payload().willMessageInBytes()).containsExactly("offline".getBytes(StandardCharsets.UTF_8));
+        assertThat(propertyValue(decoded.payload().willProperties(), MqttPropertyType.WILL_DELAY_INTERVAL))
+                .isEqualTo(5);
+        assertThat(propertyValue(decoded.payload().willProperties(), MqttPropertyType.CONTENT_TYPE))
+                .isEqualTo("text/plain");
+        assertThat(decoded.payload().userName()).isEqualTo("mqtt-user");
+        assertThat(decoded.payload().passwordInBytes()).containsExactly("s3cr3t".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void publishMessageRoundTripsRetainedQos2PayloadAndMqtt5Properties() {
+        MqttProperties properties = new MqttProperties();
+        properties.add(new IntegerProperty(MqttPropertyType.PAYLOAD_FORMAT_INDICATOR.value(), 1));
+        properties.add(new StringProperty(MqttPropertyType.CONTENT_TYPE.value(), "application/json"));
+        properties.add(new BinaryProperty(MqttPropertyType.CORRELATION_DATA.value(), new byte[] { 1, 2, 3, 5, 8 }));
+
+        ByteBuf payload = Unpooled.copiedBuffer("{\"temperature\":21.5}", StandardCharsets.UTF_8);
+        MqttPublishMessage message = MqttMessageBuilders.publish()
+                .topicName("sensors/kitchen")
+                .retained(true)
+                .qos(MqttQoS.EXACTLY_ONCE)
+                .messageId(77)
+                .properties(properties)
+                .payload(payload)
+                .build();
+
+        MqttPublishMessage decoded = (MqttPublishMessage) roundTripMqtt5(message);
+        try {
+            assertThat(decoded.fixedHeader().messageType()).isEqualTo(MqttMessageType.PUBLISH);
+            assertThat(decoded.fixedHeader().isRetain()).isTrue();
+            assertThat(decoded.fixedHeader().qosLevel()).isEqualTo(MqttQoS.EXACTLY_ONCE);
+            assertThat(decoded.variableHeader().topicName()).isEqualTo("sensors/kitchen");
+            assertThat(decoded.variableHeader().packetId()).isEqualTo(77);
+            assertThat(decoded.payload().toString(StandardCharsets.UTF_8)).isEqualTo("{\"temperature\":21.5}");
+            assertThat(propertyValue(decoded.variableHeader().properties(), MqttPropertyType.PAYLOAD_FORMAT_INDICATOR))
+                    .isEqualTo(1);
+            assertThat(propertyValue(decoded.variableHeader().properties(), MqttPropertyType.CONTENT_TYPE))
+                    .isEqualTo("application/json");
+            assertThat((byte[]) propertyValue(decoded.variableHeader().properties(), MqttPropertyType.CORRELATION_DATA))
+                    .containsExactly(1, 2, 3, 5, 8);
+        } finally {
+            decoded.release();
+        }
+    }
+
+    @Test
+    void subscribeAndUnsubscribeMessagesPreservePacketIdsOptionsAndFilters() {
+        MqttProperties subscribeProperties = new MqttProperties();
+        subscribeProperties.add(new IntegerProperty(MqttPropertyType.SUBSCRIPTION_IDENTIFIER.value(), 1234));
+        MqttSubscriptionOption commandOptions = new MqttSubscriptionOption(
+                MqttQoS.EXACTLY_ONCE,
+                true,
+                true,
+                RetainedHandlingPolicy.DONT_SEND_AT_SUBSCRIBE);
+
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+                .messageId(321)
+                .properties(subscribeProperties)
+                .addSubscription(MqttQoS.AT_LEAST_ONCE, "alerts/+")
+                .addSubscription("commands/#", commandOptions)
+                .build();
+
+        MqttSubscribeMessage decodedSubscribe = (MqttSubscribeMessage) roundTripMqtt5(subscribe);
+
+        assertThat(propertyValue(subscribe.idAndPropertiesVariableHeader().properties(),
+                MqttPropertyType.SUBSCRIPTION_IDENTIFIER)).isEqualTo(1234);
+        assertThat(decodedSubscribe.fixedHeader().messageType()).isEqualTo(MqttMessageType.SUBSCRIBE);
+        assertThat(decodedSubscribe.variableHeader().messageId()).isEqualTo(321);
+        assertThat(decodedSubscribe.payload().topicSubscriptions()).hasSize(2);
+        MqttTopicSubscription alerts = decodedSubscribe.payload().topicSubscriptions().get(0);
+        assertThat(alerts.topicName()).isEqualTo("alerts/+");
+        assertThat(alerts.option().qos()).isEqualTo(MqttQoS.AT_LEAST_ONCE);
+        MqttSubscriptionOption decodedCommandOptions = decodedSubscribe.payload().topicSubscriptions().get(1).option();
+        assertThat(decodedSubscribe.payload().topicSubscriptions().get(1).topicName()).isEqualTo("commands/#");
+        assertThat(decodedCommandOptions.qos()).isEqualTo(MqttQoS.EXACTLY_ONCE);
+        assertThat(commandOptions.isNoLocal()).isTrue();
+        assertThat(commandOptions.isRetainAsPublished()).isTrue();
+        assertThat(commandOptions.retainHandling()).isEqualTo(RetainedHandlingPolicy.DONT_SEND_AT_SUBSCRIBE);
+
+        UserProperties unsubscribeUserProperties = new UserProperties();
+        unsubscribeUserProperties.add("cleanup", "true");
+        MqttProperties unsubscribeProperties = new MqttProperties();
+        unsubscribeProperties.add(unsubscribeUserProperties);
+        MqttUnsubscribeMessage unsubscribe = MqttMessageBuilders.unsubscribe()
+                .messageId(654)
+                .properties(unsubscribeProperties)
+                .addTopicFilter("alerts/+")
+                .addTopicFilter("commands/#")
+                .build();
+
+        MqttUnsubscribeMessage decodedUnsubscribe = (MqttUnsubscribeMessage) roundTripMqtt5(unsubscribe);
+
+        assertThat(decodedUnsubscribe.fixedHeader().messageType()).isEqualTo(MqttMessageType.UNSUBSCRIBE);
+        assertThat(decodedUnsubscribe.variableHeader().messageId()).isEqualTo(654);
+        @SuppressWarnings("unchecked")
+        List<StringPair> unsubscribePairs = (List<StringPair>) propertyValue(
+                unsubscribe.idAndPropertiesVariableHeader().properties(), MqttPropertyType.USER_PROPERTY);
+        assertThat(unsubscribePairs).extracting(pair -> pair.key + "=" + pair.value).containsExactly("cleanup=true");
+        assertThat(decodedUnsubscribe.payload().topics()).containsExactly("alerts/+", "commands/#");
+    }
+
+    @Test
+    void acknowledgementAndControlMessagesRoundTripTheirReasonCodesAndProperties() {
+        MqttProperties connAckProperties = new MqttProperties();
+        connAckProperties.add(new StringProperty(
+                MqttPropertyType.ASSIGNED_CLIENT_IDENTIFIER.value(), "server-client-1"));
+        connAckProperties.add(new IntegerProperty(MqttPropertyType.SERVER_KEEP_ALIVE.value(), 30));
+        MqttConnAckMessage connAck = MqttMessageBuilders.connAck()
+                .returnCode(MqttConnectReturnCode.CONNECTION_ACCEPTED)
+                .sessionPresent(true)
+                .properties(connAckProperties)
+                .build();
+
+        MqttConnAckMessage decodedConnAck = (MqttConnAckMessage) roundTripMqtt5(connAck);
+        assertThat(decodedConnAck.fixedHeader().messageType()).isEqualTo(MqttMessageType.CONNACK);
+        assertThat(decodedConnAck.variableHeader().connectReturnCode())
+                .isEqualTo(MqttConnectReturnCode.CONNECTION_ACCEPTED);
+        assertThat(decodedConnAck.variableHeader().isSessionPresent()).isTrue();
+        assertThat(propertyValue(
+                decodedConnAck.variableHeader().properties(), MqttPropertyType.ASSIGNED_CLIENT_IDENTIFIER))
+                .isEqualTo("server-client-1");
+        assertThat(propertyValue(decodedConnAck.variableHeader().properties(), MqttPropertyType.SERVER_KEEP_ALIVE))
+                .isEqualTo(30);
+
+        MqttProperties pubAckProperties = new MqttProperties();
+        pubAckProperties.add(new StringProperty(MqttPropertyType.REASON_STRING.value(), "queued for processing"));
+        MqttMessage pubAck = MqttMessageBuilders.pubAck()
+                .packetId(100)
+                .reasonCode((byte) 16)
+                .properties(pubAckProperties)
+                .build();
+
+        MqttMessage decodedPubAck = roundTripMqtt5(pubAck);
+        MqttPubReplyMessageVariableHeader pubAckHeader =
+                (MqttPubReplyMessageVariableHeader) decodedPubAck.variableHeader();
+        assertThat(decodedPubAck.fixedHeader().messageType()).isEqualTo(MqttMessageType.PUBACK);
+        assertThat(pubAckHeader.messageId()).isEqualTo(100);
+        assertThat(pubAckHeader.reasonCode()).isEqualTo((byte) 16);
+        assertThat(propertyValue(pubAckHeader.properties(), MqttPropertyType.REASON_STRING))
+                .isEqualTo("queued for processing");
+
+        MqttSubAckMessage subAck = MqttMessageBuilders.subAck()
+                .packetId(101)
+                .addGrantedQoses(MqttQoS.AT_MOST_ONCE, MqttQoS.AT_LEAST_ONCE, MqttQoS.EXACTLY_ONCE, MqttQoS.FAILURE)
+                .build();
+
+        MqttSubAckMessage decodedSubAck = (MqttSubAckMessage) roundTrip(subAck);
+        assertThat(decodedSubAck.fixedHeader().messageType()).isEqualTo(MqttMessageType.SUBACK);
+        assertThat(decodedSubAck.variableHeader().messageId()).isEqualTo(101);
+        assertThat(decodedSubAck.payload().grantedQoSLevels()).containsExactly(0, 1, 2, 128);
+
+        MqttProperties unsubAckProperties = new MqttProperties();
+        unsubAckProperties.add(new StringProperty(MqttPropertyType.REASON_STRING.value(), "filters removed"));
+        MqttUnsubAckMessage unsubAck = MqttMessageBuilders.unsubAck()
+                .packetId(102)
+                .properties(unsubAckProperties)
+                .addReasonCodes((short) 0, (short) 17)
+                .build();
+
+        MqttUnsubAckMessage decodedUnsubAck = (MqttUnsubAckMessage) roundTripMqtt5(unsubAck);
+        assertThat(decodedUnsubAck.fixedHeader().messageType()).isEqualTo(MqttMessageType.UNSUBACK);
+        assertThat(decodedUnsubAck.variableHeader().messageId()).isEqualTo(102);
+        assertThat(propertyValue(
+                decodedUnsubAck.idAndPropertiesVariableHeader().properties(), MqttPropertyType.REASON_STRING))
+                .isEqualTo("filters removed");
+        assertThat(decodedUnsubAck.payload().unsubscribeReasonCodes()).containsExactly((short) 0, (short) 17);
+
+        assertReasonCodeAndProperty(MqttMessageBuilders.disconnect()
+                .reasonCode((byte) 4)
+                .properties(reasonString("disconnect with will message"))
+                .build(), MqttMessageType.DISCONNECT, (byte) 4, "disconnect with will message");
+        assertReasonCodeAndProperty(MqttMessageBuilders.auth()
+                .reasonCode((byte) 24)
+                .properties(reasonString("continue authentication"))
+                .build(), MqttMessageType.AUTH, (byte) 24, "continue authentication");
+        assertThat(roundTrip(MqttMessage.PINGREQ).fixedHeader().messageType()).isEqualTo(MqttMessageType.PINGREQ);
+        assertThat(roundTrip(MqttMessage.PINGRESP).fixedHeader().messageType()).isEqualTo(MqttMessageType.PINGRESP);
+    }
+
+    @Test
+    void propertiesEnumsAndFactoryObjectsExposeProtocolValues() {
+        UserProperties userProperties = new UserProperties();
+        userProperties.add("origin", "integration-test");
+        userProperties.add("purpose", "native-image-coverage");
+        MqttProperties properties = new MqttProperties();
+        properties.add(userProperties);
+
+        @SuppressWarnings("unchecked")
+        List<StringPair> pairs = (List<StringPair>) propertyValue(properties, MqttPropertyType.USER_PROPERTY);
+        assertThat(pairs)
+                .extracting(pair -> pair.key + "=" + pair.value)
+                .containsExactly("origin=integration-test", "purpose=native-image-coverage");
+        assertThat(MqttVersion.fromProtocolNameAndLevel("MQTT", MqttVersion.MQTT_5.protocolLevel()))
+                .isEqualTo(MqttVersion.MQTT_5);
+        assertThat(MqttVersion.MQTT_3_1.protocolName()).isEqualTo("MQIsdp");
+        assertThat(MqttQoS.valueOf(0)).isEqualTo(MqttQoS.AT_MOST_ONCE);
+        assertThat(MqttQoS.valueOf(1)).isEqualTo(MqttQoS.AT_LEAST_ONCE);
+        assertThat(MqttQoS.valueOf(2)).isEqualTo(MqttQoS.EXACTLY_ONCE);
+        assertThat(MqttQoS.valueOf(128)).isEqualTo(MqttQoS.FAILURE);
+        assertThat(RetainedHandlingPolicy.valueOf(2)).isEqualTo(RetainedHandlingPolicy.DONT_SEND_AT_SUBSCRIBE);
+        assertThat(MqttConnectReturnCode.valueOf((byte) 0))
+                .isEqualTo(MqttConnectReturnCode.CONNECTION_ACCEPTED);
+        assertThat(MqttConnectReturnCode.valueOf((byte) -122))
+                .isEqualTo(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD);
+        assertThat(MqttMessageIdVariableHeader.from(42).withEmptyProperties()).isInstanceOf(
+                MqttMessageIdAndPropertiesVariableHeader.class);
+        assertThat(new MqttFixedHeader(MqttMessageType.PUBREL, true, MqttQoS.AT_LEAST_ONCE, false, 2).isDup())
+                .isTrue();
+
+        assertThatThrownBy(() -> MqttVersion.fromProtocolNameAndLevel("MQTT", (byte) 2))
+                .isInstanceOf(MqttUnacceptableProtocolVersionException.class);
+        assertThatThrownBy(() -> MqttQoS.valueOf(3)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void decoderReportsFailureForRejectedClientIdentifier() {
+        ByteBuf invalidConnect = Unpooled.wrappedBuffer(new byte[] {
+                0x10, 0x0E,
+                0x00, 0x06, 'M', 'Q', 'I', 's', 'd', 'p',
+                0x03,
+                0x00,
+                0x00, 0x05,
+                0x00, 0x00
+        });
+
+        MqttMessage decoded = decode(invalidConnect, false);
+
+        DecoderResult decoderResult = decoded.decoderResult();
+        assertThat(decoderResult.isFailure()).isTrue();
+        assertThat(decoderResult.cause()).isInstanceOf(MqttIdentifierRejectedException.class);
+    }
+
+    private static void assertReasonCodeAndProperty(MqttMessage message, MqttMessageType expectedType, byte reasonCode,
+            String reasonString) {
+        MqttMessage decoded = roundTripMqtt5(message);
+        assertThat(decoded.fixedHeader().messageType()).isEqualTo(expectedType);
+        MqttReasonCodeAndPropertiesVariableHeader header =
+                (MqttReasonCodeAndPropertiesVariableHeader) decoded.variableHeader();
+        assertThat(header.reasonCode()).isEqualTo(reasonCode);
+        assertThat(propertyValue(header.properties(), MqttPropertyType.REASON_STRING)).isEqualTo(reasonString);
+    }
+
+    private static MqttProperties reasonString(String value) {
+        MqttProperties properties = new MqttProperties();
+        properties.add(new StringProperty(MqttPropertyType.REASON_STRING.value(), value));
+        return properties;
+    }
+
+    private static Object propertyValue(MqttProperties properties, MqttPropertyType type) {
+        MqttProperty<?> property = properties.getProperty(type.value());
+        assertThat(property).as("MQTT property %s", type).isNotNull();
+        return property.value();
+    }
+
+    private static MqttMessage roundTrip(MqttMessage message) {
+        MqttMessage decoded = roundTrip(message, false);
+        assertThat(decoded.decoderResult().isSuccess()).isTrue();
+        return decoded;
+    }
+
+    private static MqttMessage roundTripMqtt5(MqttMessage message) {
+        MqttMessage decoded = roundTrip(message, true);
+        assertThat(decoded.decoderResult().isSuccess()).isTrue();
+        return decoded;
+    }
+
+    private static MqttMessage roundTrip(MqttMessage message, boolean mqtt5) {
+        ByteBuf encoded = encode(message, mqtt5);
+        return decode(encoded, mqtt5);
+    }
+
+    private static ByteBuf encode(MqttMessage message, boolean mqtt5) {
+        EmbeddedChannel encoder = new EmbeddedChannel(MqttEncoder.INSTANCE);
+        try {
+            if (mqtt5) {
+                primeEncoderForMqtt5(encoder);
+            }
+            assertThat(encoder.writeOutbound(message)).isTrue();
+            ByteBuf encoded = encoder.readOutbound();
+            assertThat(encoded).isNotNull();
+            assertThat(encoded.readableBytes()).isPositive();
+            return encoded;
+        } finally {
+            encoder.finishAndReleaseAll();
+        }
+    }
+
+    private static MqttMessage decode(ByteBuf encoded, boolean mqtt5) {
+        EmbeddedChannel decoder = new EmbeddedChannel(new MqttDecoder(MAX_MESSAGE_SIZE));
+        try {
+            if (mqtt5) {
+                primeDecoderForMqtt5(decoder);
+            }
+            assertThat(decoder.writeInbound(encoded)).isTrue();
+            MqttMessage decoded = decoder.readInbound();
+            assertThat(decoded).isNotNull();
+            Object unexpectedMessage = decoder.readInbound();
+            assertThat(unexpectedMessage).isNull();
+            return decoded;
+        } finally {
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    private static void primeEncoderForMqtt5(EmbeddedChannel encoder) {
+        assertThat(encoder.writeOutbound(mqtt5Connect("encoder-prime"))).isTrue();
+        ByteBuf ignored = encoder.readOutbound();
+        assertThat(ignored).isNotNull();
+        ignored.release();
+    }
+
+    private static void primeDecoderForMqtt5(EmbeddedChannel decoder) {
+        ByteBuf encodedConnect = encode(mqtt5Connect("decoder-prime"), false);
+        assertThat(decoder.writeInbound(encodedConnect)).isTrue();
+        MqttMessage decodedConnect = decoder.readInbound();
+        assertThat(decodedConnect.decoderResult().isSuccess()).isTrue();
+        assertThat(decodedConnect.fixedHeader().messageType()).isEqualTo(MqttMessageType.CONNECT);
+        Object unexpectedMessage = decoder.readInbound();
+        assertThat(unexpectedMessage).isNull();
+    }
+
+    private static MqttConnectMessage mqtt5Connect(String clientId) {
+        return MqttMessageBuilders.connect()
+                .protocolVersion(MqttVersion.MQTT_5)
+                .clientId(clientId)
+                .cleanSession(true)
+                .keepAlive(60)
+                .build();
     }
 }

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/src/test/java/io_netty/netty_codec_mqtt/Netty_codec_mqttTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_codec_mqtt;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_codec_mqttTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.handler.codec.mqtt.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-mqtt/4.1.74.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.handler.codec.mqtt.**"
+      "includeClasses" : "io.netty.handler.codec.mqtt.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3165

This PR introduces tests and metadata for io.netty:netty-codec-mqtt:4.1.74.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 224686
- Cached input tokens: 2087424
- Output tokens: 29832
- Metadata entries: 7
- Iterations: 6
- Library coverage percentage: 77.49
- Generated lines of code: 451
- Tested library lines of code: 1387

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e0a483e21604fabcab74758f67c6ad8bcf3b3b9c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 6007/8139 (73.81%)
- Line: 1387/1790 (77.49%)
- Method: 296/384 (77.08%)
