### PR TITLE
[GenAI] Test fix for com.github.jknack:handlebars-helpers:4.4.0 using gpt-5.5

### DIFF
--- a/metadata/com.github.jknack/handlebars-helpers/4.4.0/reachability-metadata.json
+++ b/metadata/com.github.jknack/handlebars-helpers/4.4.0/reachability-metadata.json
@@ -1,0 +1,86 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.IncludeHelper"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.IncludeHelper"
+      },
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$1"
+      },
+      "type": "java.text.DateFormatSymbols",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.util.Locale"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.IncludeHelper"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.IncludeHelper"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.IncludeHelper"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$1"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$1"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$1"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$1"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$2"
+      },
+      "glob": "org/joda/time/tz/data/Europe/Zurich"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.jknack.handlebars.helper.ext.JodaHelper$2"
+      },
+      "glob": "org/joda/time/tz/data/ZoneInfoMap"
+    }
+  ]
+}

--- a/metadata/com.github.jknack/handlebars-helpers/index.json
+++ b/metadata/com.github.jknack/handlebars-helpers/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "4.4.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/jknack/handlebars-helpers/4.4.0/handlebars-helpers-4.4.0-sources.jar",
+    "repository-url" : "https://github.com/jknack/handlebars.java",
+    "test-code-url" : "https://github.com/jknack/handlebars.java/tree/v4.4.0/tests/src/test/java/com/github/jknack/handlebars/helper/ext",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/jknack/handlebars-helpers/4.4.0/handlebars-helpers-4.4.0-javadoc.jar",
+    "description" : "Handlebars Helpers provides a collection of community-contributed helper functions for Handlebars.java templates. It adds reusable helpers such as assignment, numeric predicates, row striping, include behavior, and Joda-Time helpers on top of the core Handlebars.java engine.",
     "tested-versions" : [
       "4.4.0"
     ],
     "allowed-packages" : [
-      "com.github.jknack.handlebars.helper"
+      "com.github.jknack.handlebars.helper.ext"
     ]
   },
   {

--- a/metadata/com.github.jknack/handlebars-helpers/index.json
+++ b/metadata/com.github.jknack/handlebars-helpers/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.4.0",
+    "tested-versions" : [
+      "4.4.0"
+    ],
+    "allowed-packages" : [
+      "com.github.jknack.handlebars.helper"
+    ]
+  },
+  {
     "metadata-version" : "4.3.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/jknack/handlebars-helpers/4.3.1/handlebars-helpers-4.3.1-sources.jar",
     "repository-url" : "https://github.com/jknack/handlebars.java",

--- a/stats/com.github.jknack/handlebars-helpers/4.4.0/execution-metrics.json
+++ b/stats/com.github.jknack/handlebars-helpers/4.4.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T10:17:42.519802Z",
+    "library": "com.github.jknack:handlebars-helpers:4.4.0",
+    "starting_commit": "258b73d2f74d7408d2c410c5b7103d1d863e42c1",
+    "ending_commit": "2892c8b94a417ef7f20431163dfcde9ac7fe00eb",
+    "previous_library": "com.github.jknack:handlebars-helpers:4.3.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.4.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 266,
+          "missed": 2,
+          "ratio": 0.992537,
+          "total": 268
+        },
+        "line": {
+          "covered": 42,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 42
+        },
+        "method": {
+          "covered": 25,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 25
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.3.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 298,
+          "missed": 2,
+          "ratio": 0.993333,
+          "total": 300
+        },
+        "line": {
+          "covered": 42,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 42
+        },
+        "method": {
+          "covered": 25,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 25
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 33471,
+      "cached_input_tokens_used": 147456,
+      "output_tokens_used": 1459,
+      "iterations": 1,
+      "cost_usd": 0.1175,
+      "tested_library_loc": 42,
+      "metadata_entries": 13,
+      "previous_library_metadata_entries": 14,
+      "code_coverage_percent": 100.0,
+      "previous_library_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java",
+      "metadata_file": "metadata/com.github.jknack/handlebars-helpers/4.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.jknack/handlebars-helpers/4.4.0/stats.json
+++ b/stats/com.github.jknack/handlebars-helpers/4.4.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.4.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 266,
+        "missed" : 2,
+        "ratio" : 0.992537,
+        "total" : 268
+      },
+      "line" : {
+        "covered" : 42,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 42
+      },
+      "method" : {
+        "covered" : 25,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 25
+      }
+    }
+  } ]
+}

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/.gitignore
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/build.gradle
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.github.jknack:handlebars-helpers:$libraryVersion"
+    testImplementation 'joda-time:joda-time:2.12.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/gradle.properties
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.github.jknack:handlebars-helpers:4.4.0
+library.version = 4.4.0
+metadata.dir = com.github.jknack/handlebars-helpers/4.4.0/

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/settings.gradle
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.jknack.handlebars-helpers_tests'

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_jknack.handlebars_helpers;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.helper.AssignHelper;
+import com.github.jknack.handlebars.helper.IncludeHelper;
+import com.github.jknack.handlebars.helper.JodaHelper;
+import com.github.jknack.handlebars.helper.NumberHelper;
+import com.github.jknack.handlebars.io.StringTemplateSource;
+import com.github.jknack.handlebars.io.TemplateLoader;
+import com.github.jknack.handlebars.io.TemplateSource;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Handlebars_helpersTest {
+    @Test
+    void numberHelpersRenderEvenOddStripesAndIgnoreNonNumbers() throws IOException {
+        final Handlebars handlebars = new Handlebars();
+        NumberHelper.register(handlebars);
+
+        final Template template = handlebars.compileInline("""
+                even={{isEven even "EVEN"}};
+                odd={{isOdd odd "ODD"}};
+                default-even={{isEven zero}};
+                default-odd={{isOdd one}};
+                stripes={{stripes zero "left" "right"}}/{{stripes one "left" "right"}};
+                non-number=[{{isEven text "unexpected"}}]
+                """);
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("even", 4);
+        model.put("odd", 7L);
+        model.put("zero", 0);
+        model.put("one", 1);
+        model.put("text", "not a number");
+
+        assertThat(template.apply(model)).isEqualTo("""
+                even=EVEN;
+                odd=ODD;
+                default-even=even;
+                default-odd=odd;
+                stripes=left/right;
+                non-number=[]
+                """);
+    }
+
+    @Test
+    void assignHelperStoresTrimmedBlockOutputAsDataForLaterUse() throws IOException {
+        final Handlebars handlebars = new Handlebars();
+        handlebars.registerHelper(AssignHelper.NAME, AssignHelper.INSTANCE);
+
+        final Template template = handlebars.compileInline(
+                "{{#assign \"greeting\"}} Hello {{name}} {{/assign}}Greeting:{{greeting}}");
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("name", "Ada");
+
+        assertThat(template.apply(model)).isEqualTo("Greeting:Hello Ada");
+    }
+
+    @Test
+    void includeHelperLoadsTemplateWithHashDataAndReturnsSafeHtml() throws IOException {
+        final MapBackedTemplateLoader loader = new MapBackedTemplateLoader();
+        loader.put("profile", "<article>{{title}}: {{name}}</article>");
+
+        final Handlebars handlebars = new Handlebars(loader);
+        handlebars.registerHelper(IncludeHelper.NAME, IncludeHelper.INSTANCE);
+
+        final Template template = handlebars.compileInline("""
+                {{include "profile" title="User" name=displayName}}|{{title}}|{{name}}
+                """);
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("displayName", "Grace Hopper");
+
+        assertThat(template.apply(model)).isEqualTo("""
+                <article>User: Grace Hopper</article>|User|Grace Hopper
+                """);
+    }
+
+    @Test
+    void includeHelperEscapesIncludedTemplateDataBeforeReturningSafeHtml() throws IOException {
+        final MapBackedTemplateLoader loader = new MapBackedTemplateLoader();
+        loader.put("bio", "<strong>{{displayName}}</strong>");
+
+        final Handlebars handlebars = new Handlebars(loader);
+        handlebars.registerHelper(IncludeHelper.NAME, IncludeHelper.INSTANCE);
+
+        final Template template = handlebars.compileInline("{{include \"bio\"}}");
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("displayName", "<Ada & Grace>");
+
+        assertThat(template.apply(model)).isEqualTo("<strong>&lt;Ada &amp; Grace&gt;</strong>");
+    }
+
+    @Test
+    void includeHelperResolvesTemplateLoaderPrefixAndSuffixWithCallerContext() throws IOException {
+        final MapBackedTemplateLoader loader = new MapBackedTemplateLoader();
+        loader.setPrefix("/templates/");
+        loader.setSuffix(".hbs");
+        loader.put("/templates/summary.hbs", "{{firstName}} {{lastName}} is {{role}}");
+
+        final Handlebars handlebars = new Handlebars(loader);
+        handlebars.registerHelper(IncludeHelper.NAME, IncludeHelper.INSTANCE);
+
+        final Template template = handlebars.compileInline("{{include \"summary\"}}");
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("firstName", "Ada");
+        model.put("lastName", "Lovelace");
+        model.put("role", "mathematician");
+
+        assertThat(template.apply(model)).isEqualTo("Ada Lovelace is mathematician");
+    }
+
+    @Test
+    void jodaHelpersFormatReadableInstantsWithPatternStyleAndIsoOutput() throws IOException {
+        final Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+        try {
+            final Handlebars handlebars = new Handlebars();
+            handlebars.registerHelper(JodaHelper.jodaPattern.name(), JodaHelper.jodaPattern);
+            handlebars.registerHelper(JodaHelper.jodaStyle.name(), JodaHelper.jodaStyle);
+            handlebars.registerHelper(JodaHelper.jodaISO.name(), JodaHelper.jodaISO);
+
+            final Template template = handlebars.compileInline("""
+                    {{jodaPattern when "yyyy-MM-dd HH:mm:ss.SSS Z"}}|
+                    {{jodaPattern when}}|
+                    {{jodaStyle when "S-"}}|
+                    {{jodaISO when}}|
+                    {{jodaISO when "unused" true}}
+                    """);
+
+            final Map<String, Object> model = new HashMap<>();
+            model.put("when", new DateTime(2023, 4, 5, 6, 7, 8, 9, DateTimeZone.UTC));
+
+            assertThat(template.apply(model)).isEqualTo("""
+                    2023-04-05 06:07:08.009 +0000|
+                    4 5 2023, 6:7:8 UTC|
+                    4/5/23|
+                    2023-04-05T06:07:08Z|
+                    2023-04-05T06:07:08.009Z
+                    """);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+
+    private static final class MapBackedTemplateLoader implements TemplateLoader {
+        private final Map<String, String> templates = new HashMap<>();
+        private Charset charset = StandardCharsets.UTF_8;
+        private String prefix = "";
+        private String suffix = "";
+
+        void put(final String name, final String source) {
+            templates.put(name, source);
+        }
+
+        @Override
+        public TemplateSource sourceAt(final String location) throws IOException {
+            final String resolvedLocation = resolve(location);
+            final String source = templates.containsKey(location)
+                    ? templates.get(location)
+                    : templates.get(resolvedLocation);
+            if (source == null) {
+                throw new IOException("Missing test template: " + location);
+            }
+            return new StringTemplateSource(resolvedLocation, source);
+        }
+
+        @Override
+        public String resolve(final String location) {
+            return prefix + location + suffix;
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String getSuffix() {
+            return suffix;
+        }
+
+        @Override
+        public void setPrefix(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public void setSuffix(final String suffix) {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public void setCharset(final Charset charset) {
+            this.charset = charset;
+        }
+
+        @Override
+        public Charset getCharset() {
+            return charset;
+        }
+    }
+}

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
@@ -15,10 +15,10 @@ import java.util.Map;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.helper.AssignHelper;
-import com.github.jknack.handlebars.helper.IncludeHelper;
-import com.github.jknack.handlebars.helper.JodaHelper;
-import com.github.jknack.handlebars.helper.NumberHelper;
+import com.github.jknack.handlebars.helper.ext.AssignHelper;
+import com.github.jknack.handlebars.helper.ext.IncludeHelper;
+import com.github.jknack.handlebars.helper.ext.JodaHelper;
+import com.github.jknack.handlebars.helper.ext.NumberHelper;
 import com.github.jknack.handlebars.io.StringTemplateSource;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.github.jknack.handlebars.io.TemplateSource;

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.github.jknack.handlebars.helper.**"
+    }
+  ]
+}

--- a/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
+++ b/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "com.github.jknack.handlebars.helper.**"
+      "includeClasses" : "com.github.jknack.handlebars.helper.ext.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4255

This PR provides test fixes and new metadata for com.github.jknack:handlebars-helpers:4.4.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 33471
- Cached input tokens: 147456
- Output tokens: 1459
- Metadata entries: 13
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 14
- Previous library version coverage percentage: 100.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.jknack:handlebars-helpers:4.3.1: 0/0 covered calls (100.00%)
- com.github.jknack:handlebars-helpers:4.4.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.jknack:handlebars-helpers:4.3.1: 298/300 (99.33%)
- com.github.jknack:handlebars-helpers:4.4.0: 266/268 (99.25%)

**Line:**
- com.github.jknack:handlebars-helpers:4.3.1: 42/42 (100.00%)
- com.github.jknack:handlebars-helpers:4.4.0: 42/42 (100.00%)

**Method:**
- com.github.jknack:handlebars-helpers:4.3.1: 25/25 (100.00%)
- com.github.jknack:handlebars-helpers:4.4.0: 25/25 (100.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.github.jknack/handlebars-helpers/4.3.1/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java 2/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
index 6b5c72bb65..674755a74e 100644
--- 1/tests/src/com.github.jknack/handlebars-helpers/4.3.1/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
+++ 2/tests/src/com.github.jknack/handlebars-helpers/4.4.0/src/test/java/com_github_jknack/handlebars_helpers/Handlebars_helpersTest.java
@@ -15,10 +15,10 @@ import java.util.Map;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.helper.AssignHelper;
-import com.github.jknack.handlebars.helper.IncludeHelper;
-import com.github.jknack.handlebars.helper.JodaHelper;
-import com.github.jknack.handlebars.helper.NumberHelper;
+import com.github.jknack.handlebars.helper.ext.AssignHelper;
+import com.github.jknack.handlebars.helper.ext.IncludeHelper;
+import com.github.jknack.handlebars.helper.ext.JodaHelper;
+import com.github.jknack.handlebars.helper.ext.NumberHelper;
 import com.github.jknack.handlebars.io.StringTemplateSource;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.github.jknack.handlebars.io.TemplateSource;
diff --git 1/tests/src/com.github.jknack/handlebars-helpers/4.3.1/user-code-filter.json 2/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
index ff3cc1d871..365f383431 100644
--- 1/tests/src/com.github.jknack/handlebars-helpers/4.3.1/user-code-filter.json
+++ 2/tests/src/com.github.jknack/handlebars-helpers/4.4.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "com.github.jknack.handlebars.helper.**"
+      "includeClasses" : "com.github.jknack.handlebars.helper.ext.**"
     }
   ]
 }

```
