### PR TITLE
[GenAI] Test fix for org.osgi:osgi.core:7.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.osgi/osgi.core/7.0.0/reachability-metadata.json
+++ b/metadata/org.osgi/osgi.core/7.0.0/reachability-metadata.json
@@ -1,0 +1,72 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.osgi.framework.FrameworkUtil$FilterImpl"
+      },
+      "type" : "java.math.BigInteger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.osgi.framework.FrameworkUtil$FilterImpl"
+      },
+      "type" : "java.sql.Date",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.osgi.dto.DTO"
+      },
+      "type" : "org.osgi.framework.dto.BundleDTO",
+      "fields" : [
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "lastModified"
+        },
+        {
+          "name" : "state"
+        },
+        {
+          "name" : "symbolicName"
+        },
+        {
+          "name" : "version"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.osgi.dto.DTO"
+      },
+      "type" : "org.osgi.framework.dto.FrameworkDTO",
+      "fields" : [
+        {
+          "name" : "bundles"
+        },
+        {
+          "name" : "properties"
+        },
+        {
+          "name" : "services"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.osgi/osgi.core/index.json
+++ b/metadata/org.osgi/osgi.core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "7.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/osgi.core/7.0.0/osgi.core-7.0.0-sources.jar",
+    "repository-url" : "https://github.com/osgi/osgi",
+    "test-code-url" : "https://github.com/osgi/osgi/tree/r7-core-ri-ct-final/osgi.ct",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/osgi/osgi.core/7.0.0/osgi.core-7.0.0-javadoc.jar",
+    "description" : "OSGi Core provides the Release 7 API interfaces and classes used to compile bundles for the OSGi module and service platform. It defines framework contracts for bundles, lifecycle management, service registration, permissions, and resource wiring that OSGi-compliant runtimes implement.",
     "tested-versions" : [
       "7.0.0"
     ],

--- a/metadata/org.osgi/osgi.core/index.json
+++ b/metadata/org.osgi/osgi.core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "7.0.0",
+    "tested-versions" : [
+      "7.0.0"
+    ],
+    "allowed-packages" : [
+      "org.osgi"
+    ]
+  },
+  {
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/osgi.core/6.0.0/osgi.core-6.0.0-sources.jar",
     "repository-url" : "https://github.com/osgi/osgi",

--- a/stats/org.osgi/osgi.core/7.0.0/execution-metrics.json
+++ b/stats/org.osgi/osgi.core/7.0.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T06:09:38.222149Z",
+    "library": "org.osgi:osgi.core:7.0.0",
+    "starting_commit": "3959e85e00f5c8388302a573f5483cab0b9d01ae",
+    "ending_commit": "edc3b7625082b7685c71463b99d3997f8fbae647",
+    "previous_library": "org.osgi:osgi.core:6.0.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "7.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1212,
+          "missed": 15643,
+          "ratio": 0.071907,
+          "total": 16855
+        },
+        "line": {
+          "covered": 298,
+          "missed": 3143,
+          "ratio": 0.086603,
+          "total": 3441
+        },
+        "method": {
+          "covered": 50,
+          "missed": 393,
+          "ratio": 0.112867,
+          "total": 443
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1202,
+          "missed": 15478,
+          "ratio": 0.072062,
+          "total": 16680
+        },
+        "line": {
+          "covered": 295,
+          "missed": 3088,
+          "ratio": 0.087201,
+          "total": 3383
+        },
+        "method": {
+          "covered": 50,
+          "missed": 379,
+          "ratio": 0.11655,
+          "total": 429
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 87121,
+      "cached_input_tokens_used": 685056,
+      "output_tokens_used": 4439,
+      "iterations": 2,
+      "cost_usd": 0.4757,
+      "tested_library_loc": 298,
+      "metadata_entries": 14,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 14,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 8.66,
+      "previous_library_coverage_percent": 8.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/DTOTest.java",
+      "metadata_file": "metadata/org.osgi/osgi.core/7.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.osgi/osgi.core/7.0.0/stats.json
+++ b/stats/org.osgi/osgi.core/7.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "7.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1212,
+        "missed" : 15643,
+        "ratio" : 0.071907,
+        "total" : 16855
+      },
+      "line" : {
+        "covered" : 298,
+        "missed" : 3143,
+        "ratio" : 0.086603,
+        "total" : 3441
+      },
+      "method" : {
+        "covered" : 50,
+        "missed" : 393,
+        "ratio" : 0.112867,
+        "total" : 443
+      }
+    }
+  } ]
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/.gitignore
+++ b/tests/src/org.osgi/osgi.core/7.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.osgi/osgi.core/7.0.0/build.gradle
+++ b/tests/src/org.osgi/osgi.core/7.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.osgi:osgi.core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/gradle.properties
+++ b/tests/src/org.osgi/osgi.core/7.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.osgi:osgi.core:7.0.0
+library.version = 7.0.0
+metadata.dir = org.osgi/osgi.core/7.0.0/

