### PR TITLE
[GenAI] Add support for io.netty:netty-codec-socks:4.1.60.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-codec-socks/4.1.60.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-socks/4.1.60.Final/reachability-metadata.json
@@ -1,0 +1,99 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.v4.DefaultSocks4CommandRequest"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.v4.DefaultSocks4CommandRequest"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-socks/index.json
+++ b/metadata/io.netty/netty-codec-socks/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.60.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.60.Final/netty-codec-socks-4.1.60.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.60.Final/netty-codec-socks-4.1.60.Final-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.60.Final/netty-codec-socks-4.1.60.Final-javadoc.jar",
+    "description" : "Netty Codec SOCKS provides encoders, decoders, and message types for SOCKS protocol support in Netty pipelines. It lets Netty applications implement SOCKS client or server handshakes and proxy-related messaging on top of Netty's asynchronous networking framework.",
+    "tested-versions" : [
+      "4.1.60.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec"
+    ]
+  }
+]

--- a/stats/io.netty/netty-codec-socks/4.1.60.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec-socks/4.1.60.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T05:53:31.085631Z",
+    "library": "io.netty:netty-codec-socks:4.1.60.Final",
+    "starting_commit": "dc9801b6f2ebf3cb837b1281bf890ea310bd07c9",
+    "ending_commit": "2dd8bfba5eda9349c2efba3ed134bf48a2834149",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.60.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2194,
+          "missed": 3962,
+          "ratio": 0.3564,
+          "total": 6156
+        },
+        "line": {
+          "covered": 519,
+          "missed": 787,
+          "ratio": 0.397397,
+          "total": 1306
+        },
+        "method": {
+          "covered": 133,
+          "missed": 154,
+          "ratio": 0.463415,
+          "total": 287
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 172979,
+      "cached_input_tokens_used": 1280512,
+      "output_tokens_used": 18526,
+      "iterations": 4,
+      "cost_usd": 1.1961,
+      "generated_loc": 334,
+      "tested_library_loc": 519,
+      "metadata_entries": 18,
+      "code_coverage_percent": 39.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java",
+      "metadata_file": "metadata/io.netty/netty-codec-socks/4.1.60.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-codec-socks/4.1.60.Final/stats.json
+++ b/stats/io.netty/netty-codec-socks/4.1.60.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.60.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2194,
+        "missed" : 3962,
+        "ratio" : 0.3564,
+        "total" : 6156
+      },
+      "line" : {
+        "covered" : 519,
+        "missed" : 787,
+        "ratio" : 0.397397,
+        "total" : 1306
+      },
+      "method" : {
+        "covered" : 133,
+        "missed" : 154,
+        "ratio" : 0.463415,
+        "total" : 287
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/.gitignore
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-codec-socks:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/gradle.properties
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-codec-socks:4.1.60.Final
+library.version = 4.1.60.Final
+metadata.dir = io.netty/netty-codec-socks/4.1.60.Final/

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/settings.gradle
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-codec-socks_tests'

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_codec_socks;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_codec_socksTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
@@ -29,6 +29,8 @@ import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthResponse;
+import io.netty.handler.codec.socksx.v5.Socks5AddressDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5AddressEncoder;
 import io.netty.handler.codec.socksx.v5.Socks5AddressType;
 import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
 import io.netty.handler.codec.socksx.v5.Socks5ClientEncoder;
@@ -213,6 +215,51 @@ public class Netty_codec_socksTest {
             socks4UnifiedServer.finishAndReleaseAll();
             socks5Encoder.finishAndReleaseAll();
             socks5UnifiedServer.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void socks5CommandCodecsUseCustomAddressCodecs() {
+        Socks5AddressEncoder aliasingEncoder = (addressType, address, out) -> {
+            String encodedAddress = Socks5AddressType.DOMAIN.equals(addressType) && "alias.example.test".equals(address)
+                    ? "resolved.example.test"
+                    : address;
+            Socks5AddressEncoder.DEFAULT.encodeAddress(addressType, encodedAddress, out);
+        };
+        Socks5AddressDecoder taggingDecoder = (addressType, in) ->
+                "decoded:" + Socks5AddressDecoder.DEFAULT.decodeAddress(addressType, in);
+
+        EmbeddedChannel clientEncoder = new EmbeddedChannel(new Socks5ClientEncoder(aliasingEncoder));
+        EmbeddedChannel serverDecoder = new EmbeddedChannel(new Socks5CommandRequestDecoder(taggingDecoder));
+        EmbeddedChannel serverEncoder = new EmbeddedChannel(new Socks5ServerEncoder(aliasingEncoder));
+        EmbeddedChannel clientDecoder = new EmbeddedChannel(new Socks5CommandResponseDecoder(taggingDecoder));
+        try {
+            Socks5CommandRequest request = new DefaultSocks5CommandRequest(
+                    Socks5CommandType.CONNECT, Socks5AddressType.DOMAIN, "alias.example.test", 443);
+
+            Socks5CommandRequest decodedRequest = decode(
+                    serverDecoder, encode(clientEncoder, request), Socks5CommandRequest.class);
+
+            assertThat(decodedRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedRequest.dstAddrType()).isEqualTo(Socks5AddressType.DOMAIN);
+            assertThat(decodedRequest.dstAddr()).isEqualTo("decoded:resolved.example.test");
+            assertThat(decodedRequest.dstPort()).isEqualTo(443);
+
+            Socks5CommandResponse response = new DefaultSocks5CommandResponse(
+                    Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN, "alias.example.test", 8443);
+
+            Socks5CommandResponse decodedResponse = decode(
+                    clientDecoder, encode(serverEncoder, response), Socks5CommandResponse.class);
+
+            assertThat(decodedResponse.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedResponse.bndAddrType()).isEqualTo(Socks5AddressType.DOMAIN);
+            assertThat(decodedResponse.bndAddr()).isEqualTo("decoded:resolved.example.test");
+            assertThat(decodedResponse.bndPort()).isEqualTo(8443);
+        } finally {
+            clientEncoder.finishAndReleaseAll();
+            serverDecoder.finishAndReleaseAll();
+            serverEncoder.finishAndReleaseAll();
+            clientDecoder.finishAndReleaseAll();
         }
     }
 

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
@@ -6,11 +6,309 @@
  */
 package io_netty.netty_codec_socks;
 
+import java.net.InetAddress;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.socksx.SocksPortUnificationServerHandler;
+import io.netty.handler.codec.socksx.SocksVersion;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4ClientDecoder;
+import io.netty.handler.codec.socksx.v4.Socks4ClientEncoder;
+import io.netty.handler.codec.socksx.v4.Socks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.Socks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
+import io.netty.handler.codec.socksx.v4.Socks4CommandType;
+import io.netty.handler.codec.socksx.v4.Socks4ServerDecoder;
+import io.netty.handler.codec.socksx.v4.Socks4ServerEncoder;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialRequest;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthRequest;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthResponse;
+import io.netty.handler.codec.socksx.v5.Socks5AddressType;
+import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+import io.netty.handler.codec.socksx.v5.Socks5ClientEncoder;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5CommandResponse;
+import io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
+import io.netty.handler.codec.socksx.v5.Socks5CommandType;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequest;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5InitialResponse;
+import io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequest;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponse;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthStatus;
+import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
 import org.junit.jupiter.api.Test;
 
-class Netty_codec_socksTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Netty_codec_socksTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void socks4MessagesRoundTripThroughClientAndServerCodecs() {
+        EmbeddedChannel clientEncoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        EmbeddedChannel serverDecoder = new EmbeddedChannel(new Socks4ServerDecoder());
+        EmbeddedChannel serverEncoder = new EmbeddedChannel(Socks4ServerEncoder.INSTANCE);
+        EmbeddedChannel clientDecoder = new EmbeddedChannel(new Socks4ClientDecoder());
+        try {
+            Socks4CommandRequest request = new DefaultSocks4CommandRequest(
+                    Socks4CommandType.CONNECT, "192.0.2.10", 1080, "netty-user");
+
+            Socks4CommandRequest decodedRequest = decode(
+                    serverDecoder, encode(clientEncoder, request), Socks4CommandRequest.class);
+
+            assertThat(decodedRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedRequest.version()).isEqualTo(SocksVersion.SOCKS4a);
+            assertThat(decodedRequest.type()).isEqualTo(Socks4CommandType.CONNECT);
+            assertThat(decodedRequest.dstAddr()).isEqualTo("192.0.2.10");
+            assertThat(decodedRequest.dstPort()).isEqualTo(1080);
+            assertThat(decodedRequest.userId()).isEqualTo("netty-user");
+
+            Socks4CommandResponse response = new DefaultSocks4CommandResponse(
+                    Socks4CommandStatus.SUCCESS, "198.51.100.20", 8080);
+
+            Socks4CommandResponse decodedResponse = decode(
+                    clientDecoder, encode(serverEncoder, response), Socks4CommandResponse.class);
+
+            assertThat(decodedResponse.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedResponse.version()).isEqualTo(SocksVersion.SOCKS4a);
+            assertThat(decodedResponse.status()).isEqualTo(Socks4CommandStatus.SUCCESS);
+            assertThat(decodedResponse.status().isSuccess()).isTrue();
+            assertThat(decodedResponse.dstAddr()).isEqualTo("198.51.100.20");
+            assertThat(decodedResponse.dstPort()).isEqualTo(8080);
+        } finally {
+            clientEncoder.finishAndReleaseAll();
+            serverDecoder.finishAndReleaseAll();
+            serverEncoder.finishAndReleaseAll();
+            clientDecoder.finishAndReleaseAll();
+        }
     }
+
+    @Test
+    void socks5InitialNegotiationAndPasswordAuthenticationRoundTrip() {
+        EmbeddedChannel clientEncoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        EmbeddedChannel serverEncoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        EmbeddedChannel initialRequestDecoder = new EmbeddedChannel(new Socks5InitialRequestDecoder());
+        EmbeddedChannel initialResponseDecoder = new EmbeddedChannel(new Socks5InitialResponseDecoder());
+        EmbeddedChannel passwordRequestDecoder = new EmbeddedChannel(new Socks5PasswordAuthRequestDecoder());
+        EmbeddedChannel passwordResponseDecoder = new EmbeddedChannel(new Socks5PasswordAuthResponseDecoder());
+        try {
+            Socks5InitialRequest initialRequest = new DefaultSocks5InitialRequest(
+                    Socks5AuthMethod.NO_AUTH, Socks5AuthMethod.PASSWORD);
+
+            Socks5InitialRequest decodedInitialRequest = decode(
+                    initialRequestDecoder, encode(clientEncoder, initialRequest), Socks5InitialRequest.class);
+
+            assertThat(decodedInitialRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedInitialRequest.version()).isEqualTo(SocksVersion.SOCKS5);
+            assertThat(decodedInitialRequest.authMethods())
+                    .containsExactly(Socks5AuthMethod.NO_AUTH, Socks5AuthMethod.PASSWORD);
+
+            Socks5InitialResponse decodedInitialResponse = decode(
+                    initialResponseDecoder,
+                    encode(serverEncoder, new DefaultSocks5InitialResponse(Socks5AuthMethod.PASSWORD)),
+                    Socks5InitialResponse.class);
+
+            assertThat(decodedInitialResponse.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedInitialResponse.authMethod()).isEqualTo(Socks5AuthMethod.PASSWORD);
+
+            Socks5PasswordAuthRequest decodedPasswordRequest = decode(
+                    passwordRequestDecoder,
+                    encode(clientEncoder, new DefaultSocks5PasswordAuthRequest("scott", "tiger")),
+                    Socks5PasswordAuthRequest.class);
+
+            assertThat(decodedPasswordRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedPasswordRequest.username()).isEqualTo("scott");
+            assertThat(decodedPasswordRequest.password()).isEqualTo("tiger");
+
+            Socks5PasswordAuthResponse decodedPasswordResponse = decode(
+                    passwordResponseDecoder,
+                    encode(serverEncoder, new DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus.SUCCESS)),
+                    Socks5PasswordAuthResponse.class);
+
+            assertThat(decodedPasswordResponse.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedPasswordResponse.status()).isEqualTo(Socks5PasswordAuthStatus.SUCCESS);
+            assertThat(decodedPasswordResponse.status().isSuccess()).isTrue();
+        } finally {
+            clientEncoder.finishAndReleaseAll();
+            serverEncoder.finishAndReleaseAll();
+            initialRequestDecoder.finishAndReleaseAll();
+            initialResponseDecoder.finishAndReleaseAll();
+            passwordRequestDecoder.finishAndReleaseAll();
+            passwordResponseDecoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void socks5CommandCodecsSupportIpv4DomainAndIpv6Addresses() throws Exception {
+        assertCommandRequestRoundTrip(Socks5AddressType.IPv4, "203.0.113.7", 443);
+        assertCommandRequestRoundTrip(Socks5AddressType.DOMAIN, "service.example.test", 8443);
+        assertCommandRequestRoundTrip(Socks5AddressType.IPv6, "2001:db8:0:0:0:0:0:1", 9443);
+
+        assertCommandResponseRoundTrip(Socks5AddressType.IPv4, "192.0.2.55", 53);
+        assertCommandResponseRoundTrip(Socks5AddressType.DOMAIN, "bind.example.test", 5353);
+        assertCommandResponseRoundTrip(Socks5AddressType.IPv6, "2001:db8:0:0:0:0:0:2", 9050);
+    }
+
+    @Test
+    void portUnificationServerHandlerSelectsSocks4AndSocks5Decoders() {
+        EmbeddedChannel socks4Encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        EmbeddedChannel socks4UnifiedServer = new EmbeddedChannel(new SocksPortUnificationServerHandler());
+        EmbeddedChannel socks5Encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        EmbeddedChannel socks5UnifiedServer = new EmbeddedChannel(new SocksPortUnificationServerHandler());
+        try {
+            Socks4CommandRequest socks4Request = decode(
+                    socks4UnifiedServer,
+                    encode(socks4Encoder, new DefaultSocks4CommandRequest(Socks4CommandType.BIND, "192.0.2.1", 22)),
+                    Socks4CommandRequest.class);
+
+            assertThat(socks4Request.decoderResult().isSuccess()).isTrue();
+            assertThat(socks4Request.version()).isEqualTo(SocksVersion.SOCKS4a);
+            assertThat(socks4Request.type()).isEqualTo(Socks4CommandType.BIND);
+            assertThat(socks4Request.dstAddr()).isEqualTo("192.0.2.1");
+            assertThat(socks4Request.dstPort()).isEqualTo(22);
+
+            Socks5InitialRequest socks5Request = decode(
+                    socks5UnifiedServer,
+                    encode(socks5Encoder, new DefaultSocks5InitialRequest(Socks5AuthMethod.NO_AUTH)),
+                    Socks5InitialRequest.class);
+
+            assertThat(socks5Request.decoderResult().isSuccess()).isTrue();
+            assertThat(socks5Request.version()).isEqualTo(SocksVersion.SOCKS5);
+            assertThat(socks5Request.authMethods()).containsExactly(Socks5AuthMethod.NO_AUTH);
+        } finally {
+            socks4Encoder.finishAndReleaseAll();
+            socks4UnifiedServer.finishAndReleaseAll();
+            socks5Encoder.finishAndReleaseAll();
+            socks5UnifiedServer.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void replayingDecodersWaitForCompleteFramesBeforeEmittingMessages() {
+        EmbeddedChannel passwordRequestDecoder = new EmbeddedChannel(new Socks5PasswordAuthRequestDecoder());
+        try {
+            ByteBuf firstFragment = Unpooled.copiedBuffer(new byte[] { 0x01, 0x04, 'u' });
+            ByteBuf secondFragment = Unpooled.copiedBuffer(
+                    new byte[] { 's', 'e', 'r', 0x06, 's', 'e', 'c', 'r', 'e', 't' });
+
+            assertThat(passwordRequestDecoder.writeInbound(firstFragment)).isFalse();
+            assertThat((Object) passwordRequestDecoder.readInbound()).isNull();
+            assertThat(passwordRequestDecoder.writeInbound(secondFragment)).isTrue();
+
+            Socks5PasswordAuthRequest request = passwordRequestDecoder.readInbound();
+            assertThat(request.decoderResult().isSuccess()).isTrue();
+            assertThat(request.username()).isEqualTo("user");
+            assertThat(request.password()).isEqualTo("secret");
+            assertThat((Object) passwordRequestDecoder.readInbound()).isNull();
+        } finally {
+            passwordRequestDecoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void protocolConstantsAndExtensibleValueObjectsExposeWireValues() {
+        assertThat(SocksVersion.valueOf((byte) 0x04)).isEqualTo(SocksVersion.SOCKS4a);
+        assertThat(SocksVersion.valueOf((byte) 0x05)).isEqualTo(SocksVersion.SOCKS5);
+        assertThat(SocksVersion.valueOf((byte) 0x7f)).isEqualTo(SocksVersion.UNKNOWN);
+        assertThat(SocksVersion.SOCKS5.byteValue()).isEqualTo((byte) 0x05);
+
+        assertThat(Socks4CommandType.valueOf((byte) 0x01)).isEqualTo(Socks4CommandType.CONNECT);
+        assertThat(Socks4CommandType.valueOf((byte) 0x02)).isEqualTo(Socks4CommandType.BIND);
+        assertThat(new Socks4CommandType(0x7e, "PRIVATE").byteValue()).isEqualTo((byte) 0x7e);
+        assertThat(Socks4CommandStatus.SUCCESS.isSuccess()).isTrue();
+        assertThat(Socks4CommandStatus.REJECTED_OR_FAILED.isSuccess()).isFalse();
+
+        assertThat(Socks5AuthMethod.valueOf((byte) 0x00)).isEqualTo(Socks5AuthMethod.NO_AUTH);
+        assertThat(Socks5AuthMethod.valueOf((byte) 0x02)).isEqualTo(Socks5AuthMethod.PASSWORD);
+        assertThat(new Socks5AuthMethod(0x80, "PRIVATE")).isEqualTo(Socks5AuthMethod.valueOf((byte) 0x80));
+        assertThat(Socks5CommandType.valueOf((byte) 0x03)).isEqualTo(Socks5CommandType.UDP_ASSOCIATE);
+        assertThat(Socks5AddressType.valueOf((byte) 0x03)).isEqualTo(Socks5AddressType.DOMAIN);
+        assertThat(Socks5CommandStatus.SUCCESS.isSuccess()).isTrue();
+        assertThat(Socks5CommandStatus.ADDRESS_UNSUPPORTED.isSuccess()).isFalse();
+        assertThat(Socks5PasswordAuthStatus.SUCCESS.isSuccess()).isTrue();
+        assertThat(Socks5PasswordAuthStatus.FAILURE.isSuccess()).isFalse();
+    }
+
+    private static void assertCommandRequestRoundTrip(Socks5AddressType addressType, String address, int port)
+            throws Exception {
+        EmbeddedChannel clientEncoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        EmbeddedChannel serverDecoder = new EmbeddedChannel(new Socks5CommandRequestDecoder());
+        try {
+            Socks5CommandRequest request = new DefaultSocks5CommandRequest(
+                    Socks5CommandType.CONNECT, addressType, address, port);
+
+            Socks5CommandRequest decodedRequest = decode(
+                    serverDecoder, encode(clientEncoder, request), Socks5CommandRequest.class);
+
+            assertThat(decodedRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedRequest.version()).isEqualTo(SocksVersion.SOCKS5);
+            assertThat(decodedRequest.type()).isEqualTo(Socks5CommandType.CONNECT);
+            assertThat(decodedRequest.dstAddrType()).isEqualTo(addressType);
+            assertAddressEquals(addressType, address, decodedRequest.dstAddr());
+            assertThat(decodedRequest.dstPort()).isEqualTo(port);
+        } finally {
+            clientEncoder.finishAndReleaseAll();
+            serverDecoder.finishAndReleaseAll();
+        }
+    }
+
+    private static void assertCommandResponseRoundTrip(Socks5AddressType addressType, String address, int port)
+            throws Exception {
+        EmbeddedChannel serverEncoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        EmbeddedChannel clientDecoder = new EmbeddedChannel(new Socks5CommandResponseDecoder());
+        try {
+            Socks5CommandResponse response = new DefaultSocks5CommandResponse(
+                    Socks5CommandStatus.SUCCESS, addressType, address, port);
+
+            Socks5CommandResponse decodedResponse = decode(
+                    clientDecoder, encode(serverEncoder, response), Socks5CommandResponse.class);
+
+            assertThat(decodedResponse.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedResponse.version()).isEqualTo(SocksVersion.SOCKS5);
+            assertThat(decodedResponse.status()).isEqualTo(Socks5CommandStatus.SUCCESS);
+            assertThat(decodedResponse.status().isSuccess()).isTrue();
+            assertThat(decodedResponse.bndAddrType()).isEqualTo(addressType);
+            assertAddressEquals(addressType, address, decodedResponse.bndAddr());
+            assertThat(decodedResponse.bndPort()).isEqualTo(port);
+        } finally {
+            serverEncoder.finishAndReleaseAll();
+            clientDecoder.finishAndReleaseAll();
+        }
+    }
+
+    private static void assertAddressEquals(Socks5AddressType addressType, String expected, String actual)
+            throws Exception {
+        if (Socks5AddressType.IPv6.equals(addressType)) {
+            assertThat(InetAddress.getByName(actual)).isEqualTo(InetAddress.getByName(expected));
+        } else {
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    private static ByteBuf encode(EmbeddedChannel channel, Object message) {
+        assertThat(channel.writeOutbound(message)).isTrue();
+        ByteBuf encoded = channel.readOutbound();
+        assertThat(encoded).isNotNull();
+        assertThat((Object) channel.readOutbound()).isNull();
+        return encoded;
+    }
+
+    private static <T> T decode(EmbeddedChannel channel, ByteBuf encoded, Class<T> messageType) {
+        assertThat(channel.writeInbound(encoded)).isTrue();
+        Object decoded = channel.readInbound();
+        assertThat(decoded).isInstanceOf(messageType);
+        assertThat((Object) channel.readInbound()).isNull();
+        return messageType.cast(decoded);
+    }
+
 }

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
@@ -94,6 +94,29 @@ public class Netty_codec_socksTest {
     }
 
     @Test
+    void socks4aCommandRequestSupportsDomainNames() {
+        EmbeddedChannel clientEncoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        EmbeddedChannel serverDecoder = new EmbeddedChannel(new Socks4ServerDecoder());
+        try {
+            Socks4CommandRequest request = new DefaultSocks4CommandRequest(
+                    Socks4CommandType.BIND, "destination.example.test", 9020, "domain-user");
+
+            Socks4CommandRequest decodedRequest = decode(
+                    serverDecoder, encode(clientEncoder, request), Socks4CommandRequest.class);
+
+            assertThat(decodedRequest.decoderResult().isSuccess()).isTrue();
+            assertThat(decodedRequest.version()).isEqualTo(SocksVersion.SOCKS4a);
+            assertThat(decodedRequest.type()).isEqualTo(Socks4CommandType.BIND);
+            assertThat(decodedRequest.dstAddr()).isEqualTo("destination.example.test");
+            assertThat(decodedRequest.dstPort()).isEqualTo(9020);
+            assertThat(decodedRequest.userId()).isEqualTo("domain-user");
+        } finally {
+            clientEncoder.finishAndReleaseAll();
+            serverDecoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
     void socks5InitialNegotiationAndPasswordAuthenticationRoundTrip() {
         EmbeddedChannel clientEncoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         EmbeddedChannel serverEncoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/src/test/java/io_netty/netty_codec_socks/Netty_codec_socksTest.java
@@ -267,9 +267,9 @@ public class Netty_codec_socksTest {
     void replayingDecodersWaitForCompleteFramesBeforeEmittingMessages() {
         EmbeddedChannel passwordRequestDecoder = new EmbeddedChannel(new Socks5PasswordAuthRequestDecoder());
         try {
-            ByteBuf firstFragment = Unpooled.copiedBuffer(new byte[] { 0x01, 0x04, 'u' });
+            ByteBuf firstFragment = Unpooled.copiedBuffer(new byte[] {0x01, 0x04, 'u' });
             ByteBuf secondFragment = Unpooled.copiedBuffer(
-                    new byte[] { 's', 'e', 'r', 0x06, 's', 'e', 'c', 'r', 'e', 't' });
+                    new byte[] {'s', 'e', 'r', 0x06, 's', 'e', 'c', 'r', 'e', 't' });
 
             assertThat(passwordRequestDecoder.writeInbound(firstFragment)).isFalse();
             assertThat((Object) passwordRequestDecoder.readInbound()).isNull();

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.handler.codec.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-codec-socks/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-codec-socks/4.1.60.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.handler.codec.**"
+      "includeClasses" : "io.netty.handler.codec.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1424

This PR introduces tests and metadata for io.netty:netty-codec-socks:4.1.60.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 172979
- Cached input tokens: 1280512
- Output tokens: 18526
- Metadata entries: 18
- Iterations: 4
- Library coverage percentage: 39.74
- Generated lines of code: 334
- Tested library lines of code: 519

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0e2174e8df777d155c2163f4ad9b7ead2d06aa4b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2194/6156 (35.64%)
- Line: 519/1306 (39.74%)
- Method: 133/287 (46.34%)
