### PR TITLE
[GenAI] Test fix for org.apache.parquet:parquet-format-structures:1.12.3 using gpt-5.5

### DIFF
--- a/metadata/org.apache.parquet/parquet-format-structures/1.12.3/reachability-metadata.json
+++ b/metadata/org.apache.parquet/parquet-format-structures/1.12.3/reachability-metadata.json
@@ -1,0 +1,36 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.parquet.format.event.TBaseStructConsumer"
+      },
+      "type": "org.apache.parquet.format.KeyValue",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "shaded.parquet.org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type": "org.apache.parquet.format.NullType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "shaded.parquet.org.apache.thrift.transport.TIOStreamTransport"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.parquet/parquet-format-structures/index.json
+++ b/metadata/org.apache.parquet/parquet-format-structures/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.12.3",
+    "tested-versions" : [
+      "1.12.3"
+    ],
+    "allowed-packages" : [
+      "org.apache.parquet.format",
+      "shaded.parquet.org.apache.thrift"
+    ]
+  },
+  {
     "metadata-version" : "1.12.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-format-structures/1.12.2/parquet-format-structures-1.12.2-sources.jar",
     "repository-url" : "https://github.com/apache/parquet-java",

--- a/metadata/org.apache.parquet/parquet-format-structures/index.json
+++ b/metadata/org.apache.parquet/parquet-format-structures/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.12.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-format-structures/1.12.3/parquet-format-structures-1.12.3-sources.jar",
+    "repository-url" : "https://github.com/apache/parquet-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-format-structures/1.12.3/parquet-format-structures-1.12.3-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-format-structures/1.12.3/parquet-format-structures-1.12.3-javadoc.jar",
+    "description" : "Apache Parquet Format Structures provides Java classes used by parquet-mr to work with the parquet-format Thrift structures. It packages generated model code for Parquet schema and metadata structures so Parquet Java components can read and write the format consistently.",
     "tested-versions" : [
       "1.12.3"
     ],

--- a/stats/org.apache.parquet/parquet-format-structures/1.12.3/execution-metrics.json
+++ b/stats/org.apache.parquet/parquet-format-structures/1.12.3/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T06:56:39.173271Z",
+    "library": "org.apache.parquet:parquet-format-structures:1.12.3",
+    "starting_commit": "34dee865522321a30bf472cedb3e4ac0d9536207",
+    "ending_commit": "b4b5b11aa50f3306ff89179197d14de9821e00df",
+    "previous_library": "org.apache.parquet:parquet-format-structures:1.12.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.12.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1146,
+          "missed": 62457,
+          "ratio": 0.018018,
+          "total": 63603
+        },
+        "line": {
+          "covered": 324,
+          "missed": 15540,
+          "ratio": 0.020424,
+          "total": 15864
+        },
+        "method": {
+          "covered": 89,
+          "missed": 3067,
+          "ratio": 0.0282,
+          "total": 3156
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.12.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1047,
+          "missed": 61437,
+          "ratio": 0.016756,
+          "total": 62484
+        },
+        "line": {
+          "covered": 297,
+          "missed": 15192,
+          "ratio": 0.019175,
+          "total": 15489
+        },
+        "method": {
+          "covered": 78,
+          "missed": 2943,
+          "ratio": 0.025819,
+          "total": 3021
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 58827,
+      "cached_input_tokens_used": 744448,
+      "output_tokens_used": 4649,
+      "iterations": 1,
+      "cost_usd": 0.5117,
+      "tested_library_loc": 324,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 5,
+      "code_coverage_percent": 2.04,
+      "previous_library_coverage_percent": 1.92
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.parquet/parquet-format-structures/1.12.3/src/test/java/org_apache_parquet/parquet_format_structures/TBaseStructConsumerTest.java",
+      "metadata_file": "metadata/org.apache.parquet/parquet-format-structures/1.12.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.parquet/parquet-format-structures/1.12.3/stats.json
+++ b/stats/org.apache.parquet/parquet-format-structures/1.12.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.12.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1146,
+        "missed" : 62457,
+        "ratio" : 0.018018,
+        "total" : 63603
+      },
+      "line" : {
+        "covered" : 324,
+        "missed" : 15540,
+        "ratio" : 0.020424,
+        "total" : 15864
+      },
+      "method" : {
+        "covered" : 89,
+        "missed" : 3067,
+        "ratio" : 0.0282,
+        "total" : 3156
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/.gitignore
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.parquet:parquet-format-structures:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.parquet:parquet-format-structures:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.slf4j:slf4j-api:1.7.36'
 }
 
 graalvmNative {

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/gradle.properties
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.parquet:parquet-format-structures:1.12.3
+library.version = 1.12.3
+metadata.dir = org.apache.parquet/parquet-format-structures/1.12.3/

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/settings.gradle
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.parquet.parquet-format-structures_tests'

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/src/test/java/org_apache_parquet/parquet_format_structures/FieldMetaDataTest.java
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/src/test/java/org_apache_parquet/parquet_format_structures/FieldMetaDataTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_format_structures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.apache.parquet.format.NullType;
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.org.apache.thrift.TFieldIdEnum;
+import shaded.parquet.org.apache.thrift.meta_data.FieldMetaData;
+
+public class FieldMetaDataTest {
+    @Test
+    void loadsThriftStructMetadataForClassOnDemand() {
+        Map<? extends TFieldIdEnum, FieldMetaData> metadata = FieldMetaData.getStructMetaDataMap(NullType.class);
+
+        assertThat(metadata)
+                .isSameAs(NullType.metaDataMap)
+                .isEmpty();
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/src/test/java/org_apache_parquet/parquet_format_structures/TBaseStructConsumerTest.java
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/src/test/java/org_apache_parquet/parquet_format_structures/TBaseStructConsumerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_format_structures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.parquet.format.KeyValue;
+import org.apache.parquet.format.event.Consumers;
+import org.apache.parquet.format.event.EventBasedThriftReader;
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.org.apache.thrift.protocol.TCompactProtocol;
+import shaded.parquet.org.apache.thrift.protocol.TProtocol;
+import shaded.parquet.org.apache.thrift.transport.TIOStreamTransport;
+
+public class TBaseStructConsumerTest {
+    @Test
+    void structConsumerInstantiatesAndReadsGeneratedThriftStruct() throws Exception {
+        KeyValue expected = new KeyValue("parquet.key").setValue("parquet.value");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        expected.write(new TCompactProtocol(new TIOStreamTransport(out)));
+        TProtocol protocol = new TCompactProtocol(new TIOStreamTransport(new ByteArrayInputStream(out.toByteArray())));
+        List<KeyValue> consumed = new ArrayList<>();
+
+        Consumers.struct(KeyValue.class, consumed::add)
+                .consumeStruct(protocol, new EventBasedThriftReader(protocol));
+
+        assertThat(consumed).containsExactly(expected);
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/user-code-filter.json
+++ b/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.parquet.format.**"
+    },
+    {
+      "includeClasses" : "shaded.parquet.org.apache.thrift.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4214

This PR provides test fixes and new metadata for org.apache.parquet:parquet-format-structures:1.12.3, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 58827
- Cached input tokens: 744448
- Output tokens: 4649
- Metadata entries: 5
- Iterations: 1
- Library coverage percentage: 2.04
- Previous library version metadata entries: 5
- Previous library version coverage percentage: 1.92

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4898a6265381c0b190ec5bf4708990e9808da7f9`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.parquet:parquet-format-structures:1.12.2: 2/2 covered calls (100.00%)
- org.apache.parquet:parquet-format-structures:1.12.3: 2/2 covered calls (100.00%)

**Reflection:**
- org.apache.parquet:parquet-format-structures:1.12.2: 2/2 covered calls (100.00%)
- org.apache.parquet:parquet-format-structures:1.12.3: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.parquet:parquet-format-structures:1.12.2: 1047/62484 (1.68%)
- org.apache.parquet:parquet-format-structures:1.12.3: 1146/63603 (1.80%)

**Line:**
- org.apache.parquet:parquet-format-structures:1.12.2: 297/15489 (1.92%)
- org.apache.parquet:parquet-format-structures:1.12.3: 324/15864 (2.04%)

**Method:**
- org.apache.parquet:parquet-format-structures:1.12.2: 78/3021 (2.58%)
- org.apache.parquet:parquet-format-structures:1.12.3: 89/3156 (2.82%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.parquet/parquet-format-structures/1.12.2/build.gradle 2/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
index 47d9b98149..70219285e3 100644
--- 1/tests/src/org.apache.parquet/parquet-format-structures/1.12.2/build.gradle
+++ 2/tests/src/org.apache.parquet/parquet-format-structures/1.12.3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.parquet:parquet-format-structures:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.slf4j:slf4j-api:1.7.36'
 }
 
 graalvmNative {

```
