### PR TITLE
[GenAI] Test fix for org.apache.thrift:libthrift:0.17.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
+++ b/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
@@ -1,0 +1,194 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.DHParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.provider.JavaKeyStore$DualFormatJKS",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.provider.JavaKeyStore$JKS",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.EnumCache"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.thrift/libthrift/index.json
+++ b/metadata/org.apache.thrift/libthrift/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.17.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.17.0/libthrift-0.17.0-sources.jar",
+    "repository-url" : "https://github.com/apache/thrift",
+    "test-code-url" : "https://github.com/apache/thrift/tree/v0.17.0/lib/java/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.17.0/libthrift-0.17.0-javadoc.jar",
+    "description" : "Apache Thrift libthrift provides the Java runtime library for applications that use Apache Thrift generated service and data-type code. It supplies transports, protocols, servers, clients, and support utilities for building scalable cross-language RPC services.",
     "tested-versions" : [
       "0.17.0"
     ],

--- a/metadata/org.apache.thrift/libthrift/index.json
+++ b/metadata/org.apache.thrift/libthrift/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.17.0",
+    "tested-versions" : [
+      "0.17.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.thrift"
+    ]
+  },
+  {
     "metadata-version" : "0.13.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/thrift/libthrift/0.13.0/libthrift-0.13.0-sources.jar",
     "repository-url" : "https://github.com/apache/thrift",

--- a/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
+++ b/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T06:59:00.527401Z",
+    "library": "org.apache.thrift:libthrift:0.17.0",
+    "starting_commit": "5e7e67431f7c4999d9381fe68b11e0e048c88e87",
+    "ending_commit": "2de9986be4625f53dea190c96e3e4a55a936cd4a",
+    "previous_library": "org.apache.thrift:libthrift:0.13.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 696,
+          "missed": 28584,
+          "ratio": 0.02377,
+          "total": 29280
+        },
+        "line": {
+          "covered": 182,
+          "missed": 6729,
+          "ratio": 0.026335,
+          "total": 6911
+        },
+        "method": {
+          "covered": 45,
+          "missed": 1590,
+          "ratio": 0.027523,
+          "total": 1635
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.13.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 325,
+          "missed": 21121,
+          "ratio": 0.015154,
+          "total": 21446
+        },
+        "line": {
+          "covered": 102,
+          "missed": 4984,
+          "ratio": 0.020055,
+          "total": 5086
+        },
+        "method": {
+          "covered": 24,
+          "missed": 1159,
+          "ratio": 0.020287,
+          "total": 1183
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 106769,
+      "cached_input_tokens_used": 770560,
+      "output_tokens_used": 11580,
+      "iterations": 4,
+      "cost_usd": 0.7327,
+      "tested_library_loc": 182,
+      "metadata_entries": 31,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 31,
+      "previous_library_test_only_metadata_entries": 4,
+      "code_coverage_percent": 2.63,
+      "previous_library_coverage_percent": 2.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java",
+      "metadata_file": "metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.thrift/libthrift/0.17.0/stats.json
+++ b/stats/org.apache.thrift/libthrift/0.17.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "0.17.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 696,
+        "missed" : 28584,
+        "ratio" : 0.02377,
+        "total" : 29280
+      },
+      "line" : {
+        "covered" : 182,
+        "missed" : 6729,
+        "ratio" : 0.026335,
+        "total" : 6911
+      },
+      "method" : {
+        "covered" : 45,
+        "missed" : 1590,
+        "ratio" : 0.027523,
+        "total" : 1635
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/.gitignore
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.thrift:libthrift:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
@@ -13,6 +13,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.thrift:libthrift:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.apache.commons:commons-lang3:3.11'
+    testRuntimeOnly 'org.slf4j:slf4j-api:1.7.36'
 }
 
 graalvmNative {

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/gradle.properties
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.thrift:libthrift:0.17.0
+library.version = 0.17.0
+metadata.dir = org.apache.thrift/libthrift/0.17.0/

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/settings.gradle
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.thrift.libthrift_tests'

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/EnumCacheTest.java
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/EnumCacheTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.thrift.TEnum;
+import org.apache.thrift.partial.EnumCache;
+import org.junit.jupiter.api.Test;
+
+public class EnumCacheTest {
+    @Test
+    void getBuildsCacheFromGeneratedEnumValuesMethod() {
+        EnumCache cache = new EnumCache();
+
+        TEnum enumValue = cache.get(ExampleCachedEnum.class, 2);
+
+        assertThat(enumValue).isSameAs(ExampleCachedEnum.SECOND);
+        assertThat(enumValue.getValue()).isEqualTo(2);
+        assertThat(cache.get(ExampleCachedEnum.class, 99)).isNull();
+    }
+
+    public enum ExampleCachedEnum implements TEnum {
+        FIRST(1),
+        SECOND(2);
+
+        private final int value;
+
+        ExampleCachedEnum(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/FieldMetaDataTest.java
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/FieldMetaDataTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.TFieldRequirementType;
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.meta_data.FieldValueMetaData;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TType;
+import org.junit.jupiter.api.Test;
+
+public class FieldMetaDataTest {
+    @Test
+    void getStructMetaDataMapInstantiatesGeneratedStructToRegisterMetadata() {
+        Map<? extends TFieldIdEnum, FieldMetaData> metadata =
+                FieldMetaData.getStructMetaDataMap(GeneratedStruct.class);
+
+        assertThat(metadata).hasSize(1);
+        FieldMetaData nameMetadata = metadata.get(GeneratedField.NAME);
+        assertThat(nameMetadata).isNotNull();
+        assertThat(nameMetadata.fieldName).isEqualTo("name");
+        assertThat(nameMetadata.requirementType).isEqualTo(TFieldRequirementType.DEFAULT);
+        assertThat(nameMetadata.valueMetaData.type).isEqualTo(TType.STRING);
+    }
+
+    public enum GeneratedField implements TFieldIdEnum {
+        NAME((short) 1, "name");
+
+        private final short thriftFieldId;
+        private final String fieldName;
+
+        GeneratedField(short thriftFieldId, String fieldName) {
+            this.thriftFieldId = thriftFieldId;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public short getThriftFieldId() {
+            return thriftFieldId;
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldName;
+        }
+    }
+
+    public static class GeneratedStruct implements TBase<GeneratedStruct, GeneratedField> {
+        private String name;
+
+        static {
+            Map<GeneratedField, FieldMetaData> metadata = new EnumMap<>(GeneratedField.class);
+            metadata.put(
+                    GeneratedField.NAME,
+                    new FieldMetaData(
+                            GeneratedField.NAME.getFieldName(),
+                            TFieldRequirementType.DEFAULT,
+                            new FieldValueMetaData(TType.STRING)));
+            FieldMetaData.addStructMetaDataMap(GeneratedStruct.class, metadata);
+        }
+
+        @Override
+        public GeneratedField fieldForId(int fieldId) {
+            if (fieldId == GeneratedField.NAME.getThriftFieldId()) {
+                return GeneratedField.NAME;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isSet(GeneratedField field) {
+            return field == GeneratedField.NAME && name != null;
+        }
+
+        @Override
+        public Object getFieldValue(GeneratedField field) {
+            if (field == GeneratedField.NAME) {
+                return name;
+            }
+            throw new IllegalArgumentException("Unknown field: " + field);
+        }
+
+        @Override
+        public void setFieldValue(GeneratedField field, Object value) {
+            if (field != GeneratedField.NAME) {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+            name = (String) value;
+        }
+
+        @Override
+        public GeneratedStruct deepCopy() {
+            GeneratedStruct copy = new GeneratedStruct();
+            copy.name = name;
+            return copy;
+        }
+
+        @Override
+        public void clear() {
+            name = null;
+        }
+
+        @Override
+        public void read(TProtocol iprot) throws TException {
+            throw new UnsupportedOperationException("Protocol read is not needed for metadata registration");
+        }
+
+        @Override
+        public void write(TProtocol oprot) throws TException {
+            throw new UnsupportedOperationException("Protocol write is not needed for metadata registration");
+        }
+
+        @Override
+        public int compareTo(GeneratedStruct other) {
+            if (name == null && other.name == null) {
+                return 0;
+            }
+            if (name == null) {
+                return -1;
+            }
+            if (other.name == null) {
+                return 1;
+            }
+            return name.compareTo(other.name);
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TEnumHelperTest.java
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TEnumHelperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.thrift.TEnum;
+import org.apache.thrift.TEnumHelper;
+import org.junit.jupiter.api.Test;
+
+public class TEnumHelperTest {
+    @Test
+    void getByValueFindsThriftEnumConstantThroughGeneratedLookupMethod() {
+        TEnum enumValue = TEnumHelper.getByValue(ExampleThriftEnum.class, 2);
+
+        assertThat(enumValue).isSameAs(ExampleThriftEnum.SECOND);
+        assertThat(enumValue.getValue()).isEqualTo(2);
+    }
+
+    @Test
+    void getByValueReturnsNullWhenGeneratedLookupMethodHasNoMatch() {
+        TEnum enumValue = TEnumHelper.getByValue(ExampleThriftEnum.class, 99);
+
+        assertThat(enumValue).isNull();
+    }
+
+    public enum ExampleThriftEnum implements TEnum {
+        FIRST(1),
+        SECOND(2);
+
+        private final int value;
+
+        ExampleThriftEnum(int value) {
+            this.value = value;
+        }
+
+        public static ExampleThriftEnum findByValue(int value) {
+            switch (value) {
+                case 1:
+                    return FIRST;
+                case 2:
+                    return SECOND;
+                default:
+                    return null;
+            }
+        }
+
+        @Override
+        public int getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.thrift.transport.TSSLTransportFactory;
+import org.apache.thrift.transport.TServerSocket;
+import org.junit.jupiter.api.Test;
+
+public class TSSLTransportFactoryTest {
+    private static final String TRUST_STORE_RESOURCE = "org_apache_thrift/libthrift/test-truststore.jks";
+    private static final String TRUST_STORE_PASSWORD = "changeit";
+
+    @Test
+    void sslContextLoadsTrustStoreFromContextClassLoaderResource() throws Exception {
+        byte[] trustStore = createEmptyTrustStore();
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ResourceClassLoader resourceClassLoader = new ResourceClassLoader(originalClassLoader, trustStore);
+        TServerSocket serverSocket = null;
+
+        try {
+            Thread.currentThread().setContextClassLoader(resourceClassLoader);
+
+            TSSLTransportFactory.TSSLTransportParameters parameters =
+                    new TSSLTransportFactory.TSSLTransportParameters();
+            parameters.setTrustStore(TRUST_STORE_RESOURCE, TRUST_STORE_PASSWORD);
+
+            serverSocket = TSSLTransportFactory.getServerSocket(0, 0, null, parameters);
+
+            assertThat(serverSocket.getServerSocket().isBound()).isTrue();
+            assertThat(resourceClassLoader.resourceWasRequested()).isTrue();
+        } finally {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static byte[] createEmptyTrustStore() throws GeneralSecurityException, IOException {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        keyStore.store(output, TRUST_STORE_PASSWORD.toCharArray());
+        return output.toByteArray();
+    }
+
+    private static class ResourceClassLoader extends ClassLoader {
+        private final byte[] trustStore;
+        private final AtomicBoolean requested = new AtomicBoolean();
+
+        ResourceClassLoader(ClassLoader parent, byte[] trustStore) {
+            super(parent);
+            this.trustStore = trustStore.clone();
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (TRUST_STORE_RESOURCE.equals(name)) {
+                requested.set(true);
+                return new ByteArrayInputStream(trustStore);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        boolean resourceWasRequested() {
+            return requested.get();
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/ThriftMetadataInnerThriftStructTest.java
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/ThriftMetadataInnerThriftStructTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.TFieldRequirementType;
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.meta_data.FieldValueMetaData;
+import org.apache.thrift.partial.ThriftMetadata;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TType;
+import org.junit.jupiter.api.Test;
+
+public class ThriftMetadataInnerThriftStructTest {
+    @Test
+    void createNewStructInstantiatesGeneratedStructWithDefaultConstructor() {
+        ThriftMetadata.ThriftStruct<GeneratedStruct> thriftStruct =
+                ThriftMetadata.ThriftStruct.of(GeneratedStruct.class);
+
+        GeneratedStruct generatedStruct = thriftStruct.createNewStruct();
+
+        assertThat(generatedStruct).isNotNull();
+        assertThat(generatedStruct.isSet(GeneratedField.NAME)).isFalse();
+        generatedStruct.setFieldValue(GeneratedField.NAME, "covered");
+        assertThat(generatedStruct.getFieldValue(GeneratedField.NAME)).isEqualTo("covered");
+    }
+
+    public enum GeneratedField implements TFieldIdEnum {
+        NAME((short) 1, "name");
+
+        private final short thriftFieldId;
+        private final String fieldName;
+
+        GeneratedField(short thriftFieldId, String fieldName) {
+            this.thriftFieldId = thriftFieldId;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public short getThriftFieldId() {
+            return thriftFieldId;
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldName;
+        }
+    }
+
+    public static class GeneratedStruct implements TBase<GeneratedStruct, GeneratedField> {
+        private String name;
+
+        static {
+            Map<GeneratedField, FieldMetaData> metadata = new EnumMap<>(GeneratedField.class);
+            metadata.put(
+                    GeneratedField.NAME,
+                    new FieldMetaData(
+                            GeneratedField.NAME.getFieldName(),
+                            TFieldRequirementType.DEFAULT,
+                            new FieldValueMetaData(TType.STRING)));
+            FieldMetaData.addStructMetaDataMap(GeneratedStruct.class, metadata);
+        }
+
+        @Override
+        public GeneratedField fieldForId(int fieldId) {
+            if (fieldId == GeneratedField.NAME.getThriftFieldId()) {
+                return GeneratedField.NAME;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isSet(GeneratedField field) {
+            return field == GeneratedField.NAME && name != null;
+        }
+
+        @Override
+        public Object getFieldValue(GeneratedField field) {
+            if (field == GeneratedField.NAME) {
+                return name;
+            }
+            throw new IllegalArgumentException("Unknown field: " + field);
+        }
+
+        @Override
+        public void setFieldValue(GeneratedField field, Object value) {
+            if (field != GeneratedField.NAME) {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+            name = (String) value;
+        }
+
+        @Override
+        public GeneratedStruct deepCopy() {
+            GeneratedStruct copy = new GeneratedStruct();
+            copy.name = name;
+            return copy;
+        }
+
+        @Override
+        public void clear() {
+            name = null;
+        }
+
+        @Override
+        public void read(TProtocol iprot) throws TException {
+            throw new UnsupportedOperationException("Protocol read is not needed for metadata instantiation");
+        }
+
+        @Override
+        public void write(TProtocol oprot) throws TException {
+            throw new UnsupportedOperationException("Protocol write is not needed for metadata instantiation");
+        }
+
+        @Override
+        public int compareTo(GeneratedStruct other) {
+            if (name == null && other.name == null) {
+                return 0;
+            }
+            if (name == null) {
+                return -1;
+            }
+            if (other.name == null) {
+                return 1;
+            }
+            return name.compareTo(other.name);
+        }
+    }
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type" : "org_apache_thrift.libthrift.FieldMetaDataTest$GeneratedStruct",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.TEnumHelper"
+      },
+      "type" : "org_apache_thrift.libthrift.TEnumHelperTest$ExampleThriftEnum",
+      "methods" : [
+        {
+          "name" : "findByValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -25,6 +25,18 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.EnumCache"
+      },
+      "type" : "org_apache_thrift.libthrift.EnumCacheTest$ExampleCachedEnum",
+      "methods" : [
+        {
+          "name" : "values",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -37,6 +37,18 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.ThriftMetadata$ThriftStruct"
+      },
+      "type" : "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.thrift.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4215

This PR provides test fixes and new metadata for org.apache.thrift:libthrift:0.17.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 106769
- Cached input tokens: 770560
- Output tokens: 11580
- Metadata entries: 31
- Test-only metadata entries: 8
- Iterations: 4
- Library coverage percentage: 2.63
- Previous library version metadata entries: 31
- Previous library version test-only metadata entries: 4
- Previous library version coverage percentage: 2.01

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4898a6265381c0b190ec5bf4708990e9808da7f9`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.thrift:libthrift:0.13.0: 4/4 covered calls (100.00%)
- org.apache.thrift:libthrift:0.17.0: 9/9 covered calls (100.00%)

**Reflection:**
- org.apache.thrift:libthrift:0.13.0: 3/3 covered calls (100.00%)
- org.apache.thrift:libthrift:0.17.0: 8/8 covered calls (100.00%)

**Resources:**
- org.apache.thrift:libthrift:0.13.0: 1/1 covered calls (100.00%)
- org.apache.thrift:libthrift:0.17.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.thrift:libthrift:0.13.0: 325/21446 (1.52%)
- org.apache.thrift:libthrift:0.17.0: 696/29280 (2.38%)

**Line:**
- org.apache.thrift:libthrift:0.13.0: 102/5086 (2.01%)
- org.apache.thrift:libthrift:0.17.0: 182/6911 (2.63%)

**Method:**
- org.apache.thrift:libthrift:0.13.0: 24/1183 (2.03%)
- org.apache.thrift:libthrift:0.17.0: 45/1635 (2.75%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.thrift/libthrift/0.13.0/build.gradle 2/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
index 0754e2faac..e41fdf5237 100644
--- 1/tests/src/org.apache.thrift/libthrift/0.13.0/build.gradle
+++ 2/tests/src/org.apache.thrift/libthrift/0.17.0/build.gradle
@@ -13,6 +13,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.thrift:libthrift:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.apache.commons:commons-lang3:3.11'
+    testRuntimeOnly 'org.slf4j:slf4j-api:1.7.36'
 }
 
 graalvmNative {
diff --git 1/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/EnumCacheTest.java 2/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/EnumCacheTest.java
new file mode 100644
index 0000000000..73c88859a6
--- /dev/null
+++ 2/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/EnumCacheTest.java
@@ -0,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.thrift.TEnum;
+import org.apache.thrift.partial.EnumCache;
+import org.junit.jupiter.api.Test;
+
+public class EnumCacheTest {
+    @Test
+    void getBuildsCacheFromGeneratedEnumValuesMethod() {
+        EnumCache cache = new EnumCache();
+
+        TEnum enumValue = cache.get(ExampleCachedEnum.class, 2);
+
+        assertThat(enumValue).isSameAs(ExampleCachedEnum.SECOND);
+        assertThat(enumValue.getValue()).isEqualTo(2);
+        assertThat(cache.get(ExampleCachedEnum.class, 99)).isNull();
+    }
+
+    public enum ExampleCachedEnum implements TEnum {
+        FIRST(1),
+        SECOND(2);
+
+        private final int value;
+
+        ExampleCachedEnum(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int getValue() {
+            return value;
+        }
+    }
+}
diff --git 1/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/ThriftMetadataInnerThriftStructTest.java 2/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/ThriftMetadataInnerThriftStructTest.java
new file mode 100644
index 0000000000..d36ee3b2bd
--- /dev/null
+++ 2/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/ThriftMetadataInnerThriftStructTest.java
@@ -0,0 +1,139 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_thrift.libthrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.TFieldRequirementType;
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.meta_data.FieldValueMetaData;
+import org.apache.thrift.partial.ThriftMetadata;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TType;
+import org.junit.jupiter.api.Test;
+
+public class ThriftMetadataInnerThriftStructTest {
+    @Test
+    void createNewStructInstantiatesGeneratedStructWithDefaultConstructor() {
+        ThriftMetadata.ThriftStruct<GeneratedStruct> thriftStruct =
+                ThriftMetadata.ThriftStruct.of(GeneratedStruct.class);
+
+        GeneratedStruct generatedStruct = thriftStruct.createNewStruct();
+
+        assertThat(generatedStruct).isNotNull();
+        assertThat(generatedStruct.isSet(GeneratedField.NAME)).isFalse();
+        generatedStruct.setFieldValue(GeneratedField.NAME, "covered");
+        assertThat(generatedStruct.getFieldValue(GeneratedField.NAME)).isEqualTo("covered");
+    }
+
+    public enum GeneratedField implements TFieldIdEnum {
+        NAME((short) 1, "name");
+
+        private final short thriftFieldId;
+        private final String fieldName;
+
+        GeneratedField(short thriftFieldId, String fieldName) {
+            this.thriftFieldId = thriftFieldId;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public short getThriftFieldId() {
+            return thriftFieldId;
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldName;
+        }
+    }
+
+    public static class GeneratedStruct implements TBase<GeneratedStruct, GeneratedField> {
+        private String name;
+
+        static {
+            Map<GeneratedField, FieldMetaData> metadata = new EnumMap<>(GeneratedField.class);
+            metadata.put(
+                    GeneratedField.NAME,
+                    new FieldMetaData(
+                            GeneratedField.NAME.getFieldName(),
+                            TFieldRequirementType.DEFAULT,
+                            new FieldValueMetaData(TType.STRING)));
+            FieldMetaData.addStructMetaDataMap(GeneratedStruct.class, metadata);
+        }
+
+        @Override
+        public GeneratedField fieldForId(int fieldId) {
+            if (fieldId == GeneratedField.NAME.getThriftFieldId()) {
+                return GeneratedField.NAME;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isSet(GeneratedField field) {
+            return field == GeneratedField.NAME && name != null;
+        }
+
+        @Override
+        public Object getFieldValue(GeneratedField field) {
+            if (field == GeneratedField.NAME) {
+                return name;
+            }
+            throw new IllegalArgumentException("Unknown field: " + field);
+        }
+
+        @Override
+        public void setFieldValue(GeneratedField field, Object value) {
+            if (field != GeneratedField.NAME) {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+            name = (String) value;
+        }
+
+        @Override
+        public GeneratedStruct deepCopy() {
+            GeneratedStruct copy = new GeneratedStruct();
+            copy.name = name;
+            return copy;
+        }
+
+        @Override
+        public void clear() {
+            name = null;
+        }
+
+        @Override
+        public void read(TProtocol iprot) throws TException {
+            throw new UnsupportedOperationException("Protocol read is not needed for metadata instantiation");
+        }
+
+        @Override
+        public void write(TProtocol oprot) throws TException {
+            throw new UnsupportedOperationException("Protocol write is not needed for metadata instantiation");
+        }
+
+        @Override
+        public int compareTo(GeneratedStruct other) {
+            if (name == null && other.name == null) {
+                return 0;
+            }
+            if (name == null) {
+                return -1;
+            }
+            if (other.name == null) {
+                return 1;
+            }
+            return name.compareTo(other.name);
+        }
+    }
+}

```
