### PR TITLE
[GenAI] Add support for org.aspectj:aspectjrt:1.9.6 using gpt-5.5

### DIFF
--- a/metadata/org.aspectj/aspectjrt/1.9.6/reachability-metadata.json
+++ b/metadata/org.aspectj/aspectjrt/1.9.6/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.DeclareSoftImpl"
+      },
+      "type" : "java.io.IOException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "java.lang.IllegalArgumentException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "java.lang.IndexOutOfBoundsException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.StringToType"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.StringToType"
+      },
+      "type" : "java.util.List"
+    }
+  ]
+}

--- a/metadata/org.aspectj/aspectjrt/index.json
+++ b/metadata/org.aspectj/aspectjrt/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjrt/1.9.6/aspectjrt-1.9.6-sources.jar",
+    "repository-url" : "https://github.com/eclipse-aspectj/aspectj",
+    "test-code-url" : "https://github.com/eclipse-aspectj/aspectj/tree/V1_9_6/runtime/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjrt/1.9.6/aspectjrt-1.9.6-javadoc.jar",
+    "description" : "AspectJ runtime provides the core APIs and support classes required to run applications compiled or woven with AspectJ. It includes join point, signature, annotation, reflection, and exception types used by AspectJ-generated code at runtime.",
+    "tested-versions" : [
+      "1.9.6"
+    ],
+    "allowed-packages" : [
+      "org.aspectj"
+    ]
+  }
+]

