### PR TITLE
[GenAI] Test fix for javax.servlet:servlet-api:2.4 using gpt-5.5

### DIFF
--- a/metadata/javax.servlet/servlet-api/2.4/reachability-metadata.json
+++ b/metadata/javax.servlet/servlet-api/2.4/reachability-metadata.json
@@ -1,0 +1,72 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.HttpServlet"
+      },
+      "type" : "javax.servlet.http.HttpServlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.HttpUtils"
+      },
+      "type" : "java.util.Hashtable",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.Cookie"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.ServletOutputStream"
+      },
+      "glob" : "javax/servlet/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.ServletOutputStream"
+      },
+      "glob" : "javax/servlet/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.ServletOutputStream"
+      },
+      "glob" : "javax/servlet/LocalStrings_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.Cookie"
+      },
+      "glob" : "javax/servlet/http/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.Cookie"
+      },
+      "glob" : "javax/servlet/http/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.Cookie"
+      },
+      "glob" : "javax/servlet/http/LocalStrings_en_US.properties"
+    },
+    {
+      "bundle" : "javax.servlet.LocalStrings"
+    },
+    {
+      "bundle" : "javax.servlet.http.LocalStrings"
+    }
+  ]
+}

--- a/metadata/javax.servlet/servlet-api/index.json
+++ b/metadata/javax.servlet/servlet-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/javax/servlet/servlet-api/2.4/servlet-api-2.4-sources.jar",
+    "repository-url" : "https://github.com/javaee/servlet-spec",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://download.oracle.com/otn-pub/jcp/servlet-2.4-fr-spec-oth-JSpec/servlet-2_4-fr-spec.pdf",
+    "description" : "Provides the Java Servlet 2.4 API interfaces and classes used by Java web applications and servlet containers to handle requests, responses, sessions, filters, and listeners. It lets applications compile against the standard javax.servlet contracts without bundling a servlet container implementation.",
     "tested-versions" : [
       "2.4"
     ],

--- a/metadata/javax.servlet/servlet-api/index.json
+++ b/metadata/javax.servlet/servlet-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.4",
+    "tested-versions" : [
+      "2.4"
+    ],
+    "allowed-packages" : [
+      "javax.servlet"
+    ]
+  },
+  {
     "metadata-version" : "2.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/javax/servlet/servlet-api/2.3/servlet-api-2.3-sources.jar",
     "repository-url" : "https://github.com/javaee/servlet-spec",

--- a/stats/javax.servlet/servlet-api/2.4/execution-metrics.json
+++ b/stats/javax.servlet/servlet-api/2.4/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T08:12:23.076560Z",
+    "library": "javax.servlet:servlet-api:2.4",
+    "starting_commit": "a739628bdac3ad0b400d13db014140753b9c7cfc",
+    "ending_commit": "f32902800be162132e18ce9df27830cd2641c811",
+    "previous_library": "javax.servlet:servlet-api:2.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 841,
+          "missed": 1303,
+          "ratio": 0.392257,
+          "total": 2144
+        },
+        "line": {
+          "covered": 237,
+          "missed": 356,
+          "ratio": 0.399663,
+          "total": 593
+        },
+        "method": {
+          "covered": 74,
+          "missed": 161,
+          "ratio": 0.314894,
+          "total": 235
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.857143,
+        "coveredCalls": 6,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 825,
+          "missed": 2116,
+          "ratio": 0.280517,
+          "total": 2941
+        },
+        "line": {
+          "covered": 226,
+          "missed": 594,
+          "ratio": 0.27561,
+          "total": 820
+        },
+        "method": {
+          "covered": 62,
+          "missed": 272,
+          "ratio": 0.185629,
+          "total": 334
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 89737,
+      "cached_input_tokens_used": 1431040,
+      "output_tokens_used": 10296,
+      "iterations": 1,
+      "cost_usd": 1.0244,
+      "tested_library_loc": 237,
+      "metadata_entries": 12,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 12,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 39.97,
+      "previous_library_coverage_percent": 27.56
+    },
+    "artifacts": {
+      "test_file": "tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/HttpUtilsTest.java",
+      "metadata_file": "metadata/javax.servlet/servlet-api/2.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/javax.servlet/servlet-api/2.4/stats.json
+++ b/stats/javax.servlet/servlet-api/2.4/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 841,
+        "missed" : 1303,
+        "ratio" : 0.392257,
+        "total" : 2144
+      },
+      "line" : {
+        "covered" : 237,
+        "missed" : 356,
+        "ratio" : 0.399663,
+        "total" : 593
+      },
+      "method" : {
+        "covered" : 74,
+        "missed" : 161,
+        "ratio" : 0.314894,
+        "total" : 235
+      }
+    }
+  } ]
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/.gitignore
+++ b/tests/src/javax.servlet/servlet-api/2.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/javax.servlet/servlet-api/2.4/build.gradle
+++ b/tests/src/javax.servlet/servlet-api/2.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "javax.servlet:servlet-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/gradle.properties
+++ b/tests/src/javax.servlet/servlet-api/2.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = javax.servlet:servlet-api:2.4
+library.version = 2.4
+metadata.dir = javax.servlet/servlet-api/2.4/

