### PR TITLE
[GenAI] Add support for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json
@@ -1,0 +1,79 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.MeterProviderConfiguration"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "setExemplarFilter",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.PropagatorConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "glob": "io/opentelemetry/sdk/common/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.25.0-alpha",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/opentelemetry-sdk-extension-autoconfigure-1.25.0-alpha-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.25.0/sdk-extensions/autoconfigure/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/opentelemetry-sdk-extension-autoconfigure-1.25.0-alpha-javadoc.jar",
+    "description" : "opentelemetry-sdk-extension-autoconfigure provides the OpenTelemetry Java SDK auto-configuration implementation that builds an SDK from system properties, environment variables, service-provider customizers, resources, propagators, and signal exporters. It lets applications install a fully configured OpenTelemetry SDK with minimal code while still allowing programmatic customization of traces, metrics, logs, and resources.",
+    "tested-versions" : [
+      "1.25.0-alpha"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.sdk.autoconfigure"
+    ]
+  }
+]

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T04:26:39.216214Z",
+    "library": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha",
+    "starting_commit": "53b661924a0d58c0f40b09ab9f59b13d6be50a57",
+    "ending_commit": "8101bdcecd0ff8f97bd85e57da9878471b5bcfb1",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.25.0-alpha",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1170,
+          "missed": 945,
+          "ratio": 0.553191,
+          "total": 2115
+        },
+        "line": {
+          "covered": 304,
+          "missed": 235,
+          "ratio": 0.564007,
+          "total": 539
+        },
+        "method": {
+          "covered": 64,
+          "missed": 27,
+          "ratio": 0.703297,
+          "total": 91
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 188523,
+      "cached_input_tokens_used": 3271680,
+      "output_tokens_used": 26763,
+      "iterations": 3,
+      "cost_usd": 2.4387,
+      "generated_loc": 449,
+      "tested_library_loc": 304,
+      "metadata_entries": 14,
+      "code_coverage_percent": 56.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.25.0-alpha",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1170,
+        "missed" : 945,
+        "ratio" : 0.553191,
+        "total" : 2115
+      },
+      "line" : {
+        "covered" : 304,
+        "missed" : 235,
+        "ratio" : 0.564007,
+        "total" : 539
+      },
+      "method" : {
+        "covered" : 64,
+        "missed" : 27,
+        "ratio" : 0.703297,
+        "total" : 91
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha
+library.version = 1.25.0-alpha
+metadata.dir = io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.opentelemetry-sdk-extension-autoconfigure_tests'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -18,7 +18,9 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -51,6 +53,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     private static final AttributeKey<String> SERVICE_VERSION = AttributeKey.stringKey("service.version");
     private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT = AttributeKey.stringKey("deployment.environment");
     private static final AttributeKey<String> CUSTOM_RESOURCE = AttributeKey.stringKey("custom.resource");
+    private static final ContextKey<String> TENANT_ID = ContextKey.named("tenant-id");
     private static final TextMapSetter<Map<String, String>> MAP_SETTER = Map::put;
     private static final TextMapGetter<Map<String, String>> MAP_GETTER = new MapGetter();
 
@@ -132,6 +135,44 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
             assertThat(Span.fromContext(extracted).getSpanContext().getTraceId())
                     .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
             assertThat(Baggage.fromContext(extracted).getEntryValue("tenant")).isEqualTo("green");
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
+    void propagatorCustomizerCanReplaceConfiguredPropagator() {
+        Map<String, String> properties = Map.of(
+                "otel.sdk.disabled", "false",
+                "otel.traces.exporter", "none",
+                "otel.metrics.exporter", "none",
+                "otel.logs.exporter", "none",
+                "otel.propagators", "tracecontext",
+                "custom.propagation.header", "x-test-tenant");
+        AutoConfiguredOpenTelemetrySdk configured = AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(() -> properties)
+                .addPropertiesCustomizer(config -> properties)
+                .addPropagatorCustomizer((propagator, config) -> {
+                    assertThat(propagator.fields()).contains("traceparent");
+                    String headerName = config.getString("custom.propagation.header");
+                    assertThat(headerName).isEqualTo("x-test-tenant");
+                    return new TenantPropagator(headerName);
+                })
+                .build();
+
+        try {
+            TextMapPropagator propagator = configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator();
+            assertThat(propagator.fields()).containsExactly("x-test-tenant");
+
+            Map<String, String> carrier = new HashMap<>();
+            propagator.inject(Context.root().with(TENANT_ID, "blue-team"), carrier, MAP_SETTER);
+            assertThat(carrier).containsEntry("x-test-tenant", "blue-team");
+
+            carrier.put("x-test-tenant", "red-team");
+            Context extracted = propagator.extract(Context.root(), carrier, MAP_GETTER);
+            assertThat(extracted.get(TENANT_ID)).isEqualTo("red-team");
         } finally {
             configured.getOpenTelemetrySdk().close();
         }
@@ -291,6 +332,33 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                 .addPropertiesSupplier(() -> properties)
                 .addPropertiesCustomizer(config -> properties)
                 .build();
+    }
+
+    private static final class TenantPropagator implements TextMapPropagator {
+        private final String headerName;
+
+        private TenantPropagator(String headerName) {
+            this.headerName = headerName;
+        }
+
+        @Override
+        public Collection<String> fields() {
+            return List.of(headerName);
+        }
+
+        @Override
+        public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+            String tenantId = context.get(TENANT_ID);
+            if (tenantId != null) {
+                setter.set(carrier, headerName, tenantId);
+            }
+        }
+
+        @Override
+        public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+            String tenantId = getter.get(carrier, headerName);
+            return tenantId == null ? context : context.with(TENANT_ID, tenantId);
+        }
     }
 
     private static final class RecordingSpanExporter implements SpanExporter {

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+class Opentelemetry_sdk_extension_autoconfigureTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -248,6 +248,53 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     }
 
     @Test
