### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-haproxy:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-haproxy/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-haproxy/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "methods": [
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.ByteBuf"
+          ]
+        },
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.CompositeByteBuf"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-haproxy/index.json
+++ b/metadata/io.netty/netty-codec-haproxy/index.json
@@ -1,16 +1,32 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-javadoc.jar",
-    "description" : "Netty Codec HAProxy provides encoders, decoders, and message model classes for the HAProxy PROXY protocol in Netty pipelines. It lets Netty-based servers and clients parse and emit proxy protocol headers so original client connection metadata can be preserved through load balancers and proxies.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.1.79.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.79.Final/netty-codec-haproxy-4.1.79.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.79.Final/netty-codec-haproxy-4.1.79.Final-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.79.Final/netty-codec-haproxy-4.1.79.Final-javadoc.jar",
+    "description": "Netty Codec HAProxy provides encoders, decoders, and message model classes for the HAProxy PROXY protocol in Netty pipelines. It lets Netty-based servers and clients parse and emit proxy protocol headers so original client connection metadata can be preserved through load balancers and proxies.",
+    "test-version": "4.1.74.Final",
+    "tested-versions": [
+      "4.1.79.Final"
+    ],
+    "allowed-packages": [
+      "io.netty.handler.codec.haproxy",
+      "io.netty.buffer"
+    ]
+  },
+  {
+    "metadata-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-haproxy/4.1.74.Final/netty-codec-haproxy-4.1.74.Final-javadoc.jar",
+    "description": "Netty Codec HAProxy provides encoders, decoders, and message model classes for the HAProxy PROXY protocol in Netty pipelines. It lets Netty-based servers and clients parse and emit proxy protocol headers so original client connection metadata can be preserved through load balancers and proxies.",
+    "tested-versions": [
       "4.1.74.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.netty.handler.codec.haproxy"
     ]
   }

--- a/stats/io.netty/netty-codec-haproxy/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-codec-haproxy/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1829,
+        "missed" : 987,
+        "ratio" : 0.649503,
+        "total" : 2816
+      },
+      "line" : {
+        "covered" : 420,
+        "missed" : 185,
+        "ratio" : 0.694215,
+        "total" : 605
+      },
+      "method" : {
+        "covered" : 91,
+        "missed" : 28,
+        "ratio" : 0.764706,
+        "total" : 119
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4210

This PR provides new metadata needed for the io.netty:netty-codec-haproxy:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-haproxy:4.1.74.Final`): 0
- Metadata entries (new `io.netty:netty-codec-haproxy:4.1.79.Final`): 3
- Library coverage (previous): 69.42%
- Library coverage (new): 69.42%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4898a6265381c0b190ec5bf4708990e9808da7f9`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-haproxy:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-haproxy:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-haproxy:4.1.74.Final: 1829/2816 (64.95%)
- io.netty:netty-codec-haproxy:4.1.79.Final: 1829/2816 (64.95%)

**Line:**
- io.netty:netty-codec-haproxy:4.1.74.Final: 420/605 (69.42%)
- io.netty:netty-codec-haproxy:4.1.79.Final: 420/605 (69.42%)

**Method:**
- io.netty:netty-codec-haproxy:4.1.74.Final: 91/119 (76.47%)
- io.netty:netty-codec-haproxy:4.1.79.Final: 91/119 (76.47%)
