### PR TITLE
[GenAI] Add support for io.netty:netty-handler-proxy:4.1.60.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-handler-proxy/4.1.60.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-handler-proxy/4.1.60.Final/reachability-metadata.json
@@ -1,0 +1,284 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.HttpProxyHandler"
+      },
+      "type": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.Recycler$DefaultHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.ReferenceCountUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.ResourceLeakDetector$DefaultResourceLeak"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.HttpProxyHandler"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-handler-proxy/index.json
+++ b/metadata/io.netty/netty-handler-proxy/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.60.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.60.Final/netty-handler-proxy-4.1.60.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.60.Final/netty-handler-proxy-4.1.60.Final-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.60.Final/netty-handler-proxy-4.1.60.Final-javadoc.jar",
+    "description" : "Netty Handler Proxy adds client-side support for connecting through proxy protocols such as SOCKS and HTTP CONNECT tunneling. It provides proxy channel handlers and connection events that integrate with Netty's asynchronous networking pipeline.",
+    "tested-versions" : [
+      "4.1.60.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.proxy"
+    ]
+  }
+]

--- a/stats/io.netty/netty-handler-proxy/4.1.60.Final/execution-metrics.json
+++ b/stats/io.netty/netty-handler-proxy/4.1.60.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T07:01:40.860817Z",
+    "library": "io.netty:netty-handler-proxy:4.1.60.Final",
+    "starting_commit": "2e20e1d41ebf0e317c2cfe0eab9522c6e57ce111",
+    "ending_commit": "4e8db97e0d60237d5a2ec03b786520455224ddd3",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.60.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1255,
+          "missed": 303,
+          "ratio": 0.80552,
+          "total": 1558
+        },
+        "line": {
+          "covered": 328,
+          "missed": 82,
+          "ratio": 0.8,
+          "total": 410
+        },
+        "method": {
+          "covered": 90,
+          "missed": 17,
+          "ratio": 0.841121,
+          "total": 107
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 225383,
+      "cached_input_tokens_used": 1525248,
+      "output_tokens_used": 22253,
+      "iterations": 5,
+      "cost_usd": 1.4302,
+      "generated_loc": 507,
+      "tested_library_loc": 328,
+      "metadata_entries": 55,
+      "code_coverage_percent": 80.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java",
+      "metadata_file": "metadata/io.netty/netty-handler-proxy/4.1.60.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-handler-proxy/4.1.60.Final/stats.json
+++ b/stats/io.netty/netty-handler-proxy/4.1.60.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.60.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1255,
+        "missed" : 303,
+        "ratio" : 0.80552,
+        "total" : 1558
+      },
+      "line" : {
+        "covered" : 328,
+        "missed" : 82,
+        "ratio" : 0.8,
+        "total" : 410
+      },
+      "method" : {
+        "covered" : 90,
+        "missed" : 17,
+        "ratio" : 0.841121,
+        "total" : 107
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/.gitignore
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/build.gradle
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-handler-proxy:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/gradle.properties
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-handler-proxy:4.1.60.Final
+library.version = 4.1.60.Final
+metadata.dir = io.netty/netty-handler-proxy/4.1.60.Final/

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/settings.gradle
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-handler-proxy_tests'

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_handler_proxy;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_handler_proxyTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
@@ -6,11 +6,499 @@
  */
 package io_netty.netty_handler_proxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.ProxyConnectException;
+import io.netty.handler.proxy.ProxyConnectionEvent;
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.handler.proxy.Socks4ProxyHandler;
+import io.netty.handler.proxy.Socks5ProxyHandler;
+import io.netty.resolver.NoopAddressResolverGroup;
+import io.netty.util.concurrent.Future;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
-class Netty_handler_proxyTest {
+public class Netty_handler_proxyTest {
+    private static final int IO_TIMEOUT_MILLIS = 5_000;
+    private static final InetSocketAddress HTTP_DESTINATION = InetSocketAddress.createUnresolved("service.example", 443);
+    private static final InetSocketAddress SOCKS_DOMAIN_DESTINATION =
+            InetSocketAddress.createUnresolved("destination.example", 8443);
+    private static final InetSocketAddress SOCKS_IPV4_DESTINATION =
+            new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void exposesHttpProxyConfigurationAndConnectionEvent() throws Exception {
+        HttpHeaders headers = new DefaultHttpHeaders().add("X-Trace-Id", "trace-123");
+        HttpProxyHandler handler = new HttpProxyHandler(unusedProxyAddress(), "user", "pass", headers, true);
+
+        assertThat(handler.protocol()).isEqualTo("http");
+        assertThat(handler.authScheme()).isEqualTo("basic");
+        assertThat(handler.username()).isEqualTo("user");
+        assertThat(handler.password()).isEqualTo("pass");
+        assertThat(handler.connectTimeoutMillis()).isEqualTo(10_000L);
+        handler.setConnectTimeoutMillis(-1L);
+        assertThat(handler.connectTimeoutMillis()).isZero();
+
+        ProxyConnectionEvent event = new ProxyConnectionEvent(
+                handler.protocol(), handler.authScheme(), handler.proxyAddress(), HTTP_DESTINATION);
+        assertThat(event.protocol()).isEqualTo("http");
+        assertThat(event.authScheme()).isEqualTo("basic");
+        assertThat((InetSocketAddress) event.proxyAddress()).isEqualTo(handler.proxyAddress());
+        assertThat((InetSocketAddress) event.destinationAddress()).isEqualTo(HTTP_DESTINATION);
+        assertThat(event.toString())
+                .contains("http")
+                .contains("basic")
+                .contains("service.example")
+                .contains("443");
+    }
+
+    @Test
+    void performsHttpConnectWithBasicAuthenticationAndCustomHeaders() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            List<String> requestLines = readHttpHeaderBlock(input);
+            assertThat(requestLines).isNotEmpty();
+            assertThat(requestLines.get(0)).isEqualTo("CONNECT service.example:443 HTTP/1.1");
+            assertContainsHeader(requestLines, HttpHeaderNames.HOST.toString(), "service.example");
+            assertContainsHeader(requestLines, "X-Trace-Id", "trace-456");
+            assertContainsHeader(requestLines, HttpHeaderNames.PROXY_AUTHORIZATION.toString(),
+                    basicAuthorization("user", "pass"));
+            writeAscii(output, "HTTP/1.1 200 Connection Established\r\nContent-Length: 0\r\n\r\n");
+        })) {
+            HttpHeaders headers = new DefaultHttpHeaders().add("X-Trace-Id", "trace-456");
+            HttpProxyHandler handler = new HttpProxyHandler(proxyServer.address(), "user", "pass", headers, true);
+
+            try (ClientConnection client = ClientConnection.connect(handler, HTTP_DESTINATION)) {
+                assertThat(handler.connectFuture().isSuccess()).isTrue();
+                assertThat(handler.isConnected()).isTrue();
+                assertThat((InetSocketAddress) handler.destinationAddress()).isEqualTo(HTTP_DESTINATION);
+                assertThat(client.recorder().event()).isNotNull();
+                assertThat(client.recorder().event().protocol()).isEqualTo("http");
+                assertThat(client.recorder().event().authScheme()).isEqualTo("basic");
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void reportsHttpProxyRejectionWithResponseStatus() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            List<String> requestLines = readHttpHeaderBlock(input);
+            assertThat(requestLines.get(0)).isEqualTo("CONNECT service.example:443 HTTP/1.1");
+            writeAscii(output, "HTTP/1.1 407 Proxy Authentication Required\r\n"
+                    + "Proxy-Authenticate: Basic realm=restricted\r\n"
+                    + "Content-Length: 0\r\n\r\n");
+        })) {
+            HttpProxyHandler handler = new HttpProxyHandler(proxyServer.address());
+
+            try (ClientConnection client = ClientConnection.connect(handler, HTTP_DESTINATION, false)) {
+                Future<Channel> connectFuture = handler.connectFuture();
+                assertThat(connectFuture.isDone()).isTrue();
+                assertThat(connectFuture.isSuccess()).isFalse();
+                assertThat(connectFuture.cause()).isInstanceOf(ProxyConnectException.class);
+                assertThat(connectFuture.cause().getMessage())
+                        .contains("http")
+                        .contains("none")
+                        .contains("status: 407 Proxy Authentication Required");
+                assertThat(client.recorder().event()).isNull();
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void performsSocks4aConnectWithUsernameForUnresolvedDomain() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x04, 0x01);
+            assertThat(readUnsignedShort(input)).isEqualTo(8443);
+            assertNextBytes(input, 0x00, 0x00, 0x00, 0x01);
+            assertThat(readNullTerminatedAscii(input)).isEqualTo("netty-user");
+            assertThat(readNullTerminatedAscii(input)).isEqualTo("destination.example");
+            writeBytes(output, 0x00, 0x5a, 0x20, 0xfb, 0x7f, 0x00, 0x00, 0x01);
+        })) {
+            Socks4ProxyHandler handler = new Socks4ProxyHandler(proxyServer.address(), "netty-user");
+
+            assertThat(handler.protocol()).isEqualTo("socks4");
+            assertThat(handler.authScheme()).isEqualTo("username");
+            assertThat(handler.username()).isEqualTo("netty-user");
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_DOMAIN_DESTINATION)) {
+                assertThat(handler.connectFuture().isSuccess()).isTrue();
+                assertThat(handler.isConnected()).isTrue();
+                assertThat(client.recorder().event()).isNotNull();
+                assertThat(client.recorder().event().protocol()).isEqualTo("socks4");
+                assertThat(client.recorder().event().authScheme()).isEqualTo("username");
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void reportsSocks4CommandFailureStatus() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x04, 0x01);
+            readFully(input, 6);
+            readNullTerminatedAscii(input);
+            readNullTerminatedAscii(input);
+            writeBytes(output, 0x00, 0x5b, 0x20, 0xfb, 0x00, 0x00, 0x00, 0x00);
+        })) {
+            Socks4ProxyHandler handler = new Socks4ProxyHandler(proxyServer.address());
+
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_DOMAIN_DESTINATION, false)) {
+                Future<Channel> connectFuture = handler.connectFuture();
+                assertThat(connectFuture.isDone()).isTrue();
+                assertThat(connectFuture.isSuccess()).isFalse();
+                assertThat(connectFuture.cause()).isInstanceOf(ProxyConnectException.class);
+                assertThat(connectFuture.cause().getMessage())
+                        .contains("socks4")
+                        .contains("none")
+                        .contains("REJECTED_OR_FAILED");
+                assertThat(client.recorder().event()).isNull();
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void performsSocks5NoAuthenticationConnectToDomain() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x05, 0x01, 0x00);
+            writeBytes(output, 0x05, 0x00);
+
+            assertNextBytes(input, 0x05, 0x01, 0x00, 0x03);
+            int hostLength = readUnsignedByte(input);
+            assertThat(readAscii(input, hostLength)).isEqualTo("destination.example");
+            assertThat(readUnsignedShort(input)).isEqualTo(8443);
+            writeBytes(output, 0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+        })) {
+            Socks5ProxyHandler handler = new Socks5ProxyHandler(proxyServer.address());
+
+            assertThat(handler.protocol()).isEqualTo("socks5");
+            assertThat(handler.authScheme()).isEqualTo("none");
+            assertThat(handler.username()).isNull();
+            assertThat(handler.password()).isNull();
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_DOMAIN_DESTINATION)) {
+                assertThat(handler.connectFuture().isSuccess()).isTrue();
+                assertThat(client.recorder().event()).isNotNull();
+                assertThat(client.recorder().event().protocol()).isEqualTo("socks5");
+                assertThat(client.recorder().event().authScheme()).isEqualTo("none");
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void performsSocks5PasswordAuthenticationAndIpv4Connect() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x05, 0x02, 0x00, 0x02);
+            writeBytes(output, 0x05, 0x02);
+
+            assertNextBytes(input, 0x01);
+            int usernameLength = readUnsignedByte(input);
+            assertThat(readAscii(input, usernameLength)).isEqualTo("user");
+            int passwordLength = readUnsignedByte(input);
+            assertThat(readAscii(input, passwordLength)).isEqualTo("secret");
+            writeBytes(output, 0x01, 0x00);
+
+            assertNextBytes(input, 0x05, 0x01, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01);
+            assertThat(readUnsignedShort(input)).isEqualTo(8080);
+            writeBytes(output, 0x05, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01, 0x1f, 0x90);
+        })) {
+            Socks5ProxyHandler handler = new Socks5ProxyHandler(proxyServer.address(), "user", "secret");
+
+            assertThat(handler.authScheme()).isEqualTo("password");
+            assertThat(handler.username()).isEqualTo("user");
+            assertThat(handler.password()).isEqualTo("secret");
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_IPV4_DESTINATION)) {
+                assertThat(handler.connectFuture().isSuccess()).isTrue();
+                assertThat(client.recorder().event()).isNotNull();
+                assertThat(client.recorder().event().authScheme()).isEqualTo("password");
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
+    void reportsSocks5AuthenticationFailure() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x05, 0x02, 0x00, 0x02);
+            writeBytes(output, 0x05, 0x02);
+            assertNextBytes(input, 0x01);
+            int usernameLength = readUnsignedByte(input);
+            assertThat(readAscii(input, usernameLength)).isEqualTo("user");
+            int passwordLength = readUnsignedByte(input);
+            assertThat(readAscii(input, passwordLength)).isEqualTo("wrong");
+            writeBytes(output, 0x01, 0xff);
+        })) {
+            Socks5ProxyHandler handler = new Socks5ProxyHandler(proxyServer.address(), "user", "wrong");
+
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_DOMAIN_DESTINATION, false)) {
+                Future<Channel> connectFuture = handler.connectFuture();
+                assertThat(connectFuture.isDone()).isTrue();
+                assertThat(connectFuture.isSuccess()).isFalse();
+                assertThat(connectFuture.cause()).isInstanceOf(ProxyConnectException.class);
+                assertThat(connectFuture.cause().getMessage())
+                        .contains("socks5")
+                        .contains("password")
+                        .contains("authStatus: FAILURE");
+                assertThat(client.recorder().event()).isNull();
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    private static InetSocketAddress unusedProxyAddress() {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), 6553);
+    }
+
+    private static String basicAuthorization(String username, String password) {
+        String credentials = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static List<String> readHttpHeaderBlock(InputStream input) throws IOException {
+        List<String> lines = new ArrayList<>();
+        String line;
+        while (!(line = readHttpLine(input)).isEmpty()) {
+            lines.add(line);
+        }
+        return lines;
+    }
+
+    private static void assertContainsHeader(List<String> lines, String name, String value) {
+        boolean found = lines.stream().anyMatch(line -> {
+            int colonIndex = line.indexOf(':');
+            if (colonIndex < 0) {
+                return false;
+            }
+            String actualName = line.substring(0, colonIndex);
+            String actualValue = line.substring(colonIndex + 1).trim();
+            return actualName.equalsIgnoreCase(name) && actualValue.equals(value);
+        });
+        assertThat(found).describedAs("%s: %s was present in %s", name, value, lines).isTrue();
+    }
+
+    private static String readHttpLine(InputStream input) throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream();
+        int previous = -1;
+        while (true) {
+            int value = input.read();
+            if (value < 0) {
+                throw new IOException("Unexpected end of HTTP header block");
+            }
+            if (previous == '\r' && value == '\n') {
+                byte[] bytes = line.toByteArray();
+                return new String(bytes, 0, bytes.length - 1, StandardCharsets.US_ASCII);
+            }
+            line.write(value);
+            previous = value;
+        }
+    }
+
+    private static void assertNextBytes(InputStream input, int... expectedBytes) throws IOException {
+        for (int expectedByte : expectedBytes) {
+            assertThat(readUnsignedByte(input)).isEqualTo(expectedByte);
+        }
+    }
+
+    private static byte[] readFully(InputStream input, int length) throws IOException {
+        byte[] buffer = new byte[length];
+        int offset = 0;
+        while (offset < length) {
+            int read = input.read(buffer, offset, length - offset);
+            if (read < 0) {
+                throw new IOException("Unexpected end of stream");
+            }
+            offset += read;
+        }
+        return buffer;
+    }
+
+    private static int readUnsignedByte(InputStream input) throws IOException {
+        int value = input.read();
+        if (value < 0) {
+            throw new IOException("Unexpected end of stream");
+        }
+        return value;
+    }
+
+    private static int readUnsignedShort(InputStream input) throws IOException {
+        return (readUnsignedByte(input) << 8) | readUnsignedByte(input);
+    }
+
+    private static String readAscii(InputStream input, int length) throws IOException {
+        return new String(readFully(input, length), StandardCharsets.US_ASCII);
+    }
+
+    private static String readNullTerminatedAscii(InputStream input) throws IOException {
+        ByteArrayOutputStream value = new ByteArrayOutputStream();
+        int next;
+        while ((next = readUnsignedByte(input)) != 0) {
+            value.write(next);
+        }
+        return value.toString(StandardCharsets.US_ASCII.name());
+    }
+
+    private static void writeAscii(OutputStream output, String value) throws IOException {
+        output.write(value.getBytes(StandardCharsets.US_ASCII));
+        output.flush();
+    }
+
+    private static void writeBytes(OutputStream output, int... values) throws IOException {
+        for (int value : values) {
+            output.write(value);
+        }
+        output.flush();
+    }
+
+    private interface ProxyExchange {
+        void handle(InputStream input, OutputStream output) throws Exception;
+    }
+
+    private static final class FakeProxyServer implements Closeable {
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final CountDownLatch done = new CountDownLatch(1);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        private FakeProxyServer(ServerSocket serverSocket, ProxyExchange exchange) {
+            this.serverSocket = serverSocket;
+            this.thread = new Thread(() -> run(exchange), "netty-handler-proxy-test-server");
+            this.thread.setDaemon(true);
+        }
+
+        static FakeProxyServer start(ProxyExchange exchange) throws IOException {
+            ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+            serverSocket.setSoTimeout(IO_TIMEOUT_MILLIS);
+            FakeProxyServer server = new FakeProxyServer(serverSocket, exchange);
+            server.thread.start();
+            return server;
+        }
+
+        InetSocketAddress address() {
+            return new InetSocketAddress(InetAddress.getLoopbackAddress(), serverSocket.getLocalPort());
+        }
+
+        void awaitSuccess() throws InterruptedException {
+            assertThat(done.await(IO_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            Throwable throwable = failure.get();
+            if (throwable != null) {
+                throw new AssertionError("Fake proxy exchange failed", throwable);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+        }
+
+        private void run(ProxyExchange exchange) {
+            try (Socket socket = serverSocket.accept()) {
+                socket.setSoTimeout(IO_TIMEOUT_MILLIS);
+                exchange.handle(socket.getInputStream(), socket.getOutputStream());
+            } catch (SocketTimeoutException e) {
+                failure.set(new AssertionError("Timed out waiting for proxy client data", e));
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                done.countDown();
+            }
+        }
+    }
+
+    private static final class ClientConnection implements Closeable {
+        private final EventLoopGroup group;
+        private final Channel channel;
+        private final EventRecorder recorder;
+
+        private ClientConnection(EventLoopGroup group, Channel channel, EventRecorder recorder) {
+            this.group = group;
+            this.channel = channel;
+            this.recorder = recorder;
+        }
+
+        static ClientConnection connect(ProxyHandler proxyHandler, InetSocketAddress destination) throws Exception {
+            return connect(proxyHandler, destination, true);
+        }
+
+        static ClientConnection connect(ProxyHandler proxyHandler, InetSocketAddress destination, boolean expectSuccess)
+                throws Exception {
+            EventLoopGroup group = new NioEventLoopGroup(1);
+            EventRecorder recorder = new EventRecorder();
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(group)
+                    .channel(NioSocketChannel.class)
+                    .resolver(NoopAddressResolverGroup.INSTANCE)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel channel) {
+                            channel.pipeline().addLast(proxyHandler);
+                            channel.pipeline().addLast(recorder);
+                        }
+                    });
+            ChannelFuture tcpConnectFuture = bootstrap.connect(destination);
+            assertThat(tcpConnectFuture.await(IO_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(tcpConnectFuture.isSuccess())
+                    .describedAs("TCP connection to proxy failed: %s", tcpConnectFuture.cause())
+                    .isTrue();
+            Future<Channel> proxyConnectFuture = proxyHandler.connectFuture();
+            assertThat(proxyConnectFuture.await(IO_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(proxyConnectFuture.isSuccess()).isEqualTo(expectSuccess);
+            return new ClientConnection(group, tcpConnectFuture.channel(), recorder);
+        }
+
+        EventRecorder recorder() {
+            return recorder;
+        }
+
+        @Override
+        public void close() {
+            channel.close().awaitUninterruptibly(IO_TIMEOUT_MILLIS);
+            group.shutdownGracefully(0, IO_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).awaitUninterruptibly(IO_TIMEOUT_MILLIS);
+        }
+    }
+
+    private static final class EventRecorder extends ChannelInboundHandlerAdapter {
+        private ProxyConnectionEvent event;
+
+        ProxyConnectionEvent event() {
+            return event;
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext context, Object event) throws Exception {
+            if (event instanceof ProxyConnectionEvent) {
+                this.event = (ProxyConnectionEvent) event;
+            }
+            super.userEventTriggered(context, event);
+        }
     }
 }

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
@@ -247,6 +247,35 @@ public class Netty_handler_proxyTest {
     }
 
     @Test
+    void reportsSocks5CommandFailureStatus() throws Exception {
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x05, 0x01, 0x00);
+            writeBytes(output, 0x05, 0x00);
+
+            assertNextBytes(input, 0x05, 0x01, 0x00, 0x03);
+            int hostLength = readUnsignedByte(input);
+            assertThat(readAscii(input, hostLength)).isEqualTo("destination.example");
+            assertThat(readUnsignedShort(input)).isEqualTo(8443);
+            writeBytes(output, 0x05, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+        })) {
+            Socks5ProxyHandler handler = new Socks5ProxyHandler(proxyServer.address());
+
+            try (ClientConnection client = ClientConnection.connect(handler, SOCKS_DOMAIN_DESTINATION, false)) {
+                Future<Channel> connectFuture = handler.connectFuture();
+                assertThat(connectFuture.isDone()).isTrue();
+                assertThat(connectFuture.isSuccess()).isFalse();
+                assertThat(connectFuture.cause()).isInstanceOf(ProxyConnectException.class);
+                assertThat(connectFuture.cause().getMessage())
+                        .contains("socks5")
+                        .contains("none")
+                        .contains("status: FORBIDDEN");
+                assertThat(client.recorder().event()).isNull();
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
     void performsSocks5NoAuthenticationConnectToIpv6Address() throws Exception {
         byte[] loopbackAddress = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
         InetSocketAddress ipv6Destination = new InetSocketAddress(InetAddress.getByAddress(loopbackAddress), 9443);

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/src/test/java/io_netty/netty_handler_proxy/Netty_handler_proxyTest.java
@@ -247,6 +247,39 @@ public class Netty_handler_proxyTest {
     }
 
     @Test
+    void performsSocks5NoAuthenticationConnectToIpv6Address() throws Exception {
+        byte[] loopbackAddress = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+        InetSocketAddress ipv6Destination = new InetSocketAddress(InetAddress.getByAddress(loopbackAddress), 9443);
+        try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
+            assertNextBytes(input, 0x05, 0x01, 0x00);
+            writeBytes(output, 0x05, 0x00);
+
+            assertNextBytes(input, 0x05, 0x01, 0x00, 0x04);
+            assertThat(readFully(input, loopbackAddress.length)).containsExactly(loopbackAddress);
+            assertThat(readUnsignedShort(input)).isEqualTo(9443);
+            writeBytes(output,
+                    0x05, 0x00, 0x00, 0x04,
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x01,
+                    0x24, 0xe3);
+        })) {
+            Socks5ProxyHandler handler = new Socks5ProxyHandler(proxyServer.address());
+
+            try (ClientConnection client = ClientConnection.connect(handler, ipv6Destination)) {
+                assertThat(handler.connectFuture().isSuccess()).isTrue();
+                assertThat((InetSocketAddress) handler.destinationAddress()).isEqualTo(ipv6Destination);
+                assertThat(client.recorder().event()).isNotNull();
+                assertThat(client.recorder().event().protocol()).isEqualTo("socks5");
+                assertThat(client.recorder().event().authScheme()).isEqualTo("none");
+                assertThat((InetSocketAddress) client.recorder().event().destinationAddress()).isEqualTo(ipv6Destination);
+            }
+            proxyServer.awaitSuccess();
+        }
+    }
+
+    @Test
     void reportsSocks5AuthenticationFailure() throws Exception {
         try (FakeProxyServer proxyServer = FakeProxyServer.start((input, output) -> {
             assertNextBytes(input, 0x05, 0x02, 0x00, 0x02);

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.handler.proxy.**"
+      "includeClasses" : "io.netty.handler.proxy.**"
     }
   ]
 }

--- a/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-handler-proxy/4.1.60.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.handler.proxy.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1378

This PR introduces tests and metadata for io.netty:netty-handler-proxy:4.1.60.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 225383
- Cached input tokens: 1525248
- Output tokens: 22253
- Metadata entries: 55
- Iterations: 5
- Library coverage percentage: 80.0
- Generated lines of code: 507
- Tested library lines of code: 328

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `881696e06331135fdee735a86e644c64c238f55e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1255/1558 (80.55%)
- Line: 328/410 (80.00%)
- Method: 90/107 (84.11%)
