### PR TITLE
[GenAI] Test fix for org.mongodb:mongo-java-driver:3.9.0 using gpt-5.5

### DIFF
--- a/metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json
+++ b/metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json
@@ -1,0 +1,258 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.DBCollectionObjectFactory"
+      },
+      "type" : "com.mongodb.BasicDBObject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.ReflectionDBObject$JavaWrapper"
+      },
+      "type" : "com.mongodb.ReflectionDBObject",
+      "methods" : [
+        {
+          "name" : "get_id",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "set_id",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.WriteConcern"
+      },
+      "type" : "com.mongodb.WriteConcern",
+      "fields" : [
+        {
+          "name" : "ACKNOWLEDGED"
+        },
+        {
+          "name" : "FSYNCED"
+        },
+        {
+          "name" : "FSYNC_SAFE"
+        },
+        {
+          "name" : "JOURNALED"
+        },
+        {
+          "name" : "JOURNAL_SAFE"
+        },
+        {
+          "name" : "MAJORITY"
+        },
+        {
+          "name" : "NORMAL"
+        },
+        {
+          "name" : "REPLICAS_SAFE"
+        },
+        {
+          "name" : "REPLICA_ACKNOWLEDGED"
+        },
+        {
+          "name" : "SAFE"
+        },
+        {
+          "name" : "UNACKNOWLEDGED"
+        },
+        {
+          "name" : "W1"
+        },
+        {
+          "name" : "W2"
+        },
+        {
+          "name" : "W3"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.SslHelper"
+      },
+      "type" : "com.mongodb.internal.connection.Java8SniSslHelper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter"
+      },
+      "type" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "parse",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "format",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.types.StringRangeSet"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.jsr310.Jsr310CodecProvider"
+      },
+      "type" : "java.time.Instant"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$Java8DateTimeFormatter"
+      },
+      "type" : "java.time.format.DateTimeFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CollectionPropertyCodecProvider$CollectionCodec"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.MapPropertyCodecProvider$MapCodec"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "type" : "javax.net.ssl.SNIHostName"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter"
+      },
+      "type" : "javax.xml.bind.DatatypeConverter",
+      "methods" : [
+        {
+          "name" : "parseDateTime",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "printDateTime",
+          "parameterTypes" : [
+            "java.util.Calendar"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter"
+      },
+      "type" : "org.bson.json.DateTimeFormatter$Java8DateTimeFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.diagnostics.Loggers"
+      },
+      "type" : "org.slf4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter"
+      },
+      "type" : "sun.util.calendar.JulianCalendar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter"
+      },
+      "glob" : "META-INF/services/javax.xml.datatype.DatatypeFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "module" : "java.base",
+      "glob" : "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/org.mongodb/mongo-java-driver/index.json
+++ b/metadata/org.mongodb/mongo-java-driver/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.9.0",
+    "tested-versions" : [
+      "3.9.0"
+    ],
+    "allowed-packages" : [
+      "com.mongodb",
+      "org.bson"
+    ]
+  },
+  {
     "metadata-version" : "3.4.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.4.0/mongo-java-driver-3.4.0-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/metadata/org.mongodb/mongo-java-driver/index.json
+++ b/metadata/org.mongodb/mongo-java-driver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.9.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.9.0/mongo-java-driver-3.9.0-sources.jar",
+    "repository-url" : "https://github.com/mongodb/mongo-java-driver",
+    "test-code-url" : "https://github.com/mongodb/mongo-java-driver/tree/r3.9.0",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.9.0/mongo-java-driver-3.9.0-javadoc.jar",
+    "description" : "MongoDB Java Driver provides Java APIs for connecting applications to MongoDB and performing database, collection, query, and write operations. The 3.9.0 uber-artifact bundles the legacy driver, mongodb-driver, mongodb-driver-core, and bson modules, including client APIs, protocol support, and BSON encoding and decoding.",
     "tested-versions" : [
       "3.9.0"
     ],

--- a/stats/org.mongodb/mongo-java-driver/3.9.0/execution-metrics.json
+++ b/stats/org.mongodb/mongo-java-driver/3.9.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T08:23:11.068562Z",
+    "library": "org.mongodb:mongo-java-driver:3.9.0",
+    "starting_commit": "cb99ce3c20e7e0041a7a02b15b4ee3fb1a03ba82",
+    "ending_commit": "9a38a7c2599df778f0dcd6070cab574acd04ee57",
+    "previous_library": "org.mongodb:mongo-java-driver:3.4.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 33,
+            "totalCalls": 33
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 33,
+        "totalCalls": 33
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10573,
+          "missed": 138826,
+          "ratio": 0.07077,
+          "total": 149399
+        },
+        "line": {
+          "covered": 2495,
+          "missed": 29582,
+          "ratio": 0.077782,
+          "total": 32077
+        },
+        "method": {
+          "covered": 757,
+          "missed": 8794,
+          "ratio": 0.079259,
+          "total": 9551
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1321,
+          "missed": 119926,
+          "ratio": 0.010895,
+          "total": 121247
+        },
+        "line": {
+          "covered": 296,
+          "missed": 25553,
+          "ratio": 0.011451,
+          "total": 25849
+        },
+        "method": {
+          "covered": 92,
+          "missed": 7654,
+          "ratio": 0.011877,
+          "total": 7746
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 393889,
+      "cached_input_tokens_used": 4920320,
+      "output_tokens_used": 52290,
+      "iterations": 11,
+      "cost_usd": 4.0289,
+      "tested_library_loc": 2495,
+      "metadata_entries": 50,
+      "test_only_metadata_entries": 28,
+      "previous_library_metadata_entries": 28,
+      "code_coverage_percent": 7.78,
+      "previous_library_coverage_percent": 1.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java",
+      "metadata_file": "metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.mongodb/mongo-java-driver/3.9.0/stats.json
+++ b/stats/org.mongodb/mongo-java-driver/3.9.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.9.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 33,
+          "totalCalls" : 33
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 33,
+      "totalCalls" : 33
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10573,
+        "missed" : 138826,
+        "ratio" : 0.07077,
+        "total" : 149399
+      },
+      "line" : {
+        "covered" : 2495,
+        "missed" : 29582,
+        "ratio" : 0.077782,
+        "total" : 32077
+      },
+      "method" : {
+        "covered" : 757,
+        "missed" : 8794,
+        "ratio" : 0.079259,
+        "total" : 9551
+      }
+    }
+  } ]
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/.gitignore
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.mongodb:mongo-java-driver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.mongodb:mongo-java-driver:$libraryVersion"
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/gradle.properties
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.mongodb:mongo-java-driver:3.9.0
+library.version = 3.9.0
+metadata.dir = org.mongodb/mongo-java-driver/3.9.0/

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/settings.gradle
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.mongodb.mongo-java-driver_tests'

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CollectionPropertyCodecProviderInnerCollectionCodecTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CollectionPropertyCodecProviderInnerCollectionCodecTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class CollectionPropertyCodecProviderInnerCollectionCodecTest {
+    @Test
+    void decodesPojoConcreteCollectionProperty() {
+        final BsonDocument document = new BsonDocument("tags", new BsonArray(
+                Arrays.asList(new BsonString("alpha"), new BsonString("beta"))));
+
+        final ConcreteCollectionPojo pojo = decode(ConcreteCollectionPojo.class, document);
+
+        assertThat(pojo.tags).isInstanceOf(ArrayList.class);
+        assertThat(pojo.tags).containsExactly("alpha", "beta");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static class ConcreteCollectionPojo {
+        public ArrayList<String> tags;
+
+        public ConcreteCollectionPojo() {
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Convention;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.json.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest {
+    @Test
+    void decodesPrivateFieldWithoutSetterWhenConventionIsEnabled() {
+        final PrivateFieldOnlyPojo pojo = decode(PrivateFieldOnlyPojo.class, "{ 'name': 'decoded-private-field' }");
+
+        assertThat(pojo.getName()).isEqualTo("decoded-private-field");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final String json) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder()
+                        .conventions(privateFieldConventions())
+                        .register(pojoClass)
+                        .build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new JsonReader(json), DecoderContext.builder().build());
+    }
+
+    private static List<Convention> privateFieldConventions() {
+        return asList(
+                Conventions.CLASS_AND_PROPERTY_CONVENTION,
+                Conventions.ANNOTATION_CONVENTION,
+                Conventions.SET_PRIVATE_FIELDS_CONVENTION);
+    }
+
+    public static class PrivateFieldOnlyPojo {
+        private String name;
+
+        public PrivateFieldOnlyPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.json.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class CreatorExecutableTest {
+    @Test
+    void decodesPojoWithPublicNoArgumentConstructor() {
+        final DefaultConstructedPojo pojo = decode(DefaultConstructedPojo.class, "{ 'name': 'default', 'count': 7 }");
+
+        assertThat(pojo.getName()).isEqualTo("default");
+        assertThat(pojo.getCount()).isEqualTo(7);
+    }
+
+    @Test
+    void decodesPojoWithNoArgumentCreatorMethod() {
+        final NoArgumentFactoryPojo pojo = decode(NoArgumentFactoryPojo.class, "{ 'name': 'factory', 'count': 11 }");
+
+        assertThat(pojo.getName()).isEqualTo("factory");
+        assertThat(pojo.getCount()).isEqualTo(11);
+        assertThat(pojo.isCreatedByFactory()).isTrue();
+    }
+
+    @Test
+    void decodesPojoWithCreatorConstructorParameters() {
+        final ConstructorCreatedPojo pojo = decode(
+                ConstructorCreatedPojo.class, "{ 'name': 'constructor', 'count': 13 }");
+
+        assertThat(pojo.getName()).isEqualTo("constructor");
+        assertThat(pojo.getCount()).isEqualTo(13);
+    }
+
+    @Test
+    void decodesPojoWithCreatorMethodParameters() {
+        final MethodCreatedPojo pojo = decode(MethodCreatedPojo.class, "{ 'name': 'method', 'count': 17 }");
+
+        assertThat(pojo.getName()).isEqualTo("method");
+        assertThat(pojo.getCount()).isEqualTo(17);
+        assertThat(pojo.isCreatedByFactory()).isTrue();
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final String json) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new JsonReader(json), DecoderContext.builder().build());
+    }
+
+    public static class DefaultConstructedPojo {
+        private String name;
+        private int count;
+
+        public DefaultConstructedPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+    }
+
+    public static class NoArgumentFactoryPojo {
+        private String name;
+        private int count;
+        private boolean createdByFactory;
+
+        public NoArgumentFactoryPojo() {
+        }
+
+        @BsonCreator
+        public static NoArgumentFactoryPojo create() {
+            final NoArgumentFactoryPojo pojo = new NoArgumentFactoryPojo();
+            pojo.createdByFactory = true;
+            return pojo;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+
+        public boolean isCreatedByFactory() {
+            return createdByFactory;
+        }
+    }
+
+    public static class ConstructorCreatedPojo {
+        private final String name;
+        private final int count;
+
+        @BsonCreator
+        public ConstructorCreatedPojo(@BsonProperty("name") final String name, @BsonProperty("count") final int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+    }
+
+    public static class MethodCreatedPojo {
+        private final String name;
+        private final int count;
+        private final boolean createdByFactory;
+
+        public MethodCreatedPojo() {
+            this(null, 0, false);
+        }
+
+        private MethodCreatedPojo(final String name, final int count, final boolean createdByFactory) {
+            this.name = name;
+            this.count = count;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @BsonCreator
+        public static MethodCreatedPojo create(@BsonProperty("name") final String name,
+                                               @BsonProperty("count") final int count) {
+            return new MethodCreatedPojo(name, count, true);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public boolean isCreatedByFactory() {
+            return createdByFactory;
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DBCollectionObjectFactoryTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DBCollectionObjectFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DefaultDBCallback;
+import org.bson.BSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DBCollectionObjectFactoryTest {
+    @Test
+    void defaultCallbackCreatesBasicDBObjectInstances() {
+        final DefaultDBCallback callback = new DefaultDBCallback(null);
+
+        final BSONObject document = callback.create();
+
+        document.put("name", "mongo");
+        assertThat(document).isInstanceOf(BasicDBObject.class);
+        assertThat(document.get("name")).isEqualTo("mongo");
+    }
+
+    @Test
+    void defaultCallbackCreatesBasicDBObjectForNestedDocumentPath() {
+        final DefaultDBCallback callback = new DefaultDBCallback(null);
+
+        final BSONObject document = callback.create(false, Arrays.asList("outer", "inner"));
+
+        document.put("nested", true);
+        assertThat(document).isInstanceOf(BasicDBObject.class);
+        assertThat(document.get("nested")).isEqualTo(true);
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterInnerJaxbDateTimeFormatterTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterInnerJaxbDateTimeFormatterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateTimeFormatterInnerJaxbDateTimeFormatterTest {
+    private static final String JAXB_FORMATTER_CLASS_NAME = "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter";
+    private static final String DATE_TIME_STRING = "2019-01-02T03:04:05Z";
+
+    @Test
+    void parsesAndFormatsIsoDateTimesThroughJaxbFallback() throws ReflectiveOperationException {
+        final Object formatter = newJaxbDateTimeFormatter();
+        final long expectedEpochMillis = Instant.parse(DATE_TIME_STRING).toEpochMilli();
+
+        final long parsedEpochMillis = parse(formatter, DATE_TIME_STRING);
+        final String formattedDateTime = format(formatter, parsedEpochMillis);
+
+        assertThat(parsedEpochMillis).isEqualTo(expectedEpochMillis);
+        assertThat(parse(formatter, formattedDateTime)).isEqualTo(expectedEpochMillis);
+    }
+
+    private static Object newJaxbDateTimeFormatter() throws ReflectiveOperationException {
+        final Constructor<?> constructor = Class.forName(JAXB_FORMATTER_CLASS_NAME).getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static long parse(final Object formatter, final String dateTimeString) throws ReflectiveOperationException {
+        final Method parseMethod = formatter.getClass().getDeclaredMethod("parse", String.class);
+        parseMethod.setAccessible(true);
+        return (Long) parseMethod.invoke(formatter, dateTimeString);
+    }
+
+    private static String format(final Object formatter, final long epochMillis) throws ReflectiveOperationException {
+        final Method formatMethod = formatter.getClass().getDeclaredMethod("format", long.class);
+        formatMethod.setAccessible(true);
+        return (String) formatMethod.invoke(formatter, epochMillis);
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateTimeFormatterTest {
+    private static final String DATE_TIME_STRING = "2019-01-02T03:04:05.006Z";
+
+    @Test
+    void parsesExtendedJsonDateString() {
+        final long expectedEpochMillis = Instant.parse(DATE_TIME_STRING).toEpochMilli();
+        final BsonDocument document = BsonDocument.parse("{\"createdAt\": {\"$date\": \"" + DATE_TIME_STRING + "\"}}");
+
+        assertThat(document.getDateTime("createdAt").getValue()).isEqualTo(expectedEpochMillis);
+    }
+
+    @Test
+    void writesRelaxedExtendedJsonDateString() {
+        final BsonDateTime dateTime = new BsonDateTime(Instant.parse(DATE_TIME_STRING).toEpochMilli());
+        final BsonDocument document = new BsonDocument("createdAt", dateTime);
+        final JsonWriterSettings settings = JsonWriterSettings.builder()
+                .outputMode(JsonMode.RELAXED)
+                .build();
+
+        assertThat(document.toJson(settings)).contains("\"$date\" : \"" + DATE_TIME_STRING + "\"");
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DiscriminatorLookupTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DiscriminatorLookupTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.ClassModel;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class DiscriminatorLookupTest {
+    @Test
+    void resolvesPojoSubtypeFromDiscriminatorClassName() {
+        final Codec<BaseDiscriminatedPojo> codec = codecFor(BaseDiscriminatedPojo.class);
+        final BsonDocument document = new BsonDocument()
+                .append("_t", new BsonString(ResolvedDiscriminatedPojo.class.getName()))
+                .append("name", new BsonString("resolved-by-discriminator"))
+                .append("rank", new BsonInt32(7));
+
+        final BaseDiscriminatedPojo decoded = codec.decode(
+                new BsonDocumentReader(document), DecoderContext.builder().build());
+
+        assertThat(decoded).isInstanceOf(ResolvedDiscriminatedPojo.class);
+        final ResolvedDiscriminatedPojo resolved = (ResolvedDiscriminatedPojo) decoded;
+        assertThat(resolved.getName()).isEqualTo("resolved-by-discriminator");
+        assertThat(resolved.getRank()).isEqualTo(7);
+    }
+
+    private static <T> Codec<T> codecFor(final Class<T> pojoClass) {
+        final ClassModel<T> classModel = ClassModel.builder(pojoClass)
+                .enableDiscriminator(true)
+                .discriminatorKey("_t")
+                .discriminator(pojoClass.getName())
+                .build();
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder()
+                        .automatic(true)
+                        .register(classModel)
+                        .build()));
+        return registry.get(pojoClass);
+    }
+
+    public static class BaseDiscriminatedPojo {
+        private String name;
+
+        public BaseDiscriminatedPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+
+    public static class ResolvedDiscriminatedPojo extends BaseDiscriminatedPojo {
+        private int rank;
+
+        public ResolvedDiscriminatedPojo() {
+        }
+
+        public int getRank() {
+            return rank;
+        }
+
+        public void setRank(final int rank) {
+            this.rank = rank;
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class MapPropertyCodecProviderInnerMapCodecTest {
+    @Test
+    void decodesPojoConcreteMapProperty() {
+        final BsonDocument document = new BsonDocument("attributes", new BsonDocument()
+                .append("first", new BsonString("alpha"))
+                .append("second", new BsonString("beta")));
+
+        final ConcreteMapPojo pojo = decode(ConcreteMapPojo.class, document);
+
+        assertThat(pojo.attributes).isInstanceOf(HashMap.class);
+        assertThat(pojo.attributes).containsEntry("first", "alpha");
+        assertThat(pojo.attributes).containsEntry("second", "beta");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static class ConcreteMapPojo {
+        public HashMap<String, String> attributes;
+
+        public ConcreteMapPojo() {
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/PropertyAccessorImplTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/PropertyAccessorImplTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class PropertyAccessorImplTest {
+    @Test
+    void encodesPojoPropertyThroughGetter() {
+        final GetterPojo pojo = new GetterPojo();
+        pojo.setName("getter-value");
+
+        final BsonDocument document = encode(GetterPojo.class, pojo);
+
+        assertThat(document.getString("name").getValue()).isEqualTo("getter-value");
+    }
+
+    @Test
+    void encodesAndDecodesPublicFieldProperties() {
+        final PublicFieldPojo pojo = new PublicFieldPojo();
+        pojo.name = "field-value";
+        pojo.count = 42;
+
+        final BsonDocument document = encode(PublicFieldPojo.class, pojo);
+        final PublicFieldPojo decoded = decode(PublicFieldPojo.class, document);
+
+        assertThat(document.getString("name").getValue()).isEqualTo("field-value");
+        assertThat(document.getInt32("count").getValue()).isEqualTo(42);
+        assertThat(decoded.name).isEqualTo("field-value");
+        assertThat(decoded.count).isEqualTo(42);
+    }
+
+    private static <T> BsonDocument encode(final Class<T> pojoClass, final T value) {
+        final BsonDocument document = new BsonDocument();
+        codecFor(pojoClass).encode(new BsonDocumentWriter(document), value, EncoderContext.builder().build());
+        return document;
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        return codecFor(pojoClass).decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    private static <T> Codec<T> codecFor(final Class<T> pojoClass) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        return registry.get(pojoClass);
+    }
+
+    public static class GetterPojo {
+        private String name;
+
+        public GetterPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+
+    public static class PublicFieldPojo {
+        public String name;
+        public int count;
+
+        public PublicFieldPojo() {
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ReflectionDBObjectInnerJavaWrapperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ReflectionDBObjectInnerJavaWrapperTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.ReflectionDBObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionDBObjectInnerJavaWrapperTest {
+    @Test
+    void wrapperDiscoversAndInvokesReflectionDBObjectAccessors() {
+        final ReflectionDBObject.JavaWrapper wrapper = ReflectionDBObject.getWrapper(ReflectionDBObject.class);
+        final ReflectionDocument document = new ReflectionDocument();
+
+        final Object setterResult = wrapper.set(document, "_id", "document-1");
+        final Object value = wrapper.get(document, "_id");
+
+        assertThat(wrapper.keySet()).contains("_id");
+        assertThat(setterResult).isNull();
+        assertThat(value).isEqualTo("document-1");
+        assertThat(document.get_id()).isEqualTo("document-1");
+    }
+
+    private static final class ReflectionDocument extends ReflectionDBObject {
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.internal.connection.SslHelper;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SslHelperTest {
+    @Test
+    void enablesHostNameVerificationForSslParameters() {
+        final SSLParameters sslParameters = new SSLParameters();
+
+        SslHelper.enableHostNameVerification(sslParameters);
+
+        assertThat(sslParameters.getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void enablesServerNameIndicationForHostNames() {
+        final SSLParameters sslParameters = new SSLParameters();
+        final ServerAddress address = new ServerAddress("example.mongodb.local");
+
+        SslHelper.enableSni(address, sslParameters);
+
+        final List<SNIServerName> serverNames = sslParameters.getServerNames();
+        assertThat(serverNames).hasSize(1);
+        assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
+        final SNIHostName serverName = (SNIHostName) serverNames.get(0);
+        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -6,7 +6,6 @@
  */
 package org_mongodb.mongo_java_driver;
 
-import com.mongodb.ServerAddress;
 import com.mongodb.internal.connection.SslHelper;
 import org.junit.jupiter.api.Test;
 
@@ -31,14 +30,14 @@ public class SslHelperTest {
     @Test
     void enablesServerNameIndicationForHostNames() {
         final SSLParameters sslParameters = new SSLParameters();
-        final ServerAddress address = new ServerAddress("example.mongodb.local");
+        final String host = "example.mongodb.local";
 
-        SslHelper.enableSni(address, sslParameters);
+        SslHelper.enableSni(host, sslParameters);
 
         final List<SNIServerName> serverNames = sslParameters.getServerNames();
         assertThat(serverNames).hasSize(1);
         assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
         final SNIHostName serverName = (SNIHostName) serverNames.get(0);
-        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+        assertThat(serverName.getAsciiName()).isEqualTo(host);
     }
 }

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/StringRangeSetTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/StringRangeSetTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.types.BasicBSONList;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringRangeSetTest {
+    @Test
+    void keySetCanCreateTypedArrayForAllListIndexes() {
+        final BasicBSONList list = new BasicBSONList();
+        list.put(0, "zero");
+        list.put(3, "three");
+
+        final Set<String> keys = list.keySet();
+        final String[] keyArray = keys.toArray(new String[0]);
+
+        assertThat(keyArray).containsExactly("0", "1", "2", "3");
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/WriteConcernTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/WriteConcernTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.WriteConcern;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WriteConcernTest {
+    @Test
+    void namedWriteConcernsAreDiscoveredCaseInsensitively() {
+        assertThat(WriteConcern.valueOf("acknowledged")).isSameAs(WriteConcern.ACKNOWLEDGED);
+        assertThat(WriteConcern.valueOf("W1")).isSameAs(WriteConcern.W1);
+        assertThat(WriteConcern.valueOf("w2")).isSameAs(WriteConcern.W2);
+        assertThat(WriteConcern.valueOf("w3")).isSameAs(WriteConcern.W3);
+        assertThat(WriteConcern.valueOf("unacknowledged")).isSameAs(WriteConcern.UNACKNOWLEDGED);
+        assertThat(WriteConcern.valueOf("majority")).isSameAs(WriteConcern.MAJORITY);
+        assertThat(WriteConcern.valueOf("unknown")).isNull();
+    }
+
+    @Test
+    void writeConcernOptionsProduceExpectedDocument() {
+        final WriteConcern concern = WriteConcern.MAJORITY
+                .withWTimeout(2, TimeUnit.SECONDS)
+                .withJournal(true);
+
+        final BsonDocument document = concern.asDocument();
+
+        assertThat(concern.isAcknowledged()).isTrue();
+        assertThat(concern.getWString()).isEqualTo("majority");
+        assertThat(concern.getWTimeout(TimeUnit.MILLISECONDS)).isEqualTo(2000);
+        assertThat(concern.getJournal()).isTrue();
+        assertThat(document.getString("w")).isEqualTo(new BsonString("majority"));
+        assertThat(document.getInt32("wtimeout").getValue()).isEqualTo(2000);
+        assertThat(document.getBoolean("j").getValue()).isTrue();
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/mongo-java-driver-tests/reflect-config.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/mongo-java-driver-tests/reflect-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "org_mongodb.mongo_java_driver.ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest$PrivateFieldOnlyPojo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/mongo-java-driver-tests/reflect-config.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/mongo-java-driver-tests/reflect-config.json
@@ -4,5 +4,17 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$BaseDiscriminatedPojo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$ResolvedDiscriminatedPojo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,175 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CollectionPropertyCodecProviderInnerCollectionCodecTest$ConcreteCollectionPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionSetPrivateFieldImpl$PrivateProperyAccessor"
+      },
+      "type" : "org_mongodb.mongo_java_driver.ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest$PrivateFieldOnlyPojo",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest$PrivateFieldOnlyPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorCreatedPojo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorCreatedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$DefaultConstructedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$MethodCreatedPojo",
+      "methods" : [
+        {
+          "name" : "create",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$MethodCreatedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentFactoryPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.AutomaticPojoCodec"
+      },
+      "type" : "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$BaseDiscriminatedPojo",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$BaseDiscriminatedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.AutomaticPojoCodec"
+      },
+      "type" : "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$ResolvedDiscriminatedPojo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setRank",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.DiscriminatorLookup"
+      },
+      "type" : "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$ResolvedDiscriminatedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.DiscriminatorLookupTest$ResolvedDiscriminatedPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.MapPropertyCodecProviderInnerMapCodecTest$ConcreteMapPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.PropertyAccessorImplTest$GetterPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyAccessorImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.PropertyAccessorImplTest$GetterPojo",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoCodecProvider"
+      },
+      "type" : "org_mongodb.mongo_java_driver.PropertyAccessorImplTest$PublicFieldPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyAccessorImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.PropertyAccessorImplTest$PublicFieldPojo",
+      "fields" : [
+        {
+          "name" : "count"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/user-code-filter.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.mongodb.**"
+    },
+    {
+      "includeClasses" : "org.bson.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4180

This PR provides test fixes and new metadata for org.mongodb:mongo-java-driver:3.9.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 393889
- Cached input tokens: 4920320
- Output tokens: 52290
- Metadata entries: 50
- Test-only metadata entries: 28
- Iterations: 11
- Library coverage percentage: 7.78
- Previous library version metadata entries: 28
- Previous library version coverage percentage: 1.15

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1aa2b45ebe1aa91a830414c0229406d252546ab5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.mongodb:mongo-java-driver:3.4.0: 8/8 covered calls (100.00%)
- org.mongodb:mongo-java-driver:3.9.0: 33/33 covered calls (100.00%)

**Reflection:**
- org.mongodb:mongo-java-driver:3.4.0: 8/8 covered calls (100.00%)
- org.mongodb:mongo-java-driver:3.9.0: 33/33 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.mongodb:mongo-java-driver:3.4.0: 1321/121247 (1.09%)
- org.mongodb:mongo-java-driver:3.9.0: 10573/149399 (7.08%)

**Line:**
- org.mongodb:mongo-java-driver:3.4.0: 296/25849 (1.15%)
- org.mongodb:mongo-java-driver:3.9.0: 2495/32077 (7.78%)

**Method:**
- org.mongodb:mongo-java-driver:3.4.0: 92/7746 (1.19%)
- org.mongodb:mongo-java-driver:3.9.0: 757/9551 (7.93%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/build.gradle 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
index 701d5ebbbf..261a03c1b1 100644
--- 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/build.gradle
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.mongodb:mongo-java-driver:$libraryVersion"
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CollectionPropertyCodecProviderInnerCollectionCodecTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CollectionPropertyCodecProviderInnerCollectionCodecTest.java
new file mode 100644
index 0000000000..ef41beb658
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CollectionPropertyCodecProviderInnerCollectionCodecTest.java
@@ -0,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class CollectionPropertyCodecProviderInnerCollectionCodecTest {
+    @Test
+    void decodesPojoConcreteCollectionProperty() {
+        final BsonDocument document = new BsonDocument("tags", new BsonArray(
+                Arrays.asList(new BsonString("alpha"), new BsonString("beta"))));
+
+        final ConcreteCollectionPojo pojo = decode(ConcreteCollectionPojo.class, document);
+
+        assertThat(pojo.tags).isInstanceOf(ArrayList.class);
+        assertThat(pojo.tags).containsExactly("alpha", "beta");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static class ConcreteCollectionPojo {
+        public ArrayList<String> tags;
+
+        public ConcreteCollectionPojo() {
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest.java
new file mode 100644
index 0000000000..bdf6dcfd40
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest.java
@@ -0,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Convention;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.json.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class ConventionSetPrivateFieldImplInnerPrivateProperyAccessorTest {
+    @Test
+    void decodesPrivateFieldWithoutSetterWhenConventionIsEnabled() {
+        final PrivateFieldOnlyPojo pojo = decode(PrivateFieldOnlyPojo.class, "{ 'name': 'decoded-private-field' }");
+
+        assertThat(pojo.getName()).isEqualTo("decoded-private-field");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final String json) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder()
+                        .conventions(privateFieldConventions())
+                        .register(pojoClass)
+                        .build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new JsonReader(json), DecoderContext.builder().build());
+    }
+
+    private static List<Convention> privateFieldConventions() {
+        return asList(
+                Conventions.CLASS_AND_PROPERTY_CONVENTION,
+                Conventions.ANNOTATION_CONVENTION,
+                Conventions.SET_PRIVATE_FIELDS_CONVENTION);
+    }
+
+    public static class PrivateFieldOnlyPojo {
+        private String name;
+
+        public PrivateFieldOnlyPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
new file mode 100644
index 0000000000..b9cc361126
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
@@ -0,0 +1,179 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.json.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class CreatorExecutableTest {
+    @Test
+    void decodesPojoWithPublicNoArgumentConstructor() {
+        final DefaultConstructedPojo pojo = decode(DefaultConstructedPojo.class, "{ 'name': 'default', 'count': 7 }");
+
+        assertThat(pojo.getName()).isEqualTo("default");
+        assertThat(pojo.getCount()).isEqualTo(7);
+    }
+
+    @Test
+    void decodesPojoWithNoArgumentCreatorMethod() {
+        final NoArgumentFactoryPojo pojo = decode(NoArgumentFactoryPojo.class, "{ 'name': 'factory', 'count': 11 }");
+
+        assertThat(pojo.getName()).isEqualTo("factory");
+        assertThat(pojo.getCount()).isEqualTo(11);
+        assertThat(pojo.isCreatedByFactory()).isTrue();
+    }
+
+    @Test
+    void decodesPojoWithCreatorConstructorParameters() {
+        final ConstructorCreatedPojo pojo = decode(
+                ConstructorCreatedPojo.class, "{ 'name': 'constructor', 'count': 13 }");
+
+        assertThat(pojo.getName()).isEqualTo("constructor");
+        assertThat(pojo.getCount()).isEqualTo(13);
+    }
+
+    @Test
+    void decodesPojoWithCreatorMethodParameters() {
+        final MethodCreatedPojo pojo = decode(MethodCreatedPojo.class, "{ 'name': 'method', 'count': 17 }");
+
+        assertThat(pojo.getName()).isEqualTo("method");
+        assertThat(pojo.getCount()).isEqualTo(17);
+        assertThat(pojo.isCreatedByFactory()).isTrue();
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final String json) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new JsonReader(json), DecoderContext.builder().build());
+    }
+
+    public static class DefaultConstructedPojo {
+        private String name;
+        private int count;
+
+        public DefaultConstructedPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+    }
+
+    public static class NoArgumentFactoryPojo {
+        private String name;
+        private int count;
+        private boolean createdByFactory;
+
+        public NoArgumentFactoryPojo() {
+        }
+
+        @BsonCreator
+        public static NoArgumentFactoryPojo create() {
+            final NoArgumentFactoryPojo pojo = new NoArgumentFactoryPojo();
+            pojo.createdByFactory = true;
+            return pojo;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+
+        public boolean isCreatedByFactory() {
+            return createdByFactory;
+        }
+    }
+
+    public static class ConstructorCreatedPojo {
+        private final String name;
+        private final int count;
+
+        @BsonCreator
+        public ConstructorCreatedPojo(@BsonProperty("name") final String name, @BsonProperty("count") final int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+    }
+
+    public static class MethodCreatedPojo {
+        private final String name;
+        private final int count;
+        private final boolean createdByFactory;
+
+        public MethodCreatedPojo() {
+            this(null, 0, false);
+        }
+
+        private MethodCreatedPojo(final String name, final int count, final boolean createdByFactory) {
+            this.name = name;
+            this.count = count;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @BsonCreator
+        public static MethodCreatedPojo create(@BsonProperty("name") final String name,
+                                               @BsonProperty("count") final int count) {
+            return new MethodCreatedPojo(name, count, true);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public boolean isCreatedByFactory() {
+            return createdByFactory;
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterInnerJaxbDateTimeFormatterTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterInnerJaxbDateTimeFormatterTest.java
new file mode 100644
index 0000000000..478561ef27
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterInnerJaxbDateTimeFormatterTest.java
@@ -0,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateTimeFormatterInnerJaxbDateTimeFormatterTest {
+    private static final String JAXB_FORMATTER_CLASS_NAME = "org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter";
+    private static final String DATE_TIME_STRING = "2019-01-02T03:04:05Z";
+
+    @Test
+    void parsesAndFormatsIsoDateTimesThroughJaxbFallback() throws ReflectiveOperationException {
+        final Object formatter = newJaxbDateTimeFormatter();
+        final long expectedEpochMillis = Instant.parse(DATE_TIME_STRING).toEpochMilli();
+
+        final long parsedEpochMillis = parse(formatter, DATE_TIME_STRING);
+        final String formattedDateTime = format(formatter, parsedEpochMillis);
+
+        assertThat(parsedEpochMillis).isEqualTo(expectedEpochMillis);
+        assertThat(parse(formatter, formattedDateTime)).isEqualTo(expectedEpochMillis);
+    }
+
+    private static Object newJaxbDateTimeFormatter() throws ReflectiveOperationException {
+        final Constructor<?> constructor = Class.forName(JAXB_FORMATTER_CLASS_NAME).getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static long parse(final Object formatter, final String dateTimeString) throws ReflectiveOperationException {
+        final Method parseMethod = formatter.getClass().getDeclaredMethod("parse", String.class);
+        parseMethod.setAccessible(true);
+        return (Long) parseMethod.invoke(formatter, dateTimeString);
+    }
+
+    private static String format(final Object formatter, final long epochMillis) throws ReflectiveOperationException {
+        final Method formatMethod = formatter.getClass().getDeclaredMethod("format", long.class);
+        formatMethod.setAccessible(true);
+        return (String) formatMethod.invoke(formatter, epochMillis);
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterTest.java
new file mode 100644
index 0000000000..010c5830d2
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DateTimeFormatterTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateTimeFormatterTest {
+    private static final String DATE_TIME_STRING = "2019-01-02T03:04:05.006Z";
+
+    @Test
+    void parsesExtendedJsonDateString() {
+        final long expectedEpochMillis = Instant.parse(DATE_TIME_STRING).toEpochMilli();
+        final BsonDocument document = BsonDocument.parse("{\"createdAt\": {\"$date\": \"" + DATE_TIME_STRING + "\"}}");
+
+        assertThat(document.getDateTime("createdAt").getValue()).isEqualTo(expectedEpochMillis);
+    }
+
+    @Test
+    void writesRelaxedExtendedJsonDateString() {
+        final BsonDateTime dateTime = new BsonDateTime(Instant.parse(DATE_TIME_STRING).toEpochMilli());
+        final BsonDocument document = new BsonDocument("createdAt", dateTime);
+        final JsonWriterSettings settings = JsonWriterSettings.builder()
+                .outputMode(JsonMode.RELAXED)
+                .build();
+
+        assertThat(document.toJson(settings)).contains("\"$date\" : \"" + DATE_TIME_STRING + "\"");
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DiscriminatorLookupTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DiscriminatorLookupTest.java
new file mode 100644
index 0000000000..50694f8f4c
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DiscriminatorLookupTest.java
@@ -0,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.ClassModel;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class DiscriminatorLookupTest {
+    @Test
+    void resolvesPojoSubtypeFromDiscriminatorClassName() {
+        final Codec<BaseDiscriminatedPojo> codec = codecFor(BaseDiscriminatedPojo.class);
+        final BsonDocument document = new BsonDocument()
+                .append("_t", new BsonString(ResolvedDiscriminatedPojo.class.getName()))
+                .append("name", new BsonString("resolved-by-discriminator"))
+                .append("rank", new BsonInt32(7));
+
+        final BaseDiscriminatedPojo decoded = codec.decode(
+                new BsonDocumentReader(document), DecoderContext.builder().build());
+
+        assertThat(decoded).isInstanceOf(ResolvedDiscriminatedPojo.class);
+        final ResolvedDiscriminatedPojo resolved = (ResolvedDiscriminatedPojo) decoded;
+        assertThat(resolved.getName()).isEqualTo("resolved-by-discriminator");
+        assertThat(resolved.getRank()).isEqualTo(7);
+    }
+
+    private static <T> Codec<T> codecFor(final Class<T> pojoClass) {
+        final ClassModel<T> classModel = ClassModel.builder(pojoClass)
+                .enableDiscriminator(true)
+                .discriminatorKey("_t")
+                .discriminator(pojoClass.getName())
+                .build();
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder()
+                        .automatic(true)
+                        .register(classModel)
+                        .build()));
+        return registry.get(pojoClass);
+    }
+
+    public static class BaseDiscriminatedPojo {
+        private String name;
+
+        public BaseDiscriminatedPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+
+    public static class ResolvedDiscriminatedPojo extends BaseDiscriminatedPojo {
+        private int rank;
+
+        public ResolvedDiscriminatedPojo() {
+        }
+
+        public int getRank() {
+            return rank;
+        }
+
+        public void setRank(final int rank) {
+            this.rank = rank;
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java
new file mode 100644
index 0000000000..b0503e5ba5
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/MapPropertyCodecProviderInnerMapCodecTest.java
@@ -0,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class MapPropertyCodecProviderInnerMapCodecTest {
+    @Test
+    void decodesPojoConcreteMapProperty() {
+        final BsonDocument document = new BsonDocument("attributes", new BsonDocument()
+                .append("first", new BsonString("alpha"))
+                .append("second", new BsonString("beta")));
+
+        final ConcreteMapPojo pojo = decode(ConcreteMapPojo.class, document);
+
+        assertThat(pojo.attributes).isInstanceOf(HashMap.class);
+        assertThat(pojo.attributes).containsEntry("first", "alpha");
+        assertThat(pojo.attributes).containsEntry("second", "beta");
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        final Codec<T> codec = registry.get(pojoClass);
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static class ConcreteMapPojo {
+        public HashMap<String, String> attributes;
+
+        public ConcreteMapPojo() {
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/PropertyAccessorImplTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/PropertyAccessorImplTest.java
new file mode 100644
index 0000000000..85677a7726
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/PropertyAccessorImplTest.java
@@ -0,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class PropertyAccessorImplTest {
+    @Test
+    void encodesPojoPropertyThroughGetter() {
+        final GetterPojo pojo = new GetterPojo();
+        pojo.setName("getter-value");
+
+        final BsonDocument document = encode(GetterPojo.class, pojo);
+
+        assertThat(document.getString("name").getValue()).isEqualTo("getter-value");
+    }
+
+    @Test
+    void encodesAndDecodesPublicFieldProperties() {
+        final PublicFieldPojo pojo = new PublicFieldPojo();
+        pojo.name = "field-value";
+        pojo.count = 42;
+
+        final BsonDocument document = encode(PublicFieldPojo.class, pojo);
+        final PublicFieldPojo decoded = decode(PublicFieldPojo.class, document);
+
+        assertThat(document.getString("name").getValue()).isEqualTo("field-value");
+        assertThat(document.getInt32("count").getValue()).isEqualTo(42);
+        assertThat(decoded.name).isEqualTo("field-value");
+        assertThat(decoded.count).isEqualTo(42);
+    }
+
+    private static <T> BsonDocument encode(final Class<T> pojoClass, final T value) {
+        final BsonDocument document = new BsonDocument();
+        codecFor(pojoClass).encode(new BsonDocumentWriter(document), value, EncoderContext.builder().build());
+        return document;
+    }
+
+    private static <T> T decode(final Class<T> pojoClass, final BsonDocument document) {
+        return codecFor(pojoClass).decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    private static <T> Codec<T> codecFor(final Class<T> pojoClass) {
+        final CodecRegistry registry = fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().register(pojoClass).build()));
+        return registry.get(pojoClass);
+    }
+
+    public static class GetterPojo {
+        private String name;
+
+        public GetterPojo() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+
+    public static class PublicFieldPojo {
+        public String name;
+        public int count;
+
+        public PublicFieldPojo() {
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
index 6760917d95..e967d2067f 100644
--- 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -6,7 +6,6 @@
  */
 package org_mongodb.mongo_java_driver;
 
-import com.mongodb.ServerAddress;
 import com.mongodb.internal.connection.SslHelper;
 import org.junit.jupiter.api.Test;
 
@@ -31,14 +30,14 @@ public class SslHelperTest {
     @Test
     void enablesServerNameIndicationForHostNames() {
         final SSLParameters sslParameters = new SSLParameters();
-        final ServerAddress address = new ServerAddress("example.mongodb.local");
+        final String host = "example.mongodb.local";
 
-        SslHelper.enableSni(address, sslParameters);
+        SslHelper.enableSni(host, sslParameters);
 
         final List<SNIServerName> serverNames = sslParameters.getServerNames();
         assertThat(serverNames).hasSize(1);
         assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
         final SNIHostName serverName = (SNIHostName) serverNames.get(0);
-        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+        assertThat(serverName.getAsciiName()).isEqualTo(host);
     }
 }

```
