### PR TITLE
[GenAI] Add support for io.netty:netty-resolver-dns-classes-macos:4.1.74.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/reachability-metadata.json
@@ -1,0 +1,139 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider"
+      },
+      "type": "sun.misc.VM"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-resolver-dns-classes-macos/index.json
+++ b/metadata/io.netty/netty-resolver-dns-classes-macos/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.74.Final/netty-resolver-dns-classes-macos-4.1.74.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.74.Final/netty-resolver-dns-classes-macos-4.1.74.Final-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.74.Final/netty-resolver-dns-classes-macos-4.1.74.Final-javadoc.jar",
+    "description" : "Netty Resolver DNS Classes for macOS provides the Java-side classes used by Netty's macOS DNS resolver integration. It exposes a DNS server address stream provider that loads Netty's native macOS resolver library and reads the system nameserver configuration for DNS resolution.",
+    "tested-versions" : [
+      "4.1.74.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.resolver.dns.macos"
+    ]
+  }
+]

--- a/stats/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/execution-metrics.json
+++ b/stats/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T04:02:47.113368Z",
+    "library": "io.netty:netty-resolver-dns-classes-macos:4.1.74.Final",
+    "starting_commit": "8fd23cef03651e2c31cec35971c6319bd91f49c7",
+    "ending_commit": "436f42a67644d16519e7402a19cfd568a7df1f92",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 59,
+          "missed": 312,
+          "ratio": 0.15903,
+          "total": 371
+        },
+        "line": {
+          "covered": 19,
+          "missed": 83,
+          "ratio": 0.186275,
+          "total": 102
+        },
+        "method": {
+          "covered": 7,
+          "missed": 11,
+          "ratio": 0.388889,
+          "total": 18
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 109406,
+      "cached_input_tokens_used": 1024512,
+      "output_tokens_used": 13769,
+      "iterations": 3,
+      "cost_usd": 0.9254,
+      "generated_loc": 139,
+      "tested_library_loc": 19,
+      "metadata_entries": 27,
+      "code_coverage_percent": 18.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java",
+      "metadata_file": "metadata/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/stats.json
+++ b/stats/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.74.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 59,
+        "missed" : 312,
+        "ratio" : 0.15903,
+        "total" : 371
+      },
+      "line" : {
+        "covered" : 19,
+        "missed" : 83,
+        "ratio" : 0.186275,
+        "total" : 102
+      },
+      "method" : {
+        "covered" : 7,
+        "missed" : 11,
+        "ratio" : 0.388889,
+        "total" : 18
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/.gitignore
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-resolver-dns-classes-macos:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/gradle.properties
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-resolver-dns-classes-macos:4.1.74.Final
+library.version = 4.1.74.Final
+metadata.dir = io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/settings.gradle
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-resolver-dns-classes-macos_tests'

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_resolver_dns_classes_macos;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_resolver_dns_classes_macosTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
@@ -6,11 +6,81 @@
  */
 package io_netty.netty_resolver_dns_classes_macos;
 
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import io.netty.resolver.dns.DnsServerAddressStream;
+import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
 import org.junit.jupiter.api.Test;
 
-class Netty_resolver_dns_classes_macosTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Netty_resolver_dns_classes_macosTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void availabilityMethodsExposeAConsistentNativeLibraryState() {
+        boolean available = MacOSDnsServerAddressStreamProvider.isAvailable();
+        Throwable unavailableCause = MacOSDnsServerAddressStreamProvider.unavailabilityCause();
+
+        assertThat(MacOSDnsServerAddressStreamProvider.isAvailable()).isEqualTo(available);
+        assertThat(MacOSDnsServerAddressStreamProvider.unavailabilityCause()).isSameAs(unavailableCause);
+
+        if (available) {
+            assertThat(unavailableCause).isNull();
+            assertThatCode(MacOSDnsServerAddressStreamProvider::ensureAvailability).doesNotThrowAnyException();
+        } else {
+            assertThat(unavailableCause).isNotNull();
+            assertThatThrownBy(MacOSDnsServerAddressStreamProvider::ensureAvailability)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessage("failed to load the required native library")
+                    .hasCause(unavailableCause);
+        }
+    }
+
+    @Test
+    void constructorFollowsTheSameAvailabilityContractAsEnsureAvailability() {
+        Throwable unavailableCause = MacOSDnsServerAddressStreamProvider.unavailabilityCause();
+
+        if (unavailableCause == null) {
+            MacOSDnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
+
+            assertThat(provider).isNotNull();
+        } else {
+            assertThatThrownBy(MacOSDnsServerAddressStreamProvider::new)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessage("failed to load the required native library")
+                    .hasCause(unavailableCause);
+        }
+    }
+
+    @Test
+    void availableProviderReturnsUsableStreamsForDifferentHostNameShapes() {
+        if (MacOSDnsServerAddressStreamProvider.isAvailable()) {
+            MacOSDnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
+            List<String> hostNames = List.of("example.com", "service.example.com", "localhost", "example.com.");
+
+            for (String hostName : hostNames) {
+                DnsServerAddressStream stream = provider.nameServerAddressStream(hostName);
+                DnsServerAddressStream duplicate = stream.duplicate();
+
+                assertThat(stream.size()).isGreaterThan(0);
+                assertThat(duplicate.size()).isEqualTo(stream.size());
+                assertValidNameServer(stream.next());
+                assertValidNameServer(duplicate.next());
+            }
+        } else {
+            assertThatThrownBy(MacOSDnsServerAddressStreamProvider::new)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasCause(MacOSDnsServerAddressStreamProvider.unavailabilityCause());
+        }
+    }
+
+    private static void assertValidNameServer(InetSocketAddress address) {
+        assertThat(address).isNotNull();
+        assertThat(address.isUnresolved()).isFalse();
+        assertThat(address.getAddress()).isNotNull();
+        assertThat(address.getPort()).isBetween(1, 65535);
     }
 }

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
@@ -9,6 +9,11 @@ package io_netty.netty_resolver_dns_classes_macos;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.resolver.dns.DnsServerAddressStream;
 import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
