### PR TITLE
Handle same-version Java-fail project prep

### DIFF
--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -193,12 +193,28 @@ def resolve_fix_metrics_json(
     return os.path.join(metrics_repo_dir, config.metrics_filename)
 
 
-def copy_and_prepare_project_dir(group, artifact, library_version, updated_library_version):
+def _same_filesystem_path(first_path: str, second_path: str) -> bool:
+    """Return True when two paths resolve to the same filesystem location."""
+    return os.path.normcase(os.path.realpath(first_path)) == os.path.normcase(os.path.realpath(second_path))
+
+
+def copy_and_prepare_project_dir(
+        group: str,
+        artifact: str,
+        library_version: str,
+        updated_library_version: str,
+) -> None:
     """Copy versioned test project directory and update version references."""
     src_dir = os.path.join("tests", "src", group, artifact, library_version)
     dst_dir = os.path.join("tests", "src", group, artifact, updated_library_version)
-    os.makedirs(dst_dir, exist_ok=True)
-    shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
+    if not os.path.isdir(src_dir):
+        raise FileNotFoundError(f"Missing source test project directory: {src_dir}")
+
+    if _same_filesystem_path(src_dir, dst_dir):
+        print(f"[project-prep] Source and destination test project are the same: {dst_dir}")
+    else:
+        os.makedirs(dst_dir, exist_ok=True)
+        shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
 
     gradle_properties_path = os.path.join(dst_dir, "gradle.properties")
     if os.path.isfile(gradle_properties_path):
@@ -244,6 +260,11 @@ def create_project_prep_checkpoint(config: JavaFailWorkflowConfig, group, artifa
     ]
 
     subprocess.run(["git", "add", *candidate_paths], check=False)
+
+    has_staged_changes = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    if has_staged_changes.returncode == 0:
+        print("[project-prep] No project preparation changes to commit.")
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
     subprocess.run(
         ["git", "commit", "-m", f"Prepare project for {group}:{artifact}:{updated_library_version}"],
@@ -340,6 +361,24 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
     os.chdir(reachability_repo_path)
 
+    tests_dir = os.path.join(
+        reachability_repo_path,
+        "tests",
+        "src",
+        group,
+        artifact,
+        updated_library_version,
+    )
+    metadata_dir = os.path.join(
+        reachability_repo_path,
+        "metadata",
+        group,
+        artifact,
+        updated_library_version,
+    )
+    tests_dir_preexisted = os.path.exists(tests_dir)
+    metadata_dir_preexisted = os.path.exists(metadata_dir)
+
     copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
     update_metadata_index_json(group, artifact, updated_library_version)
     create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
@@ -363,14 +402,6 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         artifact,
         updated_library_version,
         "build.gradle",
-    )
-    tests_dir = os.path.join(
-        reachability_repo_path,
-        "tests",
-        "src",
-        group,
-        artifact,
-        updated_library_version,
     )
     test_source_layout = resolve_test_source_layout(reachability_repo_path, updated_library, tests_dir)
 
@@ -420,15 +451,10 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         print("[Test fixing failed.]")
         subprocess.run(["git", "reset", "--hard", commit_checkpoint], check=True)
         ending_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-        metadata_dir = os.path.join(
-            reachability_repo_path,
-            "metadata",
-            group,
-            artifact,
-            updated_library_version,
-        )
-        shutil.rmtree(tests_dir, ignore_errors=True)
-        shutil.rmtree(metadata_dir, ignore_errors=True)
+        if not tests_dir_preexisted:
+            shutil.rmtree(tests_dir, ignore_errors=True)
+        if not metadata_dir_preexisted:
+            shutil.rmtree(metadata_dir, ignore_errors=True)
         run_metrics = create_failure_run_metrics_output(
             package=group,
             artifact=artifact,

--- a/forge/tests/test_java_fail_workflow.py
+++ b/forge/tests/test_java_fail_workflow.py
@@ -1,0 +1,63 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ai_workflows.java_fail_workflow import JAVAC_CONFIG, copy_and_prepare_project_dir, create_project_prep_checkpoint
+
+
+class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
+    def test_copy_and_prepare_project_dir_skips_same_source_and_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_project_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+            )
+            os.makedirs(test_project_dir)
+            gradle_properties_path = os.path.join(test_project_dir, "gradle.properties")
+            with open(gradle_properties_path, "w", encoding="utf-8") as file:
+                file.write("version=1.0.0\n")
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.shutil.copytree") as copytree:
+                    copy_and_prepare_project_dir("org.example", "demo", "1.0.0", "1.0.0")
+            finally:
+                os.chdir(previous_cwd)
+
+            copytree.assert_not_called()
+            with open(gradle_properties_path, "r", encoding="utf-8") as file:
+                self.assertEqual(file.read(), "version=1.0.0\n")
+
+    def test_create_project_prep_checkpoint_allows_no_staged_changes(self) -> None:
+        with patch("ai_workflows.java_fail_workflow.build_ai_branch_name", return_value="ai/test-branch"), \
+                patch("ai_workflows.java_fail_workflow.delete_remote_branch_if_exists") as delete_remote, \
+                patch("ai_workflows.java_fail_workflow.subprocess.run") as run, \
+                patch(
+                    "ai_workflows.java_fail_workflow.subprocess.check_output",
+                    return_value="abc123\n",
+                ) as check_output:
+            run.side_effect = [
+                subprocess.CompletedProcess(["git", "switch"], 0),
+                subprocess.CompletedProcess(["git", "add"], 0),
+                subprocess.CompletedProcess(["git", "diff"], 0),
+            ]
+
+            checkpoint = create_project_prep_checkpoint(JAVAC_CONFIG, "org.example", "demo", "1.0.0")
+
+        self.assertEqual(checkpoint, "abc123")
+        delete_remote.assert_called_once_with("ai/test-branch")
+        self.assertEqual(run.call_count, 3)
+        self.assertEqual(run.call_args_list[2].args[0], ["git", "diff", "--cached", "--quiet"])
+        check_output.assert_called_once_with(["git", "rev-parse", "HEAD"], text=True)


### PR DESCRIPTION
## What does this PR do?

Fixes #4283.

This PR hardens the shared Java-fail workflow project preparation for cases where the issue target version is already the current metadata version.

Summary:
- Skip `shutil.copytree` when the source and destination test project paths resolve to the same directory.
- Allow the project-prep checkpoint to use the current commit when setup has no staged changes.
- Preserve pre-existing test and metadata directories during failed-run cleanup instead of deleting them.
- Add focused regression tests for same-directory preparation and no-op checkpoints.

## Testing

- `python3 -m unittest tests.test_java_fail_workflow`
- `python3 -m py_compile ai_workflows/java_fail_workflow.py tests/test_java_fail_workflow.py`
- `python3 -m unittest discover -s tests` currently has an unrelated existing failure in `test_forge_metadata.IssueClaimPreflightTests.test_offset_issue_fetch_uses_search_page_instead_of_expanding_limit`: the test expects an issue search query without `-label:"not-for-native-image"`, while the implementation includes that exclusion.