### PR TITLE
Handle URL templates during pre-release promotion

### DIFF
--- a/skills/review-library-bulk-update/SKILL.md
+++ b/skills/review-library-bulk-update/SKILL.md
@@ -28,11 +28,17 @@ Previous reviews follow a simple pattern:
    - Expected files: `metadata/<group>/<artifact>/index.json`.
    - Normal change shape: new values appended to `tested-versions`, with formatting-only line movement around the surrounding JSON.
    - Be suspicious of changes to `latest`, `metadata-version`, `test-version`, `allowed-packages`, `requires`, or URL fields unless the PR clearly needs them.
+   - A pure pre-release-to-release promotion produced by `addTestedVersion` is allowed when it is limited to the matching library and consists only of:
+     - `metadata/<group>/<artifact>/<oldVersion> -> <newVersion>`
+     - `tests/src/<group>/<artifact>/<oldVersion> -> <newVersion>`
+     - `stats/<group>/<artifact>/<oldVersion> -> <newVersion>`
+     - matching `index.json` changes to `metadata-version`, `tested-versions`, and exact-version artifact URLs
    - Reject or close the PR if it changes:
      - `.github/workflows/**`
      - `ci.json`
      - `gradle/**`, `build.gradle`, `settings.gradle`, `gradle.properties`
-     - `tests/src/**`
+     - `tests/src/**` outside a pure matching pre-release promotion rename
+     - `stats/**` outside a pure matching pre-release promotion rename
      - generated Java sources
      - any other non-`metadata/**/index.json` file
 
@@ -51,10 +57,12 @@ Previous reviews follow a simple pattern:
    - Confirm the new versions were added under the correct `metadata-version` entry.
    - Preserve existing ordering conventions; new tested versions are typically appended in version order.
    - Do not accept dropped tested versions, entry reshuffling, or unrelated field edits without a clear reason.
+   - For pre-release promotions, confirm `metadata-version` moved from the matching pre-release to the corresponding full release, old pre-release values were removed from `tested-versions`, and any `test-version` references were updated only when they pointed at the promoted test directory.
 
 6. Apply URL verification when URL fields changed.
    - This is higher scrutiny than a normal bulk-update PR.
    - Review `source-code-url`, `test-code-url`, `documentation-url`, and `repository-url` with the same rules used by `PopulateArtifactURLs`.
+   - For pre-release promotions, verify the `source-code-url`, `test-code-url`, and `documentation-url` values were rendered from the old version to the promoted `metadata-version` or otherwise corrected to an exact-version URL. Do not accept stale URLs that still point at the old pre-release.
 
 7. If the PR is clean and approved, enable auto-merge.
    - In this repository, approved automation PRs are expected to auto-merge after approval.
@@ -72,6 +80,7 @@ If any URL field changed, verify all of the following:
 - If a Maven `-sources.jar` or `-test-sources.jar` is used, verify it contains real source files such as `.java`, `.kt`, `.scala`, or `.groovy`, not only metadata or license files.
 - If the URL points to a repository tree or archive instead of Maven, verify that it resolves to real source or test files for the exact version tag.
 - If a candidate source or test URL cannot be verified with confidence, it should not be approved as-is.
+- For pre-release promotions, template rendering is expected: old-version URL tokens may be replaced by the promoted version only when the rendered URL resolves and archive/source checks pass.
 
 Use the logic from `tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLs.java`, especially the `urlUpdateInstructions` and `sourceArtifactVerificationInstructions` rules.
 
