### PR TITLE
[GenAI] Add support for io.netty:netty-codec-dns:4.1.74.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-codec-dns/4.1.74.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-dns/4.1.74.Final/reachability-metadata.json
@@ -1,0 +1,190 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.DefaultDnsRawRecord"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-dns/index.json
+++ b/metadata/io.netty/netty-codec-dns/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-javadoc.jar",
+    "description" : "Netty Codec DNS provides DNS protocol message types, encoders, and decoders for Netty's asynchronous networking framework. It supports building and parsing DNS queries and responses for resolver and DNS-related network components.",
+    "tested-versions" : [
+      "4.1.74.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec.dns"
+    ]
+  }
+]

--- a/stats/io.netty/netty-codec-dns/4.1.74.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec-dns/4.1.74.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T04:48:37.364108Z",
+    "library": "io.netty:netty-codec-dns:4.1.74.Final",
+    "starting_commit": "541c4a1345e805b31da33fa79adfe674aae29996",
+    "ending_commit": "4e05193d86df3ed5ec582872866ea0fa634eda6d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2942,
+          "missed": 2011,
+          "ratio": 0.593983,
+          "total": 4953
+        },
+        "line": {
+          "covered": 647,
+          "missed": 504,
+          "ratio": 0.56212,
+          "total": 1151
+        },
+        "method": {
+          "covered": 194,
+          "missed": 98,
+          "ratio": 0.664384,
+          "total": 292
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 195002,
+      "cached_input_tokens_used": 1351168,
+      "output_tokens_used": 22892,
+      "iterations": 5,
+      "cost_usd": 1.3624,
+      "generated_loc": 328,
+      "tested_library_loc": 647,
+      "metadata_entries": 37,
+      "code_coverage_percent": 56.21
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java",
+      "metadata_file": "metadata/io.netty/netty-codec-dns/4.1.74.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-codec-dns/4.1.74.Final/stats.json
+++ b/stats/io.netty/netty-codec-dns/4.1.74.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.74.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2942,
+        "missed" : 2011,
+        "ratio" : 0.593983,
+        "total" : 4953
+      },
+      "line" : {
+        "covered" : 647,
+        "missed" : 504,
+        "ratio" : 0.56212,
+        "total" : 1151
+      },
+      "method" : {
+        "covered" : 194,
+        "missed" : 98,
+        "ratio" : 0.664384,
+        "total" : 292
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/.gitignore
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-codec-dns:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/gradle.properties
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-codec-dns:4.1.74.Final
+library.version = 4.1.74.Final
+metadata.dir = io.netty/netty-codec-dns/4.1.74.Final/

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/settings.gradle
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-codec-dns_tests'

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
@@ -17,6 +17,9 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.codec.dns.DatagramDnsQuery;
 import io.netty.handler.codec.dns.DatagramDnsQueryDecoder;
 import io.netty.handler.codec.dns.DatagramDnsQueryEncoder;
+import io.netty.handler.codec.dns.DatagramDnsResponse;
+import io.netty.handler.codec.dns.DatagramDnsResponseDecoder;
+import io.netty.handler.codec.dns.DatagramDnsResponseEncoder;
 import io.netty.handler.codec.dns.DefaultDnsOptEcsRecord;
 import io.netty.handler.codec.dns.DefaultDnsPtrRecord;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
@@ -227,6 +230,47 @@ public class Netty_codec_dnsTest {
             assertQuestion(decoded.recordAt(DnsSection.QUESTION),
                     "service.example.com.", DnsRecordType.SRV, DnsRecord.CLASS_IN);
             assertThat(decoded.<DnsRecord>recordAt(DnsSection.ADDITIONAL).type()).isSameAs(DnsRecordType.OPT);
+        } finally {
+            if (decoded != null) {
+                decoded.release();
+            }
+            encoder.finishAndReleaseAll();
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void datagramResponseEncoderAndDecoderRoundTripEnvelopeResponseCodeAndTruncatedFlag() {
+        DatagramDnsResponse response = new DatagramDnsResponse(
+                SERVER, CLIENT, 0xD00D, DnsOpCode.QUERY, DnsResponseCode.NXDOMAIN)
+                .setAuthoritativeAnswer(true)
+                .setTruncated(true)
+                .addRecord(DnsSection.QUESTION, new DefaultDnsQuestion("missing.example.com.", DnsRecordType.A));
+        EmbeddedChannel encoder = new EmbeddedChannel(new DatagramDnsResponseEncoder());
+        EmbeddedChannel decoder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
+        DatagramDnsResponse decoded = null;
+
+        try {
+            assertThat(encoder.writeOutbound(response)).isTrue();
+            DatagramPacket packet = encoder.readOutbound();
+
+            assertThat(packet.sender()).isNull();
+            assertThat(packet.recipient()).isEqualTo(CLIENT);
+            assertThat(packet.content().readableBytes()).isGreaterThan(12);
+
+            assertThat(decoder.writeInbound(packet)).isTrue();
+            decoded = decoder.readInbound();
+
+            assertThat(decoded.sender()).isNull();
+            assertThat(decoded.recipient()).isEqualTo(CLIENT);
+            assertThat(decoded.id()).isEqualTo(0xD00D);
+            assertThat(decoded.code()).isSameAs(DnsResponseCode.NXDOMAIN);
+            assertThat(decoded.isAuthoritativeAnswer()).isTrue();
+            assertThat(decoded.isTruncated()).isTrue();
+            assertThat(decoded.count(DnsSection.QUESTION)).isOne();
+            assertThat(decoded.count(DnsSection.ANSWER)).isZero();
+            assertQuestion(decoded.recordAt(DnsSection.QUESTION),
+                    "missing.example.com.", DnsRecordType.A, DnsRecord.CLASS_IN);
         } finally {
             if (decoded != null) {
                 decoded.release();

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_codec_dns;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_codec_dnsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.dns.DefaultDnsOptEcsRecord;
 import io.netty.handler.codec.dns.DefaultDnsPtrRecord;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsRawRecord;
+import io.netty.handler.codec.dns.DefaultDnsRecordDecoder;
 import io.netty.handler.codec.dns.DefaultDnsResponse;
 import io.netty.handler.codec.dns.DnsOpCode;
 import io.netty.handler.codec.dns.DnsOptEcsRecord;
@@ -152,6 +153,46 @@ public class Netty_codec_dnsTest {
             }
             rawRecordBuffer.release();
             ptrRecordBuffer.release();
+        }
+    }
+
+    @Test
+    void recordDecoderExpandsCompressedRecordNamesAndCanonicalNameData() throws Exception {
+        ByteBuf packet = Unpooled.buffer();
+        DnsRawRecord decodedCnameRecord = null;
+
+        try {
+            int canonicalNameOffset = packet.writerIndex();
+            writeName(packet, "canonical.example.com.");
+            int sharedSuffixOffset = canonicalNameOffset + 1 + "canonical".length();
+            packet.writeShort(DnsRecordType.A.intValue());
+            packet.writeShort(DnsRecord.CLASS_IN);
+
+            packet.writeByte("alias".length());
+            packet.writeCharSequence("alias", StandardCharsets.US_ASCII);
+            packet.writeShort(0xC000 | sharedSuffixOffset);
+            packet.writeShort(DnsRecordType.CNAME.intValue());
+            packet.writeShort(DnsRecord.CLASS_IN);
+            packet.writeInt(180);
+            packet.writeShort(Short.BYTES);
+            packet.writeShort(0xC000 | canonicalNameOffset);
+
+            DnsRecordDecoder.DEFAULT.decodeQuestion(packet);
+            decodedCnameRecord = DnsRecordDecoder.DEFAULT.decodeRecord(packet);
+
+            assertThat(decodedCnameRecord.name()).isEqualTo("alias.example.com.");
+            assertThat(decodedCnameRecord.type()).isSameAs(DnsRecordType.CNAME);
+            assertThat(decodedCnameRecord.dnsClass()).isEqualTo(DnsRecord.CLASS_IN);
+            assertThat(decodedCnameRecord.timeToLive()).isEqualTo(180);
+
+            ByteBuf canonicalNameContent = decodedCnameRecord.content().duplicate();
+            assertThat(DefaultDnsRecordDecoder.decodeName(canonicalNameContent)).isEqualTo("canonical.example.com.");
+            assertThat(canonicalNameContent.isReadable()).isFalse();
+        } finally {
+            if (decodedCnameRecord != null) {
+                decodedCnameRecord.release();
+            }
+            packet.release();
         }
     }
 

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/src/test/java/io_netty/netty_codec_dns/Netty_codec_dnsTest.java
@@ -6,11 +6,284 @@
  */
 package io_netty.netty_codec_dns;
 
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.handler.codec.dns.DatagramDnsQuery;
+import io.netty.handler.codec.dns.DatagramDnsQueryDecoder;
+import io.netty.handler.codec.dns.DatagramDnsQueryEncoder;
+import io.netty.handler.codec.dns.DefaultDnsOptEcsRecord;
+import io.netty.handler.codec.dns.DefaultDnsPtrRecord;
+import io.netty.handler.codec.dns.DefaultDnsQuestion;
+import io.netty.handler.codec.dns.DefaultDnsRawRecord;
+import io.netty.handler.codec.dns.DefaultDnsResponse;
+import io.netty.handler.codec.dns.DnsOpCode;
+import io.netty.handler.codec.dns.DnsOptEcsRecord;
+import io.netty.handler.codec.dns.DnsPtrRecord;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsRawRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordDecoder;
+import io.netty.handler.codec.dns.DnsRecordEncoder;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.handler.codec.dns.DnsSection;
+import io.netty.handler.codec.dns.TcpDnsResponseDecoder;
+import io.netty.handler.codec.dns.TcpDnsResponseEncoder;
 import org.junit.jupiter.api.Test;
 
-class Netty_codec_dnsTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Netty_codec_dnsTest {
+    private static final InetSocketAddress CLIENT = new InetSocketAddress("192.0.2.10", 53000);
+    private static final InetSocketAddress SERVER = new InetSocketAddress("198.51.100.53", 53);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void dnsMessagesManageSectionsFlagsAndReferenceCountedRecords() {
+        DnsQuestion question = new DefaultDnsQuestion("www.example.com.", DnsRecordType.AAAA);
+        DnsRawRecord answer = ipv4Record("www.example.com.", 60, 203, 0, 113, 7);
+        DnsPtrRecord authority = new DefaultDnsPtrRecord(
+                "7.113.0.203.in-addr.arpa.", DnsRecord.CLASS_IN, 120, "www.example.com.");
+        DnsOptEcsRecord additional = new DefaultDnsOptEcsRecord(
+                4096, 24, new byte[] {(byte) 203, 0, 113, 99});
+        DefaultDnsResponse response = new DefaultDnsResponse(0xCAFE, DnsOpCode.QUERY, DnsResponseCode.NOERROR);
+
+        try {
+            response.setAuthoritativeAnswer(true)
+                    .setRecursionDesired(true)
+                    .setRecursionAvailable(true)
+                    .setZ(3)
+                    .addRecord(DnsSection.QUESTION, question)
+                    .addRecord(DnsSection.ANSWER, answer)
+                    .addRecord(DnsSection.AUTHORITY, authority)
+                    .addRecord(DnsSection.ADDITIONAL, additional);
+
+            assertThat(response.id()).isEqualTo(0xCAFE);
+            assertThat(response.opCode()).isSameAs(DnsOpCode.QUERY);
+            assertThat(response.code()).isSameAs(DnsResponseCode.NOERROR);
+            assertThat(response.isAuthoritativeAnswer()).isTrue();
+            assertThat(response.isRecursionDesired()).isTrue();
+            assertThat(response.isRecursionAvailable()).isTrue();
+            assertThat(response.z()).isEqualTo(3);
+            assertThat(response.count()).isEqualTo(4);
+            assertThat(response.count(DnsSection.QUESTION)).isOne();
+            assertThat(response.<DnsQuestion>recordAt(DnsSection.QUESTION)).isSameAs(question);
+            assertThat(response.<DnsRawRecord>recordAt(DnsSection.ANSWER)).isSameAs(answer);
+            assertThat(response.<DnsPtrRecord>recordAt(DnsSection.AUTHORITY)).isSameAs(authority);
+            assertThat(response.<DnsOptEcsRecord>recordAt(DnsSection.ADDITIONAL)).isSameAs(additional);
+
+            DnsPtrRecord removed = response.removeRecord(DnsSection.AUTHORITY, 0);
+
+            assertThat(removed).isSameAs(authority);
+            assertThat(response.count(DnsSection.AUTHORITY)).isZero();
+            assertThat(response.count()).isEqualTo(3);
+        } finally {
+            response.release();
+        }
+
+        assertThat(answer.refCnt()).isZero();
+    }
+
+    @Test
+    void registryTypesCodesAndOpcodesResolveKnownAndUnknownValues() {
+        DnsRecordType privateType = DnsRecordType.valueOf(65280);
+        DnsResponseCode privateCode = DnsResponseCode.valueOf(3841);
+        DnsOpCode privateOpCode = DnsOpCode.valueOf(15);
+
+        assertThat(DnsRecordType.valueOf("A")).isSameAs(DnsRecordType.A);
+        assertThat(DnsRecordType.valueOf(DnsRecordType.A.intValue())).isSameAs(DnsRecordType.A);
+        assertThat(privateType.intValue()).isEqualTo(65280);
+        assertThat(privateType).isEqualTo(new DnsRecordType(65280, "PRIVATE"));
+        assertThat(privateType).isGreaterThan(DnsRecordType.A);
+
+        assertThat(DnsResponseCode.valueOf(DnsResponseCode.NXDOMAIN.intValue())).isSameAs(DnsResponseCode.NXDOMAIN);
+        assertThat(privateCode.intValue()).isEqualTo(3841);
+        assertThat(privateCode).isEqualTo(new DnsResponseCode(3841, "PRIVATE"));
+        assertThat(privateCode).isGreaterThan(DnsResponseCode.NOERROR);
+
+        assertThat(DnsOpCode.valueOf(DnsOpCode.UPDATE.byteValue())).isSameAs(DnsOpCode.UPDATE);
+        assertThat(privateOpCode.byteValue()).isEqualTo((byte) 15);
+        assertThat(privateOpCode).isEqualTo(new DnsOpCode(15, "PRIVATE"));
+        assertThat(privateOpCode).isGreaterThan(DnsOpCode.QUERY);
+    }
+
+    @Test
+    void recordEncoderAndDecoderRoundTripQuestionsRawRecordsAndDecodePtrRecords() throws Exception {
+        DnsQuestion question = new DefaultDnsQuestion("api.example.com.", DnsRecordType.AAAA);
+        ByteBuf questionBuffer = Unpooled.buffer();
+        DnsRawRecord rawRecord = ipv4Record("api.example.com.", 300, 192, 0, 2, 44);
+        DnsRawRecord decodedRawRecord = null;
+        ByteBuf rawRecordBuffer = Unpooled.buffer();
+        ByteBuf ptrRecordBuffer = Unpooled.buffer();
+
+        try {
+            DnsRecordEncoder.DEFAULT.encodeQuestion(question, questionBuffer);
+            DnsQuestion decodedQuestion = DnsRecordDecoder.DEFAULT.decodeQuestion(questionBuffer);
+
+            assertQuestion(decodedQuestion, "api.example.com.", DnsRecordType.AAAA, DnsRecord.CLASS_IN);
+
+            DnsRecordEncoder.DEFAULT.encodeRecord(rawRecord, rawRecordBuffer);
+            decodedRawRecord = DnsRecordDecoder.DEFAULT.decodeRecord(rawRecordBuffer);
+
+            assertThat(decodedRawRecord.name()).isEqualTo("api.example.com.");
+            assertThat(decodedRawRecord.type()).isSameAs(DnsRecordType.A);
+            assertThat(decodedRawRecord.dnsClass()).isEqualTo(DnsRecord.CLASS_IN);
+            assertThat(decodedRawRecord.timeToLive()).isEqualTo(300);
+            assertThat(readBytes(decodedRawRecord)).containsExactly((byte) 192, (byte) 0, (byte) 2, (byte) 44);
+
+            writePtrRecord(ptrRecordBuffer, "44.2.0.192.in-addr.arpa.", 600, "api.example.com.");
+            DnsPtrRecord decodedPtrRecord = DnsRecordDecoder.DEFAULT.decodeRecord(ptrRecordBuffer);
+
+            assertThat(decodedPtrRecord.name()).isEqualTo("44.2.0.192.in-addr.arpa.");
+            assertThat(decodedPtrRecord.type()).isSameAs(DnsRecordType.PTR);
+            assertThat(decodedPtrRecord.timeToLive()).isEqualTo(600);
+            assertThat(decodedPtrRecord.hostname()).isEqualTo("api.example.com.");
+        } finally {
+            questionBuffer.release();
+            rawRecord.release();
+            if (decodedRawRecord != null) {
+                decodedRawRecord.release();
+            }
+            rawRecordBuffer.release();
+            ptrRecordBuffer.release();
+        }
+    }
+
+    @Test
+    void datagramQueryEncoderAndDecoderRoundTripEnvelopeHeaderAndSections() {
+        DatagramDnsQuery query = new DatagramDnsQuery(CLIENT, SERVER, 0xBEEF)
+                .setRecursionDesired(true)
+                .addRecord(DnsSection.QUESTION, new DefaultDnsQuestion("service.example.com.", DnsRecordType.SRV))
+                .addRecord(DnsSection.ADDITIONAL, new DefaultDnsOptEcsRecord(
+                        1232, InternetProtocolFamily.IPv4));
+        EmbeddedChannel encoder = new EmbeddedChannel(new DatagramDnsQueryEncoder());
+        EmbeddedChannel decoder = new EmbeddedChannel(new DatagramDnsQueryDecoder());
+        DatagramDnsQuery decoded = null;
+
+        try {
+            assertThat(encoder.writeOutbound(query)).isTrue();
+            DatagramPacket packet = encoder.readOutbound();
+
+            assertThat(packet.sender()).isNull();
+            assertThat(packet.recipient()).isEqualTo(SERVER);
+            assertThat(packet.content().readableBytes()).isGreaterThan(12);
+
+            assertThat(decoder.writeInbound(packet)).isTrue();
+            decoded = decoder.readInbound();
+
+            assertThat(decoded.sender()).isNull();
+            assertThat(decoded.recipient()).isEqualTo(SERVER);
+            assertThat(decoded.id()).isEqualTo(0xBEEF);
+            assertThat(decoded.isRecursionDesired()).isTrue();
+            assertThat(decoded.count(DnsSection.QUESTION)).isOne();
+            assertThat(decoded.count(DnsSection.ADDITIONAL)).isOne();
+            assertQuestion(decoded.recordAt(DnsSection.QUESTION),
+                    "service.example.com.", DnsRecordType.SRV, DnsRecord.CLASS_IN);
+            assertThat(decoded.<DnsRecord>recordAt(DnsSection.ADDITIONAL).type()).isSameAs(DnsRecordType.OPT);
+        } finally {
+            if (decoded != null) {
+                decoded.release();
+            }
+            encoder.finishAndReleaseAll();
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void tcpResponseEncoderAndDecoderRoundTripLengthPrefixFlagsAndAnswers() {
+        DnsResponse response = new DefaultDnsResponse(0x1234, DnsOpCode.QUERY, DnsResponseCode.NOERROR)
+                .setAuthoritativeAnswer(true)
+                .setRecursionDesired(true)
+                .setRecursionAvailable(true)
+                .addRecord(DnsSection.QUESTION, new DefaultDnsQuestion("edge.example.com.", DnsRecordType.A))
+                .addRecord(DnsSection.ANSWER, ipv4Record("edge.example.com.", 30, 198, 51, 100, 25))
+                .addRecord(DnsSection.AUTHORITY, ipv4Record("ns.example.com.", 60, 198, 51, 100, 53));
+        EmbeddedChannel encoder = new EmbeddedChannel(new TcpDnsResponseEncoder());
+        EmbeddedChannel decoder = new EmbeddedChannel(new TcpDnsResponseDecoder());
+        DnsResponse decoded = null;
+
+        try {
+            assertThat(encoder.writeOutbound(response)).isTrue();
+            ByteBuf frame = encoder.readOutbound();
+
+            assertThat(frame.getUnsignedShort(frame.readerIndex())).isEqualTo(frame.readableBytes() - Short.BYTES);
+            assertThat(decoder.writeInbound(frame)).isTrue();
+            decoded = decoder.readInbound();
+
+            assertThat(decoded.id()).isEqualTo(0x1234);
+            assertThat(decoded.code()).isSameAs(DnsResponseCode.NOERROR);
+            assertThat(decoded.isAuthoritativeAnswer()).isTrue();
+            assertThat(decoded.isRecursionDesired()).isTrue();
+            assertThat(decoded.isRecursionAvailable()).isTrue();
+            assertQuestion(decoded.recordAt(DnsSection.QUESTION),
+                    "edge.example.com.", DnsRecordType.A, DnsRecord.CLASS_IN);
+            DnsRawRecord decodedAnswer = decoded.recordAt(DnsSection.ANSWER);
+            assertThat(decodedAnswer.timeToLive()).isEqualTo(30);
+            assertThat(readBytes(decodedAnswer)).containsExactly((byte) 198, (byte) 51, (byte) 100, (byte) 25);
+            DnsRawRecord decodedAuthority = decoded.recordAt(DnsSection.AUTHORITY);
+            assertThat(decodedAuthority.name()).isEqualTo("ns.example.com.");
+            assertThat(decodedAuthority.timeToLive()).isEqualTo(60);
+            assertThat(readBytes(decodedAuthority)).containsExactly((byte) 198, (byte) 51, (byte) 100, (byte) 53);
+        } finally {
+            if (decoded != null) {
+                decoded.release();
+            }
+            encoder.finishAndReleaseAll();
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    private static void writePtrRecord(ByteBuf buffer, String name, long timeToLive, String hostname) {
+        ByteBuf targetNameBuffer = Unpooled.buffer();
+        try {
+            writeName(buffer, name);
+            buffer.writeShort(DnsRecordType.PTR.intValue());
+            buffer.writeShort(DnsRecord.CLASS_IN);
+            buffer.writeInt((int) timeToLive);
+            writeName(targetNameBuffer, hostname);
+            buffer.writeShort(targetNameBuffer.readableBytes());
+            buffer.writeBytes(targetNameBuffer, targetNameBuffer.readerIndex(), targetNameBuffer.readableBytes());
+        } finally {
+            targetNameBuffer.release();
+        }
+    }
+
+    private static void writeName(ByteBuf buffer, String name) {
+        String normalizedName = name.endsWith(".") ? name.substring(0, name.length() - 1) : name;
+        if (normalizedName.isEmpty()) {
+            buffer.writeByte(0);
+            return;
+        }
+        for (String label : normalizedName.split("\\.")) {
+            buffer.writeByte(label.length());
+            buffer.writeCharSequence(label, StandardCharsets.US_ASCII);
+        }
+        buffer.writeByte(0);
+    }
+
+    private static DnsRawRecord ipv4Record(String name, long timeToLive, int first, int second, int third, int fourth) {
+        byte[] address = new byte[] {(byte) first, (byte) second, (byte) third, (byte) fourth};
+        return new DefaultDnsRawRecord(
+                name, DnsRecordType.A, DnsRecord.CLASS_IN, timeToLive, Unpooled.wrappedBuffer(address));
+    }
+
+    private static byte[] readBytes(DnsRawRecord record) {
+        ByteBuf content = record.content().duplicate();
+        byte[] bytes = new byte[content.readableBytes()];
+        content.readBytes(bytes);
+        return bytes;
+    }
+
+    private static void assertQuestion(
+            DnsQuestion question, String expectedName, DnsRecordType expectedType, int expectedDnsClass) {
+        assertThat(question.name()).isEqualTo(expectedName);
+        assertThat(question.type()).isSameAs(expectedType);
+        assertThat(question.dnsClass()).isEqualTo(expectedDnsClass);
     }
 }

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.handler.codec.dns.**"
+      "includeClasses" : "io.netty.handler.codec.dns.**"
     }
   ]
 }

--- a/tests/src/io.netty/netty-codec-dns/4.1.74.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-dns/4.1.74.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.handler.codec.dns.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1440

This PR introduces tests and metadata for io.netty:netty-codec-dns:4.1.74.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 195002
- Cached input tokens: 1351168
- Output tokens: 22892
- Metadata entries: 37
- Iterations: 5
- Library coverage percentage: 56.21
- Generated lines of code: 328
- Tested library lines of code: 647

### Metadata Forge

- Forge monitored branch: `origin/vj/iterative-metadata-collection`
- Forge branch: `vj/iterative-metadata-collection`
- Forge commit hash: `cbcedad5c82709e70648e67cbf381ce7c1b89d89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2942/4953 (59.40%)
- Line: 647/1151 (56.21%)
- Method: 194/292 (66.44%)
