### PR TITLE
Track artifacts not applicable to Native Image

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -32,6 +32,8 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
 from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts import metrics_writer
+from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
+from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics, validate_benchmark_run_metrics
 from utility_scripts.source_context import (
@@ -388,8 +390,25 @@ def main(argv=None):
 
     os.chdir(reachability_repo_path)
     create_feature_branch_for_library(package, artifact, library_version)
+    if is_not_for_native_image(reachability_repo_path, package, artifact):
+        log_stage("native-image-eligibility", f"{package}:{artifact} is already marked not-for-native-image")
+        return 0
     try:
         discover_artifact_metadata(reachability_repo_path, library)
+        eligibility = evaluate_native_image_eligibility(reachability_repo_path, library)
+        if eligibility.not_for_native_image:
+            marker_path = write_not_for_native_image_marker(
+                reachability_repo_path,
+                package,
+                artifact,
+                eligibility.reason or "Artifact is not applicable to GraalVM Native Image metadata.",
+                eligibility.replacement,
+            )
+            log_stage(
+                "native-image-eligibility",
+                f"Marked {package}:{artifact} as not-for-native-image in {os.path.relpath(marker_path, reachability_repo_path)}",
+            )
+            return 0
         run_scaffold(library)
     except ScaffoldError as exc:
         print(f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}", file=sys.stderr)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -66,10 +66,16 @@ from git_scripts.common_git import (
 from git_scripts.make_pr_javac_fix import main as run_make_pr_javac_fix
 from git_scripts.make_pr_java_run_fix import main as run_make_pr_java_run_fix
 from git_scripts.make_pr_new_library_support import main as run_make_pr_new_library_support
+from git_scripts.make_pr_not_for_native_image import main as run_make_pr_not_for_native_image
 from git_scripts.make_pr_ni_run_fix import main as run_make_pr_ni_run_fix
 from git_scripts.make_pr_improve_coverage import main as run_make_pr_improve_coverage
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.library_stats import resolve_stats_file_path
+from utility_scripts.metadata_index import (
+    coordinate_parts as metadata_coordinate_parts,
+    get_not_for_native_image_marker,
+    is_not_for_native_image,
+)
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import (
     add_in_metadata_repo_argument,
@@ -134,6 +140,7 @@ LABEL_PR_LIBRARY_BULK_UPDATE = "library-bulk-update"
 LABEL_PRIORITY = "priority"
 LABEL_HUMAN_INTERVENTION = "human-intervention"
 LABEL_HUMAN_INTERVENTION_FIXED = "human-intervention-fixed"
+LABEL_NOT_FOR_NATIVE_IMAGE = "not-for-native-image"
 
 SCRATCH_WORKTREE_DIRNAME = "forge_worktrees"
 SCRATCH_REVIEW_WORKTREE_DIRNAME = "forge_review_worktrees"
@@ -141,6 +148,7 @@ SCRATCH_METRICS_DIRNAME = "forge_run_metrics"
 ISSUE_CLAIM_LOCK_DIRNAME = "metadata-forge-issue-claim-locks"
 ISSUE_CLAIM_CACHE_REASON_ASSIGNED = "assigned"
 ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION = "human_intervention"
+ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE = "not_for_native_image"
 ISSUE_CLAIM_CACHE_REASON_BLOCKED = "blocked"
 ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM = "missing_project_item"
 ISSUE_CLAIM_CACHE_REASON_NON_TODO = "non_todo"
@@ -148,6 +156,7 @@ ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS = "in_progress"
 ISSUE_CLAIM_CACHE_REASONS = {
     ISSUE_CLAIM_CACHE_REASON_ASSIGNED,
     ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
+    ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
     ISSUE_CLAIM_CACHE_REASON_BLOCKED,
     ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM,
     ISSUE_CLAIM_CACHE_REASON_NON_TODO,
@@ -162,6 +171,10 @@ LOW_DYNAMIC_ACCESS_COVERAGE_RATIO = 0.10
 HUMAN_INTERVENTION_LABEL_COLOR = "B60205"
 HUMAN_INTERVENTION_LABEL_DESCRIPTION = (
     "Requires manual follow-up because automated processing needs human attention"
+)
+NOT_FOR_NATIVE_IMAGE_LABEL_COLOR = "5319E7"
+NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION = (
+    "Artifact is tracked but is not applicable to GraalVM Native Image reachability metadata"
 )
 
 
@@ -411,13 +424,21 @@ def get_issue_by_number(issue_number: int) -> tuple[dict, str]:
     sys.exit(1)
 
 
-def build_issue_search_query(label: str, extra_labels: list[str] | None = None) -> str:
+def build_issue_search_query(
+        label: str,
+        extra_labels: list[str] | None = None,
+        excluded_labels: list[str] | None = None,
+) -> str:
     """Build a GitHub issue search query for open issues with all requested labels."""
     label_terms = " ".join(
         f'label:"{label_name}"'
         for label_name in [label, *(extra_labels or [])]
     )
-    return f"repo:{REPO} is:issue is:open {label_terms}"
+    excluded_terms = " ".join(
+        f'-label:"{label_name}"'
+        for label_name in (excluded_labels or [LABEL_NOT_FOR_NATIVE_IMAGE])
+    )
+    return f"repo:{REPO} is:issue is:open {label_terms} {excluded_terms}".strip()
 
 
 def normalize_github_issue_search_item(item: dict) -> dict:
@@ -2359,10 +2380,15 @@ def post_issue_comment(issue_number: int, body: str) -> None:
 
 def add_issue_label(issue_number: int, label_name: str) -> None:
     """Add a label to a GitHub issue, creating the label if necessary."""
+    label_color = HUMAN_INTERVENTION_LABEL_COLOR
+    label_description = HUMAN_INTERVENTION_LABEL_DESCRIPTION
+    if label_name == LABEL_NOT_FOR_NATIVE_IMAGE:
+        label_color = NOT_FOR_NATIVE_IMAGE_LABEL_COLOR
+        label_description = NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION
     ensure_repo_label_exists(
         label_name,
-        HUMAN_INTERVENTION_LABEL_COLOR,
-        HUMAN_INTERVENTION_LABEL_DESCRIPTION,
+        label_color,
+        label_description,
     )
     gh(
         "issue",
@@ -3198,6 +3224,44 @@ def build_claim_metadata(
     return issue_coordinates, current_coordinates, new_version
 
 
+def maybe_handle_not_for_native_image_issue(issue: dict, base_reachability_metadata_path: str) -> bool:
+    """Apply terminal labels and comment when the repository already has a marker for the artifact."""
+    issue_coordinates = extract_maven_coordinates(issue["title"])
+    if issue_coordinates is None:
+        return False
+    group, artifact, _version = metadata_coordinate_parts(issue_coordinates)
+    if not is_not_for_native_image(base_reachability_metadata_path, group, artifact):
+        return False
+
+    marker = get_not_for_native_image_marker(base_reachability_metadata_path, group, artifact) or {}
+    reason = marker.get("reason") or "The artifact is marked as not applicable to GraalVM Native Image metadata."
+    replacement = marker.get("replacement")
+    body = (
+        f"`{group}:{artifact}` is already tracked in the repository as `not-for-native-image`, "
+        "so Forge will not run reachability-metadata workflows for this artifact.\n\n"
+        f"Reason: {reason}"
+    )
+    if replacement:
+        body += f"\n\nReplacement guidance: {replacement}"
+    try:
+        post_issue_comment(issue["number"], body)
+        add_issue_label(issue["number"], LABEL_NOT_FOR_NATIVE_IMAGE)
+        add_issue_label(issue["number"], LABEL_HUMAN_INTERVENTION)
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to apply not-for-native-image follow-up to issue #{issue['number']}: {exc!r}",
+            file=sys.stderr,
+        )
+    record_issue_claim_cache_observations([
+        IssueClaimCacheObservation(
+            issue_number=issue["number"],
+            reason=ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
+        )
+    ])
+    log_stage("issue-claim", f"Issue #{issue['number']} targets not-for-native-image artifact {group}:{artifact}. Skipping.")
+    return True
+
+
 def claim_issue_for_processing(
         issue: dict,
         label: str,
@@ -3209,6 +3273,9 @@ def claim_issue_for_processing(
     """Claim an issue and prepare its isolated execution workspace."""
     in_metadata_repo = True
     print(format_issue_processing_message(issue))
+
+    if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
+        return None
 
     claim_metadata = build_claim_metadata(issue, label, base_reachability_metadata_path)
     if claim_metadata is None:
@@ -3313,6 +3380,16 @@ def finalize_successful_issue(
 ) -> None:
     """Create the PR for a successful isolated workflow run."""
     if claimed_issue.label == LABEL_LIBRARY_NEW:
+        group, artifact, _version = metadata_coordinate_parts(claimed_issue.issue_coordinates)
+        if is_not_for_native_image(claimed_issue.worktree_path, group, artifact):
+            run_make_pr_not_for_native_image(
+                [
+                    "--coordinates", claimed_issue.issue_coordinates,
+                    "--reachability-metadata-path", claimed_issue.worktree_path,
+                    *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
+                ]
+            )
+            return
         run_make_pr_new_library_support(
             [
                 "--coordinates", claimed_issue.issue_coordinates,
@@ -3678,6 +3755,11 @@ def get_issue_claim_cache_observation_from_payload(
             issue_number=issue_number,
             reason=ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
         )
+    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
+        return IssueClaimCacheObservation(
+            issue_number=issue_number,
+            reason=ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
+        )
     payload_assignees = get_issue_payload_assignees(issue)
     if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
         return IssueClaimCacheObservation(
@@ -3732,6 +3814,8 @@ def format_cached_issue_claim_skip(cached_skip: CachedIssueClaimSkip) -> str:
         return f"recently cached as assigned to {list(cached_skip.assignees)}"
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION:
         return f"recently cached with label '{LABEL_HUMAN_INTERVENTION}'"
+    if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE:
+        return f"recently cached with label '{LABEL_NOT_FOR_NATIVE_IMAGE}'"
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_BLOCKED:
         blockers_text = ", ".join(f"#{blocker}" for blocker in cached_skip.open_blockers)
         return f"recently cached as blocked by open issue(s) {blockers_text}"
@@ -3819,6 +3903,8 @@ def issue_needs_claim_preflight(issue: dict, authenticated_user: str | None = No
     """Return True when an issue needs GraphQL preflight before claim attempts."""
     if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
         return False
+    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
+        return False
     payload_assignees = get_issue_payload_assignees(issue)
     if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
         return False
@@ -3861,6 +3947,10 @@ def should_skip_issue_from_preflight(
     if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
         print()
         log_stage("issue-claim", f"Issue #{number} has label '{LABEL_HUMAN_INTERVENTION}'. Skipping.")
+        return True
+    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
+        print()
+        log_stage("issue-claim", f"Issue #{number} has label '{LABEL_NOT_FOR_NATIVE_IMAGE}'. Skipping.")
         return True
 
     payload_assignees = get_issue_payload_assignees(issue)
@@ -3950,6 +4040,16 @@ def try_claim_issue(issue: dict, authenticated_user: str) -> Optional[str]:
             IssueClaimCacheObservation(
                 issue_number=number,
                 reason=ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
+            )
+        ])
+        return None
+    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
+        print()
+        log_stage("issue-claim", f"Issue #{number} has label '{LABEL_NOT_FOR_NATIVE_IMAGE}'. Skipping.")
+        record_issue_claim_cache_observations([
+            IssueClaimCacheObservation(
+                issue_number=number,
+                reason=ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
             )
         ])
         return None

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -1,0 +1,146 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Open a PR that records an artifact as not applicable to Native Image."""
+
+import argparse
+import os
+import shutil
+import subprocess
+
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    ensure_gh_authenticated,
+    find_issue_for_coordinates,
+    format_forge_revision_section,
+    get_configured_reviewers,
+    get_origin_owner,
+    gh,
+    parse_coordinate_parts,
+    stage_and_commit,
+)
+from utility_scripts.metadata_index import get_not_for_native_image_marker
+from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+
+
+REPO = "oracle/graalvm-reachability-metadata"
+BASE_BRANCH = "master"
+REVIEWERS = get_configured_reviewers()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(
+        prog="make_pr_not_for_native_image.py",
+        description="Create a PR that adds a not-for-native-image marker index.",
+    )
+    parser.add_argument("--coordinates", required=True, help="Coordinates in group:artifact:version form")
+    parser.add_argument("--reachability-metadata-path", help="Path to the reachability-metadata checkout")
+    add_in_metadata_repo_argument(parser)
+    return parser
+
+
+def fetch_pr_base(repo_path: str) -> str:
+    """Fetch the upstream PR base and return the ref to rebase onto."""
+    upstream_url = f"https://github.com/{REPO}.git"
+    upstream_remote_url = subprocess.run(
+        ["git", "remote", "get-url", "upstream"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
+        subprocess.run(["git", "fetch", "upstream", BASE_BRANCH], check=True, cwd=repo_path)
+        return f"upstream/{BASE_BRANCH}"
+
+    subprocess.run(["git", "fetch", upstream_url, BASE_BRANCH], check=True, cwd=repo_path)
+    return "FETCH_HEAD"
+
+
+def push_marker_branch(coordinates: str, repo_path: str) -> str:
+    """Create, commit, rebase, and push the marker branch."""
+    group, artifact, _version = parse_coordinate_parts(coordinates)
+    branch = build_ai_branch_name(f"not-for-native-image-{group}-{artifact}", cwd=repo_path)
+    delete_remote_branch_if_exists(branch, cwd=repo_path)
+    subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
+    stage_and_commit(
+        [os.path.join("metadata", group, artifact, "index.json")],
+        f"Mark {group}:{artifact} as not for Native Image",
+        cwd=repo_path,
+    )
+    base_ref = fetch_pr_base(repo_path)
+    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    subprocess.run(["git", "push", "origin", branch], check=True, cwd=repo_path)
+    return branch
+
+
+def create_pull_request(branch: str, coordinates: str, repo_path: str) -> None:
+    """Create the marker PR."""
+    if shutil.which("gh") is None:
+        print("gh CLI not found. Skipping PR creation.")
+        return
+
+    group, artifact, _version = parse_coordinate_parts(coordinates)
+    marker = get_not_for_native_image_marker(repo_path, group, artifact)
+    if marker is None:
+        raise ValueError(f"Missing not-for-native-image marker for {group}:{artifact}")
+
+    origin_owner = get_origin_owner(cwd=repo_path)
+    view = gh("pr", "view", "--repo", REPO, "--head", f"{origin_owner}:{branch}", check=False)
+    if view.returncode == 0:
+        print(f"Pull request already exists for branch {branch}.")
+        return
+
+    issue_no = find_issue_for_coordinates(coordinates, REPO)
+    title = f"[GenAI] Mark {group}:{artifact} as not for Native Image"
+    body = f"""
+## What does this PR do?
+
+Fixes: #{issue_no}
+
+This PR records `{group}:{artifact}` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.
+
+Reason:
+- {marker.get("reason")}
+"""
+    replacement = marker.get("replacement")
+    if replacement:
+        body += f"\nReplacement guidance:\n- {replacement}\n"
+    body += "\n" + format_forge_revision_section()
+
+    cmd = [
+        "gh", "pr", "create",
+        "--repo", REPO,
+        "--title", title,
+        "--body", body,
+        "--base", BASE_BRANCH,
+        "--head", f"{origin_owner}:{branch}",
+        "--label", "GenAI",
+        "--label", "library-new-request",
+        "--label", "not-for-native-image",
+    ]
+    for reviewer in REVIEWERS:
+        cmd.extend(["--reviewer", reviewer])
+    gh(*cmd[1:])
+
+
+def main(argv=None) -> None:
+    """Run the marker PR flow."""
+    args = build_parser().parse_args(argv)
+    repo_path, _metrics_path = resolve_repo_roots(
+        args.reachability_metadata_path,
+        None,
+        in_metadata_repo=args.in_metadata_repo,
+    )
+    ensure_gh_authenticated()
+    branch = push_marker_branch(args.coordinates, repo_path)
+    create_pull_request(branch, args.coordinates, repo_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/forge/utility_scripts/metadata_index.py
+++ b/forge/utility_scripts/metadata_index.py
@@ -1,0 +1,89 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Helpers for metadata/<group>/<artifact>/index.json files."""
+
+import json
+import os
+import sys
+from typing import Any
+
+
+NOT_FOR_NATIVE_IMAGE_FIELD = "not-for-native-image"
+
+
+def coordinate_parts(coordinate: str) -> tuple[str, str, str | None]:
+    """Parse group:artifact[:version] coordinates."""
+    parts = coordinate.split(":")
+    if len(parts) == 2:
+        return parts[0], parts[1], None
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    print(f"ERROR: Invalid coordinates format: {coordinate}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def index_path(repo_path: str, group: str, artifact: str) -> str:
+    """Return the metadata index path for an artifact."""
+    return os.path.join(repo_path, "metadata", group, artifact, "index.json")
+
+
+def load_index_entries(repo_path: str, group: str, artifact: str) -> list[dict[str, Any]] | None:
+    """Load an artifact index, returning None when it is absent."""
+    path = index_path(repo_path, group, artifact)
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as index_file:
+        entries = json.load(index_file)
+    if not isinstance(entries, list):
+        print(f"ERROR: Metadata index is not a JSON array: {os.path.relpath(path, repo_path)}", file=sys.stderr)
+        raise SystemExit(1)
+    return entries
+
+
+def is_not_for_native_image_entry(entry: dict[str, Any]) -> bool:
+    """Return true when an index entry is the marker entry."""
+    return entry.get(NOT_FOR_NATIVE_IMAGE_FIELD) is True
+
+
+def is_not_for_native_image(repo_path: str, group: str, artifact: str) -> bool:
+    """Return true when the artifact is marked as not applicable to Native Image."""
+    entries = load_index_entries(repo_path, group, artifact)
+    if not entries:
+        return False
+    return any(is_not_for_native_image_entry(entry) for entry in entries)
+
+
+def get_not_for_native_image_marker(repo_path: str, group: str, artifact: str) -> dict[str, Any] | None:
+    """Return the marker entry when present."""
+    entries = load_index_entries(repo_path, group, artifact)
+    if not entries:
+        return None
+    for entry in entries:
+        if is_not_for_native_image_entry(entry):
+            return entry
+    return None
+
+
+def write_not_for_native_image_marker(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        reason: str,
+        replacement: str | None = None,
+) -> str:
+    """Write a marker-only index.json for an artifact."""
+    path = index_path(repo_path, group, artifact)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    marker: dict[str, Any] = {
+        NOT_FOR_NATIVE_IMAGE_FIELD: True,
+        "reason": reason,
+    }
+    if replacement:
+        marker["replacement"] = replacement
+    with open(path, "w", encoding="utf-8") as index_file:
+        json.dump([marker], index_file, indent=2)
+        index_file.write("\n")
+    return path

--- a/forge/utility_scripts/native_image_artifact.py
+++ b/forge/utility_scripts/native_image_artifact.py
@@ -1,0 +1,221 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Conservative checks for artifacts that are not Native Image metadata targets."""
+
+from dataclasses import dataclass
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+MAVEN_CENTRAL = "https://repo1.maven.org/maven2"
+
+
+@dataclass(frozen=True)
+class NativeImageEligibility:
+    """Eligibility result for a Maven artifact."""
+
+    not_for_native_image: bool
+    reason: str | None = None
+    replacement: str | None = None
+
+
+def discovery_file_path(repo_path: str, coordinate: str) -> str:
+    """Return the Gradle build-local discovery file path for a coordinate."""
+    sanitized = coordinate.replace(":", "-").replace("/", "-")
+    return os.path.join(repo_path, "build", "discovered-artifact-metadata", f"{sanitized}.json")
+
+
+def load_discovered_eligibility(repo_path: str, coordinate: str) -> NativeImageEligibility:
+    """Read not-for-native-image eligibility from the discovery file when present."""
+    path = discovery_file_path(repo_path, coordinate)
+    if not os.path.isfile(path):
+        return NativeImageEligibility(False)
+    try:
+        with open(path, "r", encoding="utf-8") as discovery_file:
+            metadata = json.load(discovery_file)
+    except (OSError, json.JSONDecodeError):
+        return NativeImageEligibility(False)
+    if metadata.get("not-for-native-image") is not True:
+        return NativeImageEligibility(False)
+    reason = str(metadata.get("reason") or "").strip()
+    if not reason:
+        reason = "Artifact discovery identified this as not applicable to GraalVM Native Image metadata."
+    replacement = str(metadata.get("replacement") or "").strip() or None
+    return NativeImageEligibility(True, reason, replacement)
+
+
+def evaluate_native_image_eligibility(repo_path: str, coordinate: str) -> NativeImageEligibility:
+    """Return a marker result only for certain non-Native-Image artifacts."""
+    discovered = load_discovered_eligibility(repo_path, coordinate)
+    if discovered.not_for_native_image:
+        return discovered
+
+    coordinate_result = classify_coordinate_name(coordinate)
+    if coordinate_result.not_for_native_image:
+        return coordinate_result
+
+    return inspect_maven_artifact(coordinate)
+
+
+def classify_coordinate_name(coordinate: str) -> NativeImageEligibility:
+    """Classify certain platform artifacts by coordinate naming conventions."""
+    try:
+        group, artifact, _version = coordinate.split(":", 2)
+    except ValueError:
+        print(f"ERROR: Invalid coordinates format: {coordinate}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if group == "org.scala-js" or "_sjs" in artifact or "scalajs" in artifact.lower():
+        return NativeImageEligibility(
+            True,
+            "Scala.js artifact; it is not a JVM library consumed by native-image.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    android_groups = ("com.android", "androidx.")
+    if group.startswith(android_groups):
+        return NativeImageEligibility(
+            True,
+            "Android artifact; it targets the Android runtime or Android toolchain rather than JVM Native Image.",
+        )
+
+    kotlin_native_suffixes = (
+        "-iosarm64",
+        "-iosx64",
+        "-iossimulatorarm64",
+        "-linuxx64",
+        "-linuxarm64",
+        "-macosx64",
+        "-macosarm64",
+        "-mingwx64",
+        "-tvosarm64",
+        "-tvosx64",
+        "-tvossimulatorarm64",
+        "-watchosarm32",
+        "-watchosarm64",
+        "-watchosdevicearm64",
+        "-watchossimulatorarm64",
+        "-wasm-js",
+        "-wasm-wasi",
+    )
+    if artifact.endswith(kotlin_native_suffixes):
+        return NativeImageEligibility(
+            True,
+            "Kotlin Native/Wasm artifact; it is not a JVM library consumed by native-image.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    if artifact.endswith("-js") and group.startswith(("org.jetbrains.kotlin", "org.jetbrains.kotlinx")):
+        return NativeImageEligibility(
+            True,
+            "Kotlin/JavaScript artifact; it is not a JVM library consumed by native-image.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    return NativeImageEligibility(False)
+
+
+def inspect_maven_artifact(coordinate: str) -> NativeImageEligibility:
+    """Inspect Maven packaging and artifact contents when available."""
+    group, artifact, version = coordinate.split(":", 2)
+    base_path = "/".join([group.replace(".", "/"), artifact, version])
+    base_url = f"{MAVEN_CENTRAL}/{base_path}/{artifact}-{version}"
+
+    packaging = read_maven_packaging(f"{base_url}.pom")
+    if packaging in {"aar", "klib"}:
+        return NativeImageEligibility(
+            True,
+            f"Maven packaging is `{packaging}`, not a JVM JAR consumed by native-image.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    jar_bytes = fetch_url(f"{base_url}.jar")
+    if jar_bytes is None:
+        return NativeImageEligibility(False)
+
+    try:
+        with zipfile.ZipFile(jar_bytes) as jar:
+            names = jar.namelist()
+    except zipfile.BadZipFile:
+        return NativeImageEligibility(False)
+
+    class_files = [
+        name for name in names
+        if name.endswith(".class") and not name.endswith("module-info.class")
+    ]
+    if class_files:
+        return NativeImageEligibility(False)
+
+    if any(name.endswith(".sjsir") for name in names):
+        return NativeImageEligibility(
+            True,
+            "Artifact JAR contains Scala.js IR and no JVM class files.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    if any(name.endswith(".klib") or name.startswith("default/linkdata/") for name in names):
+        return NativeImageEligibility(
+            True,
+            "Artifact contains Kotlin Native metadata and no JVM class files.",
+            jvm_artifact_replacement(artifact),
+        )
+
+    return NativeImageEligibility(
+        True,
+        "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.",
+        jvm_artifact_replacement(artifact),
+    )
+
+
+def read_maven_packaging(pom_url: str) -> str | None:
+    """Read the Maven POM packaging value, defaulting to jar when omitted."""
+    pom_bytes = fetch_url(pom_url)
+    if pom_bytes is None:
+        return None
+    try:
+        root = ET.fromstring(pom_bytes.read())
+    except ET.ParseError:
+        return None
+    namespace_match = re.match(r"\{.*\}", root.tag)
+    namespace = namespace_match.group(0) if namespace_match else ""
+    packaging = root.findtext(f"{namespace}packaging")
+    return packaging.strip() if packaging else "jar"
+
+
+def fetch_url(url: str):
+    """Fetch a URL into an in-memory binary stream, returning None for missing artifacts."""
+    try:
+        with urllib.request.urlopen(url, timeout=20) as response:
+            import io
+
+            return io.BytesIO(response.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        return None
+    except (OSError, urllib.error.URLError):
+        return None
+
+
+def jvm_artifact_replacement(artifact: str) -> str | None:
+    """Suggest the likely JVM artifact when a platform suffix is obvious."""
+    replacements = [
+        r"_sjs\d+(?:\.\d+)?$",
+        r"-(?:js|wasm-js|wasm-wasi)$",
+        r"-(?:iosarm64|iosx64|iossimulatorarm64|linuxx64|linuxarm64|macosx64|macosarm64|mingwx64)$",
+        r"-(?:tvosarm64|tvosx64|tvossimulatorarm64|watchosarm32|watchosarm64|watchosdevicearm64|watchossimulatorarm64)$",
+    ]
+    for pattern in replacements:
+        replacement = re.sub(pattern, "", artifact)
+        if replacement != artifact and replacement:
+            return f"Use `{replacement}` if a JVM artifact is available."
+    return None

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from email.message import Message
 from typing import Any
 
+from utility_scripts.metadata_index import is_not_for_native_image_entry
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_task_log_path, display_log_path
 
@@ -238,6 +239,13 @@ def load_index_entry(reachability_repo_path: str, coordinate: str) -> dict[str, 
 
     with open(index_path, "r", encoding="utf-8") as index_file:
         entries = json.load(index_file)
+
+    if any(is_not_for_native_image_entry(entry) for entry in entries):
+        print(
+            f"ERROR: {group}:{artifact} is marked not-for-native-image in {index_path_display}.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     for entry in entries:
         if entry.get("metadata-version") == version:

--- a/metadata/schemas/metadata-library-index-schema-v2.0.1.json
+++ b/metadata/schemas/metadata-library-index-schema-v2.0.1.json
@@ -1,120 +1,159 @@
 {
   "$id": "https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/metadata/schemas/metadata-library-index-schema-v2.0.1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Schema for metadata/<groupId>/<artifactId>/index.json. Each entry describes a metadata bundle for a range of library versions.",
+  "description": "Schema for metadata/<groupId>/<artifactId>/index.json. Each file either describes Native Image metadata bundles for a range of library versions, or marks the artifact as not applicable to Native Image.",
   "type": "array",
   "minItems": 1,
-  "items": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-      "allowed-packages",
-      "metadata-version",
-      "tested-versions"
-    ],
-    "properties": {
-      "metadata-version": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Subdirectory name where the metadata files for this entry reside, e.g. '7.1.0.Final'."
-      },
-      "tested-versions": {
-        "type": "array",
-        "description": "Explicitly tested upstream library versions that this metadata is known to support.",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "test-version": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Overrides 'metadata-version' for use in test directories. This allows one metadata entry to share tests defined for a different version's metadata directory."
-      },
-      "source-code-url": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Optional URL pointing to the metadata source code for this entry."
-      },
-      "repository-url": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Optional URL pointing to the canonical project repository for this entry."
-      },
-      "documentation-url": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Optional URL pointing to the project documentation for this entry."
-      },
-      "description": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Optional two-sentence explanation of what the library does."
-      },
-      "language": {
-        "$ref": "#/$defs/libraryLanguage"
-      },
-      "test-code-url": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Optional URL pointing to the test source code for this entry."
-      },
-      "latest": {
-        "type": "boolean",
-        "description": "Marks this entry as the latest/default metadata for currently supported versions."
-      },
-      "default-for": {
-        "type": "string",
-        "description": "Java regular expression describing the version range for which this entry should be used by default (e.g. '7\\\\.1\\\\..*')."
-      },
-      "override": {
-        "type": "boolean",
-        "description": "When true, expresses the intent to exclude outdated built-in metadata shipped with Native Image for the matched versions."
-      },
-      "allowed-packages": {
-        "type": "array",
-        "description": "Packages expected to contain metadata entries for this library. Used by CI checks.",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "skipped-versions": {
-        "type": "array",
-        "description": "Versions explicitly excluded from support, each with a reason.",
-        "minItems": 1,
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [ "version", "reason" ],
-          "properties": {
-            "version": {
-              "type": "string",
-              "minLength": 1
-            },
-            "reason": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        }
-      },
-      "requires": {
-        "type": "array",
-        "description": "List of dependent modules (group:artifact) whose metadata is required at runtime.",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": {
-          "$ref": "#/$defs/moduleCoordinate"
-        }
+  "oneOf": [
+    {
+      "items": {
+        "$ref": "#/$defs/metadataIndexEntry"
+      }
+    },
+    {
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "$ref": "#/$defs/notForNativeImageEntry"
       }
     }
-  },
+  ],
   "$defs": {
+    "metadataIndexEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed-packages",
+        "metadata-version",
+        "tested-versions"
+      ],
+      "properties": {
+        "metadata-version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Subdirectory name where the metadata files for this entry reside, e.g. '7.1.0.Final'."
+        },
+        "tested-versions": {
+          "type": "array",
+          "description": "Explicitly tested upstream library versions that this metadata is known to support.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "test-version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Overrides 'metadata-version' for use in test directories. This allows one metadata entry to share tests defined for a different version's metadata directory."
+        },
+        "source-code-url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional URL pointing to the metadata source code for this entry."
+        },
+        "repository-url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional URL pointing to the canonical project repository for this entry."
+        },
+        "documentation-url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional URL pointing to the project documentation for this entry."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional two-sentence explanation of what the library does."
+        },
+        "language": {
+          "$ref": "#/$defs/libraryLanguage"
+        },
+        "test-code-url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional URL pointing to the test source code for this entry."
+        },
+        "latest": {
+          "type": "boolean",
+          "description": "Marks this entry as the latest/default metadata for currently supported versions."
+        },
+        "default-for": {
+          "type": "string",
+          "description": "Java regular expression describing the version range for which this entry should be used by default (e.g. '7\\\\.1\\\\..*')."
+        },
+        "override": {
+          "type": "boolean",
+          "description": "When true, expresses the intent to exclude outdated built-in metadata shipped with Native Image for the matched versions."
+        },
+        "allowed-packages": {
+          "type": "array",
+          "description": "Packages expected to contain metadata entries for this library. Used by CI checks.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "skipped-versions": {
+          "type": "array",
+          "description": "Versions explicitly excluded from support, each with a reason.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "version", "reason" ],
+            "properties": {
+              "version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "requires": {
+          "type": "array",
+          "description": "List of dependent modules (group:artifact) whose metadata is required at runtime.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/moduleCoordinate"
+          }
+        }
+      }
+    },
+    "notForNativeImageEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not-for-native-image",
+        "reason"
+      ],
+      "properties": {
+        "not-for-native-image": {
+          "type": "boolean",
+          "const": true,
+          "description": "Marks this artifact as intentionally not applicable to GraalVM Native Image metadata."
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Reason this artifact is not a Native Image metadata target."
+        },
+        "replacement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional replacement artifact or guidance for users."
+        }
+      }
+    },
     "moduleCoordinate": {
       "type": "string",
       "pattern": "^[^:]+:[^:]+$"
@@ -203,6 +242,13 @@
         "skipped-versions": [
           { "version": "1.34.0", "reason": "Dependency io.opentelemetry:opentelemetry-api:1.34.0 provides reflect-config.json which does not parse." }
         ]
+      }
+    ],
+    [
+      {
+        "not-for-native-image": true,
+        "reason": "Scala.js artifact; not a JVM library consumed by native-image.",
+        "replacement": "Use the JVM artifact if one exists."
       }
     ]
   ]

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractSubprojectTask.java
@@ -90,7 +90,11 @@ public abstract class AbstractSubprojectTask extends DefaultTask {
         for (Object entryObj : (Iterable<?>) metadataIndex) {
             @SuppressWarnings("unchecked")
             Map<String, Object> entry = (Map<String, Object>) entryObj;
-            if (((List<String>) entry.get("tested-versions")).contains(version)) {
+            List<String> testedVersions = (List<String>) entry.get("tested-versions");
+            if (testedVersions == null) {
+                continue;
+            }
+            if (testedVersions.contains(version)) {
                 if (entry.containsKey("override")) {
                     Object ov = entry.get("override");
                     if (ov instanceof Boolean b) {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
@@ -149,7 +149,11 @@ public abstract class AllCoordinatesExecTask extends CoordinatesAwareTask {
         var metadataIndex = readIndexFile(metadataDir.getParent());
         for (Object entryObj : (Iterable<?>) metadataIndex) {
             Map<String, Object> entry = (Map<String, Object>) entryObj;
-            if (((List<String>) entry.get("tested-versions")).contains(version)) {
+            List<String> testedVersions = (List<String>) entry.get("tested-versions");
+            if (testedVersions == null) {
+                continue;
+            }
+            if (testedVersions.contains(version)) {
                 if (entry.containsKey("override")) {
                     Object ov = entry.get("override");
                     if (ov instanceof Boolean b) {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
@@ -157,6 +157,10 @@ public class DiscoverArtifactMetadata extends DefaultTask {
                 - { "name": "scala", "version": "2" } for Scala 2 libraries
                 - { "name": "scala", "version": "3" } for Scala 3 libraries
                 If the library is not language-specific, leave the "language" field absent.
+                Also determine whether this artifact is not applicable to GraalVM Native Image reachability metadata because it is not a JVM artifact consumed by native-image.
+                Mark "not-for-native-image": true only for certain cases such as Android-only AAR/tooling artifacts, Scala.js artifacts, Kotlin Native/JS/Wasm artifacts, or artifacts with no JVM class files.
+                If you set "not-for-native-image": true, also set "reason" to a short evidence-based explanation and set "replacement" when there is an obvious JVM replacement artifact.
+                If the artifact might still be usable from JVM code, leave "not-for-native-image", "reason", and "replacement" absent.
                 The sources URL, the test suite URL, and the documentation URL must be for the EXACT version "%s".
                 The source, test suite, and documentation URLs should point to the right tag of the library.
                 If we have these source of these artifacts on maven, that should be prefered.
@@ -169,6 +173,7 @@ public class DiscoverArtifactMetadata extends DefaultTask {
                 - Set "source-code-url", "repository-url", "test-code-url", and "documentation-url" to the discovered values.
                 - Set "description" to the selected two-sentence explanation.
                 - If any of these URLs or the description cannot be found with confidence, set that field value to "N/A".
+                - Set "not-for-native-image", "reason", and "replacement" only when the artifact is certainly not a Native Image metadata target.
                 - Keep the JSON valid and consistently formatted.
                 """.formatted(
                 parsedCoordinates.toString(),

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
@@ -84,6 +84,10 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
             // Split by whitespace to support lists passed from GitHub Actions/CLI
             for (String singleFilter : filter.split("\\s+")) {
                 if (!singleFilter.isEmpty()) {
+                    String directIndexPath = directMetadataIndexPath(singleFilter);
+                    if (directIndexPath != null) {
+                        targetFiles.add(directIndexPath);
+                    }
                     allResolved.addAll(computeMatchingCoordinates(singleFilter));
                 }
             }
@@ -101,6 +105,15 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
                 });
 
         executeValidation(targetFiles);
+    }
+
+    private String directMetadataIndexPath(String coordinateFilter) {
+        String[] parts = coordinateFilter.split(":");
+        if (parts.length < 2 || parts.length > 3) {
+            return null;
+        }
+        String filePath = String.format("metadata/%s/%s/index.json", parts[0], parts[1]);
+        return getProject().file(filePath).exists() ? filePath : null;
     }
 
     private void executeValidation(Set<String> targetFiles) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -88,18 +88,20 @@ class ScaffoldTask extends DefaultTask {
     @TaskAction
     void run() throws IOException {
         Coordinates coordinates = Coordinates.parse(this.coordinates);
-        List<String> packageRoots = MetadataGenerationUtils.derivePackageRootsFromJar(getProject(), coordinates);
-        DiscoveredArtifactMetadata discoveredMetadata = loadDiscoveredArtifactMetadata(coordinates);
-
         Path coordinatesMetadataRoot = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$", coordinates)).toPath();
         Path coordinatesMetadataVersionRoot = coordinatesMetadataRoot.resolve(coordinates.version());
         Path coordinatesTestRoot = getProject().file(CoordinateUtils.replace("tests/src/$group$/$artifact$/$version$", coordinates)).toPath();
         Path coordinatesMetadataIndex = coordinatesMetadataRoot.resolve("index.json");
         boolean metadataRootExists = Files.exists(coordinatesMetadataIndex);
-        boolean metadataEntryExists = metadataRootExists && !shouldAddNewMetadataEntry(coordinatesMetadataRoot, coordinates);
         List<MetadataVersionsIndexEntry> existingEntries = metadataRootExists
                 ? objectMapper.readValue(coordinatesMetadataIndex.toFile(), new TypeReference<>() {})
                 : List.of();
+        if (existingEntries.stream().anyMatch(MetadataVersionsIndexEntry::isNotForNativeImage)) {
+            throw new IllegalStateException("Artifact '%s:%s' is marked not-for-native-image. Remove the marker before scaffolding Native Image metadata.".formatted(coordinates.group(), coordinates.artifact()));
+        }
+        List<String> packageRoots = MetadataGenerationUtils.derivePackageRootsFromJar(getProject(), coordinates);
+        DiscoveredArtifactMetadata discoveredMetadata = loadDiscoveredArtifactMetadata(coordinates);
+        boolean metadataEntryExists = metadataRootExists && !shouldAddNewMetadataEntry(coordinatesMetadataRoot, coordinates);
         LibraryLanguage entryLanguage = resolveEntryLanguage(discoveredMetadata, existingEntries);
 
         // Metadata
@@ -145,7 +147,9 @@ class ScaffoldTask extends DefaultTask {
     private boolean shouldAddNewMetadataEntry(Path coordinatesMetadataRoot, Coordinates coordinates) throws IOException {
         File metadataIndex = coordinatesMetadataRoot.resolve("index.json").toFile();
         List<MetadataVersionsIndexEntry> entries = objectMapper.readValue(metadataIndex, new TypeReference<>() {});
-        return entries.stream().noneMatch(e -> e.metadataVersion().equalsIgnoreCase(coordinates.version()));
+        return entries.stream()
+                .filter(MetadataVersionsIndexEntry::isSupportedMetadataEntry)
+                .noneMatch(e -> e.metadataVersion().equalsIgnoreCase(coordinates.version()));
     }
 
     private void writeTestScaffold(Path coordinatesTestRoot, Coordinates coordinates, List<String> packageRoots, LibraryLanguage language) throws IOException {
@@ -241,7 +245,10 @@ class ScaffoldTask extends DefaultTask {
                 oldEntry.testedVersions(),
                 oldEntry.skippedVersions(),
                 oldEntry.allowedPackages(),
-                oldEntry.requires()
+                oldEntry.requires(),
+                null,
+                null,
+                null
         ));
     }
 
@@ -313,6 +320,7 @@ class ScaffoldTask extends DefaultTask {
             return discoveredMetadata.language();
         }
         return existingEntries.stream()
+                .filter(MetadataVersionsIndexEntry::isSupportedMetadataEntry)
                 .filter(entry -> entry.language() != null)
                 .max(Comparator.comparing(e -> VersionNumber.parse(e.metadataVersion())))
                 .map(MetadataVersionsIndexEntry::language)
@@ -335,7 +343,10 @@ class ScaffoldTask extends DefaultTask {
                 List.of(coordinates.version()),
                 null, // skipped-versions
                 packageRoots,
-                null // requires
+                null, // requires
+                null, // not-for-native-image
+                null, // reason
+                null // replacement
         );
     }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -110,10 +110,13 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
         ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT).setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         List<MetadataVersionsIndexEntry> entries = objectMapper.readValue(coordinatesMetadataIndex, new TypeReference<>() {});
+        if (entries.stream().anyMatch(MetadataVersionsIndexEntry::isNotForNativeImage)) {
+            throw new IllegalStateException("Cannot add tested versions to not-for-native-image artifact: " + coordinatesMetadataIndex);
+        }
         for (int i = 0; i < entries.size(); i++) {
             MetadataVersionsIndexEntry entry = entries.get(i);
 
-            if (entry.testedVersions().contains(getLastSupportedVersion().get())) {
+            if (entry.testedVersions() != null && entry.testedVersions().contains(getLastSupportedVersion().get())) {
                 entry.testedVersions().add(newVersion);
                 entry.testedVersions().sort(Comparator.comparing(VersionNumber::parse));
 
@@ -184,7 +187,10 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                         entry.testedVersions(),
                         entry.skippedVersions(),
                         entry.allowedPackages(),
-                        entry.requires()
+                        entry.requires(),
+                        null,
+                        null,
+                        null
                 );
             }
         }
@@ -400,6 +406,9 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
     private void updateDependentTestVersions(String oldTestVersion, String newTestVersion, List<MetadataVersionsIndexEntry> entries) {
         for (int i = 0; i < entries.size(); i++) {
             MetadataVersionsIndexEntry entry = entries.get(i);
+            if (entry.isNotForNativeImage()) {
+                continue;
+            }
 
             // Check if the entry explicitly points to the old directory via 'test-version'
             if (oldTestVersion.equals(entry.testVersion())) {
@@ -419,7 +428,10 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                         entry.testedVersions(),
                         entry.skippedVersions(),
                         entry.allowedPackages(),
-                        entry.requires()
+                        entry.requires(),
+                        null,
+                        null,
+                        null
                 );
                 entries.set(i, updatedEntry);
             }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
@@ -183,7 +183,9 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
                     indexFile, new TypeReference<List<MetadataVersionsIndexEntry>>() {});
             List<String> testedVersions = new ArrayList<>();
             for (MetadataVersionsIndexEntry entry : entries) {
-                testedVersions.addAll(entry.testedVersions());
+                if (entry != null && entry.testedVersions() != null) {
+                    testedVersions.addAll(entry.testedVersions());
+                }
             }
             return testedVersions;
         } catch (IOException e) {
@@ -210,7 +212,7 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
 
             List<String> skipped = new ArrayList<>();
             for (MetadataVersionsIndexEntry entry : entries) {
-                if (entry.skippedVersions() != null) {
+                if (entry != null && entry.skippedVersions() != null) {
                     for (SkippedVersionEntry sve : entry.skippedVersions()) {
                         skipped.add(sve.version());
                     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/DiscoveredArtifactMetadata.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/DiscoveredArtifactMetadata.java
@@ -24,5 +24,11 @@ public record DiscoveredArtifactMetadata(
         @JsonProperty("description")
         String description,
         @JsonProperty("language")
-        LibraryLanguage language
+        LibraryLanguage language,
+        @JsonProperty("not-for-native-image")
+        Boolean notForNativeImage,
+        @JsonProperty("reason")
+        String reason,
+        @JsonProperty("replacement")
+        String replacement
 ) {}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/MetadataVersionsIndexEntry.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/MetadataVersionsIndexEntry.java
@@ -6,6 +6,7 @@
  */
 package org.graalvm.internal.tck.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -42,5 +43,21 @@ public record MetadataVersionsIndexEntry(
         @JsonProperty("allowed-packages")
         List<String> allowedPackages,
         @JsonProperty("requires")
-        List<String> requires
-) {}
+        List<String> requires,
+        @JsonProperty("not-for-native-image")
+        Boolean notForNativeImage,
+        @JsonProperty("reason")
+        String reason,
+        @JsonProperty("replacement")
+        String replacement
+) {
+    @JsonIgnore
+    public boolean isNotForNativeImage() {
+        return Boolean.TRUE.equals(notForNativeImage);
+    }
+
+    @JsonIgnore
+    public boolean isSupportedMetadataEntry() {
+        return !isNotForNativeImage() && metadataVersion != null && testedVersions != null;
+    }
+}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
@@ -382,7 +382,7 @@ public final class LibraryStatsSchemaValidator {
                 try {
                     List<MetadataVersionsIndexEntry> entries = OBJECT_MAPPER.readValue(indexFile.toFile(), INDEX_ENTRIES_TYPE);
                     for (MetadataVersionsIndexEntry entry : entries) {
-                        if (entry != null && entry.testedVersions() != null) {
+                        if (entry != null && entry.isSupportedMetadataEntry()) {
                             testedVersions.addAll(entry.testedVersions());
                         }
                     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/ReadmeBadgeSummarySupport.java
@@ -269,9 +269,15 @@ public final class ReadmeBadgeSummarySupport {
         })) {
             for (Path indexFile : paths.sorted().toList()) {
                 List<MetadataVersionsIndexEntry> entries = readIndexEntries(indexFile);
+                if (!hasMetadataIndexEntries(entries)) {
+                    continue;
+                }
                 metadataIndexes++;
-                metadataBaselines += entries.size();
                 for (MetadataVersionsIndexEntry entry : entries) {
+                    if (!isMetadataIndexEntry(entry)) {
+                        continue;
+                    }
+                    metadataBaselines++;
                     if (Boolean.TRUE.equals(entry.latest())) {
                         latestEntries++;
                     }
@@ -314,6 +320,9 @@ public final class ReadmeBadgeSummarySupport {
                 Path relative = metadataRoot.relativize(indexFile);
                 String coordinate = relative.getName(0) + ":" + relative.getName(1);
                 List<MetadataVersionsIndexEntry> indexEntries = readIndexEntries(indexFile);
+                if (!hasMetadataIndexEntries(indexEntries)) {
+                    continue;
+                }
                 entriesByCoordinate.put(
                         coordinate,
                         new CoverageTableEntry(
@@ -396,6 +405,17 @@ public final class ReadmeBadgeSummarySupport {
         } catch (IOException e) {
             throw new GradleException("Failed to read metadata index file " + indexFile, e);
         }
+    }
+
+    private static boolean hasMetadataIndexEntries(List<MetadataVersionsIndexEntry> entries) {
+        if (entries == null) {
+            return false;
+        }
+        return entries.stream().anyMatch(ReadmeBadgeSummarySupport::isMetadataIndexEntry);
+    }
+
+    private static boolean isMetadataIndexEntry(MetadataVersionsIndexEntry entry) {
+        return entry != null && !entry.isNotForNativeImage() && entry.metadataVersion() != null;
     }
 
     private static String buildMetricsOverviewGraph(ReadmeMetricsHistory history, Instant generatedAt) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/ArtifactMetadataDiscoveryUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/ArtifactMetadataDiscoveryUtils.java
@@ -45,6 +45,9 @@ public final class ArtifactMetadataDiscoveryUtils {
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
                 null
         ));
     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -244,6 +244,9 @@ public final class MetadataGenerationUtils {
         if (indexFile.exists()) {
             entries = objectMapper.readValue(indexFile, new TypeReference<>() {});
         }
+        if (entries.stream().anyMatch(MetadataVersionsIndexEntry::isNotForNativeImage)) {
+            throw new GradleException("Cannot mark a new version latest for not-for-native-image artifact: " + newCoords.group() + ":" + newCoords.artifact());
+        }
 
         // If the version already exists, no update needed
         String newVersion = newCoords.version();
@@ -279,7 +282,10 @@ public final class MetadataGenerationUtils {
                         entry.testedVersions(),
                         entry.skippedVersions(),
                         entry.allowedPackages(),
-                        entry.requires()
+                        entry.requires(),
+                        null,
+                        null,
+                        null
                 ));
                 latestAllowedPackages = entry.allowedPackages();
                 latestRequires = entry.requires();
@@ -305,7 +311,10 @@ public final class MetadataGenerationUtils {
                 testedVersions,
                 null, // skipped-versions
                 latestAllowedPackages, // allowed-packages
-                latestRequires // requires
+                latestRequires, // requires
+                null, // not-for-native-image
+                null, // reason
+                null // replacement
         );
         entries.addFirst(newEntry);
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -108,6 +108,29 @@ class ScaffoldTaskTests {
     }
 
     @Test
+    void runRejectsNotForNativeImageMarker() throws IOException {
+        Coordinates coordinates = Coordinates.parse("org.scala-js:scalajs-library_2.13:1.18.2");
+        Files.createDirectories(tempDir.resolve("metadata/org.scala-js/scalajs-library_2.13"));
+        Files.writeString(
+                tempDir.resolve("metadata/org.scala-js/scalajs-library_2.13/index.json"),
+                """
+                [
+                  {
+                    "not-for-native-image": true,
+                    "reason": "Scala.js artifact; not a JVM library consumed by native-image."
+                  }
+                ]
+                """
+        );
+        Project project = createProject();
+        ScaffoldTask task = registerScaffoldTask(project, "scaffoldMarker", coordinates);
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not-for-native-image");
+    }
+
+    @Test
     void runWithSkipTestsOmitsOnlyJavaTestStub() throws IOException {
         Coordinates coordinates = Coordinates.parse("org.postgresql:postgresql:42.7.3");
         installLibraryArtifact(coordinates, List.of(
@@ -153,7 +176,10 @@ class ScaffoldTaskTests {
                 "https://example.com/tests",
                 "https://example.com/docs",
                 "Ktor provides asynchronous servers. It is designed for Kotlin applications.",
-                new LibraryLanguage("kotlin", "2.0")
+                new LibraryLanguage("kotlin", "2.0"),
+                null,
+                null,
+                null
         ));
         ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
 
@@ -198,7 +224,10 @@ class ScaffoldTaskTests {
                 "https://example.com/tests",
                 "https://example.com/docs",
                 "Groovy JSON provides JSON parsing and generation APIs. It is designed for Groovy applications.",
-                new LibraryLanguage("groovy", "4.0")
+                new LibraryLanguage("groovy", "4.0"),
+                null,
+                null,
+                null
         ));
         ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
 
@@ -244,7 +273,10 @@ class ScaffoldTaskTests {
                 null,
                 null,
                 null,
-                new LibraryLanguage("scala", "3")
+                new LibraryLanguage("scala", "3"),
+                null,
+                null,
+                null
         ));
         ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
 
@@ -277,7 +309,10 @@ class ScaffoldTaskTests {
                 null,
                 null,
                 null,
-                new LibraryLanguage("scala", "2")
+                new LibraryLanguage("scala", "2"),
+                null,
+                null,
+                null
         ));
         ScaffoldTask task = registerScaffoldTask(project, "scaffold", coordinates);
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/TckExtensionTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/TckExtensionTests.java
@@ -80,6 +80,23 @@ class TckExtensionTests {
     }
 
     @Test
+    void getMatchingCoordinatesSkipsNotForNativeImageMarker() throws IOException {
+        TckExtension extension = createExtension(
+                """
+                [
+                  {
+                    "not-for-native-image": true,
+                    "reason": "Scala.js artifact; not a JVM library consumed by native-image."
+                  }
+                ]
+                """
+        );
+
+        assertThat(extension.getMatchingCoordinates("com.example:demo")).isEmpty();
+        assertThat(extension.getMatchingCoordinatesStrict("com.example:demo")).isEmpty();
+    }
+
+    @Test
     void getTestDirUsesSharedTestVersionForSupportedVersion() throws IOException {
         TckExtension extension = createExtension(
                 """


### PR DESCRIPTION
## What does this PR do?

Fixes #4243.

This PR adds a first-class artifact-level `not-for-native-image` marker to `metadata/<group>/<artifact>/index.json` so the repository can track artifacts that should not get GraalVM Native Image reachability metadata.

Summary:
- allows marker-only metadata index entries with `not-for-native-image`, `reason`, and optional `replacement`
- detects certain non-Native-Image artifacts before new-library scaffolding and creates marker PRs instead
- skips marked artifacts in Forge issue handling and Gradle version-update paths
- excludes marker-only artifacts from supported-library stats and coverage tables
- validates changed marker-only index files even when they have no tested versions

Verification:
- `python3 -m py_compile utility_scripts/metadata_index.py utility_scripts/native_image_artifact.py ai_workflows/add_new_library_support.py git_scripts/make_pr_not_for_native_image.py forge_metadata.py`
- `./gradlew :tck-build-logic:test --stacktrace`
- `./gradlew validateIndexFiles -Pcoordinates=org.apache.yetus:audience-annotations --stacktrace`
- direct schema validation for supported, marker, mixed, and invalid marker payloads