### PR TITLE
[GenAI] Test fix for com.github.jknack:handlebars:4.4.0 using gpt-5.5

### DIFF
--- a/metadata/com.github.jknack/handlebars/4.4.0/reachability-metadata.json
+++ b/metadata/com.github.jknack/handlebars/4.4.0/reachability-metadata.json
@@ -1,0 +1,51 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Context$CompositeValueResolver"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Context$CompositeValueResolver"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Context$CompositeValueResolver"
+      },
+      "type" : "java.util.Collections$SingletonMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Context$CompositeValueResolver"
+      },
+      "type" : "java.util.Map"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Handlebars"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.Files"
+      },
+      "glob" : "helpers.nashorn.js"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Handlebars"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "bundle" : "com_github_jknack.handlebars.DefI18nSourceTestMessages"
+    }
+  ]
+}

--- a/metadata/com.github.jknack/handlebars/index.json
+++ b/metadata/com.github.jknack/handlebars/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/github/jknack/handlebars/4.4.0/handlebars-4.4.0-sources.jar",
+    "repository-url" : "https://github.com/jknack/handlebars.java",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/github/jknack/handlebars/4.4.0/handlebars-4.4.0-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/github/jknack/handlebars/4.4.0/handlebars-4.4.0-javadoc.jar",
+    "description" : "Handlebars.java is a Java implementation of the Handlebars template language for rendering logic-less, semantic templates on the JVM. It parses templates and applies them to Java objects with support for helpers, partials, loaders, escaping, and i18n.",
     "tested-versions" : [
       "4.4.0"
     ],

--- a/metadata/com.github.jknack/handlebars/index.json
+++ b/metadata/com.github.jknack/handlebars/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.4.0",
+    "tested-versions" : [
+      "4.4.0"
+    ],
+    "allowed-packages" : [
+      "com.github.jknack.handlebars"
+    ]
+  },
+  {
     "metadata-version" : "4.3.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/jknack/handlebars/4.3.1/handlebars-4.3.1-sources.jar",
     "repository-url" : "https://github.com/jknack/handlebars.java",

--- a/stats/com.github.jknack/handlebars/4.4.0/execution-metrics.json
+++ b/stats/com.github.jknack/handlebars/4.4.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T07:31:58.858388Z",
+    "library": "com.github.jknack:handlebars:4.4.0",
+    "starting_commit": "b29d13c948a1f8fbee89395e04216eda3f7e6326",
+    "ending_commit": "0f6487af2a6a316be325ae2b3a4cdabb41fba810",
+    "previous_library": "com.github.jknack:handlebars:4.3.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 14205,
+          "missed": 37225,
+          "ratio": 0.276201,
+          "total": 51430
+        },
+        "line": {
+          "covered": 3131,
+          "missed": 8255,
+          "ratio": 0.274987,
+          "total": 11386
+        },
+        "method": {
+          "covered": 768,
+          "missed": 1929,
+          "ratio": 0.284761,
+          "total": 2697
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.3.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 35,
+            "totalCalls": 35
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 40,
+        "totalCalls": 40
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18231,
+          "missed": 84037,
+          "ratio": 0.178267,
+          "total": 102268
+        },
+        "line": {
+          "covered": 4108,
+          "missed": 17952,
+          "ratio": 0.186219,
+          "total": 22060
+        },
+        "method": {
+          "covered": 974,
+          "missed": 3909,
+          "ratio": 0.199468,
+          "total": 4883
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 135477,
+      "cached_input_tokens_used": 2243072,
+      "output_tokens_used": 9340,
+      "iterations": 2,
+      "cost_usd": 1.4017,
+      "tested_library_loc": 3131,
+      "metadata_entries": 8,
+      "test_only_metadata_entries": 50,
+      "previous_library_metadata_entries": 15,
+      "previous_library_test_only_metadata_entries": 50,
+      "code_coverage_percent": 27.5,
+      "previous_library_coverage_percent": 18.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassPathTemplateLoaderTest.java",
+      "metadata_file": "metadata/com.github.jknack/handlebars/4.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.jknack/handlebars/4.4.0/stats.json
+++ b/stats/com.github.jknack/handlebars/4.4.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.4.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 13,
+      "totalCalls" : 13
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 14205,
+        "missed" : 37225,
+        "ratio" : 0.276201,
+        "total" : 51430
+      },
+      "line" : {
+        "covered" : 3131,
+        "missed" : 8255,
+        "ratio" : 0.274987,
+        "total" : 11386
+      },
+      "method" : {
+        "covered" : 768,
+        "missed" : 1929,
+        "ratio" : 0.284761,
+        "total" : 2697
+      }
+    }
+  } ]
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/.gitignore
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.jknack/handlebars/4.4.0/build.gradle
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.github.jknack:handlebars:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/gradle.properties
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.github.jknack:handlebars:4.4.0
+library.version = 4.4.0
+metadata.dir = com.github.jknack/handlebars/4.4.0/