@@ -80,6 +89,7 @@ Use the logic from `tests/tck-build-logic/src/main/groovy/org/graalvm/internal/t
 Approve when all of these are true:
 
 - The PR is limited to the expected `metadata/**/index.json` files.
+- Or the PR is a pure verified pre-release promotion rename limited to the matching `metadata/`, `tests/src/`, `stats/`, and `index.json` changes.
 - The diff is only tested-version maintenance or clearly justified URL maintenance.
 - CI is green, or any rerun confirms green status.
 - Any changed URLs were verified against the exact version.

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLs.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLs.java
@@ -342,6 +342,7 @@ public class PopulateArtifactURLs extends DefaultTask {
                 - If you use Maven test-source artifacts, confirm `-test-sources.jar` contains real test source files.
                 - For non-Maven source/test URLs (for example repository tree pages or downloadable archives), verify that the selected URL resolves to real source/test files for the exact version.
                 - If a candidate source/test URL fails this verification, do not use it. Prefer a verified repository tag URL instead.
+                - If an existing URL can be rendered as a version template, verify the rendered exact-version candidate before writing it.
                 """.formatted(version).strip();
     }
 
@@ -354,9 +355,13 @@ public class PopulateArtifactURLs extends DefaultTask {
                     - "repository-url" must be the canonical repository root URL and must not include a version/tag/branch path (for example, no "/tree/v_1.2.11").
                     - Set "test-code-url" to the selected test suite URL.
                     - Set "documentation-url" to the selected project documentation URL for version "%s".
+                    - Treat existing versioned "source-code-url", "test-code-url", and "documentation-url" values as templates when they contain the current entry version or another artifact version.
+                    - Render template candidates for target metadata-version "%s" and verify rendered URLs before writing them.
+                    - If template verification fails, search for a correct exact-version URL instead of preserving a stale value.
+                    - A non-empty URL pointing at a different artifact version is not considered already correct when URL maintenance is requested.
                     - Set "description" to a concise explanation of the library in exactly two sentences.
                     - Set "language" to the structured language object when the library is language-specific; otherwise leave the field absent.
-                    """.formatted(version).strip();
+                    """.formatted(version, version).strip();
         }
         return """
                 - Fill only missing fields among "source-code-url", "repository-url", "test-code-url", "documentation-url", "description", and "language".
@@ -367,9 +372,13 @@ public class PopulateArtifactURLs extends DefaultTask {
                 - "repository-url" must be the canonical repository root URL and must not include a version/tag/branch path (for example, no "/tree/v_1.2.11").
                 - Set missing "test-code-url" to the selected test suite URL.
                 - Set missing "documentation-url" to the selected project documentation URL for version "%s".
+                - When URL maintenance is requested, treat existing versioned "source-code-url", "test-code-url", and "documentation-url" values as templates when they contain the current entry version or another artifact version.
+                - Render template candidates for target metadata-version "%s" and verify rendered URLs before writing them.
+                - If template verification fails, search for a correct exact-version URL instead of preserving a stale value.
+                - A non-empty URL pointing at a different artifact version is not considered already correct when URL maintenance is requested.
                 - Set missing "description" to a concise explanation of the library in exactly two sentences.
                 - Set missing "language" only when the library is language-specific; otherwise leave the field absent.
-                """.formatted(version).strip();
+                """.formatted(version, version).strip();
     }
 
     private static String currentValue(String value) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -20,6 +20,7 @@ import org.graalvm.internal.tck.stats.LibraryStatsSupport;
 
 import org.graalvm.internal.tck.utils.CoordinateUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -29,20 +30,37 @@ import org.gradle.api.tasks.options.Option;
 import org.gradle.util.internal.VersionNumber;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.nio.file.DirectoryNotEmptyException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 @SuppressWarnings("unused")
 public abstract class TestedVersionUpdaterTask extends DefaultTask {
+    private static final Duration URL_VERIFICATION_TIMEOUT = Duration.ofSeconds(20);
+    private static final int MAX_VERIFICATION_DOWNLOAD_BYTES = 25 * 1024 * 1024;
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(URL_VERIFICATION_TIMEOUT)
+            .build();
+    private static final List<String> SOURCE_FILE_EXTENSIONS = List.of(".java", ".kt", ".scala", ".groovy");
+
     /**
      * Identifies library versions, including optional pre-release, ".Final" and ".RELEASE" suffixes.
      * <p>
@@ -143,6 +161,7 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
      *   <li>If the entry's {@code metadataVersion} is a pre-release of the same base version,
      *       it is updated to the new full release. The corresponding metadata and test directories are renamed accordingly.
      *       The {@code gradle.properties} file in the tests directory is updated to refer to the new version.</li>
+     *   <li>Versioned artifact URL fields are rendered for the full release and verified before filesystem renames.</li>
      *   <li>Version parsing follows {@link #VERSION_PATTERN} and treats ".Final" and ".RELEASE" as a base version.</li>
      * </ul>
      */
@@ -162,6 +181,7 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
             String oldMetadata = entry.metadataVersion();
             Matcher metaMatcher = VERSION_PATTERN.matcher(oldMetadata);
             if (metaMatcher.matches() && metaMatcher.group(2) != null && baseVersion.equals(metaMatcher.group(1))) {
+                PromotedUrls promotedUrls = promoteArtifactUrls(entry, oldMetadata, newVersion);
                 Path oldDir = baseDir.resolve(oldMetadata);
                 Path newDir = baseDir.resolve(newVersion);
                 if (Files.exists(oldDir)) Files.move(oldDir, newDir);
@@ -175,10 +195,10 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                         entry.defaultFor(),
                         newVersion,
                         entry.testVersion(),
-                        entry.sourceCodeUrl(),
+                        promotedUrls.sourceCodeUrl(),
                         entry.repositoryUrl(),
-                        entry.testCodeUrl(),
-                        entry.documentationUrl(),
+                        promotedUrls.testCodeUrl(),
+                        promotedUrls.documentationUrl(),
                         entry.description(),
                         entry.language(),
                         entry.testedVersions(),
@@ -190,6 +210,134 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
         }
 
         return entry;
+    }
+
+    private PromotedUrls promoteArtifactUrls(MetadataVersionsIndexEntry entry, String oldVersion, String newVersion) {
+        return new PromotedUrls(
+                promoteUrl("source-code-url", entry.sourceCodeUrl(), oldVersion, newVersion, UrlVerification.ARCHIVE_WITH_SOURCES),
+                promoteUrl("test-code-url", entry.testCodeUrl(), oldVersion, newVersion, UrlVerification.TEST_CODE),
+                promoteUrl("documentation-url", entry.documentationUrl(), oldVersion, newVersion, UrlVerification.RESOLVES)
+        );
+    }
+
+    private String promoteUrl(String fieldName, String currentUrl, String oldVersion, String newVersion, UrlVerification verification) {
+        if (!hasText(currentUrl) || "N/A".equals(currentUrl)) {
+            return currentUrl;
+        }
+
+        String promotedUrl = renderVersionTemplate(currentUrl, oldVersion, newVersion);
+        verifyPromotedUrl(fieldName, promotedUrl, oldVersion, newVersion, verification);
+        return promotedUrl;
+    }
+
+    private void verifyPromotedUrl(String fieldName, String promotedUrl, String oldVersion, String newVersion, UrlVerification verification) {
+        if (!promotedUrl.contains(newVersion)) {
+            throw staleUrlException(fieldName, promotedUrl, oldVersion, newVersion, "URL does not contain the promoted metadata version");
+        }
+        if (containsIgnoreCase(promotedUrl, oldVersion)) {
+            throw staleUrlException(fieldName, promotedUrl, oldVersion, newVersion, "URL still contains the old pre-release version");
+        }
+
+        try {
+            if (verification == UrlVerification.ARCHIVE_WITH_SOURCES) {
+                verifySourceUrl(promotedUrl);
+            } else if (verification == UrlVerification.TEST_CODE && isArchiveUrl(promotedUrl)) {
+                verifyArchiveContainsSourceFiles(promotedUrl);
+            } else {
+                verifyUrlResolves(promotedUrl);
+            }
+        } catch (IOException | InterruptedException | IllegalArgumentException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw staleUrlException(fieldName, promotedUrl, oldVersion, newVersion, e.getMessage());
+        }
+    }
+
+    private static String renderVersionTemplate(String currentUrl, String oldVersion, String newVersion) {
+        if (!containsIgnoreCase(currentUrl, oldVersion)) {
+            return currentUrl;
+        }
+        Pattern oldVersionPattern = Pattern.compile(Pattern.quote(oldVersion), Pattern.CASE_INSENSITIVE);
+        return oldVersionPattern.matcher(currentUrl).replaceAll(Matcher.quoteReplacement(newVersion));
+    }
+
+    private static boolean containsIgnoreCase(String value, String token) {
+        return value.toLowerCase(Locale.ROOT).contains(token.toLowerCase(Locale.ROOT));
+    }
+
+    private void verifySourceUrl(String url) throws IOException, InterruptedException {
+        if (isArchiveUrl(url)) {
+            verifyArchiveContainsSourceFiles(url);
+        } else {
+            verifyUrlResolves(url);
+        }
+    }
+
+    private GradleException staleUrlException(String fieldName, String promotedUrl, String oldVersion, String newVersion, String reason) {
+        return new GradleException(
+                "Cannot promote " + fieldName + " from " + oldVersion + " to " + newVersion + ". " +
+                        "Candidate URL failed verification: " + promotedUrl + ". Reason: " + reason
+        );
+    }
+
+    private void verifyUrlResolves(String url) throws IOException, InterruptedException {
+        HttpResponse<Void> response = sendRequest(url, "HEAD", HttpResponse.BodyHandlers.discarding());
+        if (response.statusCode() == 405 || response.statusCode() == 403) {
+            response = sendRequest(url, "GET", HttpResponse.BodyHandlers.discarding());
+        }
+        verifySuccessStatus(url, response.statusCode());
+    }
+
+    private void verifyArchiveContainsSourceFiles(String url) throws IOException, InterruptedException {
+        HttpResponse<byte[]> response = sendRequest(url, "GET", HttpResponse.BodyHandlers.ofByteArray());
+        verifySuccessStatus(url, response.statusCode());
+        byte[] archiveBytes = response.body();
+        if (archiveBytes.length > MAX_VERIFICATION_DOWNLOAD_BYTES) {
+            throw new IOException("archive is too large to verify (" + archiveBytes.length + " bytes)");
+        }
+
+        boolean hasSourceFiles = false;
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(archiveBytes))) {
+            ZipEntry zipEntry;
+            while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+                if (!zipEntry.isDirectory() && isSourceFile(zipEntry.getName())) {
+                    hasSourceFiles = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasSourceFiles) {
+            throw new IOException("archive does not contain .java, .kt, .scala, or .groovy source files");
+        }
+    }
+
+    private <T> HttpResponse<T> sendRequest(String url, String method, HttpResponse.BodyHandler<T> bodyHandler) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(URL_VERIFICATION_TIMEOUT)
+                .method(method, HttpRequest.BodyPublishers.noBody())
+                .build();
+        return HTTP_CLIENT.send(request, bodyHandler);
+    }
+
+    private void verifySuccessStatus(String url, int statusCode) throws IOException {
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new IOException("URL did not resolve successfully: HTTP " + statusCode + " for " + url);
+        }
+    }
+
+    private static boolean isArchiveUrl(String url) {
+        String normalizedUrl = url.toLowerCase(Locale.ROOT);
+        return normalizedUrl.endsWith(".jar") || normalizedUrl.endsWith(".zip");
+    }
+
+    private static boolean isSourceFile(String path) {
+        return SOURCE_FILE_EXTENSIONS.stream().anyMatch(path::endsWith);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     /**
@@ -424,5 +572,18 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                 entries.set(i, updatedEntry);
             }
         }
+    }
+
+    private enum UrlVerification {
+        ARCHIVE_WITH_SOURCES,
+        TEST_CODE,
+        RESOLVES
+    }
+
+    private record PromotedUrls(
+            String sourceCodeUrl,
+            String testCodeUrl,
+            String documentationUrl
+    ) {
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
@@ -9,21 +9,29 @@ package org.graalvm.internal.tck;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
 import org.graalvm.internal.tck.stats.LibraryStatsSupport;
+import org.gradle.api.GradleException;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import javax.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestedVersionUpdaterTaskTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -168,6 +176,116 @@ class TestedVersionUpdaterTaskTests {
         assertThat(indexEntries.get(1)).containsEntry("test-version", "1.0.0");
     }
 
+    @Test
+    void runPromotesMavenSourceAndJavadocUrlsWhenRenderedCandidatesVerify() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        String oldVersion = "1.0.0-M20";
+        String newVersion = "1.0.0";
+        byte[] sourceJar = zipArchive("com/example/Demo.java", "package com.example; class Demo {}");
+        HttpServer server = startServer(Map.of(
+                "/maven/com/example/demo/1.0.0/demo-1.0.0-sources.jar", sourceJar,
+                "/maven/com/example/demo/1.0.0/demo-1.0.0-javadoc.jar", zipArchive("index.html", "<html></html>")
+        ));
+
+        try {
+            String baseUrl = "http://localhost:" + server.getAddress().getPort();
+            writeIndex(
+                    group,
+                    artifact,
+                    oldVersion,
+                    baseUrl + "/maven/com/example/demo/1.0.0-M20/demo-1.0.0-M20-sources.jar",
+                    "N/A",
+                    baseUrl + "/maven/com/example/demo/1.0.0-M20/demo-1.0.0-M20-javadoc.jar"
+            );
+
+            TestTestedVersionUpdaterTask task = createTask();
+            task.setCoordinates(group + ":" + artifact + ":" + newVersion);
+            task.getLastSupportedVersion().set(oldVersion);
+
+            task.run();
+
+            List<Map<String, Object>> indexEntries = readIndex(group, artifact);
+            assertThat(indexEntries.get(0))
+                    .containsEntry("metadata-version", newVersion)
+                    .containsEntry("source-code-url", baseUrl + "/maven/com/example/demo/1.0.0/demo-1.0.0-sources.jar")
+                    .containsEntry("documentation-url", baseUrl + "/maven/com/example/demo/1.0.0/demo-1.0.0-javadoc.jar");
+            assertThat(indexEntries.get(0)).containsEntry("test-code-url", "N/A");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void runPromotesRepositoryTestUrlWhenRenderedCandidateVerifies() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        String oldVersion = "2.0.0-RC1";
+        String newVersion = "2.0.0";
+        HttpServer server = startServer(Map.of(
+                "/svn/demo/tags/2.0.0/src/test", "tests".getBytes(StandardCharsets.UTF_8)
+        ));
+
+        try {
+            String baseUrl = "http://localhost:" + server.getAddress().getPort();
+            writeIndex(
+                    group,
+                    artifact,
+                    oldVersion,
+                    "N/A",
+                    baseUrl + "/svn/demo/tags/2.0.0-RC1/src/test",
+                    "N/A"
+            );
+
+            TestTestedVersionUpdaterTask task = createTask();
+            task.setCoordinates(group + ":" + artifact + ":" + newVersion);
+            task.getLastSupportedVersion().set(oldVersion);
+
+            task.run();
+
+            assertThat(readIndex(group, artifact).get(0))
+                    .containsEntry("metadata-version", newVersion)
+                    .containsEntry("test-code-url", baseUrl + "/svn/demo/tags/2.0.0/src/test");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void runFailsWithoutRenamingWhenPromotedUrlCannotVerify() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        String oldVersion = "3.0.0-RC1";
+        String newVersion = "3.0.0";
+        HttpServer server = startServer(Map.of());
+
+        try {
+            String baseUrl = "http://localhost:" + server.getAddress().getPort();
+            writeIndex(
+                    group,
+                    artifact,
+                    oldVersion,
+                    baseUrl + "/maven/com/example/demo/3.0.0-RC1/demo-3.0.0-RC1-sources.jar",
+                    "N/A",
+                    "N/A"
+            );
+
+            TestTestedVersionUpdaterTask task = createTask();
+            task.setCoordinates(group + ":" + artifact + ":" + newVersion);
+            task.getLastSupportedVersion().set(oldVersion);
+
+            assertThatThrownBy(task::run)
+                    .isInstanceOf(GradleException.class)
+                    .hasMessageContaining("Cannot promote source-code-url")
+                    .hasMessageContaining(baseUrl + "/maven/com/example/demo/3.0.0/demo-3.0.0-sources.jar")
+                    .hasMessageContaining("HTTP 404");
+            assertThat(tempDir.resolve("metadata/com.example/demo/3.0.0-RC1")).exists();
+            assertThat(tempDir.resolve("metadata/com.example/demo/3.0.0")).doesNotExist();
+        } finally {
+            server.stop(0);
+        }
+    }
+
     private TestTestedVersionUpdaterTask createTask() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
@@ -177,6 +295,10 @@ class TestedVersionUpdaterTaskTests {
     }
 
     private void writeIndex(String group, String artifact, String oldVersion) throws IOException {
+        writeIndex(group, artifact, oldVersion, null, null, null);
+    }
+
+    private void writeIndex(String group, String artifact, String oldVersion, String sourceCodeUrl, String testCodeUrl, String documentationUrl) throws IOException {
         Path indexFile = tempDir.resolve("metadata/" + group + "/" + artifact + "/index.json");
         Files.createDirectories(indexFile.getParent());
         Files.writeString(
@@ -189,6 +311,7 @@ class TestedVersionUpdaterTaskTests {
                       "com.example"
                     ],
                     "metadata-version": "%s",
+                %s
                     "tested-versions": [
                       "%s"
                     ]
@@ -204,12 +327,64 @@ class TestedVersionUpdaterTaskTests {
                     ]
                   }
                 ]
-                """.formatted(oldVersion, oldVersion, oldVersion),
+                """.formatted(oldVersion, urlFields(sourceCodeUrl, testCodeUrl, documentationUrl), oldVersion, oldVersion),
                 StandardCharsets.UTF_8
         );
         Files.createDirectories(tempDir.resolve("metadata/" + group + "/" + artifact + "/" + oldVersion));
         Files.createDirectories(tempDir.resolve("tests/src/" + group + "/" + artifact + "/" + oldVersion));
         Files.createDirectories(tempDir.resolve("stats/" + group + "/" + artifact + "/" + oldVersion));
+    }
+
+    private String urlFields(String sourceCodeUrl, String testCodeUrl, String documentationUrl) {
+        StringBuilder fields = new StringBuilder();
+        appendUrlField(fields, "source-code-url", sourceCodeUrl);
+        appendUrlField(fields, "test-code-url", testCodeUrl);
+        appendUrlField(fields, "documentation-url", documentationUrl);
+        return fields.toString();
+    }
+
+    private void appendUrlField(StringBuilder fields, String fieldName, String value) {
+        if (value != null) {
+            fields.append("    \"").append(fieldName).append("\": \"").append(value).append("\",\n");
+        }
+    }
+
+    private List<Map<String, Object>> readIndex(String group, String artifact) throws IOException {
+        return OBJECT_MAPPER.readValue(
+                tempDir.resolve("metadata/" + group + "/" + artifact + "/index.json").toFile(),
+                new TypeReference<>() {
+                }
+        );
+    }
+
+    private HttpServer startServer(Map<String, byte[]> files) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] body = files.get(exchange.getRequestURI().getPath());
+            int statusCode = body == null ? 404 : 200;
+            if ("HEAD".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(statusCode, -1);
+            } else {
+                byte[] responseBody = body == null ? new byte[0] : body;
+                exchange.sendResponseHeaders(statusCode, responseBody.length);
+                try (OutputStream responseStream = exchange.getResponseBody()) {
+                    responseStream.write(responseBody);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private byte[] zipArchive(String entryName, String content) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            zipOutputStream.putNextEntry(new ZipEntry(entryName));
+            zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+        return outputStream.toByteArray();
     }
 
     abstract static class TestTestedVersionUpdaterTask extends TestedVersionUpdaterTask {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/PopulateArtifactURLsTests.java
@@ -59,6 +59,8 @@ class PopulateArtifactURLsTests {
                 .contains("Set missing \"repository-url\" to the selected repository URL.")
                 .contains("\"repository-url\" must be the canonical repository root URL and must not include a version/tag/branch path (for example, no \"/tree/v_1.2.11\").")
                 .contains("Set missing \"documentation-url\" to the selected project documentation URL for version \"1.4.1\".")
+                .contains("Render template candidates for target metadata-version \"1.4.1\" and verify rendered URLs before writing them.")
+                .contains("A non-empty URL pointing at a different artifact version is not considered already correct when URL maintenance is requested.")
                 .contains("Set missing \"description\" to a concise explanation of the library in exactly two sentences.")
                 .contains("Set missing \"language\" only when the library is language-specific; otherwise leave the field absent.")
                 .contains("If any of these URLs or the description cannot be found with confidence, set that field value to \"N/A\".")
@@ -179,7 +181,8 @@ class PopulateArtifactURLsTests {
                 .contains("confirm `-sources.jar` contains real source files")
                 .contains("confirm `-test-sources.jar` contains real test source files.")
                 .contains("For non-Maven source/test URLs")
-                .contains("Prefer a verified repository tag URL instead.");
+                .contains("Prefer a verified repository tag URL instead.")
+                .contains("If an existing URL can be rendered as a version template, verify the rendered exact-version candidate before writing it.");
     }
 
     private Project createProjectWithMetadata() throws IOException {


### PR DESCRIPTION
Fixes #4250.

## Summary
- render and verify versioned artifact URLs when addTestedVersion promotes pre-release metadata to the matching release
- fail before filesystem renames when promoted source/test/doc URLs are stale or unverifiable
- update PopulateArtifactURLs prompt text and bulk-update review instructions for verified promotion renames

## Testing
- ./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.TestedVersionUpdaterTaskTests --tests org.graalvm.internal.tck.harness.tasks.PopulateArtifactURLsTests --stacktrace
- ./gradlew :tck-build-logic:compileJava :tck-build-logic:compileTestJava --stacktrace

Note: ./gradlew :tck-build-logic:check --stacktrace currently reaches tests but fails in validatePlugins on existing AbstractLibraryStatsTask.getStatsFile() @Internal validation.