@@ -95,6 +100,48 @@ public class Netty_resolver_dns_classes_macosTest {
                     .isInstanceOf(UnsatisfiedLinkError.class)
                     .hasCause(MacOSDnsServerAddressStreamProvider.unavailabilityCause());
         }
+    }
+
+    @Test
+    void providerCanResolveNameServerStreamsConcurrently() throws Exception {
+        if (MacOSDnsServerAddressStreamProvider.isAvailable()) {
+            MacOSDnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
+            ExecutorService executor = Executors.newFixedThreadPool(4);
+
+            try {
+                List<Callable<InetSocketAddress>> lookups = List.of(
+                        () -> firstNameServer(provider, "example.com"),
+                        () -> firstNameServer(provider, "netty.io"),
+                        () -> firstNameServer(provider, "localhost"),
+                        () -> firstNameServer(provider, "service.example.com"),
+                        () -> firstNameServer(provider, "example.org"),
+                        () -> firstNameServer(provider, "subdomain.netty.io"),
+                        () -> firstNameServer(provider, "example.net"),
+                        () -> firstNameServer(provider, "service.example.org"));
+
+                List<Future<InetSocketAddress>> futures = executor.invokeAll(lookups, 5, TimeUnit.SECONDS);
+
+                assertThat(futures).hasSize(lookups.size());
+                for (Future<InetSocketAddress> future : futures) {
+                    assertThat(future).isNotCancelled();
+                    assertValidNameServer(future.get());
+                }
+            } finally {
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            }
+        } else {
+            assertThatThrownBy(MacOSDnsServerAddressStreamProvider::new)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasCause(MacOSDnsServerAddressStreamProvider.unavailabilityCause());
+        }
+    }
+
+    private static InetSocketAddress firstNameServer(MacOSDnsServerAddressStreamProvider provider, String hostName) {
+        DnsServerAddressStream stream = provider.nameServerAddressStream(hostName);
+
+        assertThat(stream.size()).isGreaterThan(0);
+        return stream.next();
     }
 
     private static List<InetSocketAddress> nextNameServers(DnsServerAddressStream stream, int count) {

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/src/test/java/io_netty/netty_resolver_dns_classes_macos/Netty_resolver_dns_classes_macosTest.java
@@ -7,6 +7,7 @@
 package io_netty.netty_resolver_dns_classes_macos;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.resolver.dns.DnsServerAddressStream;
@@ -75,6 +76,35 @@ public class Netty_resolver_dns_classes_macosTest {
                     .isInstanceOf(UnsatisfiedLinkError.class)
                     .hasCause(MacOSDnsServerAddressStreamProvider.unavailabilityCause());
         }
+    }
+
+    @Test
+    void returnedNameServerStreamsCycleThroughAllConfiguredAddresses() {
+        if (MacOSDnsServerAddressStreamProvider.isAvailable()) {
+            MacOSDnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
+            DnsServerAddressStream stream = provider.nameServerAddressStream("example.com");
+            int size = stream.size();
+
+            List<InetSocketAddress> firstCycle = nextNameServers(stream, size);
+            List<InetSocketAddress> secondCycle = nextNameServers(stream, size);
+
+            assertThat(size).isGreaterThan(0);
+            assertThat(secondCycle).containsExactlyElementsOf(firstCycle);
+        } else {
+            assertThatThrownBy(MacOSDnsServerAddressStreamProvider::new)
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasCause(MacOSDnsServerAddressStreamProvider.unavailabilityCause());
+        }
+    }
+
+    private static List<InetSocketAddress> nextNameServers(DnsServerAddressStream stream, int count) {
+        List<InetSocketAddress> addresses = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            InetSocketAddress address = stream.next();
+            assertValidNameServer(address);
+            addresses.add(address);
+        }
+        return addresses;
     }
 
     private static void assertValidNameServer(InetSocketAddress address) {

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.resolver.dns.macos.**"
+      "includeClasses" : "io.netty.resolver.dns.macos.**"
     }
   ]
 }

--- a/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-resolver-dns-classes-macos/4.1.74.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.resolver.dns.macos.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1444

This PR introduces tests and metadata for io.netty:netty-resolver-dns-classes-macos:4.1.74.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 109406
- Cached input tokens: 1024512
- Output tokens: 13769
- Metadata entries: 27
- Iterations: 3
- Library coverage percentage: 18.63
- Generated lines of code: 139
- Tested library lines of code: 19

### Metadata Forge

- Forge monitored branch: `origin/forge-work-queue-cache-random-offset`
- Forge branch: `forge-work-queue-cache-random-offset`
- Forge commit hash: `f4f0f9be0e5eced44cb1b5ea24941f18c06b9a4f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 59/371 (15.90%)
- Line: 19/102 (18.63%)
- Method: 7/18 (38.89%)
