### PR TITLE
[Automation] Generated metadata for com.github.javaparser:javaparser-core:3.28.0

### DIFF
--- a/metadata/com.github.javaparser/javaparser-core/3.28.0/reachability-metadata.json
+++ b/metadata/com.github.javaparser/javaparser-core/3.28.0/reachability-metadata.json
@@ -1,0 +1,319 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.CompilationUnit",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "methods": [
+        {
+          "name": "getImports",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypes",
+          "parameterTypes": []
+        }
+      ],
+      "fields": [
+        {
+          "name": "imports"
+        },
+        {
+          "name": "types"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.body.BodyDeclaration",
+      "allDeclaredFields": true,
+      "fields": [
+        {
+          "name": "annotations"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.body.TypeDeclaration",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "fields": [
+        {
+          "name": "modifiers"
+        },
+        {
+          "name": "members"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.body.ClassOrInterfaceDeclaration",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "fields": [
+        {
+          "name": "typeParameters"
+        },
+        {
+          "name": "extendedTypes"
+        },
+        {
+          "name": "implementedTypes"
+        },
+        {
+          "name": "permittedTypes"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.body.CallableDeclaration",
+      "allDeclaredFields": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.body.MethodDeclaration",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.type.Type",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "fields": [
+        {
+          "name": "annotations"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.type.ClassOrInterfaceType",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "methods": [
+        {
+          "name": "getTypeArguments",
+          "parameterTypes": []
+        }
+      ],
+      "fields": [
+        {
+          "name": "typeArguments"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.type.VoidType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.stmt.BlockStmt",
+      "allDeclaredFields": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.stmt.ExpressionStmt",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.expr.MethodCallExpr",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "methods": [
+        {
+          "name": "getArguments",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypeArguments",
+          "parameterTypes": []
+        }
+      ],
+      "fields": [
+        {
+          "name": "typeArguments"
+        },
+        {
+          "name": "arguments"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.expr.FieldAccessExpr",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "methods": [
+        {
+          "name": "getTypeArguments",
+          "parameterTypes": []
+        }
+      ],
+      "fields": [
+        {
+          "name": "typeArguments"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.expr.Name",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.expr.NameExpr",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter"
+      },
+      "type": "com.github.javaparser.ast.expr.SimpleName",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.ast.observer.ObservableProperty"
+      },
+      "type": "com.github.javaparser.ast.ImportDeclaration",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        },
+        {
+          "name": "isModule",
+          "parameterTypes": []
+        },
+        {
+          "name": "isAsterisk",
+          "parameterTypes": []
+        },
+        {
+          "name": "isStatic",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.ast.observer.ObservableProperty"
+      },
+      "type": "com.github.javaparser.ast.body.CallableDeclaration",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        },
+        {
+          "name": "getParameters",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.ast.observer.ObservableProperty"
+      },
+      "type": "com.github.javaparser.ast.body.MethodDeclaration",
+      "methods": [
+        {
+          "name": "getBody",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.ast.observer.ObservableProperty"
+      },
+      "type": "com.github.javaparser.ast.expr.SimpleName",
+      "methods": [
+        {
+          "name": "getIdentifier",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.metamodel.BaseNodeMetaModel"
+      },
+      "type": "com.github.javaparser.ast.expr.SimpleName",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.ast.observer.ObservableProperty"
+      },
+      "type": "com.github.javaparser.ast.stmt.IfStmt",
+      "methods": [
+        {
+          "name": "hasElseBlock",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasElseBranch",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasThenBlock",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.javaparser.resolution.logic.FunctionalInterfaceLogic"
+      },
+      "type": "java.lang.Object"
+    }
+  ]
+}

--- a/metadata/com.github.javaparser/javaparser-core/index.json
+++ b/metadata/com.github.javaparser/javaparser-core/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.28.0",
+    "test-version" : "3.26.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/javaparser/javaparser-core/3.28.0/javaparser-core-3.28.0-sources.jar",
+    "repository-url" : "https://github.com/javaparser/javaparser",
+    "test-code-url" : "https://github.com/javaparser/javaparser/tree/javaparser-parent-3.28.0/javaparser-core-testing/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/javaparser/javaparser-core/3.28.0/javaparser-core-3.28.0-javadoc.jar",
+    "description" : "JavaParser parses Java source code and builds an abstract syntax tree that applications can inspect and transform. The core artifact provides the parser and AST model without the optional symbol solver.",
+    "tested-versions" : [
+      "3.28.0"
+    ],
+    "allowed-packages" : [
+      "com.github.javaparser"
+    ]
+  },
+  {
     "metadata-version" : "3.26.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/javaparser/javaparser-core/3.26.2/javaparser-core-3.26.2-sources.jar",
     "repository-url" : "https://github.com/javaparser/javaparser",

--- a/stats/com.github.javaparser/javaparser-core/3.28.0/stats.json
+++ b/stats/com.github.javaparser/javaparser-core/3.28.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.28.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 11,
+          "totalCalls" : 11
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 12,
+      "totalCalls" : 12
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 42495,
+        "missed" : 150443,
+        "ratio" : 0.220252,
+        "total" : 192938
+      },
+      "line" : {
+        "covered" : 7625,
+        "missed" : 30320,
+        "ratio" : 0.200949,
+        "total" : 37945
+      },
+      "method" : {
+        "covered" : 1465,
+        "missed" : 7409,
+        "ratio" : 0.165089,
+        "total" : 8874
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4170

This PR provides new metadata needed for the com.github.javaparser:javaparser-core:3.28.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.javaparser:javaparser-core:3.26.2`): 79
- Metadata entries (new `com.github.javaparser:javaparser-core:3.28.0`): 80
- Library coverage (previous): 19.75%
- Library coverage (new): 20.09%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `df81e9d7a396e726209c546fc6e140943ee06ab0`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.javaparser:javaparser-core:3.26.2: 12/12 covered calls (100.00%)
- com.github.javaparser:javaparser-core:3.28.0: 12/12 covered calls (100.00%)

**Reflection:**
- com.github.javaparser:javaparser-core:3.26.2: 11/11 covered calls (100.00%)
- com.github.javaparser:javaparser-core:3.28.0: 11/11 covered calls (100.00%)

**Resources:**
- com.github.javaparser:javaparser-core:3.26.2: 1/1 covered calls (100.00%)
- com.github.javaparser:javaparser-core:3.28.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.javaparser:javaparser-core:3.26.2: 41152/189520 (21.71%)
- com.github.javaparser:javaparser-core:3.28.0: 42495/192938 (22.03%)

**Line:**
- com.github.javaparser:javaparser-core:3.26.2: 7328/37105 (19.75%)
- com.github.javaparser:javaparser-core:3.28.0: 7625/37945 (20.09%)

**Method:**
- com.github.javaparser:javaparser-core:3.26.2: 1365/8682 (15.72%)
- com.github.javaparser:javaparser-core:3.28.0: 1465/8874 (16.51%)