--- a/stats/org.aspectj/aspectjrt/1.9.6/execution-metrics.json
+++ b/stats/org.aspectj/aspectjrt/1.9.6/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T05:33:10.268240Z",
+    "library": "org.aspectj:aspectjrt:1.9.6",
+    "starting_commit": "1c3f65a9fa123a292ab2ce2b40156b71f716e9c8",
+    "ending_commit": "8f172e9158c30cbe339848db0d95d1528c8d7688",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 72,
+            "totalCalls": 72
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 72,
+        "totalCalls": 72
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3760,
+          "missed": 6217,
+          "ratio": 0.376867,
+          "total": 9977
+        },
+        "line": {
+          "covered": 796,
+          "missed": 1271,
+          "ratio": 0.385099,
+          "total": 2067
+        },
+        "method": {
+          "covered": 157,
+          "missed": 349,
+          "ratio": 0.310277,
+          "total": 506
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 316310,
+      "cached_input_tokens_used": 4193280,
+      "output_tokens_used": 43075,
+      "iterations": 11,
+      "cost_usd": 3.3889,
+      "generated_loc": 610,
+      "tested_library_loc": 796,
+      "metadata_entries": 7,
+      "test_only_metadata_entries": 29,
+      "code_coverage_percent": 38.51
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/ConstructorSignatureImplTest.java",
+      "metadata_file": "metadata/org.aspectj/aspectjrt/1.9.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.aspectj/aspectjrt/1.9.6/stats.json
+++ b/stats/org.aspectj/aspectjrt/1.9.6/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.9.6",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 72,
+          "totalCalls" : 72
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 72,
+      "totalCalls" : 72
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3760,
+        "missed" : 6217,
+        "ratio" : 0.376867,
+        "total" : 9977
+      },
+      "line" : {
+        "covered" : 796,
+        "missed" : 1271,
+        "ratio" : 0.385099,
+        "total" : 2067
+      },
+      "method" : {
+        "covered" : 157,
+        "missed" : 349,
+        "ratio" : 0.310277,
+        "total" : 506
+      }
+    }
+  } ]
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/.gitignore
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/build.gradle
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.aspectj:aspectjrt:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/gradle.properties
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.aspectj:aspectjrt:1.9.6
+library.version = 1.9.6
+metadata.dir = org.aspectj/aspectjrt/1.9.6/

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/settings.gradle
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.aspectj.aspectjrt_tests'

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AdviceSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AdviceSignatureImplTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.AdviceSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class AdviceSignatureImplTest {
+    @Test
+    void resolvesDeclaredAdviceMethodOnDeclaringType() {
+        Factory factory = new Factory("AdviceSignatureImplTest.java", AdviceSignatureImplTest.class);
+        AdviceSignature signature = factory.makeAdviceSig(
+                Modifier.PUBLIC | Modifier.STATIC,
+                "beforeAdvice",
+                AdviceHost.class,
+                new Class[] {String.class},
+                new String[] {"value"},
+                new Class[0],
+                void.class);
+
+        Method method = signature.getAdvice();
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(AdviceHost.class);
+        assertThat(method.getName()).isEqualTo("beforeAdvice");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+        assertThat(method.getReturnType()).isEqualTo(void.class);
+    }
+
+    public static class AdviceHost {
+        public static void beforeAdvice(String value) {
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AjTypeImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AjTypeImplTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+import org.aspectj.internal.lang.annotation.ajcDeclareAnnotation;
+import org.aspectj.internal.lang.annotation.ajcDeclareEoW;
+import org.aspectj.internal.lang.annotation.ajcDeclareParents;
+import org.aspectj.internal.lang.annotation.ajcDeclarePrecedence;
+import org.aspectj.internal.lang.annotation.ajcDeclareSoft;
+import org.aspectj.internal.lang.annotation.ajcITD;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.DeclareError;
+import org.aspectj.lang.annotation.DeclareParents;
+import org.aspectj.lang.annotation.DeclarePrecedence;
+import org.aspectj.lang.annotation.DeclareWarning;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.Advice;
+import org.aspectj.lang.reflect.AdviceKind;
+import org.aspectj.lang.reflect.AjType;
+import org.aspectj.lang.reflect.AjTypeSystem;
+import org.aspectj.lang.reflect.DeclareAnnotation;
+import org.aspectj.lang.reflect.DeclareErrorOrWarning;
+import org.aspectj.lang.reflect.InterTypeConstructorDeclaration;
+import org.aspectj.lang.reflect.InterTypeFieldDeclaration;
+import org.aspectj.lang.reflect.InterTypeMethodDeclaration;
+import org.junit.jupiter.api.Test;
+
+public class AjTypeImplTest {
+    private static final String TARGET_TYPE_NAME = "org_aspectj.aspectjrt.AjTypeImplTest$TargetType";
+
+    @Test
+    void exposesJavaTypeMembersThroughAjType() throws Exception {
+        AjType<SampleType> type = AjTypeSystem.getAjType(SampleType.class);
+        AjType<String> stringType = AjTypeSystem.getAjType(String.class);
+
+        assertThat(javaClassNames(type.getAjTypes())).contains(SampleType.PublicNested.class.getName());
+        assertThat(javaClassNames(type.getDeclaredAjTypes()))
+                .contains(SampleType.PublicNested.class.getName(), SampleType.PackageNested.class.getName());
+
+        Constructor<?> constructor = type.getConstructor();
+        assertThat(constructor.getParameterCount()).isZero();
+        Constructor<?> declaredConstructor = type.getDeclaredConstructor(stringType);
+        assertThat(declaredConstructor.getParameterCount()).isEqualTo(1);
+        assertThat(type.getConstructors()).isNotEmpty();
+        assertThat(type.getDeclaredConstructors()).hasSizeGreaterThanOrEqualTo(2);
+
+        Field declaredField = type.getDeclaredField("privateField");
+        assertThat(declaredField.getName()).isEqualTo("privateField");
+        assertThat(type.getDeclaredFields()).extracting(Field::getName)
+                .contains("privateField", "publicField")
+                .doesNotContain("ajc$hiddenField");
+        Field publicField = type.getField("publicField");
+        assertThat(publicField.getName()).isEqualTo("publicField");
+        assertThat(type.getFields()).extracting(Field::getName).contains("publicField");
+
+        Method privateMethod = type.getDeclaredMethod("privateMethod");
+        assertThat(privateMethod.getName()).isEqualTo("privateMethod");
+        Method publicMethod = type.getMethod("publicMethod", stringType);
+        assertThat(publicMethod.getReturnType()).isEqualTo(String.class);
+        assertThat(type.getDeclaredMethods()).extracting(Method::getName)
+                .contains("privateMethod", "publicMethod")
+                .doesNotContain("ajc$hiddenMethod");
+        assertThat(type.getMethods()).extracting(Method::getName).contains("publicMethod");
+    }
+
+    @Test
+    void exposesAspectDeclarationsAndAnnotationStyleIntroductions() throws Exception {
+        AjType<AnnotationStyleAspect> aspectType = AjTypeSystem.getAjType(AnnotationStyleAspect.class);
+        AjType<TargetType> targetType = AjTypeSystem.getAjType(TargetType.class);
+        AjType<String> stringType = AjTypeSystem.getAjType(String.class);
+
+        assertThat(aspectType.isAspect()).isTrue();
+        assertThat(aspectType.getDeclaredPointcuts()).extracting(pointcut -> pointcut.getName()).contains("anyOperation");
+        assertThat(aspectType.getPointcuts()).extracting(pointcut -> pointcut.getName()).contains("anyOperation");
+
+        Advice[] declaredAdvice = aspectType.getDeclaredAdvice();
+        assertThat(declaredAdvice).extracting(Advice::getName).contains("beforeAnyOperation");
+        assertThat(aspectType.getAdvice(AdviceKind.BEFORE)).extracting(Advice::getName).contains("beforeAnyOperation");
+        assertThat(aspectType.getDeclaredAdvice("beforeAnyOperation").getKind()).isEqualTo(AdviceKind.BEFORE);
+        assertThat(aspectType.getAdvice("beforeAnyOperation").getKind()).isEqualTo(AdviceKind.BEFORE);
+
+        InterTypeMethodDeclaration[] declaredIntroducedMethods = aspectType.getDeclaredITDMethods();
+        assertThat(declaredIntroducedMethods).extracting(InterTypeMethodDeclaration::getName)
+                .contains("wovenMethod", "mixinMethod");
+        assertThat(aspectType.getITDMethods()).extracting(InterTypeMethodDeclaration::getName)
+                .contains("wovenMethod", "mixinMethod");
+        InterTypeMethodDeclaration introducedMethod = aspectType.getDeclaredITDMethod("wovenMethod", targetType, stringType);
+        assertThat(introducedMethod.getReturnType().getJavaClass()).isEqualTo(String.class);
+        assertThat(aspectType.getITDMethod("wovenMethod", targetType, stringType).getName()).isEqualTo("wovenMethod");
+
+        InterTypeConstructorDeclaration[] declaredConstructors = aspectType.getDeclaredITDConstructors();
+        assertThat(declaredConstructors).hasSize(1);
+        assertThat(aspectType.getITDConstructors()).hasSize(1);
+        assertThat(aspectType.getDeclaredITDConstructor(targetType, stringType).getParameterTypes()).hasSize(1);
+        assertThat(aspectType.getITDConstructor(targetType, stringType).getParameterTypes()).hasSize(1);
+
+        InterTypeFieldDeclaration[] declaredFields = aspectType.getDeclaredITDFields();
+        assertThat(declaredFields).extracting(InterTypeFieldDeclaration::getName).contains("wovenField");
+        assertThat(aspectType.getITDFields()).extracting(InterTypeFieldDeclaration::getName).contains("wovenField");
+        assertThat(aspectType.getDeclaredITDField("wovenField", targetType).getType().getJavaClass()).isEqualTo(int.class);
+        assertThat(aspectType.getITDField("wovenField", targetType).getType().getJavaClass()).isEqualTo(int.class);
+
+        DeclareErrorOrWarning[] declareErrorOrWarnings = aspectType.getDeclareErrorOrWarnings();
+        assertThat(declareErrorOrWarnings).extracting(DeclareErrorOrWarning::getMessage)
+                .contains("warning from field", "error from field", "warning from method");
+        assertThat(declareErrorOrWarnings).extracting(DeclareErrorOrWarning::isError).contains(true, false);
+
+        assertThat(aspectType.getDeclareParents()).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(aspectType.getDeclareSofts()).hasSize(1);
+        DeclareAnnotation[] declareAnnotations = aspectType.getDeclareAnnotations();
+        assertThat(declareAnnotations).hasSize(1);
+        assertThat(aspectType.getDeclarePrecedence()).hasSize(2);
+    }
+
+    private static String[] javaClassNames(AjType<?>[] types) {
+        return Arrays.stream(types)
+                .map(AjType::getJavaClass)
+                .map(Class::getName)
+                .toArray(String[]::new);
+    }
+
+    public static class SampleType {
+        public String publicField = "public";
+        public String ajc$hiddenField = "synthetic";
+        private String privateField = "private";
+
+        public SampleType() {
+        }
+
+        private SampleType(String value) {
+            privateField = value;
+        }
+
+        public String publicMethod(String value) {
+            return value + publicField;
+        }
+
+        private String privateMethod() {
+            return privateField;
+        }
+
+        public void ajc$hiddenMethod() {
+        }
+
+        public static class PublicNested {
+        }
+
+        static class PackageNested {
+        }
+    }
+
+    public interface MixinContract {
+        String mixinMethod(String value);
+    }
+
+    public static class MixinDefault implements MixinContract {
+        @Override
+        public String mixinMethod(String value) {
+            return value;
+        }
+    }
+
+    public static class TargetType {
+        private int wovenField;
+    }
+
+    @Aspect
+    @DeclarePrecedence("org_aspectj.aspectjrt..*, *")
+    public static class AnnotationStyleAspect {
+        @DeclareWarning("execution(* *(..))")
+        public static String warningMessage = "warning from field";
+
+        @DeclareError("execution(* *(..))")
+        public static String errorMessage = "error from field";
+
+        @DeclareParents(value = "org_aspectj.aspectjrt..*", defaultImpl = MixinDefault.class)
+        public MixinContract mixin;
+
+        @Pointcut("execution(* *(..))")
+        public void anyOperation() {
+        }
+
+        @Before("anyOperation()")
+        public void beforeAnyOperation() {
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = TARGET_TYPE_NAME, name = "wovenMethod")
+        public static String ajc$interMethod$org_aspectj_aspectjrt_TargetType$wovenMethod(TargetType target, String value) {
+            return value;
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = TARGET_TYPE_NAME, name = "wovenMethod")
+        public static String ajc$interMethodDispatch1$org_aspectj_aspectjrt_TargetType$wovenMethod(TargetType target, String value) {
+            return value;
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = TARGET_TYPE_NAME, name = "wovenField")
+        public static void ajc$interFieldInit$org_aspectj_aspectjrt_TargetType$wovenField(TargetType target) {
+            target.wovenField = 7;
+        }
+
+        public static int ajc$interFieldGetDispatch$org_aspectj_aspectjrt_TargetType$wovenField(TargetType target) {
+            return target.wovenField;
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = TARGET_TYPE_NAME, name = "new")
+        public static void ajc$postInterConstructor$org_aspectj_aspectjrt_TargetType(TargetType target, String value) {
+            target.wovenField = value.length();
+        }
+
+        @ajcDeclareEoW(message = "warning from method", pointcut = "execution(* *(..))", isError = false)
+        public static void declareWarningFromMethod() {
+        }
+
+        @ajcDeclareParents(targetTypePattern = "org_aspectj.aspectjrt..*", parentTypes = "java.io.Serializable", isExtends = false)
+        public static void declareSerializableParent() {
+        }
+
+        @ajcDeclareSoft(exceptionType = "java.io.IOException", pointcut = "execution(* *(..))")
+        public static void declareSoftIOException() throws IOException {
+        }
+
+        @Deprecated
+        @ajcDeclareAnnotation(kind = "at_method", pattern = "* *(..)", annotation = "@java.lang.Deprecated")
+        public static void declareDeprecatedAnnotation() {
+        }
+
+        @ajcDeclarePrecedence("org_aspectj.aspectjrt..*, *")
+        public static void declareAdditionalPrecedence() {
+        }
+    }
+
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectjrtTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectjrtTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import org.junit.jupiter.api.Test;
+
+class AspectjrtTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectjrtTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectjrtTest.java
@@ -6,11 +6,14 @@
  */
 package org_aspectj.aspectjrt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.JoinPoint;
 import org.junit.jupiter.api.Test;
 
-class AspectjrtTest {
+public class AspectjrtTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void exposesAspectjRuntimeApi() {
+        assertThat(JoinPoint.class.getName()).isEqualTo("org.aspectj.lang.JoinPoint");
     }
 }

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/Aspects14Test.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/Aspects14Test.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.Aspects14;
+import org.junit.jupiter.api.Test;
+
+public class Aspects14Test {
+    @Test
+    void resolvesAndInvokesAspectFactoriesForAllScopingStyles() {
+        Object perObject = new Object();
+
+        LegacyScopedAspect singletonAspect = (LegacyScopedAspect) Aspects14.aspectOf(LegacyScopedAspect.class);
+        LegacyScopedAspect objectAspect = (LegacyScopedAspect) Aspects14.aspectOf(LegacyScopedAspect.class, perObject);
+        LegacyScopedAspect typeAspect = (LegacyScopedAspect) Aspects14.aspectOf(LegacyScopedAspect.class, String.class);
+
+        assertThat(singletonAspect.scope()).isEqualTo("singleton");
+        assertThat(objectAspect.scope()).isEqualTo("object:" + perObject.getClass().getName());
+        assertThat(typeAspect.scope()).isEqualTo("type:" + String.class.getName());
+    }
+
+    @Test
+    void resolvesAndInvokesHasAspectChecksForAllScopingStyles() {
+        assertThat(Aspects14.hasAspect(LegacyScopedAspect.class)).isTrue();
+        assertThat(Aspects14.hasAspect(LegacyScopedAspect.class, new Object())).isTrue();
+        assertThat(Aspects14.hasAspect(LegacyScopedAspect.class, String.class)).isTrue();
+    }
+
+    public static class LegacyScopedAspect {
+        private final String scope;
+
+        private LegacyScopedAspect(String scope) {
+            this.scope = scope;
+        }
+
+        public static LegacyScopedAspect aspectOf() {
+            return new LegacyScopedAspect("singleton");
+        }
+
+        public static LegacyScopedAspect aspectOf(Object perObject) {
+            return new LegacyScopedAspect("object:" + perObject.getClass().getName());
+        }
+
+        public static LegacyScopedAspect aspectOf(Class perTypeWithin) {
+            return new LegacyScopedAspect("type:" + perTypeWithin.getName());
+        }
+
+        public static boolean hasAspect() {
+            return true;
+        }
+
+        public static boolean hasAspect(Object perObject) {
+            return perObject != null;
+        }
+
+        public static boolean hasAspect(Class perTypeWithin) {
+            return perTypeWithin != null;
+        }
+
+        String scope() {
+            return scope;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectsTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/AspectsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.Aspects;
+import org.junit.jupiter.api.Test;
+
+public class AspectsTest {
+    @Test
+    void resolvesAndInvokesAspectFactoriesForAllScopingStyles() {
+        Object perObject = new Object();
+
+        ScopedAspect singletonAspect = Aspects.aspectOf(ScopedAspect.class);
+        ScopedAspect objectAspect = Aspects.aspectOf(ScopedAspect.class, perObject);
+        ScopedAspect typeAspect = Aspects.aspectOf(ScopedAspect.class, String.class);
+
+        assertThat(singletonAspect.scope()).isEqualTo("singleton");
+        assertThat(objectAspect.scope()).isEqualTo("object:" + perObject.getClass().getName());
+        assertThat(typeAspect.scope()).isEqualTo("type:" + String.class.getName());
+    }
+
+    @Test
+    void resolvesAndInvokesHasAspectChecksForAllScopingStyles() {
+        assertThat(Aspects.hasAspect(ScopedAspect.class)).isTrue();
+        assertThat(Aspects.hasAspect(ScopedAspect.class, new Object())).isTrue();
+        assertThat(Aspects.hasAspect(ScopedAspect.class, String.class)).isTrue();
+    }
+
+    public static class ScopedAspect {
+        private final String scope;
+
+        private ScopedAspect(String scope) {
+            this.scope = scope;
+        }
+
+        public static ScopedAspect aspectOf() {
+            return new ScopedAspect("singleton");
+        }
+
+        public static ScopedAspect aspectOf(Object perObject) {
+            return new ScopedAspect("object:" + perObject.getClass().getName());
+        }
+
+        public static ScopedAspect aspectOf(Class<?> perTypeWithin) {
+            return new ScopedAspect("type:" + perTypeWithin.getName());
+        }
+
+        public static boolean hasAspect() {
+            return true;
+        }
+
+        public static boolean hasAspect(Object perObject) {
+            return perObject != null;
+        }
+
+        public static boolean hasAspect(Class<?> perTypeWithin) {
+            return perTypeWithin != null;
+        }
+
+        String scope() {
+            return scope;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/ConstructorSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/ConstructorSignatureImplTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.ConstructorSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class ConstructorSignatureImplTest {
+    @Test
+    void resolvesDeclaredConstructorOnDeclaringType() {
+        Factory factory = new Factory("ConstructorSignatureImplTest.java", ConstructorSignatureImplTest.class);
+        ConstructorSignature signature = factory.makeConstructorSig(
+                Modifier.PUBLIC,
+                ConstructedService.class,
+                new Class[] {String.class, int.class},
+                new String[] {"name", "priority"},
+                new Class[] {IllegalArgumentException.class});
+
+        Constructor constructor = signature.getConstructor();
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructedService.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class);
+        assertThat(constructor.getExceptionTypes()).containsExactly(IllegalArgumentException.class);
+    }
+
+    public static class ConstructedService {
+        public ConstructedService(String name, int priority) throws IllegalArgumentException {
+            if (name == null || priority < 0) {
+                throw new IllegalArgumentException("name must be set and priority must be non-negative");
+            }
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/FactoryTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/FactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.reflect.MethodSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class FactoryTest {
+    @Test
+    void resolvesSignatureTypesWithBootstrapClassLoader() {
+        Factory factory = new Factory("String.java", String.class);
+
+        MethodSignature signature = factory.makeMethodSig(
+                "1",
+                "substring",
+                "java.lang.String",
+                "int:int",
+                "beginIndex:endIndex",
+                "java.lang.IndexOutOfBoundsException",
+                "java.lang.String");
+
+        assertThat(signature.getDeclaringType()).isEqualTo(String.class);
+        assertThat(signature.getParameterTypes()).containsExactly(int.class, int.class);
+        assertThat(signature.getExceptionTypes()).containsExactly(IndexOutOfBoundsException.class);
+        assertThat(signature.getReturnType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void resolvesSignatureTypesWithApplicationClassLoader() {
+        Factory factory = new Factory("FactoryTest.java", FactoryTest.class);
+
+        MethodSignature signature = factory.makeMethodSig(
+                "1",
+                "accept",
+                "org_aspectj.aspectjrt.FactoryTest$SampleService",
+                "org_aspectj.aspectjrt.FactoryTest$SamplePayload",
+                "payload",
+                "java.lang.IllegalArgumentException",
+                "org_aspectj.aspectjrt.FactoryTest$SampleResult");
+
+        assertThat(signature.getDeclaringType()).isEqualTo(SampleService.class);
+        assertThat(signature.getParameterTypes()).containsExactly(SamplePayload.class);
+        assertThat(signature.getExceptionTypes()).containsExactly(IllegalArgumentException.class);
+        assertThat(signature.getReturnType()).isEqualTo(SampleResult.class);
+    }
+
+    public interface SampleService {
+        SampleResult accept(SamplePayload payload);
+    }
+
+    public static class SamplePayload {
+    }
+
+    public static class SampleResult {
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/FieldSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/FieldSignatureImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.FieldSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class FieldSignatureImplTest {
+    @Test
+    void resolvesDeclaredFieldOnDeclaringType() {
+        Factory factory = new Factory("FieldSignatureImplTest.java", FieldSignatureImplTest.class);
+        FieldSignature signature = factory.makeFieldSig(
+                Modifier.PRIVATE,
+                "identifier",
+                FieldHoldingService.class,
+                String.class);
+
+        Field field = signature.getField();
+
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(FieldHoldingService.class);
+        assertThat(field.getName()).isEqualTo("identifier");
+        assertThat(field.getType()).isEqualTo(String.class);
+        assertThat(Modifier.isPrivate(field.getModifiers())).isTrue();
+        assertThat(signature.getFieldType()).isEqualTo(String.class);
+    }
+
+    public static class FieldHoldingService {
+        private String identifier = "aspectj";
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/InitializerSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/InitializerSignatureImplTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.InitializerSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class InitializerSignatureImplTest {
+    @Test
+    void resolvesNoArgumentConstructorForInstanceInitializer() {
+        Factory factory = new Factory("InitializerSignatureImplTest.java", InitializerSignatureImplTest.class);
+        InitializerSignature signature = factory.makeInitializerSig(Modifier.PUBLIC, InitializerHost.class);
+
+        Constructor constructor = signature.getInitializer();
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(InitializerHost.class);
+        assertThat(constructor.getParameterTypes()).isEmpty();
+    }
+
+    public static class InitializerHost {
+        public InitializerHost() {
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/MethodSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/MethodSignatureImplTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.MethodSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+public class MethodSignatureImplTest {
+    @Test
+    void resolvesDeclaredMethodOnDeclaringType() {
+        Factory factory = new Factory("MethodSignatureImplTest.java", MethodSignatureImplTest.class);
+        MethodSignature signature = factory.makeMethodSig(
+                Modifier.PUBLIC,
+                "echo",
+                DeclaringService.class,
+                new Class[] {String.class},
+                new String[] {"value"},
+                new Class[] {IllegalStateException.class},
+                String.class);
+
+        Method method = signature.getMethod();
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(DeclaringService.class);
+        assertThat(method.getName()).isEqualTo("echo");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+        assertThat(method.getReturnType()).isEqualTo(String.class);
+        assertThat(method.getExceptionTypes()).containsExactly(IllegalStateException.class);
+    }
+
+    @Test
+    void searchesSuperclassWhenDeclaringTypeDoesNotDefineMethod() {
+        Factory factory = new Factory("MethodSignatureImplTest.java", MethodSignatureImplTest.class);
+        MethodSignature signature = factory.makeMethodSig(
+                Modifier.PUBLIC,
+                "inheritedEcho",
+                ChildService.class,
+                new Class[] {String.class},
+                new String[] {"value"},
+                new Class[0],
+                String.class);
+
+        Method method = signature.getMethod();
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(ParentService.class);
+        assertThat(method.getName()).isEqualTo("inheritedEcho");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+        assertThat(method.getReturnType()).isEqualTo(String.class);
+    }
+
+    public static class DeclaringService {
+        public String echo(String value) throws IllegalStateException {
+            return value;
+        }
+    }
+
+    public static class ParentService {
+        public String inheritedEcho(String value) {
+            return value;
+        }
+    }
+
+    public static class ChildService extends ParentService {
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/StringToTypeTest.java
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/java/org_aspectj/aspectjrt/StringToTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.aspectj.internal.lang.reflect.StringToType;
+import org.aspectj.lang.reflect.AjType;
+import org.junit.jupiter.api.Test;
+
+public class StringToTypeTest {
+    @Test
+    void convertsParameterizedTypeNameUsingScopeClassLoader() throws Exception {
+        Type type = StringToType.stringToType("java.util.List<java.lang.String>", GenericScope.class);
+
+        assertThat(type).isInstanceOf(ParameterizedType.class);
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        assertThat(parameterizedType.getRawType()).isEqualTo(List.class);
+        assertThat(parameterizedType.getOwnerType()).isNull();
+        assertThat(parameterizedType.getActualTypeArguments()).hasSize(1);
+
+        Type typeArgument = parameterizedType.getActualTypeArguments()[0];
+        assertThat(typeArgument).isInstanceOf(AjType.class);
+        assertThat(((AjType<?>) typeArgument).getJavaClass()).isEqualTo(String.class);
+    }
+
+    public static class GenericScope<T> {
+    }
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
@@ -52,5 +52,10 @@
     "name": "org_aspectj.aspectjrt.AspectsTest$ScopedAspect",
     "allDeclaredMethods": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.Aspects14Test$LegacyScopedAspect",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
@@ -72,5 +72,10 @@
     "name": "org_aspectj.aspectjrt.MethodSignatureImplTest$ChildService",
     "allDeclaredMethods": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AdviceSignatureImplTest$AdviceHost",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
@@ -47,5 +47,10 @@
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AspectsTest$ScopedAspect",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$SampleType",
+    "allDeclaredClasses": true,
+    "allPublicClasses": true,
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$SampleType$PublicNested",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$SampleType$PackageNested",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$AnnotationStyleAspect",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$MixinContract",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$MixinDefault",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.AjTypeImplTest$TargetType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/aspectjrt-tests-only/reflect-config.json
@@ -57,5 +57,20 @@
     "name": "org_aspectj.aspectjrt.Aspects14Test$LegacyScopedAspect",
     "allDeclaredMethods": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.MethodSignatureImplTest$DeclaringService",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.MethodSignatureImplTest$ParentService",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org_aspectj.aspectjrt.MethodSignatureImplTest$ChildService",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,170 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.AdviceSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.AdviceSignatureImplTest$AdviceHost"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.AjTypeImplTest$AnnotationStyleAspect",
+      "fields" : [
+        {
+          "name" : "errorMessage"
+        },
+        {
+          "name" : "warningMessage"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.AjTypeImplTest$MixinContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.AjTypeImplTest$SampleType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.InterTypeDeclarationImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.AjTypeImplTest$TargetType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.lang.Aspects14"
+      },
+      "type" : "org_aspectj.aspectjrt.Aspects14Test$LegacyScopedAspect",
+      "methods" : [
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.lang.Aspects"
+      },
+      "type" : "org_aspectj.aspectjrt.AspectsTest$ScopedAspect",
+      "methods" : [
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.ConstructorSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.ConstructorSignatureImplTest$ConstructedService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "org_aspectj.aspectjrt.FactoryTest$SamplePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "org_aspectj.aspectjrt.FactoryTest$SampleResult"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "org_aspectj.aspectjrt.FactoryTest$SampleService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.FieldSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.FieldSignatureImplTest$FieldHoldingService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.InitializerSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.InitializerSignatureImplTest$InitializerHost"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.MethodSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.MethodSignatureImplTest$ChildService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.MethodSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjrt.MethodSignatureImplTest$DeclaringService"
+    }
+  ]
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/user-code-filter.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.aspectj.**"
+    }
+  ]
+}

--- a/tests/src/org.aspectj/aspectjrt/1.9.6/user-code-filter.json
+++ b/tests/src/org.aspectj/aspectjrt/1.9.6/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.aspectj.**"
+      "includeClasses" : "org.aspectj.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2623

This PR introduces tests and metadata for org.aspectj:aspectjrt:1.9.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 316310
- Cached input tokens: 4193280
- Output tokens: 43075
- Metadata entries: 7
- Test-only metadata entries: 29
- Iterations: 11
- Library coverage percentage: 38.51
- Generated lines of code: 610
- Tested library lines of code: 796

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0e2174e8df777d155c2163f4ad9b7ead2d06aa4b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 72/72 covered calls (100.00%)
- Reflection: 72/72 covered calls (100.00%)

Library coverage:
- Instruction: 3760/9977 (37.69%)
- Line: 796/2067 (38.51%)
- Method: 157/506 (31.03%)
