### PR TITLE
[GenAI] Add support for io.netty:netty-transport-native-epoll:4.1.42.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-native-epoll/4.1.42.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-native-epoll/4.1.42.Final/reachability-metadata.json
@@ -1,0 +1,168 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.EpollSocketChannel"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.EpollEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.EpollEventLoopGroup"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll.so"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.epoll.Native"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-native-epoll/index.json
+++ b/metadata/io.netty/netty-transport-native-epoll/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.42.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.42.Final/netty-transport-native-epoll-4.1.42.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://github.com/netty/netty/tree/netty-4.1.42.Final/transport-native-epoll/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.42.Final/netty-transport-native-epoll-4.1.42.Final-javadoc.jar",
+    "description" : "Netty Transport Native Epoll provides Linux epoll-based native transport support for Netty. It gives Netty applications high-performance event loops, channels, and JNI-backed native socket features on Linux.",
+    "tested-versions" : [
+      "4.1.42.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.epoll"
+    ]
+  }
+]

--- a/stats/io.netty/netty-transport-native-epoll/4.1.42.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-native-epoll/4.1.42.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T06:46:28.553395Z",
+    "library": "io.netty:netty-transport-native-epoll:4.1.42.Final",
+    "starting_commit": "119f3e30f85199ed2986fb27dbf3604162eeaeb3",
+    "ending_commit": "1cebaf56467465f15f32389a4c0097b4146e0134",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.42.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 430,
+          "missed": 10082,
+          "ratio": 0.040906,
+          "total": 10512
+        },
+        "line": {
+          "covered": 102,
+          "missed": 2495,
+          "ratio": 0.039276,
+          "total": 2597
+        },
+        "method": {
+          "covered": 49,
+          "missed": 590,
+          "ratio": 0.076682,
+          "total": 639
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 190283,
+      "cached_input_tokens_used": 1655296,
+      "output_tokens_used": 17873,
+      "iterations": 4,
+      "cost_usd": 1.3638,
+      "generated_loc": 593,
+      "tested_library_loc": 102,
+      "metadata_entries": 31,
+      "code_coverage_percent": 3.93
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-native-epoll/4.1.42.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-native-epoll/4.1.42.Final/stats.json
+++ b/stats/io.netty/netty-transport-native-epoll/4.1.42.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.42.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 430,
+        "missed" : 10082,
+        "ratio" : 0.040906,
+        "total" : 10512
+      },
+      "line" : {
+        "covered" : 102,
+        "missed" : 2495,
+        "ratio" : 0.039276,
+        "total" : 2597
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 590,
+        "ratio" : 0.076682,
+        "total" : 639
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-native-epoll:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-native-epoll:4.1.42.Final
+library.version = 4.1.42.Final
+metadata.dir = io.netty/netty-transport-native-epoll/4.1.42.Final/

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-native-epoll_tests'

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
@@ -6,6 +6,7 @@
  */
 package io_netty.netty_transport_native_epoll;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,6 +24,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -45,6 +47,7 @@ import io.netty.channel.epoll.EpollTcpInfo;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.channel.unix.PeerCredentials;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
@@ -286,6 +289,89 @@ public class Netty_transport_native_epollTest {
             assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
             assertThat(failure.get()).isNull();
             assertThat(response.get()).isEqualTo("echo:domain");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            serverGroup.shutdownGracefully().syncUninterruptibly();
+            Files.deleteIfExists(socketPath);
+        }
+    }
+
+    @Test
+    void epollDomainSocketChannelsExposePeerCredentialsWhenAvailable() throws Exception {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        Path socketPath = Files.createTempFile("netty-epoll-peer-", ".sock");
+        Files.deleteIfExists(socketPath);
+        DomainSocketAddress socketAddress = new DomainSocketAddress(socketPath.toFile());
+        EventLoopGroup serverGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup clientGroup = new EpollEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch credentialsReceived = new CountDownLatch(1);
+            AtomicReference<PeerCredentials> credentials = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(serverGroup)
+                    .channel(EpollServerDomainSocketChannel.class)
+                    .childHandler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelActive(ChannelHandlerContext ctx) {
+                                    try {
+                                        credentials.set(((EpollDomainSocketChannel) ctx.channel()).peerCredentials());
+                                    } catch (IOException e) {
+                                        failure.compareAndSet(null, e);
+                                    } finally {
+                                        credentialsReceived.countDown();
+                                        ctx.close();
+                                    }
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    credentialsReceived.countDown();
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            serverChannel = serverBootstrap.bind(socketAddress).syncUninterruptibly().channel();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(EpollDomainSocketChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                        }
+                    });
+            clientChannel = clientBootstrap.connect(socketAddress).syncUninterruptibly().channel();
+            clientChannel.closeFuture().syncUninterruptibly();
+
+            assertThat(credentialsReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            PeerCredentials peerCredentials = credentials.get();
+            assertThat(peerCredentials).isNotNull();
+            assertThat(peerCredentials.pid()).isPositive();
+            assertThat(peerCredentials.uid()).isGreaterThanOrEqualTo(0);
+            assertThat(peerCredentials.gids()).isNotNull();
+            for (int gid : peerCredentials.gids()) {
+                assertThat(gid).isGreaterThanOrEqualTo(0);
+            }
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().syncUninterruptibly();

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
@@ -44,6 +44,7 @@ import io.netty.channel.epoll.EpollServerSocketChannelConfig;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannelConfig;
 import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -245,6 +246,95 @@ public class Netty_transport_native_epollTest {
             assertThat(failure.get()).isNull();
             assertThat(response.get()).isEqualTo("echo:ping");
         } finally {
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            workerGroup.shutdownGracefully().syncUninterruptibly();
+            bossGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void epollTcpChannelsSupportHalfClosureWhenAvailable() throws Exception {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EventLoopGroup bossGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup workerGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup clientGroup = new EpollEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            CountDownLatch inputShutdownReceived = new CountDownLatch(1);
+            AtomicReference<String> request = new AtomicReference<>();
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(bossGroup, workerGroup)
+                    .channel(EpollServerSocketChannel.class)
+                    .childOption(ChannelOption.ALLOW_HALF_CLOSURE, true)
+                    .childHandler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                                    request.set(msg.toString(CharsetUtil.UTF_8));
+                                }
+
+                                @Override
+                                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                                    if (evt == ChannelInputShutdownEvent.INSTANCE) {
+                                        inputShutdownReceived.countDown();
+                                        ctx.writeAndFlush(Unpooled.copiedBuffer(
+                                                "ack:" + request.get(),
+                                                CharsetUtil.UTF_8
+                                        )).addListener(ChannelFutureListener.CLOSE);
+                                        return;
+                                    }
+
+                                    ctx.fireUserEventTriggered(evt);
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    inputShutdownReceived.countDown();
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            serverChannel = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(EpollSocketChannel.class)
+                    .option(ChannelOption.ALLOW_HALF_CLOSURE, true)
+                    .handler(new EchoClientInitializer(response, responseReceived, failure));
+            clientChannel = clientBootstrap.connect("127.0.0.1", port).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(Unpooled.copiedBuffer("half-close", CharsetUtil.UTF_8)).syncUninterruptibly();
+
+            EpollSocketChannel epollClientChannel = (EpollSocketChannel) clientChannel;
+            epollClientChannel.shutdownOutput().syncUninterruptibly();
+
+            assertThat(epollClientChannel.isOutputShutdown()).isTrue();
+            assertThat(epollClientChannel.isInputShutdown()).isFalse();
+            assertThat(inputShutdownReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(request.get()).isEqualTo("half-close");
+            assertThat(response.get()).isEqualTo("ack:half-close");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
             if (serverChannel != null) {
                 serverChannel.close().syncUninterruptibly();
             }

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
@@ -6,11 +6,477 @@
  */
 package io_netty.netty_transport_native_epoll;
 
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollDatagramChannelConfig;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollDomainSocketChannelConfig;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollMode;
+import io.netty.channel.epoll.EpollServerDomainSocketChannel;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollServerSocketChannelConfig;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannelConfig;
+import io.netty.channel.epoll.EpollTcpInfo;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-class Netty_transport_native_epollTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_transport_native_epollTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void epollAvailabilityContractIsSelfConsistent() {
+        boolean available = Epoll.isAvailable();
+        Throwable cause = Epoll.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(Epoll::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        Throwable thrown = catchThrowable(Epoll::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void epollPublicTypesRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(EpollSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollDatagramChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(EpollServerDomainSocketChannel::new);
+        assertEventLoopGroupConstructorMatchesAvailability(EpollEventLoopGroup::new);
+    }
+
+    @Test
+    void epollChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                EpollChannelOption.TCP_CORK,
+                EpollChannelOption.TCP_NOTSENT_LOWAT,
+                EpollChannelOption.TCP_KEEPIDLE,
+                EpollChannelOption.TCP_KEEPINTVL,
+                EpollChannelOption.TCP_KEEPCNT,
+                EpollChannelOption.TCP_USER_TIMEOUT,
+                EpollChannelOption.IP_FREEBIND,
+                EpollChannelOption.IP_TRANSPARENT,
+                EpollChannelOption.IP_RECVORIGDSTADDR,
+                EpollChannelOption.TCP_FASTOPEN,
+                EpollChannelOption.TCP_FASTOPEN_CONNECT,
+                EpollChannelOption.TCP_DEFER_ACCEPT,
+                EpollChannelOption.TCP_QUICKACK,
+                EpollChannelOption.SO_BUSY_POLL,
+                EpollChannelOption.EPOLL_MODE,
+                EpollChannelOption.TCP_MD5SIG,
+                EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void epollModesExposeStableEnumSemantics() {
+        assertThat(EpollMode.valueOf("EDGE_TRIGGERED")).isSameAs(EpollMode.EDGE_TRIGGERED);
+        assertThat(EpollMode.valueOf("LEVEL_TRIGGERED")).isSameAs(EpollMode.LEVEL_TRIGGERED);
+        assertThat(EpollMode.values()).containsExactly(EpollMode.EDGE_TRIGGERED, EpollMode.LEVEL_TRIGGERED);
+    }
+
+    @Test
+    void defaultTcpInfoContainsKernelCounterSnapshotAccessors() {
+        EpollTcpInfo tcpInfo = new EpollTcpInfo();
+
+        assertThat(tcpInfo.state()).isZero();
+        assertThat(tcpInfo.caState()).isZero();
+        assertThat(tcpInfo.retransmits()).isZero();
+        assertThat(tcpInfo.probes()).isZero();
+        assertThat(tcpInfo.backoff()).isZero();
+        assertThat(tcpInfo.options()).isZero();
+        assertThat(tcpInfo.sndWscale()).isZero();
+        assertThat(tcpInfo.rcvWscale()).isZero();
+        assertThat(tcpInfo.rto()).isZero();
+        assertThat(tcpInfo.ato()).isZero();
+        assertThat(tcpInfo.sndMss()).isZero();
+        assertThat(tcpInfo.rcvMss()).isZero();
+        assertThat(tcpInfo.unacked()).isZero();
+        assertThat(tcpInfo.sacked()).isZero();
+        assertThat(tcpInfo.lost()).isZero();
+        assertThat(tcpInfo.retrans()).isZero();
+        assertThat(tcpInfo.fackets()).isZero();
+        assertThat(tcpInfo.lastDataSent()).isZero();
+        assertThat(tcpInfo.lastAckSent()).isZero();
+        assertThat(tcpInfo.lastDataRecv()).isZero();
+        assertThat(tcpInfo.lastAckRecv()).isZero();
+        assertThat(tcpInfo.pmtu()).isZero();
+        assertThat(tcpInfo.rcvSsthresh()).isZero();
+        assertThat(tcpInfo.rtt()).isZero();
+        assertThat(tcpInfo.rttvar()).isZero();
+        assertThat(tcpInfo.sndSsthresh()).isZero();
+        assertThat(tcpInfo.sndCwnd()).isZero();
+        assertThat(tcpInfo.advmss()).isZero();
+        assertThat(tcpInfo.reordering()).isZero();
+        assertThat(tcpInfo.rcvRtt()).isZero();
+        assertThat(tcpInfo.rcvSpace()).isZero();
+        assertThat(tcpInfo.totalRetrans()).isZero();
+    }
+
+    @Test
+    void epollChannelConfigurationRoundTripsPortableOptionsWhenAvailable() {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollSocketChannel::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EpollSocketChannel socketChannel = new EpollSocketChannel();
+        EpollServerSocketChannel serverSocketChannel = new EpollServerSocketChannel();
+        EpollDatagramChannel datagramChannel = new EpollDatagramChannel();
+        EpollDomainSocketChannel domainSocketChannel = new EpollDomainSocketChannel();
+        try {
+            EpollSocketChannelConfig socketConfig = socketChannel.config();
+            assertThat(socketConfig.getOptions()).containsKeys(
+                    EpollChannelOption.TCP_CORK,
+                    EpollChannelOption.TCP_QUICKACK,
+                    EpollChannelOption.EPOLL_MODE
+            );
+
+            socketConfig.setTcpCork(false);
+            assertThat(socketConfig.isTcpCork()).isFalse();
+            socketConfig.setTcpQuickAck(true);
+            assertThat(socketConfig.isTcpQuickAck()).isTrue();
+            socketConfig.setEpollMode(EpollMode.LEVEL_TRIGGERED);
+            assertThat(socketConfig.getEpollMode()).isSameAs(EpollMode.LEVEL_TRIGGERED);
+            socketConfig.setOption(EpollChannelOption.EPOLL_MODE, EpollMode.EDGE_TRIGGERED);
+            assertThat(socketConfig.getOption(EpollChannelOption.EPOLL_MODE)).isSameAs(EpollMode.EDGE_TRIGGERED);
+
+            EpollServerSocketChannelConfig serverConfig = serverSocketChannel.config();
+            serverConfig.setTcpDeferAccept(0);
+            assertThat(serverConfig.getTcpDeferAccept()).isZero();
+
+            EpollDatagramChannelConfig datagramConfig = datagramChannel.config();
+            datagramConfig.setMaxDatagramPayloadSize(2048);
+            assertThat(datagramConfig.getMaxDatagramPayloadSize()).isEqualTo(2048);
+            assertThat(datagramConfig.getOption(EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE)).isEqualTo(2048);
+
+            EpollDomainSocketChannelConfig domainConfig = domainSocketChannel.config();
+            domainConfig.setReadMode(DomainSocketReadMode.FILE_DESCRIPTORS);
+            assertThat(domainConfig.getReadMode()).isSameAs(DomainSocketReadMode.FILE_DESCRIPTORS);
+            domainConfig.setReadMode(DomainSocketReadMode.BYTES);
+            assertThat(domainConfig.getReadMode()).isSameAs(DomainSocketReadMode.BYTES);
+        } finally {
+            domainSocketChannel.close().syncUninterruptibly();
+            datagramChannel.close().syncUninterruptibly();
+            serverSocketChannel.close().syncUninterruptibly();
+            socketChannel.close().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void epollTcpChannelsCanExchangeBytesWhenAvailable() throws Exception {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EventLoopGroup bossGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup workerGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup clientGroup = new EpollEventLoopGroup(1);
+        Channel serverChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(bossGroup, workerGroup)
+                    .channel(EpollServerSocketChannel.class)
+                    .childHandler(new EchoServerInitializer(failure));
+            serverChannel = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(EpollSocketChannel.class)
+                    .handler(new EchoClientInitializer(response, responseReceived, failure));
+            Channel clientChannel = clientBootstrap.connect("127.0.0.1", port).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(Unpooled.copiedBuffer("ping", CharsetUtil.UTF_8)).syncUninterruptibly();
+            clientChannel.closeFuture().syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("echo:ping");
+        } finally {
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            workerGroup.shutdownGracefully().syncUninterruptibly();
+            bossGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void epollDomainSocketChannelsCanExchangeBytesWhenAvailable() throws Exception {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        Path socketPath = Files.createTempFile("netty-epoll-domain-", ".sock");
+        Files.deleteIfExists(socketPath);
+        DomainSocketAddress socketAddress = new DomainSocketAddress(socketPath.toFile());
+        EventLoopGroup serverGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup clientGroup = new EpollEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(serverGroup)
+                    .channel(EpollServerDomainSocketChannel.class)
+                    .childHandler(new EchoServerInitializer(failure));
+            serverChannel = serverBootstrap.bind(socketAddress).syncUninterruptibly().channel();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(EpollDomainSocketChannel.class)
+                    .handler(new EchoClientInitializer(response, responseReceived, failure));
+            clientChannel = clientBootstrap.connect(socketAddress).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(Unpooled.copiedBuffer("domain", CharsetUtil.UTF_8)).syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("echo:domain");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            serverGroup.shutdownGracefully().syncUninterruptibly();
+            Files.deleteIfExists(socketPath);
+        }
+    }
+
+    @Test
+    void epollDatagramChannelsCanExchangePacketsWhenAvailable() throws Exception {
+        if (!Epoll.isAvailable()) {
+            assertThatThrownBy(EpollEventLoopGroup::new).isInstanceOf(LinkageError.class);
+            return;
+        }
+
+        EventLoopGroup serverGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup clientGroup = new EpollEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            CountDownLatch responseReceived = new CountDownLatch(1);
+            AtomicReference<String> response = new AtomicReference<>();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            Bootstrap serverBootstrap = new Bootstrap()
+                    .group(serverGroup)
+                    .channel(EpollDatagramChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                                    String request = packet.content().toString(CharsetUtil.UTF_8);
+                                    ctx.writeAndFlush(new DatagramPacket(
+                                            Unpooled.copiedBuffer("datagram:" + request, CharsetUtil.UTF_8),
+                                            packet.sender()
+                                    ));
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            serverChannel = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            InetSocketAddress serverAddress = (InetSocketAddress) serverChannel.localAddress();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channel(EpollDatagramChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                                    response.set(packet.content().toString(CharsetUtil.UTF_8));
+                                    responseReceived.countDown();
+                                    ctx.close();
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                    failure.compareAndSet(null, cause);
+                                    responseReceived.countDown();
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    });
+            clientChannel = clientBootstrap.bind(new InetSocketAddress("127.0.0.1", 0)).syncUninterruptibly().channel();
+            clientChannel.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer("ping", CharsetUtil.UTF_8),
+                    serverAddress
+            )).syncUninterruptibly();
+
+            assertThat(responseReceived.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(response.get()).isEqualTo("datagram:ping");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            clientGroup.shutdownGracefully().syncUninterruptibly();
+            serverGroup.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (Epoll.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(LinkageError.class);
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(
+            Supplier<? extends EventLoopGroup> constructor
+    ) {
+        if (Epoll.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(LinkageError.class);
+    }
+
+    private static final class EchoServerInitializer extends ChannelInitializer<Channel> {
+        private final AtomicReference<Throwable> failure;
+
+        private EchoServerInitializer(AtomicReference<Throwable> failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        protected void initChannel(Channel channel) {
+            channel.pipeline().addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                    String request = msg.toString(CharsetUtil.UTF_8);
+                    ctx.writeAndFlush(Unpooled.copiedBuffer("echo:" + request, CharsetUtil.UTF_8))
+                            .addListener(ChannelFutureListener.CLOSE);
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    failure.compareAndSet(null, cause);
+                    ctx.close();
+                }
+            });
+        }
+    }
+
+    private static final class EchoClientInitializer extends ChannelInitializer<Channel> {
+        private final AtomicReference<String> response;
+
+        private final CountDownLatch responseReceived;
+
+        private final AtomicReference<Throwable> failure;
+
+        private EchoClientInitializer(
+                AtomicReference<String> response,
+                CountDownLatch responseReceived,
+                AtomicReference<Throwable> failure
+        ) {
+            this.response = response;
+            this.responseReceived = responseReceived;
+            this.failure = failure;
+        }
+
+        @Override
+        protected void initChannel(Channel channel) {
+            ChannelPipeline pipeline = channel.pipeline();
+            pipeline.addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                    response.set(msg.toString(CharsetUtil.UTF_8));
+                    responseReceived.countDown();
+                    ctx.close();
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    failure.compareAndSet(null, cause);
+                    responseReceived.countDown();
+                    ctx.close();
+                }
+            });
+        }
     }
 }

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/src/test/java/io_netty/netty_transport_native_epoll/Netty_transport_native_epollTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_native_epoll;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_transport_native_epollTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.channel.epoll.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-native-epoll/4.1.42.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.channel.epoll.**"
+      "includeClasses" : "io.netty.channel.epoll.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1385

This PR introduces tests and metadata for io.netty:netty-transport-native-epoll:4.1.42.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 190283
- Cached input tokens: 1655296
- Output tokens: 17873
- Metadata entries: 31
- Iterations: 4
- Library coverage percentage: 3.93
- Generated lines of code: 593
- Tested library lines of code: 102

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `881696e06331135fdee735a86e644c64c238f55e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 430/10512 (4.09%)
- Line: 102/2597 (3.93%)
- Method: 49/639 (7.67%)
