### PR TITLE
[GenAI] Test fix for org.glassfish.hk2:hk2-utils:2.5.0 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.hk2/hk2-utils/2.5.0/reachability-metadata.json
+++ b/metadata/org.glassfish.hk2/hk2-utils/2.5.0/reachability-metadata.json
@@ -1,0 +1,58 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.general.GeneralUtilities"
+      },
+      "type" : "int[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.BeanReflectionHelper"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "getClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperUtilities$1"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperUtilities$2"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.general.GeneralUtilities"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.general.GeneralUtilities"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : "java.util.List[]"
+    }
+  ]
+}

--- a/metadata/org.glassfish.hk2/hk2-utils/index.json
+++ b/metadata/org.glassfish.hk2/hk2-utils/index.json
@@ -1,6 +1,17 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.5.0",
+    "tested-versions" : [
+      "2.5.0"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.hk2.utilities",
+      "org.jvnet.hk2.component",
+      "org.jvnet.tiger_types"
+    ]
+  },
+  {
     "metadata-version" : "2.5.0-b05",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-utils/2.5.0-b05/hk2-utils-2.5.0-b05-sources.jar",
     "repository-url" : "https://github.com/javaee/hk2",

--- a/metadata/org.glassfish.hk2/hk2-utils/index.json
+++ b/metadata/org.glassfish.hk2/hk2-utils/index.json
@@ -2,13 +2,17 @@
   {
     "latest" : true,
     "metadata-version" : "2.5.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-utils/2.5.0/hk2-utils-2.5.0-sources.jar",
+    "repository-url" : "https://github.com/eclipse-ee4j/glassfish-hk2",
+    "test-code-url" : "https://github.com/eclipse-ee4j/glassfish-hk2/tree/2.5.0-RELEASE/hk2-utils/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-utils/2.5.0/hk2-utils-2.5.0-javadoc.jar",
+    "description" : "HK2 Utils provides utility classes used by the HK2 dependency injection framework, including reflection helpers, cache abstractions, weak-reference collections, and general-purpose support code. It supports HK2 internals and applications built on HK2 by centralizing reusable Java utilities for type inspection, cache management, and lightweight data structures.",
     "tested-versions" : [
       "2.5.0"
     ],
     "allowed-packages" : [
       "org.glassfish.hk2.utilities",
-      "org.jvnet.hk2.component",
-      "org.jvnet.tiger_types"
+      "org.jvnet.hk2.component"
     ]
   },
   {

--- a/stats/org.glassfish.hk2/hk2-utils/2.5.0/execution-metrics.json
+++ b/stats/org.glassfish.hk2/hk2-utils/2.5.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T06:46:18.270813Z",
+    "library": "org.glassfish.hk2:hk2-utils:2.5.0",
+    "starting_commit": "bba5e936556e3b98f5fc7960f3b359d9c96e30e5",
+    "ending_commit": "69ff18e8ba4a0a33a0b97703e0fdddec8ea427fd",
+    "previous_library": "org.glassfish.hk2:hk2-utils:2.5.0-b05",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 16,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 16,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1567,
+          "missed": 7958,
+          "ratio": 0.164514,
+          "total": 9525
+        },
+        "line": {
+          "covered": 338,
+          "missed": 1919,
+          "ratio": 0.149756,
+          "total": 2257
+        },
+        "method": {
+          "covered": 92,
+          "missed": 359,
+          "ratio": 0.203991,
+          "total": 451
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.5.0-b05",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 22,
+            "totalCalls": 22
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1970,
+          "missed": 7654,
+          "ratio": 0.204697,
+          "total": 9624
+        },
+        "line": {
+          "covered": 424,
+          "missed": 1780,
+          "ratio": 0.192377,
+          "total": 2204
+        },
+        "method": {
+          "covered": 121,
+          "missed": 313,
+          "ratio": 0.278802,
+          "total": 434
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 58004,
+      "cached_input_tokens_used": 574976,
+      "output_tokens_used": 6409,
+      "iterations": 1,
+      "cost_usd": 0.4798,
+      "tested_library_loc": 338,
+      "metadata_entries": 9,
+      "test_only_metadata_entries": 15,
+      "previous_library_metadata_entries": 16,
+      "previous_library_test_only_metadata_entries": 15,
+      "code_coverage_percent": 14.98,
+      "previous_library_coverage_percent": 19.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperUtilitiesAnonymous4Test.java",
+      "metadata_file": "metadata/org.glassfish.hk2/hk2-utils/2.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.hk2/hk2-utils/2.5.0/stats.json
+++ b/stats/org.glassfish.hk2/hk2-utils/2.5.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.5.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 16,
+          "totalCalls" : 16
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 16,
+      "totalCalls" : 16
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1567,
+        "missed" : 7958,
+        "ratio" : 0.164514,
+        "total" : 9525
+      },
+      "line" : {
+        "covered" : 338,
+        "missed" : 1919,
+        "ratio" : 0.149756,
+        "total" : 2257
+      },
+      "method" : {
+        "covered" : 92,
+        "missed" : 359,
+        "ratio" : 0.203991,
+        "total" : 451
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/.gitignore
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/build.gradle
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.hk2:hk2-utils:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/gradle.properties
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.hk2:hk2-utils:2.5.0
+library.version = 2.5.0
+metadata.dir = org.glassfish.hk2/hk2-utils/2.5.0/

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/settings.gradle
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.hk2.hk2-utils_tests'

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/BeanReflectionHelperTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/BeanReflectionHelperTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.beans.PropertyChangeEvent;
+import java.util.Map;
+
+import org.glassfish.hk2.utilities.reflection.BeanReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReflectionHelperTest {
+    private final ClassReflectionHelper helper = new ClassReflectionHelperImpl();
+
+    @Test
+    public void reportsChangedBeanPropertiesFromPublicGetters() {
+        final AccountState previousState = new AccountState("available", true, 3);
+        final AccountState currentState = new AccountState("busy", true, 5);
+
+        final PropertyChangeEvent[] events = BeanReflectionHelper.getChangeEvents(
+                helper,
+                previousState,
+                currentState
+        );
+
+        assertThat(events)
+                .extracting(PropertyChangeEvent::getPropertyName)
+                .containsExactlyInAnyOrder("status", "priority");
+        assertThat(events)
+                .filteredOn(event -> "status".equals(event.getPropertyName()))
+                .singleElement()
+                .satisfies(event -> {
+                    assertThat(event.getOldValue()).isEqualTo("available");
+                    assertThat(event.getNewValue()).isEqualTo("busy");
+                    assertThat(event.getSource()).isSameAs(currentState);
+                });
+        assertThat(events)
+                .filteredOn(event -> "priority".equals(event.getPropertyName()))
+                .singleElement()
+                .satisfies(event -> {
+                    assertThat(event.getOldValue()).isEqualTo(3);
+                    assertThat(event.getNewValue()).isEqualTo(5);
+                });
+    }
+
+    @Test
+    public void convertsJavaBeanGettersToBeanLikeMap() {
+        final AccountState state = new AccountState("available", false, 7);
+
+        final Map<String, Object> values = BeanReflectionHelper.convertJavaBeanToBeanLikeMap(
+                helper,
+                state
+        );
+
+        assertThat(values)
+                .containsEntry("status", "available")
+                .containsEntry("active", false)
+                .containsEntry("priority", 7)
+                .doesNotContainKey("class");
+    }
+
+    public static final class AccountState {
+        private final String status;
+        private final boolean active;
+        private final int priority;
+
+        public AccountState(String status, boolean active, int priority) {
+            this.status = status;
+            this.active = active;
+            this.priority = priority;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public String status() {
+            return status;
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperImplTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.Method;
+
+import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReflectionHelperImplTest {
+    private final ClassReflectionHelper helper = new ClassReflectionHelperImpl();
+
+    @Test
+    public void findsConventionLifecycleMethodsThroughMatchingClassOptimization() {
+        final Method postConstruct = helper.findPostConstruct(LifecycleService.class, LifecycleMarker.class);
+        final Method preDestroy = helper.findPreDestroy(LifecycleService.class, LifecycleMarker.class);
+
+        assertThat(postConstruct.getName()).isEqualTo("postConstruct");
+        assertThat(postConstruct.getParameterCount()).isZero();
+        assertThat(postConstruct.getDeclaringClass()).isEqualTo(LifecycleService.class);
+        assertThat(preDestroy.getName()).isEqualTo("preDestroy");
+        assertThat(preDestroy.getParameterCount()).isZero();
+        assertThat(preDestroy.getDeclaringClass()).isEqualTo(LifecycleService.class);
+    }
+
+    public interface LifecycleMarker {
+    }
+
+    public static final class LifecycleService implements LifecycleMarker {
+        public void postConstruct() {
+        }
+
+        public void preDestroy() {
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperUtilitiesAnonymous4Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperUtilitiesAnonymous4Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReflectionHelperUtilitiesAnonymous4Test {
+    private final ClassReflectionHelper helper = new ClassReflectionHelperImpl();
+
+    @Test
+    public void findsDeclaredFieldsAcrossConcreteClassHierarchy() {
+        final Set<String> fields = helper.getAllFields(FieldChildService.class)
+                .stream()
+                .map(ClassReflectionHelperUtilitiesAnonymous4Test::qualifiedFieldName)
+                .collect(Collectors.toSet());
+
+        assertThat(fields).containsExactlyInAnyOrder(
+                "FieldParentService#parentId",
+                "FieldChildService#childName"
+        );
+    }
+
+    private static String qualifiedFieldName(final Field field) {
+        return field.getDeclaringClass().getSimpleName() + "#" + field.getName();
+    }
+
+    private static class FieldParentService {
+        private long parentId;
+    }
+
+    private static final class FieldChildService extends FieldParentService {
+        private String childName;
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperUtilitiesTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ClassReflectionHelperUtilitiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.MethodWrapper;
+import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReflectionHelperUtilitiesTest {
+    private final ClassReflectionHelper helper = new ClassReflectionHelperImpl();
+
+    @Test
+    public void findsMethodsDeclaredOnInterfaceHierarchy() {
+        final Set<String> methodNames = helper.getAllMethods(ClassReflectionHelperUtilitiesChildContract.class)
+                .stream()
+                .map(MethodWrapper::getMethod)
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(methodNames).containsExactlyInAnyOrder("parentOperation", "childOperation");
+    }
+}
+
+interface ClassReflectionHelperUtilitiesParentContract {
+    String parentOperation();
+}
+
+interface ClassReflectionHelperUtilitiesChildContract extends ClassReflectionHelperUtilitiesParentContract {
+    String childOperation();
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/GeneralUtilitiesTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/GeneralUtilitiesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.glassfish.hk2.utilities.general.GeneralUtilities;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GeneralUtilitiesTest {
+    @Test
+    public void loadsNamedClassWithProvidedClassLoader() {
+        final MappingClassLoader classLoader = new MappingClassLoader();
+
+        final Class<?> loadedClass = GeneralUtilities.loadClass(classLoader, String.class.getName());
+
+        assertThat(loadedClass).isEqualTo(String.class);
+        assertThat(classLoader.requestedNames()).containsExactly(String.class.getName());
+    }
+
+    @Test
+    public void loadsPrimitiveAndReferenceArrayClassDescriptors() {
+        final MappingClassLoader classLoader = new MappingClassLoader();
+
+        assertThat(GeneralUtilities.loadClass(classLoader, "[[I")).isEqualTo(int[][].class);
+        assertThat(classLoader.requestedNames()).isEmpty();
+
+        assertThat(GeneralUtilities.loadClass(classLoader, "[Ljava.lang.String;")).isEqualTo(String[].class);
+        assertThat(classLoader.requestedNames()).containsExactly(String.class.getName());
+    }
+
+    private static final class MappingClassLoader extends ClassLoader {
+        private final List<String> requestedNames = new ArrayList<>();
+
+        private MappingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            requestedNames.add(name);
+            if (String.class.getName().equals(name)) {
+                return String.class;
+            }
+            throw new ClassNotFoundException(name);
+        }
+
+        private List<String> requestedNames() {
+            return Collections.unmodifiableList(requestedNames);
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import org.jvnet.tiger_types.Lister;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListerAnonymous1Test {
+    @Test
+    public void convertsAccumulatedItemsToTypedArray() {
+        final Lister<?> lister = Lister.create(String[].class, String[].class);
+        lister.add("alpha");
+        lister.add("beta");
+
+        final Object collection = lister.toCollection();
+
+        assertThat(collection).isInstanceOf(String[].class);
+        assertThat((String[]) collection).containsExactly("alpha", "beta");
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
@@ -6,21 +6,20 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
-import org.jvnet.tiger_types.Lister;
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ListerAnonymous1Test {
     @Test
-    public void convertsAccumulatedItemsToTypedArray() {
-        final Lister<?> lister = Lister.create(String[].class, String[].class);
-        lister.add("alpha");
-        lister.add("beta");
+    public void convertsGenericArrayTypeWithClassComponentToArrayClass() {
+        final GenericArrayTypeImpl stringArrayType = new GenericArrayTypeImpl(String.class);
 
-        final Object collection = lister.toCollection();
+        final Class<?> rawClass = ReflectionHelper.getRawClass(stringArrayType);
 
-        assertThat(collection).isInstanceOf(String[].class);
-        assertThat((String[]) collection).containsExactly("alpha", "beta");
+        assertThat(rawClass).isEqualTo(String[].class);
+        assertThat(rawClass.getComponentType()).isEqualTo(String.class);
     }
 }

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jvnet.tiger_types.Lister;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListerTest {
+    @Test
+    public void createsRequestedConcreteCollectionType() {
+        final Lister<?> lister = Lister.create(ArrayList.class, ArrayList.class);
+        lister.add("alpha");
+        lister.add("beta");
+
+        final Object collection = lister.toCollection();
+
+        assertThat(collection).isInstanceOf(ArrayList.class);
+        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+    }
+
+    @Test
+    public void fallsBackToConcreteCollectionForCollectionInterface() {
+        final Lister<?> lister = Lister.create(List.class, List.class);
+        lister.add("alpha");
+        lister.add("beta");
+
+        final Object collection = lister.toCollection();
+
+        assertThat(collection).isInstanceOf(ArrayList.class);
+        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
@@ -6,36 +6,33 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.tiger_types.Lister;
+import org.glassfish.hk2.utilities.reflection.ParameterizedTypeImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ListerTest {
     @Test
-    public void createsRequestedConcreteCollectionType() {
-        final Lister<?> lister = Lister.create(ArrayList.class, ArrayList.class);
-        lister.add("alpha");
-        lister.add("beta");
+    public void createsParameterizedTypeWithRequestedRawTypeAndArgument() {
+        final ParameterizedType type = new ParameterizedTypeImpl(ArrayList.class, String.class);
 
-        final Object collection = lister.toCollection();
-
-        assertThat(collection).isInstanceOf(ArrayList.class);
-        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+        assertThat(type.getRawType()).isEqualTo(ArrayList.class);
+        assertThat(type.getActualTypeArguments()).containsExactly(String.class);
+        assertThat(type.getOwnerType()).isNull();
     }
 
     @Test
-    public void fallsBackToConcreteCollectionForCollectionInterface() {
-        final Lister<?> lister = Lister.create(List.class, List.class);
-        lister.add("alpha");
-        lister.add("beta");
+    public void comparesParameterizedTypesByRawTypeAndArguments() {
+        final ParameterizedType stringList = new ParameterizedTypeImpl(List.class, String.class);
+        final ParameterizedType anotherStringList = new ParameterizedTypeImpl(List.class, String.class);
+        final ParameterizedType integerList = new ParameterizedTypeImpl(List.class, Integer.class);
 
-        final Object collection = lister.toCollection();
-
-        assertThat(collection).isInstanceOf(ArrayList.class);
-        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+        assertThat(stringList).isEqualTo(anotherStringList);
+        assertThat(stringList).hasSameHashCodeAs(anotherStringList);
+        assertThat(stringList).isNotEqualTo(integerList);
     }
 }

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ReflectionHelperTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ReflectionHelperTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionHelperTest {
+    @Test
+    public void resolvesRawClassForParameterizedGenericArray() throws NoSuchFieldException {
+        final Type genericArrayType = ParameterizedArrayContainer.class.getDeclaredField("values").getGenericType();
+
+        assertThat(ReflectionHelper.getRawClass(genericArrayType)).isEqualTo(List[].class);
+    }
+
+    @Test
+    public void resolvesTypeVariableArrayToConcreteArrayClass() throws NoSuchFieldException {
+        final Field field = GenericArrayContainer.class.getDeclaredField("values");
+
+        assertThat(ReflectionHelper.resolveField(StringArrayContainer.class, field)).isEqualTo(String[].class);
+    }
+
+    @Test
+    public void createsInstancesSetsFieldsAndInvokesMethods() throws Throwable {
+        final Constructor<MutableService> constructor = MutableService.class.getConstructor(String.class);
+        final MutableService service = (MutableService) ReflectionHelper.makeMe(
+                constructor,
+                new Object[] {"hk2"},
+                true
+        );
+        assertThat(service.getName()).isEqualTo("hk2");
+
+        final Field nameField = MutableService.class.getDeclaredField("name");
+        ReflectionHelper.setField(nameField, service, "glassfish");
+        assertThat(service.getName()).isEqualTo("glassfish");
+
+        final Method method = MutableService.class.getMethod("describe", String.class, int.class);
+        assertThat(ReflectionHelper.invoke(service, method, new Object[] {"run", 2}, true))
+                .isEqualTo("run:glassfish:2");
+    }
+
+    private static final class ParameterizedArrayContainer {
+        private List<String>[] values;
+    }
+
+    private static class GenericArrayContainer<T> {
+        private T[] values;
+    }
+
+    private static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    public static final class MutableService {
+        private String name;
+
+        public MutableService(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String describe(String prefix, int count) {
+            return prefix + ":" + name + ":" + count;
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.tiger_types.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypesAnonymous3Test {
+    @Test
+    public void erasureCreatesArrayClassForGenericArrayType() {
+        final GenericArrayType stringArrayType = new SimpleGenericArrayType(String.class);
+
+        final Class<?> erasedType = Types.erasure(stringArrayType);
+
+        assertThat(erasedType).isEqualTo(String[].class);
+        assertThat(erasedType.getComponentType()).isEqualTo(String.class);
+    }
+
+    private static final class SimpleGenericArrayType implements GenericArrayType {
+        private final Type genericComponentType;
+
+        private SimpleGenericArrayType(Type genericComponentType) {
+            this.genericComponentType = genericComponentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return genericComponentType;
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
@@ -7,34 +7,21 @@
 package org_glassfish_hk2.hk2_utils;
 
 import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Type;
 
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
 import org.junit.jupiter.api.Test;
-import org.jvnet.tiger_types.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypesAnonymous3Test {
     @Test
     public void erasureCreatesArrayClassForGenericArrayType() {
-        final GenericArrayType stringArrayType = new SimpleGenericArrayType(String.class);
+        final GenericArrayType stringArrayType = new GenericArrayTypeImpl(String.class);
 
-        final Class<?> erasedType = Types.erasure(stringArrayType);
+        final Class<?> erasedType = ReflectionHelper.getRawClass(stringArrayType);
 
         assertThat(erasedType).isEqualTo(String[].class);
         assertThat(erasedType.getComponentType()).isEqualTo(String.class);
-    }
-
-    private static final class SimpleGenericArrayType implements GenericArrayType {
-        private final Type genericComponentType;
-
-        private SimpleGenericArrayType(Type genericComponentType) {
-            this.genericComponentType = genericComponentType;
-        }
-
-        @Override
-        public Type getGenericComponentType() {
-            return genericComponentType;
-        }
     }
 }

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_utils;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.tiger_types.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypesTest {
+    @Test
+    public void detectsOverriddenMethodDeclaredOnBaseClass() throws NoSuchMethodException {
+        final Method method = ChildService.class.getMethod("describe", String.class);
+
+        assertThat(Types.isOverriding(method, ParentService.class)).isTrue();
+    }
+
+    @Test
+    public void convertsGenericArrayTypeArgumentWithClassComponentToArrayClass() {
+        final Type genericStringArrayType = new SimpleGenericArrayType(String.class);
+        final ParameterizedType listType = Types.createParameterizedType(List.class, genericStringArrayType);
+
+        assertThat(Types.getTypeArgument(listType, 0)).isEqualTo(String[].class);
+    }
+
+    public static class ParentService {
+        public String describe(String value) {
+            return "parent:" + value;
+        }
+    }
+
+    public static final class ChildService extends ParentService {
+        @Override
+        public String describe(String value) {
+            return "child:" + value;
+        }
+    }
+
+    private static final class SimpleGenericArrayType implements GenericArrayType {
+        private final Type genericComponentType;
+
+        private SimpleGenericArrayType(Type genericComponentType) {
+            this.genericComponentType = genericComponentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return genericComponentType;
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
@@ -6,31 +6,35 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ParameterizedTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.internal.MethodWrapperImpl;
 import org.junit.jupiter.api.Test;
-import org.jvnet.tiger_types.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypesTest {
     @Test
-    public void detectsOverriddenMethodDeclaredOnBaseClass() throws NoSuchMethodException {
-        final Method method = ChildService.class.getMethod("describe", String.class);
+    public void treatsOverriddenMethodsAsEquivalentWrappers() throws NoSuchMethodException {
+        final Method childMethod = ChildService.class.getMethod("describe", String.class);
+        final Method parentMethod = ParentService.class.getMethod("describe", String.class);
 
-        assertThat(Types.isOverriding(method, ParentService.class)).isTrue();
+        assertThat(new MethodWrapperImpl(childMethod)).isEqualTo(new MethodWrapperImpl(parentMethod));
     }
 
     @Test
     public void convertsGenericArrayTypeArgumentWithClassComponentToArrayClass() {
-        final Type genericStringArrayType = new SimpleGenericArrayType(String.class);
-        final ParameterizedType listType = Types.createParameterizedType(List.class, genericStringArrayType);
+        final Type genericStringArrayType = new GenericArrayTypeImpl(String.class);
+        final ParameterizedType listType = new ParameterizedTypeImpl(List.class, genericStringArrayType);
 
-        assertThat(Types.getTypeArgument(listType, 0)).isEqualTo(String[].class);
+        assertThat(listType.getRawType()).isEqualTo(List.class);
+        assertThat(ReflectionHelper.getRawClass(listType.getActualTypeArguments()[0])).isEqualTo(String[].class);
     }
 
     public static class ParentService {
@@ -43,19 +47,6 @@ public class TypesTest {
         @Override
         public String describe(String value) {
             return "child:" + value;
-        }
-    }
-
-    private static final class SimpleGenericArrayType implements GenericArrayType {
-        private final Type genericComponentType;
-
-        private SimpleGenericArrayType(Type genericComponentType) {
-            this.genericComponentType = genericComponentType;
-        }
-
-        @Override
-        public Type getGenericComponentType() {
-            return genericComponentType;
         }
     }
 }

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,82 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.BeanReflectionHelper"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.BeanReflectionHelperTest$AccountState",
+      "methods" : [
+        {
+          "name" : "getPriority",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getStatus",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isActive",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperUtilities$3"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.BeanReflectionHelperTest$AccountState"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.ClassReflectionHelperUtilitiesChildContract",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.ClassReflectionHelperUtilitiesParentContract",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.ClassReflectionHelperImplTest$LifecycleService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.ReflectionHelperTest$MutableService",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "describe",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jvnet.tiger_types.Types"
+      },
+      "type" : "org_glassfish_hk2.hk2_utils.TypesTest$ParentService"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.utilities.**"
+    },
+    {
+      "includeClasses" : "org.jvnet.hk2.component.**"
+    },
+    {
+      "includeClasses" : "org.jvnet.tiger_types.**"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
+++ b/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
@@ -8,9 +8,6 @@
     },
     {
       "includeClasses" : "org.jvnet.hk2.component.**"
-    },
-    {
-      "includeClasses" : "org.jvnet.tiger_types.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4216

This PR provides test fixes and new metadata for org.glassfish.hk2:hk2-utils:2.5.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 58004
- Cached input tokens: 574976
- Output tokens: 6409
- Metadata entries: 9
- Test-only metadata entries: 15
- Iterations: 1
- Library coverage percentage: 14.98
- Previous library version metadata entries: 16
- Previous library version test-only metadata entries: 15
- Previous library version coverage percentage: 19.24

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4898a6265381c0b190ec5bf4708990e9808da7f9`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.hk2:hk2-utils:2.5.0-b05: 22/22 covered calls (100.00%)
- org.glassfish.hk2:hk2-utils:2.5.0: 16/16 covered calls (100.00%)

**Reflection:**
- org.glassfish.hk2:hk2-utils:2.5.0-b05: 22/22 covered calls (100.00%)
- org.glassfish.hk2:hk2-utils:2.5.0: 16/16 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.hk2:hk2-utils:2.5.0-b05: 1970/9624 (20.47%)
- org.glassfish.hk2:hk2-utils:2.5.0: 1567/9525 (16.45%)

**Line:**
- org.glassfish.hk2:hk2-utils:2.5.0-b05: 424/2204 (19.24%)
- org.glassfish.hk2:hk2-utils:2.5.0: 338/2257 (14.98%)

**Method:**
- org.glassfish.hk2:hk2-utils:2.5.0-b05: 121/434 (27.88%)
- org.glassfish.hk2:hk2-utils:2.5.0: 92/451 (20.40%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
index eaeccd1933..9da313f954 100644
--- 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
+++ 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerAnonymous1Test.java
@@ -6,21 +6,20 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
-import org.jvnet.tiger_types.Lister;
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ListerAnonymous1Test {
     @Test
-    public void convertsAccumulatedItemsToTypedArray() {
-        final Lister<?> lister = Lister.create(String[].class, String[].class);
-        lister.add("alpha");
-        lister.add("beta");
+    public void convertsGenericArrayTypeWithClassComponentToArrayClass() {
+        final GenericArrayTypeImpl stringArrayType = new GenericArrayTypeImpl(String.class);
 
-        final Object collection = lister.toCollection();
+        final Class<?> rawClass = ReflectionHelper.getRawClass(stringArrayType);
 
-        assertThat(collection).isInstanceOf(String[].class);
-        assertThat((String[]) collection).containsExactly("alpha", "beta");
+        assertThat(rawClass).isEqualTo(String[].class);
+        assertThat(rawClass.getComponentType()).isEqualTo(String.class);
     }
 }
diff --git 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
index f2a5455a4f..2d9f195531 100644
--- 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
+++ 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/ListerTest.java
@@ -6,36 +6,33 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.tiger_types.Lister;
+import org.glassfish.hk2.utilities.reflection.ParameterizedTypeImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ListerTest {
     @Test
-    public void createsRequestedConcreteCollectionType() {
-        final Lister<?> lister = Lister.create(ArrayList.class, ArrayList.class);
-        lister.add("alpha");
-        lister.add("beta");
+    public void createsParameterizedTypeWithRequestedRawTypeAndArgument() {
+        final ParameterizedType type = new ParameterizedTypeImpl(ArrayList.class, String.class);
 
-        final Object collection = lister.toCollection();
-
-        assertThat(collection).isInstanceOf(ArrayList.class);
-        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+        assertThat(type.getRawType()).isEqualTo(ArrayList.class);
+        assertThat(type.getActualTypeArguments()).containsExactly(String.class);
+        assertThat(type.getOwnerType()).isNull();
     }
 
     @Test
-    public void fallsBackToConcreteCollectionForCollectionInterface() {
-        final Lister<?> lister = Lister.create(List.class, List.class);
-        lister.add("alpha");
-        lister.add("beta");
-
-        final Object collection = lister.toCollection();
-
-        assertThat(collection).isInstanceOf(ArrayList.class);
-        assertThat(collection).isEqualTo(List.of("alpha", "beta"));
+    public void comparesParameterizedTypesByRawTypeAndArguments() {
+        final ParameterizedType stringList = new ParameterizedTypeImpl(List.class, String.class);
+        final ParameterizedType anotherStringList = new ParameterizedTypeImpl(List.class, String.class);
+        final ParameterizedType integerList = new ParameterizedTypeImpl(List.class, Integer.class);
+
+        assertThat(stringList).isEqualTo(anotherStringList);
+        assertThat(stringList).hasSameHashCodeAs(anotherStringList);
+        assertThat(stringList).isNotEqualTo(integerList);
     }
 }
diff --git 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
index ddfb433f25..75a8a0303c 100644
--- 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
+++ 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesAnonymous3Test.java
@@ -7,34 +7,21 @@
 package org_glassfish_hk2.hk2_utils;
 
 import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Type;
 
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
 import org.junit.jupiter.api.Test;
-import org.jvnet.tiger_types.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypesAnonymous3Test {
     @Test
     public void erasureCreatesArrayClassForGenericArrayType() {
-        final GenericArrayType stringArrayType = new SimpleGenericArrayType(String.class);
+        final GenericArrayType stringArrayType = new GenericArrayTypeImpl(String.class);
 
-        final Class<?> erasedType = Types.erasure(stringArrayType);
+        final Class<?> erasedType = ReflectionHelper.getRawClass(stringArrayType);
 
         assertThat(erasedType).isEqualTo(String[].class);
         assertThat(erasedType.getComponentType()).isEqualTo(String.class);
     }
-
-    private static final class SimpleGenericArrayType implements GenericArrayType {
-        private final Type genericComponentType;
-
-        private SimpleGenericArrayType(Type genericComponentType) {
-            this.genericComponentType = genericComponentType;
-        }
-
-        @Override
-        public Type getGenericComponentType() {
-            return genericComponentType;
-        }
-    }
 }
diff --git 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
index 0699b7b41f..6afeccea58 100644
--- 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
+++ 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/src/test/java/org_glassfish_hk2/hk2_utils/TypesTest.java
@@ -6,31 +6,35 @@
  */
 package org_glassfish_hk2.hk2_utils;
 
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.glassfish.hk2.utilities.reflection.GenericArrayTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ParameterizedTypeImpl;
+import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
+import org.glassfish.hk2.utilities.reflection.internal.MethodWrapperImpl;
 import org.junit.jupiter.api.Test;
-import org.jvnet.tiger_types.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypesTest {
     @Test
-    public void detectsOverriddenMethodDeclaredOnBaseClass() throws NoSuchMethodException {
-        final Method method = ChildService.class.getMethod("describe", String.class);
+    public void treatsOverriddenMethodsAsEquivalentWrappers() throws NoSuchMethodException {
+        final Method childMethod = ChildService.class.getMethod("describe", String.class);
+        final Method parentMethod = ParentService.class.getMethod("describe", String.class);
 
-        assertThat(Types.isOverriding(method, ParentService.class)).isTrue();
+        assertThat(new MethodWrapperImpl(childMethod)).isEqualTo(new MethodWrapperImpl(parentMethod));
     }
 
     @Test
     public void convertsGenericArrayTypeArgumentWithClassComponentToArrayClass() {
-        final Type genericStringArrayType = new SimpleGenericArrayType(String.class);
-        final ParameterizedType listType = Types.createParameterizedType(List.class, genericStringArrayType);
+        final Type genericStringArrayType = new GenericArrayTypeImpl(String.class);
+        final ParameterizedType listType = new ParameterizedTypeImpl(List.class, genericStringArrayType);
 
-        assertThat(Types.getTypeArgument(listType, 0)).isEqualTo(String[].class);
+        assertThat(listType.getRawType()).isEqualTo(List.class);
+        assertThat(ReflectionHelper.getRawClass(listType.getActualTypeArguments()[0])).isEqualTo(String[].class);
     }
 
     public static class ParentService {
@@ -45,17 +49,4 @@ public class TypesTest {
             return "child:" + value;
         }
     }
-
-    private static final class SimpleGenericArrayType implements GenericArrayType {
-        private final Type genericComponentType;
-
-        private SimpleGenericArrayType(Type genericComponentType) {
-            this.genericComponentType = genericComponentType;
-        }
-
-        @Override
-        public Type getGenericComponentType() {
-            return genericComponentType;
-        }
-    }
 }
diff --git 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/user-code-filter.json 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
index 5119a02e83..268238d7fd 100644
--- 1/tests/src/org.glassfish.hk2/hk2-utils/2.5.0-b05/user-code-filter.json
+++ 2/tests/src/org.glassfish.hk2/hk2-utils/2.5.0/user-code-filter.json
@@ -8,9 +8,6 @@
     },
     {
       "includeClasses" : "org.jvnet.hk2.component.**"
-    },
-    {
-      "includeClasses" : "org.jvnet.tiger_types.**"
     }
   ]
 }

```
