### PR TITLE
[GenAI] Test fix for org.javamoney.moneta:moneta-core:1.4 using gpt-5.5

### DIFF
--- a/metadata/org.javamoney.moneta/moneta-core/1.4/reachability-metadata.json
+++ b/metadata/org.javamoney.moneta/moneta-core/1.4/reachability-metadata.json
@@ -1,0 +1,54 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi"
+      },
+      "type" : "org.javamoney.moneta.FastMoney"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.MonetaryConfig"
+      },
+      "type" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.MonetaryConfig"
+      },
+      "glob" : "META-INF/services/javax.money.spi.ServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.JDKCurrencyProvider"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/currency.data"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle" : "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.javamoney.moneta/moneta-core/index.json
+++ b/metadata/org.javamoney.moneta/moneta-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.4",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/1.4/moneta-core-1.4-sources.jar",
+    "repository-url" : "https://github.com/JavaMoney/jsr354-ri",
+    "test-code-url" : "https://github.com/JavaMoney/jsr354-ri/tree/1.4/moneta-core/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/1.4/moneta-core-1.4-javadoc.jar",
+    "description" : "Moneta Core is the core implementation module of JavaMoney's JSR 354 reference implementation. It provides monetary amount, currency, formatting, loading, and SPI support for Java applications that use the javax.money API.",
     "tested-versions" : [
       "1.4"
     ],

--- a/metadata/org.javamoney.moneta/moneta-core/index.json
+++ b/metadata/org.javamoney.moneta/moneta-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.4",
+    "tested-versions" : [
+      "1.4"
+    ],
+    "allowed-packages" : [
+      "org.javamoney.moneta"
+    ]
+  },
+  {
     "metadata-version" : "1.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/1.3/moneta-core-1.3-sources.jar",
     "repository-url" : "https://github.com/JavaMoney/jsr354-ri",

--- a/stats/org.javamoney.moneta/moneta-core/1.4/execution-metrics.json
+++ b/stats/org.javamoney.moneta/moneta-core/1.4/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T08:01:28.274999Z",
+    "library": "org.javamoney.moneta:moneta-core:1.4",
+    "starting_commit": "992eb51988ada5f6997adf96b6d4195ac79e1f80",
+    "ending_commit": "59d5fbccba4d0302434a115c4165f6454e763141",
+    "previous_library": "org.javamoney.moneta:moneta-core:1.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1479,
+          "missed": 15647,
+          "ratio": 0.08636,
+          "total": 17126
+        },
+        "line": {
+          "covered": 360,
+          "missed": 3150,
+          "ratio": 0.102564,
+          "total": 3510
+        },
+        "method": {
+          "covered": 101,
+          "missed": 853,
+          "ratio": 0.10587,
+          "total": 954
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 998,
+          "missed": 16977,
+          "ratio": 0.055522,
+          "total": 17975
+        },
+        "line": {
+          "covered": 238,
+          "missed": 3463,
+          "ratio": 0.064307,
+          "total": 3701
+        },
+        "method": {
+          "covered": 65,
+          "missed": 1041,
+          "ratio": 0.05877,
+          "total": 1106
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 48992,
+      "cached_input_tokens_used": 336384,
+      "output_tokens_used": 4909,
+      "iterations": 2,
+      "cost_usd": 0.3155,
+      "tested_library_loc": 360,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 9,
+      "previous_library_test_only_metadata_entries": 3,
+      "code_coverage_percent": 10.26,
+      "previous_library_coverage_percent": 6.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java",
+      "metadata_file": "metadata/org.javamoney.moneta/moneta-core/1.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.javamoney.moneta/moneta-core/1.4/stats.json
+++ b/stats/org.javamoney.moneta/moneta-core/1.4/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1479,
+        "missed" : 15647,
+        "ratio" : 0.08636,
+        "total" : 17126
+      },
+      "line" : {
+        "covered" : 360,
+        "missed" : 3150,
+        "ratio" : 0.102564,
+        "total" : 3510
+      },
+      "method" : {
+        "covered" : 101,
+        "missed" : 853,
+        "ratio" : 0.10587,
+        "total" : 954
+      }
+    }
+  } ]
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/.gitignore
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/build.gradle
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.javamoney.moneta:moneta-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/gradle.properties
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.javamoney.moneta:moneta-core:1.4
+library.version = 1.4
+metadata.dir = org.javamoney.moneta/moneta-core/1.4/

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/settings.gradle
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.javamoney.moneta.moneta-core_tests'

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.FastMoney;
+import org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultMonetaryAmountsSingletonSpiTest {
+    private static final String DEFAULT_AMOUNT_TYPE_PROPERTY = "org.javamoney.moneta.Money.defaults.amountType";
+
+    @Test
+    public void getDefaultAmountTypeLoadsConfiguredAmountClass() {
+        String previousValue = System.getProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+        try {
+            System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
+
+            DefaultMonetaryAmountsSingletonSpi amounts = new DefaultMonetaryAmountsSingletonSpi();
+
+            assertThat(amounts.getDefaultAmountType()).isEqualTo(FastMoney.class);
+            assertThat(amounts.getAmountTypes()).contains(FastMoney.class);
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+            } else {
+                System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue);
+            }
+        }
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.internal.loader.DefaultLoaderService;
+import org.javamoney.moneta.spi.LoaderService;
+import org.javamoney.moneta.spi.LoaderService.UpdatePolicy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoaderConfiguratorTest {
+    private static final String RESOURCE_ID = "loader-configurator-absolute";
+
+    @Test
+    public void loadRegistersResourceFoundThroughOwningClass() {
+        LoaderService loaderService = new DefaultLoaderService();
+
+        assertThat(loaderService.isResourceRegistered(RESOURCE_ID)).isTrue();
+        assertThat(loaderService.getUpdatePolicy(RESOURCE_ID)).isEqualTo(UpdatePolicy.LAZY);
+        assertThat(loaderService.getUpdateConfiguration(RESOURCE_ID))
+                .containsEntry("resource", "/javamoney.properties")
+                .containsEntry("type", "LAZY");
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
@@ -6,9 +6,9 @@
  */
 package org_javamoney_moneta.moneta_core;
 
-import org.javamoney.moneta.internal.loader.DefaultLoaderService;
-import org.javamoney.moneta.spi.LoaderService;
-import org.javamoney.moneta.spi.LoaderService.UpdatePolicy;
+import org.javamoney.moneta.spi.loader.DefaultLoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService.UpdatePolicy;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.internal.loader.LoaderConfigurator"
+      },
+      "glob" : "/javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.internal.loader.LoaderConfigurator"
+      },
+      "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.MonetaryConfig"
+      },
+      "glob" : "javamoney.properties"
+    }
+  ]
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -17,6 +17,24 @@
         "typeReached" : "org.javamoney.moneta.spi.MonetaryConfig"
       },
       "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "glob" : "/javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.DefaultConfigProvider"