--- a/tests/src/javax.servlet/servlet-api/2.4/settings.gradle
+++ b/tests/src/javax.servlet/servlet-api/2.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'javax.servlet.servlet-api_tests'

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.servlet.http.Cookie;
+
+import org.junit.jupiter.api.Test;
+
+public class CookieTest {
+    @Test
+    void constructorInitializesCookieResourceBundleAndDefaultState() {
+        final Cookie cookie = new Cookie("sessionId", "abc123");
+
+        assertThat(cookie.getName()).isEqualTo("sessionId");
+        assertThat(cookie.getValue()).isEqualTo("abc123");
+        assertThat(cookie.getComment()).isNull();
+        assertThat(cookie.getDomain()).isNull();
+        assertThat(cookie.getMaxAge()).isEqualTo(-1);
+        assertThat(cookie.getPath()).isNull();
+        assertThat(cookie.getSecure()).isFalse();
+        assertThat(cookie.getVersion()).isZero();
+    }
+
+    @Test
+    void constructorUsesCookieResourceBundleForReservedTokenMessages() {
+        assertThatThrownBy(() -> new Cookie("Comment", "ignored"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cookie name Comment is a reserved token");
+    }
+
+    @Test
+    void accessorsMutateCookieAttributes() {
+        final Cookie cookie = new Cookie("theme", "light");
+
+        cookie.setValue("dark");
+        cookie.setComment("user preference");
+        cookie.setDomain("Example.COM");
+        cookie.setMaxAge(3600);
+        cookie.setPath("/settings");
+        cookie.setSecure(true);
+        cookie.setVersion(1);
+
+        assertThat(cookie.getValue()).isEqualTo("dark");
+        assertThat(cookie.getComment()).isEqualTo("user preference");
+        assertThat(cookie.getDomain()).isEqualTo("example.com");
+        assertThat(cookie.getMaxAge()).isEqualTo(3600);
+        assertThat(cookie.getPath()).isEqualTo("/settings");
+        assertThat(cookie.getSecure()).isTrue();
+        assertThat(cookie.getVersion()).isEqualTo(1);
+    }
+
+    @Test
+    void cloneCopiesCookieStateWithoutSharingIdentity() {
+        final Cookie cookie = new Cookie("cart", "full");
+        cookie.setPath("/shop");
+        cookie.setSecure(true);
+
+        final Cookie clone = (Cookie) cookie.clone();
+
+        assertThat(clone).isNotSameAs(cookie);
+        assertThat(clone.getName()).isEqualTo(cookie.getName());
+        assertThat(clone.getValue()).isEqualTo(cookie.getValue());
+        assertThat(clone.getPath()).isEqualTo(cookie.getPath());
+        assertThat(clone.getSecure()).isEqualTo(cookie.getSecure());
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
@@ -32,7 +32,7 @@ public class CookieTest {
     void constructorUsesCookieResourceBundleForReservedTokenMessages() {
         assertThatThrownBy(() -> new Cookie("Comment", "ignored"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cookie name Comment is a reserved token");
+                .hasMessage("Cookie name \"Comment\" is a reserved token");
     }
 
     @Test

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/HttpServletTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/HttpServletTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class HttpServletTest {
+    @Test
+    void defaultLastModifiedIsUnknownAfterLoadingHttpServletResources() {
+        final ExposedHttpServlet servlet = new ExposedHttpServlet();
+
+        assertThat(servlet.invokeGetLastModified()).isEqualTo(-1L);
+    }
+
+    @Test
+    void doOptionsDiscoversSupportedMethodsFromDeclaredServletMethods() throws ServletException, IOException {
+        final ExposedHttpServlet servlet = new ExposedHttpServlet();
+        final RecordedResponse response = new RecordedResponse();
+
+        servlet.invokeDoOptions(response.asHttpServletResponse());
+
+        assertThat(response.headerName()).isEqualTo("Allow");
+        assertThat(response.headerValue()).isEqualTo("GET, HEAD, POST, TRACE, OPTIONS");
+    }
+
+    private static final class ExposedHttpServlet extends HttpServlet {
+        long invokeGetLastModified() {
+            final HttpServletRequest request = null;
+
+            return super.getLastModified(request);
+        }
+
+        void invokeDoOptions(final HttpServletResponse response) throws ServletException, IOException {
+            final HttpServletRequest request = null;
+
+            super.doOptions(request, response);
+        }
+
+        @Override
+        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) {
+        }
+
+        @Override
+        protected void doPost(final HttpServletRequest request, final HttpServletResponse response) {
+        }
+    }
+
+    private static final class RecordedResponse {
+        private String headerName;
+        private String headerValue;
+
+        HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    HttpServletTest.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        String headerName() {
+            return headerName;
+        }
+
+        String headerValue() {
+            return headerValue;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("setHeader") && arguments.length == 2) {
+                headerName = (String) arguments[0];
+                headerValue = (String) arguments[1];
+                return null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static boolean isObjectMethod(final Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(final Object proxy, final Method method, final Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/HttpUtilsTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/HttpUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Hashtable;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpUtils;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"deprecation", "unchecked"})
+public class HttpUtilsTest {
+    @Test
+    void constructorInitializesLocalizedHttpUtilsResources() {
+        final HttpUtils httpUtils = new HttpUtils();
+
+        assertThat(httpUtils).isNotNull();
+    }
+
+    @Test
+    void parseQueryStringDecodesNamesAndCollectsRepeatedParameters() {
+        final Hashtable<String, String[]> parameters = HttpUtils.parseQueryString(
+                "name=Servlet+API&name=legacy&encoded=%2Froot%2Bleaf&empty=");
+
+        assertThat(parameters).containsOnlyKeys("name", "encoded", "empty");
+        assertThat(parameters.get("name")).containsExactly("Servlet API", "legacy");
+        assertThat(parameters.get("encoded")).containsExactly("/root+leaf");
+        assertThat(parameters.get("empty")).containsExactly("");
+    }
+
+    @Test
+    void parsePostDataReadsTheExpectedNumberOfBytes() {
+        final byte[] formData = "mode=compact&mode=expanded".getBytes(StandardCharsets.ISO_8859_1);
+
+        final Hashtable<String, String[]> parameters = HttpUtils.parsePostData(
+                formData.length,
+                new ByteArrayServletInputStream(formData));
+
+        assertThat(parameters.get("mode")).containsExactly("compact", "expanded");
+    }
+
+    @Test
+    void parsePostDataReportsShortReadsWithLocalizedMessage() {
+        final byte[] formData = "name=value".getBytes(StandardCharsets.ISO_8859_1);
+
+        assertThatThrownBy(() -> HttpUtils.parsePostData(
+                formData.length + 1,
+                new ByteArrayServletInputStream(formData)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Short Read");
+    }
+
+    private static final class ByteArrayServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream delegate;
+
+        private ByteArrayServletInputStream(final byte[] bytes) {
+            this.delegate = new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/NoBodyOutputStreamTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/NoBodyOutputStreamTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class NoBodyOutputStreamTest {
+    @Test
+    void headRequestInitializesNoBodyOutputStreamAndCountsOutputBytes() throws ServletException, IOException {
+        final OutputStreamHeadServlet servlet = new OutputStreamHeadServlet();
+        final ServletRequest request = requestWithMethod("HEAD");
+        final RecordedHeadResponse response = new RecordedHeadResponse();
+        final ServletResponse servletResponse = response.asHttpServletResponse();
+
+        servlet.service(request, servletResponse);
+
+        assertThat(response.contentLength()).isEqualTo(5);
+        assertThat(response.containsHeaderName()).isEqualTo("Last-Modified");
+        assertThat(response.outputStreamRequested()).isFalse();
+    }
+
+    private static HttpServletRequest requestWithMethod(final String methodName) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                NoBodyOutputStreamTest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                new RequestInvocationHandler(methodName));
+    }
+
+    private static final class OutputStreamHeadServlet extends HttpServlet {
+        @Override
+        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+            response.getOutputStream().write('h');
+            response.getOutputStream().write("ello".getBytes(StandardCharsets.UTF_8), 0, 4);
+        }
+    }
+
+    private static final class RecordedHeadResponse {
+        private int contentLength = -1;
+        private String containsHeaderName;
+        private boolean outputStreamRequested;
+
+        HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    NoBodyOutputStreamTest.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        int contentLength() {
+            return contentLength;
+        }
+
+        String containsHeaderName() {
+            return containsHeaderName;
+        }
+
+        boolean outputStreamRequested() {
+            return outputStreamRequested;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments)
+                throws IOException {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("containsHeader") && arguments.length == 1) {
+                containsHeaderName = (String) arguments[0];
+                return false;
+            }
+            if (method.getName().equals("setContentLength") && arguments.length == 1) {
+                contentLength = (Integer) arguments[0];
+                return null;
+            }
+            if (method.getName().equals("getOutputStream")) {
+                outputStreamRequested = true;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static final class RequestInvocationHandler implements InvocationHandler {
+        private final String methodName;
+
+        RequestInvocationHandler(final String methodName) {
+            this.methodName = methodName;
+        }
+
+        @Override
+        public Object invoke(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("getMethod")) {
+                return methodName;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static boolean isObjectMethod(final Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(final Object proxy, final Method method, final Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/ServletOutputStreamTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/ServletOutputStreamTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.CharConversionException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+public class ServletOutputStreamTest {
+    @Test
+    void printBooleanValuesUsesServletResourceBundle() throws IOException {
+        final RecordingServletOutputStream outputStream = new RecordingServletOutputStream();
+
+        outputStream.print(true);
+        outputStream.print(false);
+
+        assertThat(outputStream.content()).isEqualTo("truefalse");
+    }
+
+    @Test
+    void printRejectsNonIso88591CharactersUsingServletResourceBundleMessage() {
+        final RecordingServletOutputStream outputStream = new RecordingServletOutputStream();
+
+        assertThatThrownBy(() -> outputStream.print('\u0100'))
+                .isInstanceOf(CharConversionException.class)
+                .hasMessage("Not an ISO 8859-1 character: \u0100");
+    }
+
+    private static final class RecordingServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        @Override
+        public void write(int value) {
+            bytes.write(value);
+        }
+
+        String content() {
+            return new String(bytes.toByteArray(), StandardCharsets.ISO_8859_1);
+        }
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javax_servlet.servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.Tag;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.junit.jupiter.api.Test;
+
+public class TagSupportTest {
+    @Test
+    void findAncestorWithClassReturnsNearestAssignableParent() {
+        final TagSupport grandparent = new MarkerTag();
+        final TagSupport intermediateParent = new PlainTag();
+        final TagSupport parent = new TagSupport();
+        final TagSupport child = new TagSupport();
+        intermediateParent.setParent(grandparent);
+        parent.setParent(intermediateParent);
+        child.setParent(parent);
+
+        assertThat(TagSupport.findAncestorWithClass(child, Tag.class)).isSameAs(parent);
+        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isSameAs(parent);
+        assertThat(TagSupport.findAncestorWithClass(parent, TagSupportTestMarker.class)).isSameAs(grandparent);
+        assertThat(TagSupport.findAncestorWithClass(parent, PlainTag.class)).isSameAs(intermediateParent);
+    }
+
+    @Test
+    void findAncestorWithClassRejectsInvalidInputsAndMissingAncestors() {
+        final TagSupport child = new TagSupport();
+
+        assertThat(TagSupport.findAncestorWithClass(null, TagSupport.class)).isNull();
+        assertThat(TagSupport.findAncestorWithClass(child, null)).isNull();
+        assertThat(TagSupport.findAncestorWithClass(child, String.class)).isNull();
+        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isNull();
+    }
+
+    @Test
+    void lifecycleMethodsUseDefaultTagContract() throws JspException {
+        final TagSupport tag = new TagSupport();
+
+        assertThat(tag.doStartTag()).isEqualTo(Tag.SKIP_BODY);
+        assertThat(tag.doEndTag()).isEqualTo(Tag.EVAL_PAGE);
+        assertThat(tag.doAfterBody()).isEqualTo(Tag.SKIP_BODY);
+    }
+
+    @Test
+    void stateAccessorsManageIdParentAndValues() {
+        final TagSupport tag = new TagSupport();
+        final TagSupport parent = new TagSupport();
+
+        assertThat(tag.getParent()).isNull();
+        assertThat(tag.getId()).isNull();
+        assertThat(tag.getValue("missing")).isNull();
+        assertThat(tag.getValues()).isNull();
+
+        tag.setParent(parent);
+        tag.setPageContext(null);
+        tag.setId("tagId");
+        tag.setValue("number", Integer.valueOf(42));
+        tag.setValue("text", "value");
+
+        assertThat(tag.getParent()).isSameAs(parent);
+        assertThat(tag.getId()).isEqualTo("tagId");
+        assertThat(tag.getValue("number")).isEqualTo(Integer.valueOf(42));
+        assertThat(tag.getValue("text")).isEqualTo("value");
+        assertThat(Collections.list(tag.getValues())).containsExactlyInAnyOrder("number", "text");
+
+        tag.removeValue("number");
+        assertThat(tag.getValue("number")).isNull();
+        assertThat(Collections.list(tag.getValues())).containsExactly("text");
+
+        tag.release();
+        assertThat(tag.getParent()).isNull();
+        assertThat(tag.getId()).isEqualTo("tagId");
+        assertThat(tag.getValue("text")).isEqualTo("value");
+    }
+
+    private interface TagSupportTestMarker {
+    }
+
+    private static final class MarkerTag extends TagSupport implements TagSupportTestMarker {
+    }
+
+    private static final class PlainTag extends TagSupport {
+    }
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
@@ -7,89 +7,238 @@
 package javax_servlet.servlet_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
 
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.Tag;
-import javax.servlet.jsp.tagext.TagSupport;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletResponseWrapper;
 
 import org.junit.jupiter.api.Test;
 
-public class TagSupportTest {
+class ServletWrapperTest {
     @Test
-    void findAncestorWithClassReturnsNearestAssignableParent() {
-        final TagSupport grandparent = new MarkerTag();
-        final TagSupport intermediateParent = new PlainTag();
-        final TagSupport parent = new TagSupport();
-        final TagSupport child = new TagSupport();
-        intermediateParent.setParent(grandparent);
-        parent.setParent(intermediateParent);
-        child.setParent(parent);
+    void requestWrapperRejectsNullAndTracksWrappedRequests() {
+        final ServletRequest firstRequest = RecordedServletRequest.create("first").asServletRequest();
+        final ServletRequest secondRequest = RecordedServletRequest.create("second").asServletRequest();
+        final ServletRequestWrapper wrapper = new ServletRequestWrapper(firstRequest);
 
-        assertThat(TagSupport.findAncestorWithClass(child, Tag.class)).isSameAs(parent);
-        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isSameAs(parent);
-        assertThat(TagSupport.findAncestorWithClass(parent, TagSupportTestMarker.class)).isSameAs(grandparent);
-        assertThat(TagSupport.findAncestorWithClass(parent, PlainTag.class)).isSameAs(intermediateParent);
-    }
+        assertThatThrownBy(() -> new ServletRequestWrapper(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Request cannot be null");
+        assertThat(wrapper.getRequest()).isSameAs(firstRequest);
 
-    @Test
-    void findAncestorWithClassRejectsInvalidInputsAndMissingAncestors() {
-        final TagSupport child = new TagSupport();
+        wrapper.setRequest(secondRequest);
 
-        assertThat(TagSupport.findAncestorWithClass(null, TagSupport.class)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, null)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, String.class)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isNull();
+        assertThat(wrapper.getRequest()).isSameAs(secondRequest);
     }
 
     @Test
-    void lifecycleMethodsUseDefaultTagContract() throws JspException {
-        final TagSupport tag = new TagSupport();
+    void requestWrapperDelegatesAccessorsAndMutatorsToWrappedRequest() throws Exception {
+        final RecordedServletRequest recordedRequest = RecordedServletRequest.create("request");
+        final ServletRequestWrapper wrapper = new ServletRequestWrapper(recordedRequest.asServletRequest());
 
-        assertThat(tag.doStartTag()).isEqualTo(Tag.SKIP_BODY);
-        assertThat(tag.doEndTag()).isEqualTo(Tag.EVAL_PAGE);
-        assertThat(tag.doAfterBody()).isEqualTo(Tag.SKIP_BODY);
+        wrapper.setCharacterEncoding("UTF-16");
+
+        assertThat(wrapper.getCharacterEncoding()).isEqualTo("UTF-16");
+        assertThat(wrapper.getAttribute("user")).isEqualTo("duke");
+        assertThat(attributeNames(wrapper)).containsExactly("user");
+        assertThat(wrapper.getParameter("mode")).isEqualTo("native");
+        assertThat(wrapper.getRemotePort()).isEqualTo(8443);
+        assertThat(wrapper.getLocalName()).isEqualTo("localhost");
+        assertThat(wrapper.getLocalAddr()).isEqualTo("127.0.0.1");
+        assertThat(wrapper.getLocalPort()).isEqualTo(8080);
+        assertThat(recordedRequest.characterEncoding()).isEqualTo("UTF-16");
     }
 
     @Test
-    void stateAccessorsManageIdParentAndValues() {
-        final TagSupport tag = new TagSupport();
-        final TagSupport parent = new TagSupport();
+    void responseWrapperRejectsNullAndTracksWrappedResponses() {
+        final ServletResponse firstResponse = new RecordedServletResponse().asServletResponse();
+        final ServletResponse secondResponse = new RecordedServletResponse().asServletResponse();
+        final ServletResponseWrapper wrapper = new ServletResponseWrapper(firstResponse);
 
-        assertThat(tag.getParent()).isNull();
-        assertThat(tag.getId()).isNull();
-        assertThat(tag.getValue("missing")).isNull();
-        assertThat(tag.getValues()).isNull();
+        assertThatThrownBy(() -> new ServletResponseWrapper(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Response cannot be null");
+        assertThat(wrapper.getResponse()).isSameAs(firstResponse);
 
-        tag.setParent(parent);
-        tag.setPageContext(null);
-        tag.setId("tagId");
-        tag.setValue("number", Integer.valueOf(42));
-        tag.setValue("text", "value");
+        wrapper.setResponse(secondResponse);
 
-        assertThat(tag.getParent()).isSameAs(parent);
-        assertThat(tag.getId()).isEqualTo("tagId");
-        assertThat(tag.getValue("number")).isEqualTo(Integer.valueOf(42));
-        assertThat(tag.getValue("text")).isEqualTo("value");
-        assertThat(Collections.list(tag.getValues())).containsExactlyInAnyOrder("number", "text");
-
-        tag.removeValue("number");
-        assertThat(tag.getValue("number")).isNull();
-        assertThat(Collections.list(tag.getValues())).containsExactly("text");
-
-        tag.release();
-        assertThat(tag.getParent()).isNull();
-        assertThat(tag.getId()).isEqualTo("tagId");
-        assertThat(tag.getValue("text")).isEqualTo("value");
+        assertThat(wrapper.getResponse()).isSameAs(secondResponse);
     }
 
-    private interface TagSupportTestMarker {
+    @Test
+    void responseWrapperDelegatesAccessorsAndMutatorsToWrappedResponse() throws IOException {
+        final RecordedServletResponse recordedResponse = new RecordedServletResponse();
+        final ServletResponseWrapper wrapper = new ServletResponseWrapper(recordedResponse.asServletResponse());
+
+        wrapper.setCharacterEncoding("UTF-16");
+        wrapper.setContentLength(42);
+        wrapper.setContentType("text/plain");
+        wrapper.setBufferSize(8192);
+        wrapper.setLocale(Locale.CANADA_FRENCH);
+        wrapper.flushBuffer();
+        wrapper.resetBuffer();
+
+        assertThat(wrapper.getCharacterEncoding()).isEqualTo("UTF-16");
+        assertThat(wrapper.getContentType()).isEqualTo("text/plain");
+        assertThat(wrapper.getBufferSize()).isEqualTo(8192);
+        assertThat(wrapper.getLocale()).isEqualTo(Locale.CANADA_FRENCH);
+        assertThat(wrapper.isCommitted()).isTrue();
+        assertThat(recordedResponse.contentLength()).isEqualTo(42);
+        assertThat(recordedResponse.contentType()).isEqualTo("text/plain");
+        assertThat(recordedResponse.bufferReset()).isTrue();
     }
 
-    private static final class MarkerTag extends TagSupport implements TagSupportTestMarker {
+    private static final class RecordedServletRequest {
+        private final String proxyName;
+        private String characterEncoding = "UTF-8";
+
+        private RecordedServletRequest(final String proxyName) {
+            this.proxyName = proxyName;
+        }
+
+        static RecordedServletRequest create(final String proxyName) {
+            return new RecordedServletRequest(proxyName);
+        }
+
+        ServletRequest asServletRequest() {
+            return (ServletRequest) Proxy.newProxyInstance(
+                    ServletWrapperTest.class.getClassLoader(),
+                    new Class<?>[]{ServletRequest.class},
+                    this::handleInvocation);
+        }
+
+        String characterEncoding() {
+            return characterEncoding;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments, proxyName);
+            }
+            return switch (method.getName()) {
+                case "getCharacterEncoding" -> characterEncoding;
+                case "setCharacterEncoding" -> {
+                    characterEncoding = (String) arguments[0];
+                    yield null;
+                }
+                case "getAttribute" -> "user".equals(arguments[0]) ? "duke" : null;
+                case "getAttributeNames" -> namedEnumeration("user");
+                case "getParameter" -> "mode".equals(arguments[0]) ? "native" : null;
+                case "getRemotePort" -> 8443;
+                case "getLocalName" -> "localhost";
+                case "getLocalAddr" -> "127.0.0.1";
+                case "getLocalPort" -> 8080;
+                default -> throw new UnsupportedOperationException(method.toGenericString());
+            };
+        }
     }
 
-    private static final class PlainTag extends TagSupport {
+    private static final class RecordedServletResponse {
+        private int contentLength = -1;
+        private int bufferSize;
+        private String characterEncoding = "ISO-8859-1";
+        private String contentType;
+        private Locale locale = Locale.getDefault();
+        private boolean committed;
+        private boolean bufferReset;
+
+        ServletResponse asServletResponse() {
+            return (ServletResponse) Proxy.newProxyInstance(
+                    ServletWrapperTest.class.getClassLoader(),
+                    new Class<?>[]{ServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        int contentLength() {
+            return contentLength;
+        }
+
+        String contentType() {
+            return contentType;
+        }
+
+        boolean bufferReset() {
+            return bufferReset;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments, "response");
+            }
+            return switch (method.getName()) {
+                case "setCharacterEncoding" -> {
+                    characterEncoding = (String) arguments[0];
+                    yield null;
+                }
+                case "getCharacterEncoding" -> characterEncoding;
+                case "setContentLength" -> {
+                    contentLength = (Integer) arguments[0];
+                    yield null;
+                }
+                case "setContentType" -> {
+                    contentType = (String) arguments[0];
+                    yield null;
+                }
+                case "getContentType" -> contentType;
+                case "setBufferSize" -> {
+                    bufferSize = (Integer) arguments[0];
+                    yield null;
+                }
+                case "getBufferSize" -> bufferSize;
+                case "flushBuffer" -> {
+                    committed = true;
+                    yield null;
+                }
+                case "resetBuffer" -> {
+                    bufferReset = true;
+                    yield null;
+                }
+                case "isCommitted" -> committed;
+                case "setLocale" -> {
+                    locale = (Locale) arguments[0];
+                    yield null;
+                }
+                case "getLocale" -> locale;
+                default -> throw new UnsupportedOperationException(method.toGenericString());
+            };
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> attributeNames(final ServletRequestWrapper wrapper) {
+        return Collections.list((Enumeration<String>) wrapper.getAttributeNames());
+    }
+
+    private static Enumeration<String> namedEnumeration(final String name) {
+        final List<String> names = List.of(name);
+
+        return Collections.enumeration(names);
+    }
+
+    private static boolean isObjectMethod(final Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(
+            final Object proxy,
+            final Method method,
+            final Object[] arguments,
+            final String proxyName) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxyName;
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
     }
 }

--- a/tests/src/javax.servlet/servlet-api/2.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/javax.servlet/servlet-api/2.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.servlet.http.HttpServlet"
+      },
+      "type" : "javax_servlet.servlet_api.HttpServletTest$ExposedHttpServlet"
+    }
+  ]
+}

--- a/tests/src/javax.servlet/servlet-api/2.4/user-code-filter.json
+++ b/tests/src/javax.servlet/servlet-api/2.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4176

This PR provides test fixes and new metadata for javax.servlet:servlet-api:2.4, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 89737
- Cached input tokens: 1431040
- Output tokens: 10296
- Metadata entries: 12
- Test-only metadata entries: 1
- Iterations: 1
- Library coverage percentage: 39.97
- Previous library version metadata entries: 12
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 27.56

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1aa2b45ebe1aa91a830414c0229406d252546ab5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- javax.servlet:servlet-api:2.3: 6/7 covered calls (85.71%)
- javax.servlet:servlet-api:2.4: 7/7 covered calls (100.00%)

**Reflection:**
- javax.servlet:servlet-api:2.3: 1/2 covered calls (50.00%)
- javax.servlet:servlet-api:2.4: 2/2 covered calls (100.00%)

**Resources:**
- javax.servlet:servlet-api:2.3: 5/5 covered calls (100.00%)
- javax.servlet:servlet-api:2.4: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- javax.servlet:servlet-api:2.3: 825/2941 (28.05%)
- javax.servlet:servlet-api:2.4: 841/2144 (39.23%)

**Line:**
- javax.servlet:servlet-api:2.3: 226/820 (27.56%)
- javax.servlet:servlet-api:2.4: 237/593 (39.97%)

**Method:**
- javax.servlet:servlet-api:2.3: 62/334 (18.56%)
- javax.servlet:servlet-api:2.4: 74/235 (31.49%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/javax.servlet/servlet-api/2.3/src/test/java/javax_servlet/servlet_api/CookieTest.java 2/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
index 830ae150d5..a6e046b4b3 100644
--- 1/tests/src/javax.servlet/servlet-api/2.3/src/test/java/javax_servlet/servlet_api/CookieTest.java
+++ 2/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/CookieTest.java
@@ -32,7 +32,7 @@ public class CookieTest {
     void constructorUsesCookieResourceBundleForReservedTokenMessages() {
         assertThatThrownBy(() -> new Cookie("Comment", "ignored"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cookie name Comment is a reserved token");
+                .hasMessage("Cookie name \"Comment\" is a reserved token");
     }
 
     @Test
diff --git 1/tests/src/javax.servlet/servlet-api/2.3/src/test/java/javax_servlet/servlet_api/TagSupportTest.java 2/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
index 3d9ef01cdc..a88c2651bf 100644
--- 1/tests/src/javax.servlet/servlet-api/2.3/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
+++ 2/tests/src/javax.servlet/servlet-api/2.4/src/test/java/javax_servlet/servlet_api/TagSupportTest.java
@@ -7,89 +7,238 @@
 package javax_servlet.servlet_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
 
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.Tag;
-import javax.servlet.jsp.tagext.TagSupport;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletResponseWrapper;
 
 import org.junit.jupiter.api.Test;
 
-public class TagSupportTest {
+class ServletWrapperTest {
     @Test
-    void findAncestorWithClassReturnsNearestAssignableParent() {
-        final TagSupport grandparent = new MarkerTag();
-        final TagSupport intermediateParent = new PlainTag();
-        final TagSupport parent = new TagSupport();
-        final TagSupport child = new TagSupport();
-        intermediateParent.setParent(grandparent);
-        parent.setParent(intermediateParent);
-        child.setParent(parent);
-
-        assertThat(TagSupport.findAncestorWithClass(child, Tag.class)).isSameAs(parent);
-        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isSameAs(parent);
-        assertThat(TagSupport.findAncestorWithClass(parent, TagSupportTestMarker.class)).isSameAs(grandparent);
-        assertThat(TagSupport.findAncestorWithClass(parent, PlainTag.class)).isSameAs(intermediateParent);
+    void requestWrapperRejectsNullAndTracksWrappedRequests() {
+        final ServletRequest firstRequest = RecordedServletRequest.create("first").asServletRequest();
+        final ServletRequest secondRequest = RecordedServletRequest.create("second").asServletRequest();
+        final ServletRequestWrapper wrapper = new ServletRequestWrapper(firstRequest);
+
+        assertThatThrownBy(() -> new ServletRequestWrapper(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Request cannot be null");
+        assertThat(wrapper.getRequest()).isSameAs(firstRequest);
+
+        wrapper.setRequest(secondRequest);
+
+        assertThat(wrapper.getRequest()).isSameAs(secondRequest);
     }
 
     @Test
-    void findAncestorWithClassRejectsInvalidInputsAndMissingAncestors() {
-        final TagSupport child = new TagSupport();
-
-        assertThat(TagSupport.findAncestorWithClass(null, TagSupport.class)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, null)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, String.class)).isNull();
-        assertThat(TagSupport.findAncestorWithClass(child, TagSupport.class)).isNull();
+    void requestWrapperDelegatesAccessorsAndMutatorsToWrappedRequest() throws Exception {
+        final RecordedServletRequest recordedRequest = RecordedServletRequest.create("request");
+        final ServletRequestWrapper wrapper = new ServletRequestWrapper(recordedRequest.asServletRequest());
+
+        wrapper.setCharacterEncoding("UTF-16");
+
+        assertThat(wrapper.getCharacterEncoding()).isEqualTo("UTF-16");
+        assertThat(wrapper.getAttribute("user")).isEqualTo("duke");
+        assertThat(attributeNames(wrapper)).containsExactly("user");
+        assertThat(wrapper.getParameter("mode")).isEqualTo("native");
+        assertThat(wrapper.getRemotePort()).isEqualTo(8443);
+        assertThat(wrapper.getLocalName()).isEqualTo("localhost");
+        assertThat(wrapper.getLocalAddr()).isEqualTo("127.0.0.1");
+        assertThat(wrapper.getLocalPort()).isEqualTo(8080);
+        assertThat(recordedRequest.characterEncoding()).isEqualTo("UTF-16");
     }
 
     @Test
-    void lifecycleMethodsUseDefaultTagContract() throws JspException {
-        final TagSupport tag = new TagSupport();
+    void responseWrapperRejectsNullAndTracksWrappedResponses() {
+        final ServletResponse firstResponse = new RecordedServletResponse().asServletResponse();
+        final ServletResponse secondResponse = new RecordedServletResponse().asServletResponse();
+        final ServletResponseWrapper wrapper = new ServletResponseWrapper(firstResponse);
 
-        assertThat(tag.doStartTag()).isEqualTo(Tag.SKIP_BODY);
-        assertThat(tag.doEndTag()).isEqualTo(Tag.EVAL_PAGE);
-        assertThat(tag.doAfterBody()).isEqualTo(Tag.SKIP_BODY);
+        assertThatThrownBy(() -> new ServletResponseWrapper(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Response cannot be null");
+        assertThat(wrapper.getResponse()).isSameAs(firstResponse);
+
+        wrapper.setResponse(secondResponse);
+
+        assertThat(wrapper.getResponse()).isSameAs(secondResponse);
     }
 
     @Test
-    void stateAccessorsManageIdParentAndValues() {
-        final TagSupport tag = new TagSupport();
-        final TagSupport parent = new TagSupport();
-
-        assertThat(tag.getParent()).isNull();
-        assertThat(tag.getId()).isNull();
-        assertThat(tag.getValue("missing")).isNull();
-        assertThat(tag.getValues()).isNull();
-
-        tag.setParent(parent);
-        tag.setPageContext(null);
-        tag.setId("tagId");
-        tag.setValue("number", Integer.valueOf(42));
-        tag.setValue("text", "value");
-
-        assertThat(tag.getParent()).isSameAs(parent);
-        assertThat(tag.getId()).isEqualTo("tagId");
-        assertThat(tag.getValue("number")).isEqualTo(Integer.valueOf(42));
-        assertThat(tag.getValue("text")).isEqualTo("value");
-        assertThat(Collections.list(tag.getValues())).containsExactlyInAnyOrder("number", "text");
-
-        tag.removeValue("number");
-        assertThat(tag.getValue("number")).isNull();
-        assertThat(Collections.list(tag.getValues())).containsExactly("text");
-
-        tag.release();
-        assertThat(tag.getParent()).isNull();
-        assertThat(tag.getId()).isEqualTo("tagId");
-        assertThat(tag.getValue("text")).isEqualTo("value");
+    void responseWrapperDelegatesAccessorsAndMutatorsToWrappedResponse() throws IOException {
+        final RecordedServletResponse recordedResponse = new RecordedServletResponse();
+        final ServletResponseWrapper wrapper = new ServletResponseWrapper(recordedResponse.asServletResponse());
+
+        wrapper.setCharacterEncoding("UTF-16");
+        wrapper.setContentLength(42);
+        wrapper.setContentType("text/plain");
+        wrapper.setBufferSize(8192);
+        wrapper.setLocale(Locale.CANADA_FRENCH);
+        wrapper.flushBuffer();
+        wrapper.resetBuffer();
+
+        assertThat(wrapper.getCharacterEncoding()).isEqualTo("UTF-16");
+        assertThat(wrapper.getContentType()).isEqualTo("text/plain");
+        assertThat(wrapper.getBufferSize()).isEqualTo(8192);
+        assertThat(wrapper.getLocale()).isEqualTo(Locale.CANADA_FRENCH);
+        assertThat(wrapper.isCommitted()).isTrue();
+        assertThat(recordedResponse.contentLength()).isEqualTo(42);
+        assertThat(recordedResponse.contentType()).isEqualTo("text/plain");
+        assertThat(recordedResponse.bufferReset()).isTrue();
     }
 
-    private interface TagSupportTestMarker {
+    private static final class RecordedServletRequest {
+        private final String proxyName;
+        private String characterEncoding = "UTF-8";
+
+        private RecordedServletRequest(final String proxyName) {
+            this.proxyName = proxyName;
+        }
+
+        static RecordedServletRequest create(final String proxyName) {
+            return new RecordedServletRequest(proxyName);
+        }
+
+        ServletRequest asServletRequest() {
+            return (ServletRequest) Proxy.newProxyInstance(
+                    ServletWrapperTest.class.getClassLoader(),
+                    new Class<?>[]{ServletRequest.class},
+                    this::handleInvocation);
+        }
+
+        String characterEncoding() {
+            return characterEncoding;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments, proxyName);
+            }
+            return switch (method.getName()) {
+                case "getCharacterEncoding" -> characterEncoding;
+                case "setCharacterEncoding" -> {
+                    characterEncoding = (String) arguments[0];
+                    yield null;
+                }
+                case "getAttribute" -> "user".equals(arguments[0]) ? "duke" : null;
+                case "getAttributeNames" -> namedEnumeration("user");
+                case "getParameter" -> "mode".equals(arguments[0]) ? "native" : null;
+                case "getRemotePort" -> 8443;
+                case "getLocalName" -> "localhost";
+                case "getLocalAddr" -> "127.0.0.1";
+                case "getLocalPort" -> 8080;
+                default -> throw new UnsupportedOperationException(method.toGenericString());
+            };
+        }
+    }
+
+    private static final class RecordedServletResponse {
+        private int contentLength = -1;
+        private int bufferSize;
+        private String characterEncoding = "ISO-8859-1";
+        private String contentType;
+        private Locale locale = Locale.getDefault();
+        private boolean committed;
+        private boolean bufferReset;
+
+        ServletResponse asServletResponse() {
+            return (ServletResponse) Proxy.newProxyInstance(
+                    ServletWrapperTest.class.getClassLoader(),
+                    new Class<?>[]{ServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        int contentLength() {
+            return contentLength;
+        }
+
+        String contentType() {
+            return contentType;
+        }
+
+        boolean bufferReset() {
+            return bufferReset;
+        }
+
+        private Object handleInvocation(final Object proxy, final Method method, final Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments, "response");
+            }
+            return switch (method.getName()) {
+                case "setCharacterEncoding" -> {
+                    characterEncoding = (String) arguments[0];
+                    yield null;
+                }
+                case "getCharacterEncoding" -> characterEncoding;
+                case "setContentLength" -> {
+                    contentLength = (Integer) arguments[0];
+                    yield null;
+                }
+                case "setContentType" -> {
+                    contentType = (String) arguments[0];
+                    yield null;
+                }
+                case "getContentType" -> contentType;
+                case "setBufferSize" -> {
+                    bufferSize = (Integer) arguments[0];
+                    yield null;
+                }
+                case "getBufferSize" -> bufferSize;
+                case "flushBuffer" -> {
+                    committed = true;
+                    yield null;
+                }
+                case "resetBuffer" -> {
+                    bufferReset = true;
+                    yield null;
+                }
+                case "isCommitted" -> committed;
+                case "setLocale" -> {
+                    locale = (Locale) arguments[0];
+                    yield null;
+                }
+                case "getLocale" -> locale;
+                default -> throw new UnsupportedOperationException(method.toGenericString());
+            };
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> attributeNames(final ServletRequestWrapper wrapper) {
+        return Collections.list((Enumeration<String>) wrapper.getAttributeNames());
+    }
+
+    private static Enumeration<String> namedEnumeration(final String name) {
+        final List<String> names = List.of(name);
+
+        return Collections.enumeration(names);
     }
 
-    private static final class MarkerTag extends TagSupport implements TagSupportTestMarker {
+    private static boolean isObjectMethod(final Method method) {
+        return method.getDeclaringClass().equals(Object.class);
     }
 
-    private static final class PlainTag extends TagSupport {
+    private static Object handleObjectMethod(
+            final Object proxy,
+            final Method method,
+            final Object[] arguments,
+            final String proxyName) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxyName;
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
     }
 }

```