--- a/tests/src/org.osgi/osgi.core/7.0.0/settings.gradle
+++ b/tests/src/org.osgi/osgi.core/7.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.osgi.osgi.core_tests'

--- a/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/DTOTest.java
+++ b/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/DTOTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.dto.BundleDTO;
+import org.osgi.framework.dto.FrameworkDTO;
+
+public class DTOTest {
+    @Test
+    void toStringReadsPublicFieldsFromFrameworkDto() {
+        BundleDTO bundle = new BundleDTO();
+        bundle.id = 7L;
+        bundle.lastModified = 1234L;
+        bundle.state = 32;
+        bundle.symbolicName = "example.bundle";
+        bundle.version = "1.2.3";
+
+        String rendered = bundle.toString();
+
+        assertThat(rendered)
+                .startsWith("{")
+                .endsWith("}")
+                .contains("\"id\":7")
+                .contains("\"lastModified\":1234")
+                .contains("\"state\":32")
+                .contains("\"symbolicName\":\"example.bundle\"")
+                .contains("\"version\":\"1.2.3\"");
+    }
+
+    @Test
+    void toStringRendersNestedDtosAndAggregates() {
+        BundleDTO bundle = new BundleDTO();
+        bundle.id = 42L;
+        bundle.symbolicName = "nested.bundle";
+
+        FrameworkDTO framework = new FrameworkDTO();
+        framework.bundles = List.of(bundle);
+        framework.properties = Map.of("framework.name", "OSGi", "active", Boolean.TRUE);
+        framework.services = List.of();
+
+        String rendered = framework.toString();
+
+        assertThat(rendered)
+                .contains("\"bundles\":[{")
+                .contains("\"id\":42")
+                .contains("\"symbolicName\":\"nested.bundle\"")
+                .contains("\"properties\":{")
+                .contains("\"framework.name\":\"OSGi\"")
+                .contains("\"active\":true")
+                .contains("\"services\":[]");
+    }
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/FrameworkUtilInnerFilterImplTest.java
+++ b/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/FrameworkUtilInnerFilterImplTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.sql.Date;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+public class FrameworkUtilInnerFilterImplTest {
+    @Test
+    void matchesComparableValuesUsingStringConstructorConversion() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter("(ranking>=42)");
+
+        assertThat(filter.matches(Map.of("ranking", new BigInteger("42")))).isTrue();
+        assertThat(filter.matches(Map.of("ranking", new BigInteger("41")))).isFalse();
+    }
+
+    @Test
+    void matchesComparableValuesUsingStaticValueOfConversion() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter("(releaseDate>=2024-01-15)");
+
+        assertThat(filter.matches(Map.of("releaseDate", Date.valueOf("2024-01-16")))).isTrue();
+        assertThat(filter.matches(Map.of("releaseDate", Date.valueOf("2024-01-14")))).isFalse();
+    }
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
+++ b/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_osgi.osgi_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+public class ServiceTrackerTest {
+    @Test
+    void getServicesCreatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        GreetingService firstService = () -> "first";
+        GreetingService secondService = () -> "second";
+        SimpleServiceReference<GreetingService> firstReference = new SimpleServiceReference<>(1L, 10);
+        SimpleServiceReference<GreetingService> secondReference = new SimpleServiceReference<>(2L, 20);
+        SimpleBundleContext context = new SimpleBundleContext(List.of(firstReference, secondReference));
+        ServiceTrackerCustomizer<GreetingService, GreetingService> customizer = new MapBackedCustomizer<>(
+                Map.of(firstReference, firstService, secondReference, secondService));
+        ServiceTracker<GreetingService, GreetingService> tracker = new ServiceTracker<>(
+                context, GreetingService.class, customizer);
+
+        tracker.open();
+        GreetingService[] providedArray = new GreetingService[1];
+
+        GreetingService[] trackedServices = tracker.getServices(providedArray);
+
+        assertThat(trackedServices).isNotSameAs(providedArray);
+        assertThat(trackedServices).hasSize(2);
+        assertThat(trackedServices.getClass().getComponentType()).isEqualTo(GreetingService.class);
+        assertThat(trackedServices).containsExactlyInAnyOrder(firstService, secondService);
+        assertThat(context.registeredListener).isNotNull();
+    }
+
+    private interface GreetingService {
+        String greeting();
+    }
+
+    private static final class MapBackedCustomizer<S> implements ServiceTrackerCustomizer<S, S> {
+        private final Map<ServiceReference<S>, S> services;
+
+        private MapBackedCustomizer(Map<ServiceReference<S>, S> services) {
+            this.services = services;
+        }
+
+        @Override
+        public S addingService(ServiceReference<S> reference) {
+            return services.get(reference);
+        }
+
+        @Override
+        public void modifiedService(ServiceReference<S> reference, S service) {
+        }
+
+        @Override
+        public void removedService(ServiceReference<S> reference, S service) {
+        }
+    }
+
+    private static final class SimpleServiceReference<S> implements ServiceReference<S> {
+        private final Long serviceId;
+        private final Integer ranking;
+
+        private SimpleServiceReference(Long serviceId, Integer ranking) {
+            this.serviceId = serviceId;
+            this.ranking = ranking;
+        }
+
+        @Override
+        public Object getProperty(String key) {
+            if (Constants.SERVICE_ID.equals(key)) {
+                return serviceId;
+            }
+            if (Constants.SERVICE_RANKING.equals(key)) {
+                return ranking;
+            }
+            return null;
+        }
+
+        @Override
+        public String[] getPropertyKeys() {
+            return new String[] {Constants.SERVICE_ID, Constants.SERVICE_RANKING};
+        }
+
+        @Override
+        public Bundle getBundle() {
+            return null;
+        }
+
+        @Override
+        public Bundle[] getUsingBundles() {
+            return null;
+        }
+
+        @Override
+        public boolean isAssignableTo(Bundle bundle, String className) {
+            return true;
+        }
+
+        @Override
+        public int compareTo(Object reference) {
+            ServiceReference<?> other = (ServiceReference<?>) reference;
+            int rankingComparison = ranking.compareTo((Integer) other.getProperty(Constants.SERVICE_RANKING));
+            if (rankingComparison != 0) {
+                return rankingComparison;
+            }
+            return ((Long) other.getProperty(Constants.SERVICE_ID)).compareTo(serviceId);
+        }
+    }
+
+    private static final class SimpleBundleContext implements BundleContext {
+        private final List<? extends ServiceReference<?>> references;
+        private ServiceListener registeredListener;
+
+        private SimpleBundleContext(List<? extends ServiceReference<?>> references) {
+            this.references = references;
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return null;
+        }
+
+        @Override
+        public Bundle getBundle() {
+            return null;
+        }
+
+        @Override
+        public Bundle installBundle(String location, InputStream input) throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Bundle installBundle(String location) throws BundleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Bundle getBundle(long id) {
+            return null;
+        }
+
+        @Override
+        public Bundle[] getBundles() {
+            return new Bundle[0];
+        }
+
+        @Override
+        public void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException {
+            FrameworkUtil.createFilter(filter);
+            registeredListener = listener;
+        }
+
+        @Override
+        public void addServiceListener(ServiceListener listener) {
+            registeredListener = listener;
+        }
+
+        @Override
+        public void removeServiceListener(ServiceListener listener) {
+            if (registeredListener == listener) {
+                registeredListener = null;
+            }
+        }
+
+        @Override
+        public void addBundleListener(BundleListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeBundleListener(BundleListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addFrameworkListener(FrameworkListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeFrameworkListener(FrameworkListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServiceRegistration<?> registerService(
+                String[] clazzes, Object service, Dictionary<String, ?> properties) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <S> ServiceRegistration<S> registerService(
+                Class<S> clazz, ServiceFactory<S> factory, Dictionary<String, ?> properties) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+            if (filter != null) {
+                FrameworkUtil.createFilter(filter);
+            }
+            return references.toArray(new ServiceReference<?>[0]);
+        }
+
+        @Override
+        public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+            return getServiceReferences(clazz, filter);
+        }
+
+        @Override
+        public ServiceReference<?> getServiceReference(String clazz) {
+            return references.get(0);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
+            return (ServiceReference<S>) references.get(0);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+                throws InvalidSyntaxException {
+            if (filter != null) {
+                FrameworkUtil.createFilter(filter);
+            }
+            return (Collection<ServiceReference<S>>) references;
+        }
+
+        @Override
+        public <S> S getService(ServiceReference<S> reference) {
+            return null;
+        }
+
+        @Override
+        public boolean ungetService(ServiceReference<?> reference) {
+            return true;
+        }
+
+        @Override
+        public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public File getDataFile(String filename) {
+            return null;
+        }
+
+        @Override
+        public Filter createFilter(String filter) throws InvalidSyntaxException {
+            return FrameworkUtil.createFilter(filter);
+        }
+
+        @Override
+        public Bundle getBundle(String location) {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
+++ b/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
@@ -11,7 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
@@ -106,6 +108,46 @@ public class ServiceTrackerTest {
         @Override
         public String[] getPropertyKeys() {
             return new String[] {Constants.SERVICE_ID, Constants.SERVICE_RANKING};
+        }
+
+        @Override
+        public Dictionary<String, Object> getProperties() {
+            return new Dictionary<>() {
+                @Override
+                public int size() {
+                    return 2;
+                }
+
+                @Override
+                public boolean isEmpty() {
+                    return false;
+                }
+
+                @Override
+                public Enumeration<String> keys() {
+                    return Collections.enumeration(List.of(Constants.SERVICE_ID, Constants.SERVICE_RANKING));
+                }
+
+                @Override
+                public Enumeration<Object> elements() {
+                    return Collections.enumeration(List.of(serviceId, ranking));
+                }
+
+                @Override
+                public Object get(Object key) {
+                    return key instanceof String ? getProperty((String) key) : null;
+                }
+
+                @Override
+                public Object put(String key, Object value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Object remove(Object key) {
+                    throw new UnsupportedOperationException();
+                }
+            };
         }
 
         @Override

--- a/tests/src/org.osgi/osgi.core/7.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.osgi/osgi.core/7.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.osgi.util.tracker.ServiceTracker"
+      },
+      "type" : "org_osgi.osgi_core.ServiceTrackerTest$GreetingService[]"
+    }
+  ]
+}

--- a/tests/src/org.osgi/osgi.core/7.0.0/user-code-filter.json
+++ b/tests/src/org.osgi/osgi.core/7.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.osgi.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4181

This PR provides test fixes and new metadata for org.osgi:osgi.core:7.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 87121
- Cached input tokens: 685056
- Output tokens: 4439
- Metadata entries: 14
- Test-only metadata entries: 1
- Iterations: 2
- Library coverage percentage: 8.66
- Previous library version metadata entries: 14
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 8.72

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `881696e06331135fdee735a86e644c64c238f55e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.osgi:osgi.core:6.0.0: 7/7 covered calls (100.00%)
- org.osgi:osgi.core:7.0.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.osgi:osgi.core:6.0.0: 7/7 covered calls (100.00%)
- org.osgi:osgi.core:7.0.0: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.osgi:osgi.core:6.0.0: 1202/16680 (7.21%)
- org.osgi:osgi.core:7.0.0: 1212/16855 (7.19%)

**Line:**
- org.osgi:osgi.core:6.0.0: 295/3383 (8.72%)
- org.osgi:osgi.core:7.0.0: 298/3441 (8.66%)

**Method:**
- org.osgi:osgi.core:6.0.0: 50/429 (11.65%)
- org.osgi:osgi.core:7.0.0: 50/443 (11.29%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.osgi/osgi.core/6.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java 2/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
index f3093568a6..3851c0d484 100644
--- 1/tests/src/org.osgi/osgi.core/6.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
+++ 2/tests/src/org.osgi/osgi.core/7.0.0/src/test/java/org_osgi/osgi_core/ServiceTrackerTest.java
@@ -11,7 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
@@ -108,6 +110,46 @@ public class ServiceTrackerTest {
             return new String[] {Constants.SERVICE_ID, Constants.SERVICE_RANKING};
         }
 
+        @Override
+        public Dictionary<String, Object> getProperties() {
+            return new Dictionary<>() {
+                @Override
+                public int size() {
+                    return 2;
+                }
+
+                @Override
+                public boolean isEmpty() {
+                    return false;
+                }
+
+                @Override
+                public Enumeration<String> keys() {
+                    return Collections.enumeration(List.of(Constants.SERVICE_ID, Constants.SERVICE_RANKING));
+                }
+
+                @Override
+                public Enumeration<Object> elements() {
+                    return Collections.enumeration(List.of(serviceId, ranking));
+                }
+
+                @Override
+                public Object get(Object key) {
+                    return key instanceof String ? getProperty((String) key) : null;
+                }
+
+                @Override
+                public Object put(String key, Object value) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Object remove(Object key) {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
         @Override
         public Bundle getBundle() {
             return null;

```
