### PR TITLE
[GenAI] Test fix for io.netty:netty-transport-native-unix-common:4.1.57.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-native-unix-common/4.1.57.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/4.1.57.Final/reachability-metadata.json
@@ -1,0 +1,322 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.PreferredDirectByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.ChannelException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.Buffer",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.DatagramSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "int",
+            "int",
+            "io.netty.channel.unix.DatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.FileDescriptor"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.LimitsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.channel.unix.Socket",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.io.IOException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.lang.OutOfMemoryError",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.lang.RuntimeException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.net.InetSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.net.PortUnreachableException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.nio.Buffer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "address"
+        },
+        {
+          "name": "limit"
+        },
+        {
+          "name": "position"
+        }
+      ],
+      "methods": [
+        {
+          "name": "limit",
+          "parameterTypes": []
+        },
+        {
+          "name": "position",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "java.nio.channels.ClosedChannelException",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "sun.misc.VM"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.unix.Unix"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_unix_linux_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-native-unix-common/index.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/index.json
@@ -2,12 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.57.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.57.Final/netty-transport-native-unix-common-4.1.57.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.57.Final/netty-transport-native-unix-common-tests-4.1.57.Final-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.57.Final/netty-transport-native-unix-common-4.1.57.Final-javadoc.jar",
+    "description" : "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
     "tested-versions" : [
       "4.1.57.Final"
     ],
     "allowed-packages" : [
-      "io.netty.channel.unix",
-      "io.netty.util.internal"
+      "io.netty.channel.unix"
     ]
   },
   {

--- a/metadata/io.netty/netty-transport-native-unix-common/index.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/index.json
@@ -1,16 +1,26 @@
 [
   {
-    "latest": true,
-    "metadata-version": "4.1.42.Final",
-    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-sources.jar",
-    "repository-url": "https://github.com/netty/netty",
-    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.42.Final/netty-transport-native-unix-common-tests-4.1.42.Final-sources.jar",
-    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-javadoc.jar",
-    "description": "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "4.1.57.Final",
+    "tested-versions" : [
+      "4.1.57.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.unix",
+      "io.netty.util.internal"
+    ]
+  },
+  {
+    "metadata-version" : "4.1.42.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common-tests/4.1.42.Final/netty-transport-native-unix-common-tests-4.1.42.Final-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/4.1.42.Final/netty-transport-native-unix-common-4.1.42.Final-javadoc.jar",
+    "description" : "Netty Transport Native Unix Common provides shared JNI-backed Unix utility classes and native support used by Netty's Unix-based transport modules. It supplies common Unix socket address, file descriptor, and native library plumbing that higher-level Netty transports build on for asynchronous network clients and servers.",
+    "tested-versions" : [
       "4.1.42.Final"
     ],
-    "allowed-packages": [
+    "allowed-packages" : [
       "io.netty.channel.unix",
       "io.netty.util.internal"
     ]

--- a/stats/io.netty/netty-transport-native-unix-common/4.1.57.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-native-unix-common/4.1.57.Final/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T06:20:56.740990Z",
+    "library": "io.netty:netty-transport-native-unix-common:4.1.57.Final",
+    "starting_commit": "e9122ee39e2614890c1c2133ea844296c427ab77",
+    "ending_commit": "089d4a72d673b2f423c26fb0c3c17617856a2af6",
+    "previous_library": "io.netty:netty-transport-native-unix-common:4.1.42.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.57.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 502,
+          "missed": 1935,
+          "ratio": 0.205991,
+          "total": 2437
+        },
+        "line": {
+          "covered": 117,
+          "missed": 466,
+          "ratio": 0.200686,
+          "total": 583
+        },
+        "method": {
+          "covered": 46,
+          "missed": 125,
+          "ratio": 0.269006,
+          "total": 171
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.1.42.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 425,
+          "missed": 1817,
+          "ratio": 0.189563,
+          "total": 2242
+        },
+        "line": {
+          "covered": 87,
+          "missed": 443,
+          "ratio": 0.164151,
+          "total": 530
+        },
+        "method": {
+          "covered": 40,
+          "missed": 123,
+          "ratio": 0.245399,
+          "total": 163
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 59298,
+      "cached_input_tokens_used": 441856,
+      "output_tokens_used": 4566,
+      "iterations": 1,
+      "cost_usd": 0.3579,
+      "tested_library_loc": 117,
+      "metadata_entries": 68,
+      "previous_library_metadata_entries": 29,
+      "code_coverage_percent": 20.07,
+      "previous_library_coverage_percent": 16.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-native-unix-common/4.1.57.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-native-unix-common/4.1.57.Final/stats.json
+++ b/stats/io.netty/netty-transport-native-unix-common/4.1.57.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.57.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 502,
+        "missed" : 1935,
+        "ratio" : 0.205991,
+        "total" : 2437
+      },
+      "line" : {
+        "covered" : 117,
+        "missed" : 466,
+        "ratio" : 0.200686,
+        "total" : 583
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 125,
+        "ratio" : 0.269006,
+        "total" : 171
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-native-unix-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
@@ -9,10 +9,34 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String nativeClassifier = nettyNativeClassifier()
 
 dependencies {
     testImplementation "io.netty:netty-transport-native-unix-common:$libraryVersion"
+    if (nativeClassifier != null) {
+        testRuntimeOnly "io.netty:netty-transport-native-unix-common:$libraryVersion:$nativeClassifier"
+    }
     testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+String nettyNativeClassifier() {
+    String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+    String osArch = System.getProperty("os.arch").toLowerCase(Locale.ROOT)
+
+    if (osName.startsWith("linux")) {
+        if (osArch == "amd64" || osArch == "x86_64") {
+            return "linux-x86_64"
+        }
+        if (osArch == "aarch64") {
+            return "linux-aarch_64"
+        }
+    }
+    if (osName.startsWith("mac") || osName.startsWith("osx")) {
+        if (osArch == "amd64" || osArch == "x86_64") {
+            return "osx-x86_64"
+        }
+    }
+    return null
 }
 
 graalvmNative {

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-native-unix-common:4.1.57.Final
+library.version = 4.1.57.Final
+metadata.dir = io.netty/netty-transport-native-unix-common/4.1.57.Final/

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-native-unix-common_tests'

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_native_unix_common;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.unix.Buffer;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.NativeInetAddress;
+import io.netty.channel.unix.PreferredDirectByteBufAllocator;
+import io.netty.channel.unix.UnixChannelOption;
+import io.netty.channel.unix.UnixChannelUtil;
+import java.io.File;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Netty_transport_native_unix_commonTest {
+    @Test
+    void domainSocketAddressExposesPathAndValueSemantics() {
+        DomainSocketAddress stringAddress = new DomainSocketAddress("/tmp/netty-test.sock");
+        DomainSocketAddress equalAddress = new DomainSocketAddress(new File("/tmp/netty-test.sock"));
+        DomainSocketAddress otherAddress = new DomainSocketAddress("/tmp/netty-other.sock");
+
+        assertThat(stringAddress.path()).isEqualTo("/tmp/netty-test.sock");
+        assertThat(stringAddress.toString()).isEqualTo("/tmp/netty-test.sock");
+        assertThat(stringAddress).isEqualTo(equalAddress);
+        assertThat(stringAddress.hashCode()).isEqualTo(equalAddress.hashCode());
+        assertThat(stringAddress).isNotEqualTo(otherAddress);
+        assertThat(stringAddress).isNotEqualTo("/tmp/netty-test.sock");
+        assertThatNullPointerException()
+                .isThrownBy(() -> new DomainSocketAddress((String) null));
+    }
+
+    @Test
+    void nativeInetAddressMapsIpv4AddressToIpv4MappedIpv6Bytes() throws Exception {
+        InetAddress loopback = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+        NativeInetAddress nativeAddress = NativeInetAddress.newInstance(loopback);
+        byte[] expected = new byte[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, (byte) 0xff, (byte) 0xff,
+                127, 0, 0, 1
+        };
+
+        assertThat(nativeAddress.address()).containsExactly(expected);
+        assertThat(nativeAddress.scopeId()).isZero();
+        assertThat(NativeInetAddress.ipv4MappedIpv6Address(loopback.getAddress())).containsExactly(expected);
+
+        byte[] copied = new byte[16];
+        NativeInetAddress.copyIpv4MappedIpv6Address(new byte[] {10, 20, 30, 40}, copied);
+        assertThat(copied).containsExactly(
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, (byte) 0xff, (byte) 0xff,
+                10, 20, 30, 40);
+    }
+
+    @Test
+    void nativeInetAddressPreservesIpv6BytesAndScope() throws Exception {
+        byte[] ipv6Bytes = new byte[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 1
+        };
+        Inet6Address loopback = Inet6Address.getByAddress(null, ipv6Bytes, 0);
+        NativeInetAddress nativeAddress = NativeInetAddress.newInstance(loopback);
+
+        assertThat(nativeAddress.address()).containsExactly(ipv6Bytes);
+        assertThat(nativeAddress.scopeId()).isEqualTo(loopback.getScopeId());
+
+        NativeInetAddress explicitScope = new NativeInetAddress(ipv6Bytes, 7);
+        assertThat(explicitScope.address()).containsExactly(ipv6Bytes);
+        assertThat(explicitScope.scopeId()).isEqualTo(7);
+    }
+
+    @Test
+    void nativeInetAddressDecodesIpv4SocketAddressWithOffset() throws Exception {
+        byte[] encoded = new byte[12];
+        int offset = 2;
+        encoded[offset] = (byte) 192;
+        encoded[offset + 1] = (byte) 168;
+        encoded[offset + 2] = 1;
+        encoded[offset + 3] = 25;
+        encodeInt(encoded, offset + 4, 8080);
+
+        InetSocketAddress socketAddress = NativeInetAddress.address(encoded, offset, 8);
+
+        assertThat(socketAddress.getAddress().getAddress()).containsExactly((byte) 192, (byte) 168, 1, 25);
+        assertThat(socketAddress.getPort()).isEqualTo(8080);
+    }
+
+    @Test
+    void nativeInetAddressDecodesIpv6SocketAddressWithScopeAndOffset() throws Exception {
+        byte[] encoded = new byte[30];
+        int offset = 3;
+        byte[] ipv6Bytes = new byte[] {
+                0x20, 0x01, 0x0d, (byte) 0xb8,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 5
+        };
+        System.arraycopy(ipv6Bytes, 0, encoded, offset, ipv6Bytes.length);
+        encodeInt(encoded, offset + 16, 9);
+        encodeInt(encoded, offset + 20, 443);
+
+        InetSocketAddress socketAddress = NativeInetAddress.address(encoded, offset, 24);
+
+        assertThat(socketAddress.getAddress()).isInstanceOf(Inet6Address.class);
+        assertThat(socketAddress.getAddress().getAddress()).containsExactly(ipv6Bytes);
+        assertThat(((Inet6Address) socketAddress.getAddress()).getScopeId()).isEqualTo(9);
+        assertThat(socketAddress.getPort()).isEqualTo(443);
+    }
+
+    @Test
+    void bufferAllocatesDirectByteBufferUsingNativeByteOrder() {
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(32);
+
+        assertThat(buffer.isDirect()).isTrue();
+        assertThat(buffer.capacity()).isEqualTo(32);
+        assertThat(buffer.order()).isEqualTo(ByteOrder.nativeOrder());
+    }
+
+    @Test
+    void preferredAllocatorDelegatesToDirectBuffersForGenericAndIoAllocations() {
+        PreferredDirectByteBufAllocator allocator = new PreferredDirectByteBufAllocator();
+        allocator.updateAllocator(UnpooledByteBufAllocator.DEFAULT);
+        ByteBuf buffer = allocator.buffer(16, 64);
+        ByteBuf ioBuffer = allocator.ioBuffer(8);
+        ByteBuf directBuffer = allocator.directBuffer(4);
+        ByteBuf heapBuffer = allocator.heapBuffer(4);
+        CompositeByteBuf compositeBuffer = allocator.compositeBuffer(2);
+        CompositeByteBuf compositeHeapBuffer = allocator.compositeHeapBuffer(2);
+        CompositeByteBuf compositeDirectBuffer = allocator.compositeDirectBuffer(2);
+        compositeBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.directBuffer(1).writeByte(1));
+        compositeHeapBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.heapBuffer(1).writeByte(2));
+        compositeDirectBuffer.addComponent(true, UnpooledByteBufAllocator.DEFAULT.directBuffer(1).writeByte(3));
+
+        try {
+            assertThat(buffer.isDirect()).isTrue();
+            assertThat(buffer.capacity()).isEqualTo(16);
+            assertThat(buffer.maxCapacity()).isEqualTo(64);
+            assertThat(ioBuffer.isDirect()).isTrue();
+            assertThat(directBuffer.isDirect()).isTrue();
+            assertThat(heapBuffer.isDirect()).isFalse();
+            assertThat(compositeBuffer.isDirect()).isTrue();
+            assertThat(compositeHeapBuffer.isDirect()).isFalse();
+            assertThat(compositeDirectBuffer.isDirect()).isTrue();
+            assertThat(allocator.isDirectBufferPooled())
+                    .isEqualTo(UnpooledByteBufAllocator.DEFAULT.isDirectBufferPooled());
+            assertThat(allocator.calculateNewCapacity(33, 128))
+                    .isEqualTo(UnpooledByteBufAllocator.DEFAULT.calculateNewCapacity(33, 128));
+        } finally {
+            buffer.release();
+            ioBuffer.release();
+            directBuffer.release();
+            heapBuffer.release();
+            compositeBuffer.release();
+            compositeHeapBuffer.release();
+            compositeDirectBuffer.release();
+        }
+    }
+
+    @Test
+    void nativeInetAddressConstructsFromEncodedBytesWithDefaultScope() {
+        byte[] addressBytes = new byte[] {
+                0x20, 0x01, 0x0d, (byte) 0xb8,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 9
+        };
+        NativeInetAddress nativeAddress = new NativeInetAddress(addressBytes);
+
+        assertThat(nativeAddress.address()).containsExactly(addressBytes);
+        assertThat(nativeAddress.scopeId()).isZero();
+    }
+
+    @Test
+    void nativeInetAddressRejectsUnsupportedSocketAddressPayloadLength() {
+        byte[] encoded = new byte[16];
+
+        assertThatThrownBy(() -> NativeInetAddress.address(encoded, 0, 12))
+                .isInstanceOf(Error.class);
+    }
+
+    @Test
+    void unixChannelUtilKeepsRequestedHostNameWhenOsAddressIsAvailable() throws Exception {
+        InetSocketAddress requested = InetSocketAddress.createUnresolved("requested.example", 1111);
+        InetSocketAddress operatingSystemAddress = new InetSocketAddress(
+                InetAddress.getByAddress(new byte[] {10, 11, 12, 13}), 2222);
+
+        InetSocketAddress computed = UnixChannelUtil.computeRemoteAddr(requested, operatingSystemAddress);
+
+        assertThat(computed.getHostString()).isEqualTo("requested.example");
+        assertThat(computed.getAddress().getAddress()).containsExactly(10, 11, 12, 13);
+        assertThat(computed.getPort()).isEqualTo(2222);
+        assertThat(UnixChannelUtil.computeRemoteAddr(requested, null)).isSameAs(requested);
+    }
+
+    @Test
+    void unixChannelOptionsExposeTypedConstantsAndValidation() {
+        ChannelOption<Boolean> reusePort = UnixChannelOption.SO_REUSEPORT;
+        ChannelOption<DomainSocketReadMode> readMode = UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
+
+        assertThat(reusePort).isSameAs(ChannelOption.valueOf(UnixChannelOption.class, "SO_REUSEPORT"));
+        assertThat(readMode).isSameAs(ChannelOption.valueOf(UnixChannelOption.class, "DOMAIN_SOCKET_READ_MODE"));
+        assertThat(reusePort.name()).endsWith("SO_REUSEPORT");
+        assertThat(readMode.name()).endsWith("DOMAIN_SOCKET_READ_MODE");
+        reusePort.validate(Boolean.TRUE);
+        readMode.validate(DomainSocketReadMode.BYTES);
+        assertThatNullPointerException().isThrownBy(() -> readMode.validate(null));
+    }
+
+    @Test
+    void domainSocketReadModeSupportsStableEnumLookup() {
+        assertThat(DomainSocketReadMode.values()).containsExactly(
+                DomainSocketReadMode.BYTES,
+                DomainSocketReadMode.FILE_DESCRIPTORS);
+        assertThat(DomainSocketReadMode.valueOf("BYTES")).isSameAs(DomainSocketReadMode.BYTES);
+        assertThat(DomainSocketReadMode.valueOf("FILE_DESCRIPTORS"))
+                .isSameAs(DomainSocketReadMode.FILE_DESCRIPTORS);
+    }
+
+    @Test
+    void fileDescriptorWrapsIntegerDescriptorWithValueSemanticsWithoutClosingIt() {
+        FileDescriptor descriptor = new FileDescriptor(7);
+        FileDescriptor equalDescriptor = new FileDescriptor(7);
+        FileDescriptor otherDescriptor = new FileDescriptor(8);
+
+        assertThat(descriptor.intValue()).isEqualTo(7);
+        assertThat(descriptor.isOpen()).isTrue();
+        assertThat(descriptor).isEqualTo(equalDescriptor);
+        assertThat(descriptor.hashCode()).isEqualTo(equalDescriptor.hashCode());
+        assertThat(descriptor).isNotEqualTo(otherDescriptor);
+        assertThat(descriptor.toString()).isEqualTo("FileDescriptor{fd=7}");
+        assertThatThrownBy(() -> new FileDescriptor(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void encodeInt(byte[] target, int index, int value) {
+        target[index] = (byte) (value >>> 24);
+        target[index + 1] = (byte) (value >>> 16);
+        target[index + 2] = (byte) (value >>> 8);
+        target[index + 3] = (byte) value;
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -16,6 +16,7 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.NativeInetAddress;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
+import io.netty.channel.unix.Unix;
 import io.netty.channel.unix.UnixChannelOption;
 import io.netty.channel.unix.UnixChannelUtil;
 import java.io.File;
@@ -235,6 +236,13 @@ public class Netty_transport_native_unix_commonTest {
 
     @Test
     void fileDescriptorWrapsIntegerDescriptorWithValueSemanticsWithoutClosingIt() {
+        if (!Unix.isAvailable()) {
+            assertThatThrownBy(() -> new FileDescriptor(7))
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessageContaining("failed to load the required native library");
+            return;
+        }
+
         FileDescriptor descriptor = new FileDescriptor(7);
         FileDescriptor equalDescriptor = new FileDescriptor(7);
         FileDescriptor otherDescriptor = new FileDescriptor(8);

--- a/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.netty.channel.unix.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4174

This PR provides test fixes and new metadata for io.netty:netty-transport-native-unix-common:4.1.57.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 59298
- Cached input tokens: 441856
- Output tokens: 4566
- Metadata entries: 68
- Iterations: 1
- Library coverage percentage: 20.07
- Previous library version metadata entries: 29
- Previous library version coverage percentage: 16.42

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `881696e06331135fdee735a86e644c64c238f55e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-transport-native-unix-common:4.1.42.Final: 0/0 covered calls (100.00%)
- io.netty:netty-transport-native-unix-common:4.1.57.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-transport-native-unix-common:4.1.42.Final: 425/2242 (18.96%)
- io.netty:netty-transport-native-unix-common:4.1.57.Final: 502/2437 (20.60%)

**Line:**
- io.netty:netty-transport-native-unix-common:4.1.42.Final: 87/530 (16.42%)
- io.netty:netty-transport-native-unix-common:4.1.57.Final: 117/583 (20.07%)

**Method:**
- io.netty:netty-transport-native-unix-common:4.1.42.Final: 40/163 (24.54%)
- io.netty:netty-transport-native-unix-common:4.1.57.Final: 46/171 (26.90%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/build.gradle 2/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
index b118e8bb4f..9bcaf922d7 100644
--- 1/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/build.gradle
+++ 2/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/build.gradle
@@ -9,12 +9,36 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String nativeClassifier = nettyNativeClassifier()
 
 dependencies {
     testImplementation "io.netty:netty-transport-native-unix-common:$libraryVersion"
+    if (nativeClassifier != null) {
+        testRuntimeOnly "io.netty:netty-transport-native-unix-common:$libraryVersion:$nativeClassifier"
+    }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+String nettyNativeClassifier() {
+    String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+    String osArch = System.getProperty("os.arch").toLowerCase(Locale.ROOT)
+
+    if (osName.startsWith("linux")) {
+        if (osArch == "amd64" || osArch == "x86_64") {
+            return "linux-x86_64"
+        }
+        if (osArch == "aarch64") {
+            return "linux-aarch_64"
+        }
+    }
+    if (osName.startsWith("mac") || osName.startsWith("osx")) {
+        if (osArch == "amd64" || osArch == "x86_64") {
+            return "osx-x86_64"
+        }
+    }
+    return null
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
diff --git 1/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java 2/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
index a97f0f83c1..8b0233eaef 100644
--- 1/tests/src/io.netty/netty-transport-native-unix-common/4.1.42.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
+++ 2/tests/src/io.netty/netty-transport-native-unix-common/4.1.57.Final/src/test/java/io_netty/netty_transport_native_unix_common/Netty_transport_native_unix_commonTest.java
@@ -16,6 +16,7 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.NativeInetAddress;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
+import io.netty.channel.unix.Unix;
 import io.netty.channel.unix.UnixChannelOption;
 import io.netty.channel.unix.UnixChannelUtil;
 import java.io.File;
@@ -235,6 +236,13 @@ public class Netty_transport_native_unix_commonTest {
 
     @Test
     void fileDescriptorWrapsIntegerDescriptorWithValueSemanticsWithoutClosingIt() {
+        if (!Unix.isAvailable()) {
+            assertThatThrownBy(() -> new FileDescriptor(7))
+                    .isInstanceOf(UnsatisfiedLinkError.class)
+                    .hasMessageContaining("failed to load the required native library");
+            return;
+        }
+
         FileDescriptor descriptor = new FileDescriptor(7);
         FileDescriptor equalDescriptor = new FileDescriptor(7);
         FileDescriptor otherDescriptor = new FileDescriptor(8);

```