+      },
+      "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "glob" : "javamoney.properties"
     }
   ]
 }

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/javamoney.properties
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/resources/javamoney.properties
@@ -1,0 +1,2 @@
+load.loader-configurator-absolute.type=LAZY
+load.loader-configurator-absolute.resource=/javamoney.properties

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4/user-code-filter.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.javamoney.moneta.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4179

This PR provides test fixes and new metadata for org.javamoney.moneta:moneta-core:1.4, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 48992
- Cached input tokens: 336384
- Output tokens: 4909
- Metadata entries: 11
- Test-only metadata entries: 6
- Iterations: 2
- Library coverage percentage: 10.26
- Previous library version metadata entries: 9
- Previous library version test-only metadata entries: 3
- Previous library version coverage percentage: 6.43

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1aa2b45ebe1aa91a830414c0229406d252546ab5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.javamoney.moneta:moneta-core:1.3: 3/3 covered calls (100.00%)
- org.javamoney.moneta:moneta-core:1.4: 4/4 covered calls (100.00%)

**Reflection:**
- org.javamoney.moneta:moneta-core:1.3: N/A
- org.javamoney.moneta:moneta-core:1.4: 1/1 covered calls (100.00%)

**Resources:**
- org.javamoney.moneta:moneta-core:1.3: 3/3 covered calls (100.00%)
- org.javamoney.moneta:moneta-core:1.4: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.javamoney.moneta:moneta-core:1.3: 998/17975 (5.55%)
- org.javamoney.moneta:moneta-core:1.4: 1479/17126 (8.64%)

**Line:**
- org.javamoney.moneta:moneta-core:1.3: 238/3701 (6.43%)
- org.javamoney.moneta:moneta-core:1.4: 360/3510 (10.26%)

**Method:**
- org.javamoney.moneta:moneta-core:1.3: 65/1106 (5.88%)
- org.javamoney.moneta:moneta-core:1.4: 101/954 (10.59%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java 2/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
new file mode 100644
index 0000000000..75d2f0c08c
--- /dev/null
+++ 2/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
@@ -0,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.FastMoney;
+import org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultMonetaryAmountsSingletonSpiTest {
+    private static final String DEFAULT_AMOUNT_TYPE_PROPERTY = "org.javamoney.moneta.Money.defaults.amountType";
+
+    @Test
+    public void getDefaultAmountTypeLoadsConfiguredAmountClass() {
+        String previousValue = System.getProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+        try {
+            System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
+
+            DefaultMonetaryAmountsSingletonSpi amounts = new DefaultMonetaryAmountsSingletonSpi();
+
+            assertThat(amounts.getDefaultAmountType()).isEqualTo(FastMoney.class);
+            assertThat(amounts.getAmountTypes()).contains(FastMoney.class);
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+            } else {
+                System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue);
+            }
+        }
+    }
+}
diff --git 1/tests/src/org.javamoney.moneta/moneta-core/1.3/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java 2/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
index 6a89b0c07d..7d06db75d7 100644
--- 1/tests/src/org.javamoney.moneta/moneta-core/1.3/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
+++ 2/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
@@ -6,9 +6,9 @@
  */
 package org_javamoney_moneta.moneta_core;
 
-import org.javamoney.moneta.internal.loader.DefaultLoaderService;
-import org.javamoney.moneta.spi.LoaderService;
-import org.javamoney.moneta.spi.LoaderService.UpdatePolicy;
+import org.javamoney.moneta.spi.loader.DefaultLoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService.UpdatePolicy;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

```