+    void configuredSpanLimitsAreAppliedToExportedSpanData() {
+        RecordingSpanExporter spanExporter = new RecordingSpanExporter();
+        Map<String, String> properties = Map.of(
+                "otel.sdk.disabled", "false",
+                "otel.traces.exporter", "none",
+                "otel.metrics.exporter", "none",
+                "otel.logs.exporter", "none",
+                "otel.propagators", "tracecontext",
+                "otel.traces.sampler", "always_on",
+                "otel.span.attribute.count.limit", "2",
+                "otel.span.event.count.limit", "1");
+        AutoConfiguredOpenTelemetrySdk configured = AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(() -> properties)
+                .addPropertiesCustomizer(config -> properties)
+                .addTracerProviderCustomizer((builder, config) ->
+                        builder.addSpanProcessor(SimpleSpanProcessor.create(spanExporter)))
+                .build();
+
+        try {
+            Span span = configured.getOpenTelemetrySdk().getTracer("span-limits-test")
+                    .spanBuilder("limited-span")
+                    .startSpan();
+            span.setAttribute("first.attribute", "first");
+            span.setAttribute("second.attribute", "second");
+            span.setAttribute("third.attribute", "third");
+            span.addEvent("first-event");
+            span.addEvent("second-event");
+            span.end();
+
+            assertThat(configured.getOpenTelemetrySdk().getSdkTracerProvider().forceFlush()
+                    .join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+
+            assertThat(spanExporter.getExportedSpans()).hasSize(1);
+            SpanData exportedSpan = spanExporter.getExportedSpans().get(0);
+            assertThat(exportedSpan.getName()).isEqualTo("limited-span");
+            assertThat(exportedSpan.getAttributes().size()).isEqualTo(2);
+            assertThat(exportedSpan.getTotalAttributeCount()).isEqualTo(3);
+            assertThat(exportedSpan.getEvents()).hasSize(1);
+            assertThat(exportedSpan.getTotalRecordedEvents()).isEqualTo(2);
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
     void disabledSdkDoesNotConfigureExportersButStillExposesResourceAndConfig() {
         Map<String, String> properties = Map.of(
                 "otel.sdk.disabled", "true",

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -6,11 +6,384 @@
  */
 package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class Opentelemetry_sdk_extension_autoconfigureTest {
+public class Opentelemetry_sdk_extension_autoconfigureTest {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> SERVICE_VERSION = AttributeKey.stringKey("service.version");
+    private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT = AttributeKey.stringKey("deployment.environment");
+    private static final AttributeKey<String> CUSTOM_RESOURCE = AttributeKey.stringKey("custom.resource");
+    private static final TextMapSetter<Map<String, String>> MAP_SETTER = Map::put;
+    private static final TextMapGetter<Map<String, String>> MAP_GETTER = new MapGetter();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void buildsSdkFromSuppliersCustomizersAndTypedConfigProperties() {
+        AutoConfiguredOpenTelemetrySdk configured = AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(Opentelemetry_sdk_extension_autoconfigureTest::comprehensiveProperties)
+                .addPropertiesCustomizer(config -> {
+                    Map<String, String> overrides = comprehensiveProperties();
+                    overrides.put("custom.previous.service", "autoconfigured-service");
+                    overrides.put("custom.list", "alpha,beta,gamma");
+                    return overrides;
+                })
+                .addResourceCustomizer((resource, config) -> resource.merge(Resource.create(Attributes.of(
+                        CUSTOM_RESOURCE, config.getString("custom.previous.service")))))
+                .addSamplerCustomizer((sampler, config) -> {
+                    assertThat(sampler.getDescription()).contains("TraceIdRatioBased", "0.250000");
+                    return Sampler.alwaysOn();
+                })
+                .build();
+
+        try {
+            Resource resource = configured.getResource();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("autoconfigured-service");
+            assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isEqualTo("native test");
+            assertThat(resource.getAttribute(SERVICE_VERSION)).isNull();
+            assertThat(resource.getAttribute(CUSTOM_RESOURCE)).isEqualTo("autoconfigured-service");
+
+            ConfigProperties config = configured.getConfig();
+            assertThat(config.getBoolean("custom.enabled")).isTrue();
+            assertThat(config.getBoolean("missing.boolean", true)).isTrue();
+            assertThat(config.getInt("custom.retries")).isEqualTo(7);
+            assertThat(config.getInt("missing.int", 9)).isEqualTo(9);
+            assertThat(config.getLong("custom.timeout.nanos")).isEqualTo(123456789L);
+            assertThat(config.getLong("missing.long", 11L)).isEqualTo(11L);
+            assertThat(config.getDouble("custom.ratio")).isEqualTo(0.75d);
+            assertThat(config.getDouble("missing.double", 0.5d)).isEqualTo(0.5d);
+            assertThat(config.getDuration("otel.bsp.schedule.delay")).isEqualTo(Duration.ofSeconds(2));
+            assertThat(config.getDuration("missing.duration", Duration.ofMillis(3)))
+                    .isEqualTo(Duration.ofMillis(3));
+            assertThat(config.getList("custom.list")).containsExactly("alpha", "beta", "gamma");
+            assertThat(config.getList("missing.list", List.of("fallback"))).containsExactly("fallback");
+            assertThat(config.getMap("custom.map")).containsEntry("first", "one").containsEntry("second", "two");
+            assertThat(config.getMap("missing.map", Map.of("fallback", "value")))
+                    .containsEntry("fallback", "value");
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
+    void defaultW3cPropagatorsInjectAndExtractTraceContextAndBaggage() {
+        AutoConfiguredOpenTelemetrySdk configured =
+                buildWithExportersDisabled(Map.of("otel.propagators", "tracecontext,baggage"));
+        try {
+            SpanContext spanContext = SpanContext.create(
+                    "4bf92f3577b34da6a3ce929d0e0e4736",
+                    "00f067aa0ba902b7",
+                    TraceFlags.getSampled(),
+                    TraceState.getDefault());
+            Context context = Baggage.builder()
+                    .put("tenant", "green")
+                    .put("region", "emea")
+                    .build()
+                    .storeInContext(Span.wrap(spanContext).storeInContext(Context.root()));
+            Map<String, String> carrier = new HashMap<>();
+
+            configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .inject(context, carrier, MAP_SETTER);
+
+            assertThat(carrier).containsEntry(
+                    "traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+            assertThat(carrier.get("baggage")).contains("tenant=green", "region=emea");
+
+            Context extracted = configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .extract(Context.root(), carrier, MAP_GETTER);
+            assertThat(Span.fromContext(extracted).getSpanContext().getTraceId())
+                    .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+            assertThat(Baggage.fromContext(extracted).getEntryValue("tenant")).isEqualTo("green");
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
+    void providerCustomizersCanAddProcessorsReadersAndExportTelemetry() {
+        RecordingSpanExporter spanExporter = new RecordingSpanExporter();
+        RecordingLogRecordExporter logExporter = new RecordingLogRecordExporter();
+        RecordingMetricReader metricReader = new RecordingMetricReader();
+
+        Map<String, String> properties = Map.of(
+                "otel.sdk.disabled", "false",
+                "otel.traces.exporter", "none",
+                "otel.metrics.exporter", "none",
+                "otel.logs.exporter", "none",
+                "otel.propagators", "tracecontext,baggage",
+                "otel.traces.sampler", "parentbased_always_on",
+                "otel.service.name", "customized-service");
+        AutoConfiguredOpenTelemetrySdk configured = AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(() -> properties)
+                .addPropertiesCustomizer(config -> properties)
+                .addTracerProviderCustomizer((builder, config) ->
+                        builder.addSpanProcessor(SimpleSpanProcessor.create(spanExporter)))
+                .addLoggerProviderCustomizer((builder, config) ->
+                        builder.addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter)))
+                .addMeterProviderCustomizer((builder, config) -> builder.registerMetricReader(metricReader))
+                .build();
+
+        try {
+            Span span = configured.getOpenTelemetrySdk().getTracer("autoconfigure-test")
+                    .spanBuilder("customized-span")
+                    .setAttribute("component", "tracer-provider-customizer")
+                    .startSpan();
+            span.end();
+
+            configured.getOpenTelemetrySdk().getSdkLoggerProvider().get("autoconfigure-test")
+                    .logRecordBuilder()
+                    .setSeverity(Severity.INFO)
+                    .setBody("customized-log")
+                    .setAttribute(AttributeKey.stringKey("component"), "logger-provider-customizer")
+                    .emit();
+
+            assertThat(configured.getOpenTelemetrySdk().getSdkMeterProvider().forceFlush()
+                    .join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+            assertThat(configured.getOpenTelemetrySdk().getSdkTracerProvider().forceFlush()
+                    .join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+            assertThat(configured.getOpenTelemetrySdk().getSdkLoggerProvider().forceFlush()
+                    .join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+
+            assertThat(spanExporter.getExportedSpans()).hasSize(1);
+            SpanData exportedSpan = spanExporter.getExportedSpans().get(0);
+            assertThat(exportedSpan.getName()).isEqualTo("customized-span");
+            assertThat(exportedSpan.getResource().getAttribute(SERVICE_NAME)).isEqualTo("customized-service");
+            assertThat(exportedSpan.getAttributes().get(AttributeKey.stringKey("component")))
+                    .isEqualTo("tracer-provider-customizer");
+
+            assertThat(logExporter.getExportedLogs()).hasSize(1);
+            LogRecordData exportedLog = logExporter.getExportedLogs().get(0);
+            assertThat(exportedLog.getSeverity()).isEqualTo(Severity.INFO);
+            assertThat(exportedLog.getBody().asString()).isEqualTo("customized-log");
+            assertThat(exportedLog.getResource().getAttribute(SERVICE_NAME)).isEqualTo("customized-service");
+            assertThat(exportedLog.getAttributes().get(AttributeKey.stringKey("component")))
+                    .isEqualTo("logger-provider-customizer");
+
+            assertThat(metricReader.getRegisterCount()).isEqualTo(1);
+            assertThat(metricReader.getForceFlushCount()).isEqualTo(1);
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
+    void disabledSdkDoesNotConfigureExportersButStillExposesResourceAndConfig() {
+        Map<String, String> properties = Map.of(
+                "otel.sdk.disabled", "true",
+                "otel.traces.exporter", "missing-exporter-is-ignored-when-sdk-disabled",
+                "otel.metrics.exporter", "missing-exporter-is-ignored-when-sdk-disabled",
+                "otel.logs.exporter", "missing-exporter-is-ignored-when-sdk-disabled",
+                "otel.service.name", "disabled-service");
+        AutoConfiguredOpenTelemetrySdk configured = AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(() -> properties)
+                .addPropertiesCustomizer(config -> properties)
+                .build();
+
+        try {
+            assertThat(configured.getConfig().getBoolean("otel.sdk.disabled")).isTrue();
+            assertThat(configured.getResource().getAttribute(SERVICE_NAME)).isEqualTo("disabled-service");
+            assertThat(configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator().fields())
+                    .isEmpty();
+        } finally {
+            configured.getOpenTelemetrySdk().close();
+        }
+    }
+
+    @Test
+    void invalidConfigurationValuesFailWithClearConfigurationExceptions() {
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.propagators", "none,baggage")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.propagators contains 'none' along with other propagators");
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.propagators", "unknown")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Unrecognized value for otel.propagators: unknown");
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.traces.sampler", "unknown")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Unrecognized value for otel.traces.sampler: unknown");
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.traces.exporter", "none,zipkin")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.traces.exporter contains none along with other exporters");
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.metrics.exporter", "none,otlp")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.metrics.exporter contains none along with other exporters");
+        assertThatThrownBy(() -> buildWithExportersDisabled(Map.of("otel.logs.exporter", "none,otlp")))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.logs.exporter contains none along with other exporters");
+    }
+
+    private static Map<String, String> comprehensiveProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put(
+                "otel.resource.attributes",
+                "service.version=1.25.0-alpha,deployment.environment=native%20test");
+        properties.put("otel.experimental.resource.disabled.keys", "service.version");
+        properties.put("otel.service.name", "autoconfigured-service");
+        properties.put("otel.propagators", "tracecontext,baggage");
+        properties.put("otel.traces.sampler", "traceidratio");
+        properties.put("otel.traces.sampler.arg", "0.25");
+        properties.put("otel.bsp.schedule.delay", "2s");
+        properties.put("custom.enabled", "true");
+        properties.put("custom.retries", "7");
+        properties.put("custom.timeout.nanos", "123456789");
+        properties.put("custom.ratio", "0.75");
+        properties.put("custom.map", "first=one,second=two");
+        return properties;
+    }
+
+    private static AutoConfiguredOpenTelemetrySdk buildWithExportersDisabled(Map<String, String> overrides) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.propagators", "tracecontext,baggage");
+        properties.put("otel.traces.sampler", "parentbased_always_on");
+        properties.putAll(overrides);
+        return AutoConfiguredOpenTelemetrySdk.builder()
+                .registerShutdownHook(false)
+                .setResultAsGlobal(false)
+                .addPropertiesSupplier(() -> properties)
+                .addPropertiesCustomizer(config -> properties)
+                .build();
+    }
+
+    private static final class RecordingSpanExporter implements SpanExporter {
+        private final List<SpanData> exportedSpans = new ArrayList<>();
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            exportedSpans.addAll(spans);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        private List<SpanData> getExportedSpans() {
+            return exportedSpans;
+        }
+    }
+
+    private static final class RecordingLogRecordExporter implements LogRecordExporter {
+        private final List<LogRecordData> exportedLogs = new ArrayList<>();
+
+        @Override
+        public CompletableResultCode export(Collection<LogRecordData> logs) {
+            exportedLogs.addAll(logs);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        private List<LogRecordData> getExportedLogs() {
+            return exportedLogs;
+        }
+    }
+
+    private static final class RecordingMetricReader implements MetricReader {
+        private final AtomicInteger registerCount = new AtomicInteger();
+        private final AtomicInteger forceFlushCount = new AtomicInteger();
+
+        @Override
+        public void register(CollectionRegistration registration) {
+            registerCount.incrementAndGet();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public CompletableResultCode forceFlush() {
+            forceFlushCount.incrementAndGet();
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        private int getRegisterCount() {
+            return registerCount.get();
+        }
+
+        private int getForceFlushCount() {
+            return forceFlushCount.get();
+        }
+    }
+
+    private static final class MapGetter implements TextMapGetter<Map<String, String>> {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+        }
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.opentelemetry.sdk.autoconfigure.**"
+      "includeClasses" : "io.opentelemetry.sdk.autoconfigure.**"
     }
   ]
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.sdk.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3885

This PR introduces tests and metadata for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 188523
- Cached input tokens: 3271680
- Output tokens: 26763
- Metadata entries: 14
- Iterations: 3
- Library coverage percentage: 56.4
- Generated lines of code: 449
- Tested library lines of code: 304

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1170/2115 (55.32%)
- Line: 304/539 (56.40%)
- Method: 64/91 (70.33%)