--- a/tests/src/com.github.jknack/handlebars/4.4.0/settings.gradle
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.jknack.handlebars_tests'

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+
+public class ArrayUtilsTest {
+    @Test
+    public void addCreatesArraysForNullAndExistingInputs() {
+        String[] insertedIntoNullArray = ArrayUtils.add((String[]) null, 0, "alpha");
+        String[] insertedIntoExistingArray = ArrayUtils.add(new String[] {"alpha", "gamma"}, 1, "beta");
+        String[] appendedToNullArray = ArrayUtils.add((String[]) null, "delta");
+        String[] appendedToExistingArray = ArrayUtils.add(new String[] {"epsilon"}, "zeta");
+
+        assertThat(insertedIntoNullArray).containsExactly("alpha");
+        assertThat(insertedIntoExistingArray).containsExactly("alpha", "beta", "gamma");
+        assertThat(appendedToNullArray).containsExactly("delta");
+        assertThat(appendedToExistingArray).containsExactly("epsilon", "zeta");
+    }
+
+    @Test
+    public void addAllAndInsertCreateArraysWithSourceComponentType() {
+        String[] joined = ArrayUtils.addAll(new String[] {"alpha"}, "beta", "gamma");
+        String[] inserted = ArrayUtils.insert(1, new String[] {"alpha", "delta"}, "beta", "gamma");
+
+        assertThat(joined).containsExactly("alpha", "beta", "gamma");
+        assertThat(inserted).containsExactly("alpha", "beta", "gamma", "delta");
+    }
+
+    @Test
+    public void nullToEmptyCreatesTypedEmptyArray() {
+        String[] empty = ArrayUtils.nullToEmpty(null, String[].class);
+        String[] original = new String[] {"alpha"};
+
+        assertThat(empty).isEmpty();
+        assertThat(empty).isInstanceOf(String[].class);
+        assertThat(ArrayUtils.nullToEmpty(original, String[].class)).isSameAs(original);
+    }
+
+    @Test
+    public void removeAndRemoveAllCreateArraysWithRemainingElements() {
+        String[] removedSingleIndex = ArrayUtils.remove(new String[] {"alpha", "beta", "gamma"}, 1);
+        String[] removedMultipleIndices = ArrayUtils.removeAll(
+                new String[] {"alpha", "beta", "gamma", "delta"}, 1, 3);
+        String[] removedMatchingValues = ArrayUtils.removeElements(
+                new String[] {"alpha", "beta", "alpha", "gamma"}, "alpha", "gamma");
+
+        assertThat(removedSingleIndex).containsExactly("alpha", "gamma");
+        assertThat(removedMultipleIndices).containsExactly("alpha", "gamma");
+        assertThat(removedMatchingValues).containsExactly("beta", "alpha");
+    }
+
+    @Test
+    public void subarrayCreatesEmptyAndNonEmptyTypedArrays() {
+        String[] source = new String[] {"alpha", "beta", "gamma"};
+        String[] empty = ArrayUtils.subarray(source, 2, 1);
+        String[] middle = ArrayUtils.subarray(source, 1, 3);
+
+        assertThat(empty).isEmpty();
+        assertThat(empty).isInstanceOf(String[].class);
+        assertThat(middle).containsExactly("beta", "gamma");
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
@@ -8,18 +8,18 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 public class ArrayUtilsTest {
     @Test
-    public void addCreatesArraysForNullAndExistingInputs() {
-        String[] insertedIntoNullArray = ArrayUtils.add((String[]) null, 0, "alpha");
-        String[] insertedIntoExistingArray = ArrayUtils.add(new String[] {"alpha", "gamma"}, 1, "beta");
+    public void addAndInsertCreateArraysForNullAndExistingInputs() {
+        String[] insertedIntoEmptyArray = ArrayUtils.insert(0, new String[0], "alpha");
+        String[] insertedIntoExistingArray = ArrayUtils.insert(1, new String[] {"alpha", "gamma"}, "beta");
         String[] appendedToNullArray = ArrayUtils.add((String[]) null, "delta");
         String[] appendedToExistingArray = ArrayUtils.add(new String[] {"epsilon"}, "zeta");
 
-        assertThat(insertedIntoNullArray).containsExactly("alpha");
+        assertThat(insertedIntoEmptyArray).containsExactly("alpha");
         assertThat(insertedIntoExistingArray).containsExactly("alpha", "beta", "gamma");
         assertThat(appendedToNullArray).containsExactly("delta");
         assertThat(appendedToExistingArray).containsExactly("epsilon", "zeta");

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/BaseTemplateAnonymous1Test.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/BaseTemplateAnonymous1Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.TypeSafeTemplate;
+import org.junit.jupiter.api.Test;
+
+public class BaseTemplateAnonymous1Test {
+    @Test
+    public void invokesDefaultMethodOnTypeSafeTemplateProxy() throws IOException {
+        Template template = new Handlebars().compileInline("{{prefix}} {{name}}");
+        DefaultMethodTemplate defaultMethodTemplate = template.as(DefaultMethodTemplate.class);
+
+        String rendered = defaultMethodTemplate.applyWithDefaultPrefix(Collections.singletonMap("name", "Ada"));
+
+        assertThat(rendered).isEqualTo("Default Ada");
+    }
+
+    public interface DefaultMethodTemplate extends TypeSafeTemplate<Map<String, String>> {
+        DefaultMethodTemplate setPrefix(String prefix);
+
+        default String applyWithDefaultPrefix(Map<String, String> context) throws IOException {
+            return setPrefix("Default").apply(context);
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/BaseTemplateTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/BaseTemplateTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Collections;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.TypeSafeTemplate;
+import org.junit.jupiter.api.Test;
+
+public class BaseTemplateTest {
+    @Test
+    public void createsTypeSafeTemplateProxyForCustomTemplateInterface() throws IOException {
+        Template template = new Handlebars().compileInline("{{salutation}}, {{name}}!");
+
+        GreetingTemplate greetingTemplate = template.as(GreetingTemplate.class);
+        GreetingTemplate configuredTemplate = greetingTemplate.setSalutation("Hello");
+
+        assertThat(configuredTemplate).isSameAs(greetingTemplate);
+        assertThat(greetingTemplate)
+                .hasToString("TypeSafeTemplateProxy{interface=GreetingTemplate}");
+        assertThat(greetingTemplate.apply(Collections.singletonMap("name", "Ada")))
+                .isEqualTo("Hello, Ada!");
+    }
+
+    @Test
+    public void appliesTypeSafeTemplateProxyToWriter() throws IOException {
+        Template template = new Handlebars().compileInline("{{salutation}}, {{name}}!");
+        GreetingTemplate greetingTemplate = template.as(GreetingTemplate.class);
+        Writer writer = new StringWriter();
+
+        greetingTemplate.setSalutation("Welcome")
+                .apply(Collections.singletonMap("name", "Grace"), writer);
+
+        assertThat(writer.toString()).isEqualTo("Welcome, Grace!");
+    }
+
+    public interface GreetingTemplate extends TypeSafeTemplate<Object> {
+        GreetingTemplate setSalutation(String salutation);
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassPathTemplateLoaderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassPathTemplateLoaderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateSource;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class ClassPathTemplateLoaderTest {
+    private static final String TEMPLATE_LOCATION = "/templates/classpath-loader/welcome.hbs";
+
+    @Test
+    public void loadsTemplateSourceFromClasspathResource() throws IOException {
+        ClassPathTemplateLoader loader = new ClassPathTemplateLoader("/templates/classpath-loader");
+
+        TemplateSource source = loader.sourceAt("welcome");
+
+        assertThat(source.filename()).isEqualTo(TEMPLATE_LOCATION);
+        assertThat(source.content(StandardCharsets.UTF_8)).contains("Hello {{name}} from ClassPathTemplateLoader!");
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.ClassUtils;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilsTest {
+    @Test
+    public void convertClassNamesLoadsKnownClasses() {
+        List<Class<?>> classes = ClassUtils.convertClassNamesToClasses(
+                Arrays.asList(String.class.getName(), Integer.class.getName()));
+
+        assertThat(classes).containsExactly(String.class, Integer.class);
+    }
+
+    @Test
+    public void getClassLoadsUsingProvidedClassLoader() throws ClassNotFoundException {
+        ClassLoader classLoader = ClassUtilsTest.class.getClassLoader();
+        Class<?> loadedClass = ClassUtils.getClass(classLoader, String.class.getName(), false);
+
+        assertThat(loadedClass).isSameAs(String.class);
+    }
+
+    @Test
+    public void getPublicMethodReturnsMethodDeclaredByPublicClass() throws NoSuchMethodException {
+        Method method = ClassUtils.getPublicMethod(String.class, "substring", int.class);
+
+        assertThat(method.getDeclaringClass()).isSameAs(String.class);
+        assertThat(method.getName()).isEqualTo("substring");
+    }
+
+    @Test
+    public void getPublicMethodFindsPublicInterfaceMethodForPrivateImplementation() throws NoSuchMethodException {
+        Method method = ClassUtils.getPublicMethod(PrivateRenderer.class, "render");
+
+        assertThat(method.getDeclaringClass()).isSameAs(PublicRenderer.class);
+        assertThat(method.getName()).isEqualTo("render");
+    }
+
+    public interface PublicRenderer {
+        String render();
+    }
+
+    private static final class PrivateRenderer implements PublicRenderer {
+        @Override
+        public String render() {
+            return "rendered";
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.builder.CompareToBuilder;
+import org.junit.jupiter.api.Test;
+
+public class CompareToBuilderTest {
+    @Test
+    public void reflectionCompareReadsDeclaredFields() {
+        Document left = new Document("alpha", 1, "draft");
+        Document right = new Document("beta", 2, "published");
+        Document sameAsLeft = new Document("alpha", 1, "archived");
+
+        assertThat(CompareToBuilder.reflectionCompare(left, right)).isNegative();
+        assertThat(CompareToBuilder.reflectionCompare(left, sameAsLeft)).isZero();
+    }
+
+    @Test
+    public void reflectionCompareCanIncludeTransientDeclaredFields() {
+        Document left = new Document("alpha", 1, "draft");
+        Document right = new Document("alpha", 1, "published");
+
+        assertThat(CompareToBuilder.reflectionCompare(left, right)).isZero();
+        assertThat(CompareToBuilder.reflectionCompare(left, right, true)).isNegative();
+    }
+
+    @Test
+    public void reflectionCompareIgnoresExcludedDeclaredFields() {
+        Document left = new Document("alpha", 1, "draft");
+        Document right = new Document("beta", 2, "draft");
+
+        assertThat(CompareToBuilder.reflectionCompare(left, right, "title", "priority")).isZero();
+    }
+
+    private static final class Document {
+        private static final String TYPE = "document";
+
+        private final String title;
+        private final int priority;
+        private transient String state;
+
+        private Document(String title, int priority, String state) {
+            this.title = title;
+            this.priority = priority;
+            this.state = state;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.junit.jupiter.api.Test;
 
 public class CompareToBuilderTest {

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/DefI18nSourceTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/DefI18nSourceTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class DefI18nSourceTest {
+    private static final String BUNDLE_NAME =
+            "com_github_jknack.handlebars.DefI18nSourceTestMessages";
+
+    @Test
+    public void rendersMessageFromResourceBundle() throws IOException {
+        Handlebars handlebars = new Handlebars();
+        Template template = handlebars.compileInline(
+                "{{i18n \"welcome\" \"GraalVM\" bundle=\"" + BUNDLE_NAME + "\" locale=\"\"}}");
+
+        String rendered = template.apply(new Object());
+
+        assertThat(rendered).isEqualTo("Welcome GraalVM!");
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/DefaultHelperRegistryTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/DefaultHelperRegistryTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.helper.DefaultHelperRegistry;
+import org.junit.jupiter.api.Test;
+
+public class DefaultHelperRegistryTest {
+    @Test
+    public void registerHelpersDiscoversPublicMethodsOnHelperSource() throws IOException {
+        DefaultHelperRegistry registry = new DefaultHelperRegistry();
+
+        registry.registerHelpers(new TextHelpers());
+
+        Helper<Object> helper = registry.helper("bracket");
+        assertThat(helper).isNotNull();
+        assertThat(helper.apply("ready", null)).isEqualTo("[ready]");
+    }
+
+    public static final class TextHelpers {
+        public String bracket(Object value) {
+            return "[" + value + "]";
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.builder.EqualsBuilder;
+import org.junit.jupiter.api.Test;
+
+public class EqualsBuilderTest {
+    @Test
+    public void reflectionEqualsReadsDeclaredFields() {
+        Document left = new Document("guide", 2, "draft");
+        Document sameAsLeft = new Document("guide", 2, "published");
+        Document different = new Document("guide", 3, "draft");
+
+        assertThat(EqualsBuilder.reflectionEquals(left, sameAsLeft)).isTrue();
+        assertThat(EqualsBuilder.reflectionEquals(left, different)).isFalse();
+    }
+
+    @Test
+    public void reflectionEqualsCanIncludeTransientDeclaredFields() {
+        Document left = new Document("guide", 2, "draft");
+        Document right = new Document("guide", 2, "published");
+
+        assertThat(EqualsBuilder.reflectionEquals(left, right)).isTrue();
+        assertThat(EqualsBuilder.reflectionEquals(left, right, true)).isFalse();
+    }
+
+    @Test
+    public void reflectionEqualsIgnoresExcludedDeclaredFields() {
+        Document left = new Document("guide", 2, "draft");
+        Document right = new Document("guide", 3, "draft");
+
+        assertThat(EqualsBuilder.reflectionEquals(left, right, "priority")).isTrue();
+    }
+
+    private static final class Document {
+        private static final String TYPE = "document";
+
+        private final String title;
+        private final int priority;
+        private transient String state;
+
+        private Document(String title, int priority, String state) {
+            this.title = title;
+            this.priority = priority;
+            this.state = state;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.junit.jupiter.api.Test;
 
 public class EqualsBuilderTest {

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/FieldValueResolverTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/FieldValueResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.ValueResolver;
+import com.github.jknack.handlebars.context.FieldValueResolver;
+import org.junit.jupiter.api.Test;
+
+public class FieldValueResolverTest {
+    @Test
+    public void resolveReadsDeclaredAndInheritedInstanceFields() {
+        FieldBackedModel model = new FieldBackedModel("declared", "inherited");
+        FieldValueResolver resolver = new FieldValueResolver();
+
+        Object declaredValue = resolver.resolve(model, "declaredLabel");
+        Object inheritedValue = resolver.resolve(model, "inheritedLabel");
+        Object staticValue = resolver.resolve(model, "staticLabel");
+
+        assertThat(declaredValue).isEqualTo("declared");
+        assertThat(inheritedValue).isEqualTo("inherited");
+        assertThat(staticValue).isSameAs(ValueResolver.UNRESOLVED);
+    }
+
+    private static class BaseFieldModel {
+        private final String inheritedLabel;
+
+        private BaseFieldModel(String inheritedLabel) {
+            this.inheritedLabel = inheritedLabel;
+        }
+    }
+
+    private static final class FieldBackedModel extends BaseFieldModel {
+        private static String staticLabel = "static";
+
+        private final String declaredLabel;
+
+        private FieldBackedModel(String declaredLabel, String inheritedLabel) {
+            super(inheritedLabel);
+            this.declaredLabel = declaredLabel;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HandlebarsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HandlebarsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.Handlebars;
+import org.junit.jupiter.api.Test;
+
+public class HandlebarsTest {
+    private static final String CUSTOM_HANDLEBARS_JS = "/custom-handlebars.js";
+
+    @Test
+    public void configuresCustomHandlebarsJsResource() {
+        Handlebars handlebars = new Handlebars();
+
+        Handlebars configured = handlebars.handlebarsJsFile(CUSTOM_HANDLEBARS_JS);
+
+        assertThat(configured).isSameAs(handlebars);
+        assertThat(handlebars.handlebarsJsFile()).isEqualTo(CUSTOM_HANDLEBARS_JS);
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+public class HashCodeBuilderTest {
+    @Test
+    public void reflectionHashCodeReadsPrivateFieldsAcrossTheClassHierarchy() {
+        RankedRecord first = new RankedRecord("id-1", "alpha");
+        RankedRecord second = new RankedRecord("id-2", "alpha");
+
+        int firstHash = HashCodeBuilder.reflectionHashCode(first, false);
+        int secondHash = HashCodeBuilder.reflectionHashCode(second, false);
+
+        assertThat(firstHash).isNotEqualTo(secondHash);
+    }
+
+    @Test
+    public void reflectionHashCodeCanIncludeTransientFieldsWhenRequested() {
+        SessionRecord first = new SessionRecord("alpha", "session-1");
+        SessionRecord second = new SessionRecord("alpha", "session-2");
+
+        int defaultFirstHash = HashCodeBuilder.reflectionHashCode(first, false);
+        int defaultSecondHash = HashCodeBuilder.reflectionHashCode(second, false);
+        int transientFirstHash = HashCodeBuilder.reflectionHashCode(first, true);
+        int transientSecondHash = HashCodeBuilder.reflectionHashCode(second, true);
+
+        assertThat(defaultFirstHash).isEqualTo(defaultSecondHash);
+        assertThat(transientFirstHash).isNotEqualTo(transientSecondHash);
+    }
+
+    @Test
+    public void reflectionHashCodeIgnoresExcludedDeclaredFields() {
+        RankedRecord first = new RankedRecord("id-1", "alpha");
+        RankedRecord second = new RankedRecord("id-2", "alpha");
+
+        int firstHash = HashCodeBuilder.reflectionHashCode(first, "identifier");
+        int secondHash = HashCodeBuilder.reflectionHashCode(second, "identifier");
+
+        assertThat(firstHash).isEqualTo(secondHash);
+    }
+
+    private static class IdentifiedRecord {
+        private final String identifier;
+
+        private IdentifiedRecord(String identifier) {
+            this.identifier = identifier;
+        }
+    }
+
+    private static final class RankedRecord extends IdentifiedRecord {
+        private final String label;
+
+        private RankedRecord(String identifier, String label) {
+            super(identifier);
+            this.label = label;
+        }
+    }
+
+    private static final class SessionRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private SessionRecord(String label, String sessionToken) {
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.jupiter.api.Test;
 
 public class HashCodeBuilderTest {

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/MethodValueResolverTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/MethodValueResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.context.MethodValueResolver;
+import org.junit.jupiter.api.Test;
+
+public class MethodValueResolverTest {
+    @Test
+    public void resolveInvokesPublicZeroArgumentMethod() {
+        MethodBackedModel model = new MethodBackedModel("ready");
+        MethodValueResolver resolver = new MethodValueResolver();
+
+        Object resolvedValue = resolver.resolve(model, "status");
+
+        assertThat(resolvedValue).isEqualTo("ready");
+    }
+
+    public static final class MethodBackedModel {
+        private final String status;
+
+        public MethodBackedModel(String status) {
+            this.status = status;
+        }
+
+        public String status() {
+            return status;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.ObjectUtils;
+import org.junit.jupiter.api.Test;
+
+public class ObjectUtilsTest {
+    @Test
+    public void cloneCopiesPrimitiveArrays() {
+        int[] original = new int[] {1, 2, 3};
+
+        int[] cloned = ObjectUtils.clone(original);
+
+        assertThat(cloned).containsExactly(1, 2, 3);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    public void cloneInvokesPublicCloneMethodOnCloneableObjects() {
+        CopyableDocument original = new CopyableDocument("title", new StringBuilder("body"));
+
+        CopyableDocument cloned = ObjectUtils.clone(original);
+
+        assertThat(cloned).isNotSameAs(original);
+        assertThat(cloned.title()).isEqualTo("title");
+        assertThat(cloned.body()).hasToString("body");
+        assertThat(cloned.body()).isNotSameAs(original.body());
+    }
+
+    public static final class CopyableDocument implements Cloneable {
+        private final String title;
+        private final StringBuilder body;
+
+        public CopyableDocument(String title, StringBuilder body) {
+            this.title = title;
+            this.body = body;
+        }
+
+        public String title() {
+            return title;
+        }
+
+        public StringBuilder body() {
+            return body;
+        }
+
+        @Override
+        public CopyableDocument clone() {
+            return new CopyableDocument(title, new StringBuilder(body));
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.junit.jupiter.api.Test;
 
 public class ObjectUtilsTest {

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.jknack.handlebars.internal.lang3.builder.ReflectionToStringBuilder;
+import com.github.jknack.handlebars.internal.lang3.builder.ToStringStyle;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionToStringBuilderTest {
+    @Test
+    public void toStringReadsDeclaredFields() {
+        Release release = new Release("handlebars", 7, "draft", null);
+
+        String description = ReflectionToStringBuilder.toString(release, ToStringStyle.SHORT_PREFIX_STYLE, true, false);
+
+        assertThat(description)
+                .contains("name=handlebars")
+                .contains("priority=7")
+                .contains("state=draft")
+                .contains("owner=<null>");
+    }
+
+    @Test
+    public void toStringCanExcludeNullAndNamedFields() {
+        Release release = new Release("handlebars", 7, "draft", null);
+
+        ReflectionToStringBuilder builder = new ReflectionToStringBuilder(release, ToStringStyle.SHORT_PREFIX_STYLE);
+        builder.setAppendTransients(true);
+        builder.setExcludeNullValues(true);
+        builder.setExcludeFieldNames("priority");
+
+        String description = builder.toString();
+
+        assertThat(description)
+                .contains("name=handlebars")
+                .contains("state=draft")
+                .doesNotContain("priority")
+                .doesNotContain("owner");
+    }
+
+    private static final class Release {
+        private final String name;
+        private final int priority;
+        private transient String state;
+        private final String owner;
+
+        private Release(String name, int priority, String state, String owner) {
+            this.name = name;
+            this.priority = priority;
+            this.state = state;
+            this.owner = owner;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
@@ -8,8 +8,8 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.ReflectionToStringBuilder;
-import com.github.jknack.handlebars.internal.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionToStringBuilderTest {

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,283 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.HashCodeBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.HashCodeBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.HashCodeBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$BaseFieldModel",
+      "fields" : [
+        {
+          "name" : "inheritedLabel"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$FieldBackedModel",
+      "fields" : [
+        {
+          "name" : "declaredLabel"
+        },
+        {
+          "name" : "staticLabel"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.helper.DefaultHelperRegistry"
+      },
+      "type" : "com_github_jknack.handlebars.DefaultHelperRegistryTest$TextHelpers",
+      "methods" : [
+        {
+          "name" : "bracket",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.BaseTemplate"
+      },
+      "type" : {
+        "proxy" : [
+          "com_github_jknack.handlebars.BaseTemplateTest$GreetingTemplate"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.BaseTemplate$1"
+      },
+      "type" : "com_github_jknack.handlebars.BaseTemplateAnonymous1Test$DefaultMethodTemplate",
+      "methods" : [
+        {
+          "name" : "applyWithDefaultPrefix",
+          "parameterTypes" : [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.ClassUtils"
+      },
+      "type" : "com_github_jknack.handlebars.ClassUtilsTest$PrivateRenderer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.ClassUtils"
+      },
+      "type" : "com_github_jknack.handlebars.ClassUtilsTest$PublicRenderer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.CompareToBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.CompareToBuilderTest$Document",
+      "fields" : [
+        {
+          "name" : "priority"
+        },
+        {
+          "name" : "state"
+        },
+        {
+          "name" : "title"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.helper.DefaultHelperRegistry"
+      },
+      "type" : "com_github_jknack.handlebars.DefaultHelperRegistryTest$TextHelpers"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.helper.MethodHelper"
+      },
+      "type" : "com_github_jknack.handlebars.DefaultHelperRegistryTest$TextHelpers",
+      "methods" : [
+        {
+          "name" : "bracket",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.EqualsBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.EqualsBuilderTest$Document",
+      "fields" : [
+        {
+          "name" : "priority"
+        },
+        {
+          "name" : "state"
+        },
+        {
+          "name" : "title"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$BaseFieldModel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver$FieldMember"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$BaseFieldModel",
+      "fields" : [
+        {
+          "name" : "inheritedLabel"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$FieldBackedModel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.FieldValueResolver$FieldMember"
+      },
+      "type" : "com_github_jknack.handlebars.FieldValueResolverTest$FieldBackedModel",
+      "fields" : [
+        {
+          "name" : "declaredLabel"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.context.MethodValueResolver"
+      },
+      "type" : "com_github_jknack.handlebars.MethodValueResolverTest$MethodBackedModel",
+      "methods" : [
+        {
+          "name" : "status",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.ObjectUtils"
+      },
+      "type" : "com_github_jknack.handlebars.ObjectUtilsTest$CopyableDocument",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type" : "com_github_jknack.handlebars.ReflectionToStringBuilderTest$Release",
+      "fields" : [
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "owner"
+        },
+        {
+          "name" : "priority"
+        },
+        {
+          "name" : "state"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.internal.BaseTemplate"
+      },
+      "type" : {
+        "proxy" : [
+          "com_github_jknack.handlebars.BaseTemplateAnonymous1Test$DefaultMethodTemplate"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.Handlebars"
+      },
+      "glob" : "custom-handlebars.js"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.helper.DefI18nSource"
+      },
+      "glob" : "com_github_jknack/handlebars/DefI18nSourceTestMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.io.ClassPathTemplateLoader"
+      },
+      "glob" : "templates/classpath-loader/welcome.hbs"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.jknack.handlebars.helper.DefI18nSource$UTF8Control"
+      },
+      "glob" : "com_github_jknack/handlebars/DefI18nSourceTestMessages.properties"
+    }
+  ]
+}

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/com_github_jknack/handlebars/DefI18nSourceTestMessages.properties
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/com_github_jknack/handlebars/DefI18nSourceTestMessages.properties
@@ -1,0 +1,1 @@
+welcome=Welcome {0}!

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/custom-handlebars.js
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/custom-handlebars.js
@@ -1,0 +1,1 @@
+// Minimal test resource used to exercise Handlebars.handlebarsJsFile resource lookup.

--- a/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/templates/classpath-loader/welcome.hbs
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/src/test/resources/templates/classpath-loader/welcome.hbs
@@ -1,0 +1,1 @@
+Hello {{name}} from ClassPathTemplateLoader!

--- a/tests/src/com.github.jknack/handlebars/4.4.0/user-code-filter.json
+++ b/tests/src/com.github.jknack/handlebars/4.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.github.jknack.handlebars.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4208

This PR provides test fixes and new metadata for com.github.jknack:handlebars:4.4.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 135477
- Cached input tokens: 2243072
- Output tokens: 9340
- Metadata entries: 8
- Test-only metadata entries: 50
- Iterations: 2
- Library coverage percentage: 27.5
- Previous library version metadata entries: 15
- Previous library version test-only metadata entries: 50
- Previous library version coverage percentage: 18.62

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `df81e9d7a396e726209c546fc6e140943ee06ab0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.jknack:handlebars:4.3.1: 40/40 covered calls (100.00%)
- com.github.jknack:handlebars:4.4.0: 13/13 covered calls (100.00%)

**Reflection:**
- com.github.jknack:handlebars:4.3.1: 35/35 covered calls (100.00%)
- com.github.jknack:handlebars:4.4.0: 8/8 covered calls (100.00%)

**Resources:**
- com.github.jknack:handlebars:4.3.1: 5/5 covered calls (100.00%)
- com.github.jknack:handlebars:4.4.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.jknack:handlebars:4.3.1: 18231/102268 (17.83%)
- com.github.jknack:handlebars:4.4.0: 14205/51430 (27.62%)

**Line:**
- com.github.jknack:handlebars:4.3.1: 4108/22060 (18.62%)
- com.github.jknack:handlebars:4.4.0: 3131/11386 (27.50%)

**Method:**
- com.github.jknack:handlebars:4.3.1: 974/4883 (19.95%)
- com.github.jknack:handlebars:4.4.0: 768/2697 (28.48%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
index b7519eb302..ebbec160c6 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ArrayUtilsTest.java
@@ -8,18 +8,18 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 public class ArrayUtilsTest {
     @Test
-    public void addCreatesArraysForNullAndExistingInputs() {
-        String[] insertedIntoNullArray = ArrayUtils.add((String[]) null, 0, "alpha");
-        String[] insertedIntoExistingArray = ArrayUtils.add(new String[] {"alpha", "gamma"}, 1, "beta");
+    public void addAndInsertCreateArraysForNullAndExistingInputs() {
+        String[] insertedIntoEmptyArray = ArrayUtils.insert(0, new String[0], "alpha");
+        String[] insertedIntoExistingArray = ArrayUtils.insert(1, new String[] {"alpha", "gamma"}, "beta");
         String[] appendedToNullArray = ArrayUtils.add((String[]) null, "delta");
         String[] appendedToExistingArray = ArrayUtils.add(new String[] {"epsilon"}, "zeta");
 
-        assertThat(insertedIntoNullArray).containsExactly("alpha");
+        assertThat(insertedIntoEmptyArray).containsExactly("alpha");
         assertThat(insertedIntoExistingArray).containsExactly("alpha", "beta", "gamma");
         assertThat(appendedToNullArray).containsExactly("delta");
         assertThat(appendedToExistingArray).containsExactly("epsilon", "zeta");
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
index 5894dc0137..967fb91d21 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ClassUtilsTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
index fd6c0ec8f1..69fec16b6b 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/CompareToBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.junit.jupiter.api.Test;
 
 public class CompareToBuilderTest {
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
index afbf838a1a..ecfe6a7293 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/EqualsBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.junit.jupiter.api.Test;
 
 public class EqualsBuilderTest {
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
index 60aade16fa..f5cad340b6 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/HashCodeBuilderTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.junit.jupiter.api.Test;
 
 public class HashCodeBuilderTest {
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
index aba114d3d0..afcc8a2717 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ObjectUtilsTest.java
@@ -8,7 +8,7 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.junit.jupiter.api.Test;
 
 public class ObjectUtilsTest {
diff --git 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
index f53e03a4d5..a773c8cbfb 100644
--- 1/tests/src/com.github.jknack/handlebars/4.3.1/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
+++ 2/tests/src/com.github.jknack/handlebars/4.4.0/src/test/java/com_github_jknack/handlebars/ReflectionToStringBuilderTest.java
@@ -8,8 +8,8 @@ package com_github_jknack.handlebars;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jknack.handlebars.internal.lang3.builder.ReflectionToStringBuilder;
-import com.github.jknack.handlebars.internal.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionToStringBuilderTest {

```
