### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.28.0

### DIFF
--- a/metadata/org.eclipse.jdt/ecj/3.28.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jdt/ecj/3.28.0/reachability-metadata.json
@@ -1,0 +1,4778 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main"
+      },
+      "type" : "java.lang.module.ModuleDescriptor$Version",
+      "methods" : [
+        {
+          "name" : "parse",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.JrtFileSystem"
+      },
+      "type" : "jdk.internal.jrtfs.JrtFileSystemProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$Logger"
+      },
+      "type" : "org.eclipse.jdt.core.compiler.IProblem",
+      "fields" : [
+        {
+          "name" : "AbstractMethodCannotBeOverridden"
+        },
+        {
+          "name" : "AbstractMethodInAbstractClass"
+        },
+        {
+          "name" : "AbstractMethodInEnum"
+        },
+        {
+          "name" : "AbstractMethodMustBeImplemented"
+        },
+        {
+          "name" : "AbstractMethodMustBeImplementedOverConcreteMethod"
+        },
+        {
+          "name" : "AbstractMethodsInConcreteClass"
+        },
+        {
+          "name" : "AbstractServiceImplementation"
+        },
+        {
+          "name" : "AmbiguousConstructor"
+        },
+        {
+          "name" : "AmbiguousConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "AmbiguousConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "AmbiguousField"
+        },
+        {
+          "name" : "AmbiguousMethod"
+        },
+        {
+          "name" : "AmbiguousType"
+        },
+        {
+          "name" : "AnnotatedTypeArgumentToUnannotated"
+        },
+        {
+          "name" : "AnnotatedTypeArgumentToUnannotatedSuperHint"
+        },
+        {
+          "name" : "AnnotationCannotOverrideMethod"
+        },
+        {
+          "name" : "AnnotationCircularity"
+        },
+        {
+          "name" : "AnnotationCircularitySelfReference"
+        },
+        {
+          "name" : "AnnotationFieldNeedConstantInitialization"
+        },
+        {
+          "name" : "AnnotationMembersCannotHaveParameters"
+        },
+        {
+          "name" : "AnnotationMembersCannotHaveTypeParameters"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveConstructor"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveSuperclass"
+        },
+        {
+          "name" : "AnnotationTypeDeclarationCannotHaveSuperinterfaces"
+        },
+        {
+          "name" : "AnnotationTypeUsedAsSuperInterface"
+        },
+        {
+          "name" : "AnnotationValueMustBeAnEnumConstant"
+        },
+        {
+          "name" : "AnnotationValueMustBeAnnotation"
+        },
+        {
+          "name" : "AnnotationValueMustBeArrayInitializer"
+        },
+        {
+          "name" : "AnnotationValueMustBeClassLiteral"
+        },
+        {
+          "name" : "AnnotationValueMustBeConstant"
+        },
+        {
+          "name" : "AnonymousClassCannotExtendFinalClass"
+        },
+        {
+          "name" : "ApplicableMethodOverriddenByInapplicable"
+        },
+        {
+          "name" : "ArgumentHidingField"
+        },
+        {
+          "name" : "ArgumentHidingLocalVariable"
+        },
+        {
+          "name" : "ArgumentIsNeverUsed"
+        },
+        {
+          "name" : "ArgumentTypeAmbiguous"
+        },
+        {
+          "name" : "ArgumentTypeCannotBeVoid"
+        },
+        {
+          "name" : "ArgumentTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "ArgumentTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ArgumentTypeInternalNameProvided"
+        },
+        {
+          "name" : "ArgumentTypeNotFound"
+        },
+        {
+          "name" : "ArgumentTypeNotVisible"
+        },
+        {
+          "name" : "ArrayConstantsOnlyInArrayInitializers"
+        },
+        {
+          "name" : "ArrayReferencePotentialNullReference"
+        },
+        {
+          "name" : "ArrayReferenceRequired"
+        },
+        {
+          "name" : "ArrowInCaseStatementsNotSupported"
+        },
+        {
+          "name" : "AssignmentHasNoEffect"
+        },
+        {
+          "name" : "AssignmentToMultiCatchParameter"
+        },
+        {
+          "name" : "AssignmentToResource"
+        },
+        {
+          "name" : "AutoManagedResourceNotBelow17"
+        },
+        {
+          "name" : "AutoManagedVariableResourceNotBelow9"
+        },
+        {
+          "name" : "BinaryLiteralNotBelow17"
+        },
+        {
+          "name" : "BodyForAbstractMethod"
+        },
+        {
+          "name" : "BodyForNativeMethod"
+        },
+        {
+          "name" : "BoundCannotBeArray"
+        },
+        {
+          "name" : "BoundHasConflictingArguments"
+        },
+        {
+          "name" : "BoundMustBeAnInterface"
+        },
+        {
+          "name" : "BoxingConversion"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimit"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimitForClinit"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimitForConstructor"
+        },
+        {
+          "name" : "BytecodeExceeds64KLimitForSwitchTable"
+        },
+        {
+          "name" : "CannotAllocateVoidArray"
+        },
+        {
+          "name" : "CannotDeclareEnumSpecialMethod"
+        },
+        {
+          "name" : "CannotDefineAnnotationInLocalType"
+        },
+        {
+          "name" : "CannotDefineDimensionExpressionsWithInit"
+        },
+        {
+          "name" : "CannotDefineEnumInLocalType"
+        },
+        {
+          "name" : "CannotDefineInterfaceInLocalType"
+        },
+        {
+          "name" : "CannotDefineStaticInitializerInLocalType"
+        },
+        {
+          "name" : "CannotExtendEnum"
+        },
+        {
+          "name" : "CannotHideAnInstanceMethodWithAStaticMethod"
+        },
+        {
+          "name" : "CannotImplementIncompatibleNullness"
+        },
+        {
+          "name" : "CannotImportPackage"
+        },
+        {
+          "name" : "CannotInferElidedTypes"
+        },
+        {
+          "name" : "CannotInferInvocationType"
+        },
+        {
+          "name" : "CannotInvokeSuperConstructorInEnum"
+        },
+        {
+          "name" : "CannotMixNullAndNonTypePattern"
+        },
+        {
+          "name" : "CannotMixPatternAndDefault"
+        },
+        {
+          "name" : "CannotOverrideAStaticMethodWithAnInstanceMethod"
+        },
+        {
+          "name" : "CannotReadSource"
+        },
+        {
+          "name" : "CannotReturnInInitializer"
+        },
+        {
+          "name" : "CannotThrowNull"
+        },
+        {
+          "name" : "CannotThrowType"
+        },
+        {
+          "name" : "CannotUseDiamondWithAnonymousClasses"
+        },
+        {
+          "name" : "CannotUseDiamondWithExplicitTypeArguments"
+        },
+        {
+          "name" : "CannotUseSuperInCodeSnippet"
+        },
+        {
+          "name" : "ClassExtendFinalClass"
+        },
+        {
+          "name" : "ClassExtendFinalRecord"
+        },
+        {
+          "name" : "CodeCannotBeReached"
+        },
+        {
+          "name" : "CodeSnippetMissingClass"
+        },
+        {
+          "name" : "CodeSnippetMissingMethod"
+        },
+        {
+          "name" : "ComparingIdentical"
+        },
+        {
+          "name" : "Compliance"
+        },
+        {
+          "name" : "ConflictingImport"
+        },
+        {
+          "name" : "ConflictingInheritedNullAnnotations"
+        },
+        {
+          "name" : "ConflictingNullAnnotations"
+        },
+        {
+          "name" : "ConflictingPackageFromModules"
+        },
+        {
+          "name" : "ConflictingPackageFromOtherModules"
+        },
+        {
+          "name" : "ConflictingPackageInModules"
+        },
+        {
+          "name" : "ConstNonNullFieldComparisonYieldsFalse"
+        },
+        {
+          "name" : "ConstantWithPatternIncompatible"
+        },
+        {
+          "name" : "ConstructedArrayIncompatible"
+        },
+        {
+          "name" : "ConstructionTypeMismatch"
+        },
+        {
+          "name" : "ConstructorReferenceNotBelow18"
+        },
+        {
+          "name" : "ConstructorRelated"
+        },
+        {
+          "name" : "ConstructorVarargsArgumentNeedCast"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasNonDefaultMembers"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasShorterRetention"
+        },
+        {
+          "name" : "ContainerAnnotationTypeHasWrongValueType"
+        },
+        {
+          "name" : "ContainerAnnotationTypeMustHaveValue"
+        },
+        {
+          "name" : "ContradictoryNullAnnotations"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsInferred"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsInferredFunctionType"
+        },
+        {
+          "name" : "ContradictoryNullAnnotationsOnBound"
+        },
+        {
+          "name" : "CorruptedSignature"
+        },
+        {
+          "name" : "CyclicModuleDependency"
+        },
+        {
+          "name" : "DanglingReference"
+        },
+        {
+          "name" : "DeadCode"
+        },
+        {
+          "name" : "DefaultMethodNotBelow18"
+        },
+        {
+          "name" : "DefaultMethodOverridesObjectMethod"
+        },
+        {
+          "name" : "DereferencingNullableExpression"
+        },
+        {
+          "name" : "DiamondNotBelow17"
+        },
+        {
+          "name" : "DirectInvocationOfAbstractMethod"
+        },
+        {
+          "name" : "DisallowedExplicitThisParameter"
+        },
+        {
+          "name" : "DisallowedTargetForAnnotation"
+        },
+        {
+          "name" : "DisallowedTargetForContainerAnnotationType"
+        },
+        {
+          "name" : "DiscouragedReference"
+        },
+        {
+          "name" : "DiscouragedValueBasedTypeSynchronization"
+        },
+        {
+          "name" : "DuplicateAnnotation"
+        },
+        {
+          "name" : "DuplicateAnnotationMember"
+        },
+        {
+          "name" : "DuplicateAnnotationNotMarkedRepeatable"
+        },
+        {
+          "name" : "DuplicateBlankFinalFieldInitialization"
+        },
+        {
+          "name" : "DuplicateBoundInIntersectionCast"
+        },
+        {
+          "name" : "DuplicateBounds"
+        },
+        {
+          "name" : "DuplicateCase"
+        },
+        {
+          "name" : "DuplicateDefaultCase"
+        },
+        {
+          "name" : "DuplicateExports"
+        },
+        {
+          "name" : "DuplicateField"
+        },
+        {
+          "name" : "DuplicateFinalLocalInitialization"
+        },
+        {
+          "name" : "DuplicateImport"
+        },
+        {
+          "name" : "DuplicateInheritedDefaultMethods"
+        },
+        {
+          "name" : "DuplicateInheritedMethods"
+        },
+        {
+          "name" : "DuplicateLabel"
+        },
+        {
+          "name" : "DuplicateMethod"
+        },
+        {
+          "name" : "DuplicateMethodErasure"
+        },
+        {
+          "name" : "DuplicateModifierForArgument"
+        },
+        {
+          "name" : "DuplicateModifierForField"
+        },
+        {
+          "name" : "DuplicateModifierForMethod"
+        },
+        {
+          "name" : "DuplicateModifierForType"
+        },
+        {
+          "name" : "DuplicateModifierForVariable"
+        },
+        {
+          "name" : "DuplicateModuleRef"
+        },
+        {
+          "name" : "DuplicateNestedType"
+        },
+        {
+          "name" : "DuplicateOpens"
+        },
+        {
+          "name" : "DuplicateParameterizedMethods"
+        },
+        {
+          "name" : "DuplicateRequires"
+        },
+        {
+          "name" : "DuplicateResource"
+        },
+        {
+          "name" : "DuplicateServices"
+        },
+        {
+          "name" : "DuplicateSuperInterface"
+        },
+        {
+          "name" : "DuplicateTargetInTargetAnnotation"
+        },
+        {
+          "name" : "DuplicateTotalPattern"
+        },
+        {
+          "name" : "DuplicateTypeVariable"
+        },
+        {
+          "name" : "DuplicateTypes"
+        },
+        {
+          "name" : "DuplicateUses"
+        },
+        {
+          "name" : "EmptyControlFlowStatement"
+        },
+        {
+          "name" : "EnclosingInstanceInConstructorCall"
+        },
+        {
+          "name" : "EndOfSource"
+        },
+        {
+          "name" : "EnhancedSwitchMissingDefault"
+        },
+        {
+          "name" : "EnumAbstractMethodMustBeImplemented"
+        },
+        {
+          "name" : "EnumConstantCannotDefineAbstractMethod"
+        },
+        {
+          "name" : "EnumConstantMustImplementAbstractMethod"
+        },
+        {
+          "name" : "EnumConstantsCannotBeSurroundedByParenthesis"
+        },
+        {
+          "name" : "EnumStaticFieldInInInitializerContext"
+        },
+        {
+          "name" : "EnumSwitchCannotTargetField"
+        },
+        {
+          "name" : "ErrorUseOfUnderscoreAsAnIdentifier"
+        },
+        {
+          "name" : "ExceptionParameterIsNeverUsed"
+        },
+        {
+          "name" : "ExceptionTypeAmbiguous"
+        },
+        {
+          "name" : "ExceptionTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ExceptionTypeInternalNameProvided"
+        },
+        {
+          "name" : "ExceptionTypeNotFound"
+        },
+        {
+          "name" : "ExceptionTypeNotVisible"
+        },
+        {
+          "name" : "ExplicitAnnotationTargetRequired"
+        },
+        {
+          "name" : "ExplicitThisParameterNotBelow18"
+        },
+        {
+          "name" : "ExplicitThisParameterNotInLambda"
+        },
+        {
+          "name" : "ExplicitlyClosedAutoCloseable"
+        },
+        {
+          "name" : "ExportingForeignPackage"
+        },
+        {
+          "name" : "ExpressionShouldBeAVariable"
+        },
+        {
+          "name" : "ExternalProblemFixable"
+        },
+        {
+          "name" : "ExternalProblemNotFixable"
+        },
+        {
+          "name" : "FallthroughCase"
+        },
+        {
+          "name" : "FeatureNotSupported"
+        },
+        {
+          "name" : "FieldComparisonYieldsFalse"
+        },
+        {
+          "name" : "FieldHidingField"
+        },
+        {
+          "name" : "FieldHidingLocalVariable"
+        },
+        {
+          "name" : "FieldMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "FieldMustBeFinal"
+        },
+        {
+          "name" : "FieldRelated"
+        },
+        {
+          "name" : "FieldTypeAmbiguous"
+        },
+        {
+          "name" : "FieldTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "FieldTypeInternalNameProvided"
+        },
+        {
+          "name" : "FieldTypeNotFound"
+        },
+        {
+          "name" : "FieldTypeNotVisible"
+        },
+        {
+          "name" : "FinalBoundForTypeVariable"
+        },
+        {
+          "name" : "FinalFieldAssignment"
+        },
+        {
+          "name" : "FinalMethodCannotBeOverridden"
+        },
+        {
+          "name" : "FinalOuterLocalAssignment"
+        },
+        {
+          "name" : "FinallyMustCompleteNormally"
+        },
+        {
+          "name" : "ForbiddenReference"
+        },
+        {
+          "name" : "GenericConstructorTypeArgumentMismatch"
+        },
+        {
+          "name" : "GenericInferenceError"
+        },
+        {
+          "name" : "GenericMethodTypeArgumentMismatch"
+        },
+        {
+          "name" : "GenericTypeCannotExtendThrowable"
+        },
+        {
+          "name" : "HidingEnclosingType"
+        },
+        {
+          "name" : "HierarchyCircularity"
+        },
+        {
+          "name" : "HierarchyCircularitySelfReference"
+        },
+        {
+          "name" : "HierarchyHasProblems"
+        },
+        {
+          "name" : "IgnoreCategoriesMask"
+        },
+        {
+          "name" : "IllegalAbstractModifierCombinationForMethod"
+        },
+        {
+          "name" : "IllegalAccessFromTypeVariable"
+        },
+        {
+          "name" : "IllegalAnnotationForBaseType"
+        },
+        {
+          "name" : "IllegalArrayOfUnionType"
+        },
+        {
+          "name" : "IllegalArrayTypeInIntersectionCast"
+        },
+        {
+          "name" : "IllegalBasetypeInIntersectionCast"
+        },
+        {
+          "name" : "IllegalCast"
+        },
+        {
+          "name" : "IllegalClassLiteralForTypeVariable"
+        },
+        {
+          "name" : "IllegalDeclarationOfThisParameter"
+        },
+        {
+          "name" : "IllegalDefaultModifierSpecification"
+        },
+        {
+          "name" : "IllegalDefinitionToNonNullParameter"
+        },
+        {
+          "name" : "IllegalDimension"
+        },
+        {
+          "name" : "IllegalEnclosingInstanceSpecification"
+        },
+        {
+          "name" : "IllegalExtendedDimensions"
+        },
+        {
+          "name" : "IllegalExtendedDimensionsForVarArgs"
+        },
+        {
+          "name" : "IllegalFallthroughToPattern"
+        },
+        {
+          "name" : "IllegalGenericArray"
+        },
+        {
+          "name" : "IllegalHexaLiteral"
+        },
+        {
+          "name" : "IllegalInstanceofParameterizedType"
+        },
+        {
+          "name" : "IllegalInstanceofTypeParameter"
+        },
+        {
+          "name" : "IllegalModifierCombinationFinalAbstractForClass"
+        },
+        {
+          "name" : "IllegalModifierCombinationFinalVolatileForField"
+        },
+        {
+          "name" : "IllegalModifierCombinationForInterfaceMethod"
+        },
+        {
+          "name" : "IllegalModifierCombinationForPrivateInterfaceMethod9"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationField"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationMemberType"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationMethod"
+        },
+        {
+          "name" : "IllegalModifierForAnnotationType"
+        },
+        {
+          "name" : "IllegalModifierForArgument"
+        },
+        {
+          "name" : "IllegalModifierForClass"
+        },
+        {
+          "name" : "IllegalModifierForConstructor"
+        },
+        {
+          "name" : "IllegalModifierForEnum"
+        },
+        {
+          "name" : "IllegalModifierForEnumConstant"
+        },
+        {
+          "name" : "IllegalModifierForEnumConstructor"
+        },
+        {
+          "name" : "IllegalModifierForField"
+        },
+        {
+          "name" : "IllegalModifierForInterface"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceField"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceMethod"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceMethod18"
+        },
+        {
+          "name" : "IllegalModifierForInterfaceMethod9"
+        },
+        {
+          "name" : "IllegalModifierForLocalClass"
+        },
+        {
+          "name" : "IllegalModifierForLocalEnum"
+        },
+        {
+          "name" : "IllegalModifierForLocalEnumDeclaration"
+        },
+        {
+          "name" : "IllegalModifierForMemberClass"
+        },
+        {
+          "name" : "IllegalModifierForMemberEnum"
+        },
+        {
+          "name" : "IllegalModifierForMemberInterface"
+        },
+        {
+          "name" : "IllegalModifierForMethod"
+        },
+        {
+          "name" : "IllegalModifierForModule"
+        },
+        {
+          "name" : "IllegalModifierForPatternVariable"
+        },
+        {
+          "name" : "IllegalModifierForVariable"
+        },
+        {
+          "name" : "IllegalModifiers"
+        },
+        {
+          "name" : "IllegalModifiersForElidedType"
+        },
+        {
+          "name" : "IllegalParameterNullityRedefinition"
+        },
+        {
+          "name" : "IllegalPrimitiveOrArrayTypeForEnclosingInstance"
+        },
+        {
+          "name" : "IllegalQualifiedEnumConstantLabel"
+        },
+        {
+          "name" : "IllegalQualifiedParameterizedTypeAllocation"
+        },
+        {
+          "name" : "IllegalQualifierForExplicitThis"
+        },
+        {
+          "name" : "IllegalQualifierForExplicitThis2"
+        },
+        {
+          "name" : "IllegalRedefinitionOfTypeVariable"
+        },
+        {
+          "name" : "IllegalRedefinitionToNonNullParameter"
+        },
+        {
+          "name" : "IllegalReturnNullityRedefinition"
+        },
+        {
+          "name" : "IllegalReturnNullityRedefinitionFreeTypeVariable"
+        },
+        {
+          "name" : "IllegalStaticModifierForMemberType"
+        },
+        {
+          "name" : "IllegalStrictfpForAbstractInterfaceMethod"
+        },
+        {
+          "name" : "IllegalTotalPatternWithDefault"
+        },
+        {
+          "name" : "IllegalTypeAnnotationsInStaticMemberAccess"
+        },
+        {
+          "name" : "IllegalTypeArgumentsInRawConstructorReference"
+        },
+        {
+          "name" : "IllegalTypeForExplicitThis"
+        },
+        {
+          "name" : "IllegalTypeVariableSuperReference"
+        },
+        {
+          "name" : "IllegalUnderscorePosition"
+        },
+        {
+          "name" : "IllegalUsageOfQualifiedTypeReference"
+        },
+        {
+          "name" : "IllegalUsageOfTypeAnnotations"
+        },
+        {
+          "name" : "IllegalUseOfUnderscoreAsAnIdentifier"
+        },
+        {
+          "name" : "IllegalVararg"
+        },
+        {
+          "name" : "IllegalVarargInLambda"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForField"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForMemberType"
+        },
+        {
+          "name" : "IllegalVisibilityModifierCombinationForMethod"
+        },
+        {
+          "name" : "IllegalVisibilityModifierForInterfaceMemberType"
+        },
+        {
+          "name" : "ImplicitObjectBoundNoNullDefault"
+        },
+        {
+          "name" : "ImportAmbiguous"
+        },
+        {
+          "name" : "ImportInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ImportInternalNameProvided"
+        },
+        {
+          "name" : "ImportNotFound"
+        },
+        {
+          "name" : "ImportNotVisible"
+        },
+        {
+          "name" : "ImportRelated"
+        },
+        {
+          "name" : "IncompatibleExceptionInInheritedMethodThrowsClause"
+        },
+        {
+          "name" : "IncompatibleExceptionInThrowsClause"
+        },
+        {
+          "name" : "IncompatibleExceptionInThrowsClauseForNonInheritedInterfaceMethod"
+        },
+        {
+          "name" : "IncompatibleLambdaParameterType"
+        },
+        {
+          "name" : "IncompatibleMethodReference"
+        },
+        {
+          "name" : "IncompatibleReturnType"
+        },
+        {
+          "name" : "IncompatibleReturnTypeForNonInheritedInterfaceMethod"
+        },
+        {
+          "name" : "IncompatibleTypesInConditionalOperator"
+        },
+        {
+          "name" : "IncompatibleTypesInEqualityOperator"
+        },
+        {
+          "name" : "IncompatibleTypesInForeach"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedConstructor"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedMethod"
+        },
+        {
+          "name" : "IncorrectArityForParameterizedType"
+        },
+        {
+          "name" : "IncorrectEnclosingInstanceReference"
+        },
+        {
+          "name" : "IncorrectSwitchType"
+        },
+        {
+          "name" : "IncorrectSwitchType17"
+        },
+        {
+          "name" : "IndirectAccessToStaticField"
+        },
+        {
+          "name" : "IndirectAccessToStaticMethod"
+        },
+        {
+          "name" : "IndirectAccessToStaticType"
+        },
+        {
+          "name" : "InheritedDefaultMethodConflictsWithOtherInherited"
+        },
+        {
+          "name" : "InheritedFieldHidesEnclosingName"
+        },
+        {
+          "name" : "InheritedIncompatibleReturnType"
+        },
+        {
+          "name" : "InheritedMethodHidesEnclosingName"
+        },
+        {
+          "name" : "InheritedMethodReducesVisibility"
+        },
+        {
+          "name" : "InheritedParameterLackingNonNullAnnotation"
+        },
+        {
+          "name" : "InheritedTypeHidesEnclosingName"
+        },
+        {
+          "name" : "InitializerMustCompleteNormally"
+        },
+        {
+          "name" : "InstanceFieldDuringConstructorInvocation"
+        },
+        {
+          "name" : "InstanceMethodDuringConstructorInvocation"
+        },
+        {
+          "name" : "InterfaceAmbiguous"
+        },
+        {
+          "name" : "InterfaceCannotHaveConstructors"
+        },
+        {
+          "name" : "InterfaceCannotHaveInitializers"
+        },
+        {
+          "name" : "InterfaceInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "InterfaceInternalNameProvided"
+        },
+        {
+          "name" : "InterfaceNotFound"
+        },
+        {
+          "name" : "InterfaceNotFunctionalInterface"
+        },
+        {
+          "name" : "InterfaceNotVisible"
+        },
+        {
+          "name" : "InterfaceStaticMethodInvocationNotBelow18"
+        },
+        {
+          "name" : "InterfaceSuperInvocationNotBelow18"
+        },
+        {
+          "name" : "Internal"
+        },
+        {
+          "name" : "InternalTypeNameProvided"
+        },
+        {
+          "name" : "IntersectionCastNotBelow18"
+        },
+        {
+          "name" : "InvalidAnnotationMemberType"
+        },
+        {
+          "name" : "InvalidArrayConstructorReference"
+        },
+        {
+          "name" : "InvalidBinary"
+        },
+        {
+          "name" : "InvalidBreak"
+        },
+        {
+          "name" : "InvalidCatchBlockSequence"
+        },
+        {
+          "name" : "InvalidCharacterConstant"
+        },
+        {
+          "name" : "InvalidClassInstantiation"
+        },
+        {
+          "name" : "InvalidContinue"
+        },
+        {
+          "name" : "InvalidDigit"
+        },
+        {
+          "name" : "InvalidEncoding"
+        },
+        {
+          "name" : "InvalidEscape"
+        },
+        {
+          "name" : "InvalidExplicitConstructorCall"
+        },
+        {
+          "name" : "InvalidExpressionAsStatement"
+        },
+        {
+          "name" : "InvalidFileNameForPackageAnnotations"
+        },
+        {
+          "name" : "InvalidFloat"
+        },
+        {
+          "name" : "InvalidHexa"
+        },
+        {
+          "name" : "InvalidHighSurrogate"
+        },
+        {
+          "name" : "InvalidInput"
+        },
+        {
+          "name" : "InvalidLowSurrogate"
+        },
+        {
+          "name" : "InvalidNullToSynchronized"
+        },
+        {
+          "name" : "InvalidOctal"
+        },
+        {
+          "name" : "InvalidOpensStatement"
+        },
+        {
+          "name" : "InvalidOperator"
+        },
+        {
+          "name" : "InvalidParameterizedExceptionType"
+        },
+        {
+          "name" : "InvalidParenthesizedExpression"
+        },
+        {
+          "name" : "InvalidServiceImplType"
+        },
+        {
+          "name" : "InvalidServiceIntfType"
+        },
+        {
+          "name" : "InvalidTypeArguments"
+        },
+        {
+          "name" : "InvalidTypeExpression"
+        },
+        {
+          "name" : "InvalidTypeForCollection"
+        },
+        {
+          "name" : "InvalidTypeForCollectionTarget14"
+        },
+        {
+          "name" : "InvalidTypeForStaticImport"
+        },
+        {
+          "name" : "InvalidTypeToSynchronized"
+        },
+        {
+          "name" : "InvalidTypeVariableExceptionType"
+        },
+        {
+          "name" : "InvalidUnaryExpression"
+        },
+        {
+          "name" : "InvalidUnicodeEscape"
+        },
+        {
+          "name" : "InvalidUnionTypeReferenceSequence"
+        },
+        {
+          "name" : "InvalidUsageOfAnnotationDeclarations"
+        },
+        {
+          "name" : "InvalidUsageOfAnnotations"
+        },
+        {
+          "name" : "InvalidUsageOfEnumDeclarations"
+        },
+        {
+          "name" : "InvalidUsageOfForeachStatements"
+        },
+        {
+          "name" : "InvalidUsageOfStaticImports"
+        },
+        {
+          "name" : "InvalidUsageOfTypeAnnotations"
+        },
+        {
+          "name" : "InvalidUsageOfTypeArguments"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParameters"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParametersForAnnotationDeclaration"
+        },
+        {
+          "name" : "InvalidUsageOfTypeParametersForEnumDeclaration"
+        },
+        {
+          "name" : "InvalidUsageOfVarargs"
+        },
+        {
+          "name" : "InvalidUsageOfWildcard"
+        },
+        {
+          "name" : "InvalidVoidExpression"
+        },
+        {
+          "name" : "IsClassPathCorrect"
+        },
+        {
+          "name" : "Javadoc"
+        },
+        {
+          "name" : "JavadocAmbiguousConstructor"
+        },
+        {
+          "name" : "JavadocAmbiguousField"
+        },
+        {
+          "name" : "JavadocAmbiguousMethod"
+        },
+        {
+          "name" : "JavadocAmbiguousMethodReference"
+        },
+        {
+          "name" : "JavadocAmbiguousType"
+        },
+        {
+          "name" : "JavadocDuplicateParamName"
+        },
+        {
+          "name" : "JavadocDuplicateProvidesTag"
+        },
+        {
+          "name" : "JavadocDuplicateReturnTag"
+        },
+        {
+          "name" : "JavadocDuplicateTag"
+        },
+        {
+          "name" : "JavadocDuplicateThrowsClassName"
+        },
+        {
+          "name" : "JavadocDuplicateUsesTag"
+        },
+        {
+          "name" : "JavadocEmptyReturnTag"
+        },
+        {
+          "name" : "JavadocGenericConstructorTypeArgumentMismatch"
+        },
+        {
+          "name" : "JavadocGenericMethodTypeArgumentMismatch"
+        },
+        {
+          "name" : "JavadocHiddenReference"
+        },
+        {
+          "name" : "JavadocIncorrectArityForParameterizedConstructor"
+        },
+        {
+          "name" : "JavadocIncorrectArityForParameterizedMethod"
+        },
+        {
+          "name" : "JavadocInheritedFieldHidesEnclosingName"
+        },
+        {
+          "name" : "JavadocInheritedMethodHidesEnclosingName"
+        },
+        {
+          "name" : "JavadocInheritedNameHidesEnclosingTypeName"
+        },
+        {
+          "name" : "JavadocInternalTypeNameProvided"
+        },
+        {
+          "name" : "JavadocInvalidMemberTypeQualification"
+        },
+        {
+          "name" : "JavadocInvalidModuleQualification"
+        },
+        {
+          "name" : "JavadocInvalidParamName"
+        },
+        {
+          "name" : "JavadocInvalidParamTagName"
+        },
+        {
+          "name" : "JavadocInvalidParamTagTypeParameter"
+        },
+        {
+          "name" : "JavadocInvalidProvidesClass"
+        },
+        {
+          "name" : "JavadocInvalidProvidesClassName"
+        },
+        {
+          "name" : "JavadocInvalidSeeArgs"
+        },
+        {
+          "name" : "JavadocInvalidSeeHref"
+        },
+        {
+          "name" : "JavadocInvalidSeeReference"
+        },
+        {
+          "name" : "JavadocInvalidSeeUrlReference"
+        },
+        {
+          "name" : "JavadocInvalidTag"
+        },
+        {
+          "name" : "JavadocInvalidThrowsClass"
+        },
+        {
+          "name" : "JavadocInvalidThrowsClassName"
+        },
+        {
+          "name" : "JavadocInvalidUsesClass"
+        },
+        {
+          "name" : "JavadocInvalidUsesClassName"
+        },
+        {
+          "name" : "JavadocInvalidValueReference"
+        },
+        {
+          "name" : "JavadocMalformedSeeReference"
+        },
+        {
+          "name" : "JavadocMessagePrefix"
+        },
+        {
+          "name" : "JavadocMissing"
+        },
+        {
+          "name" : "JavadocMissingHashCharacter"
+        },
+        {
+          "name" : "JavadocMissingIdentifier"
+        },
+        {
+          "name" : "JavadocMissingParamName"
+        },
+        {
+          "name" : "JavadocMissingParamTag"
+        },
+        {
+          "name" : "JavadocMissingProvidesClassName"
+        },
+        {
+          "name" : "JavadocMissingProvidesTag"
+        },
+        {
+          "name" : "JavadocMissingReturnTag"
+        },
+        {
+          "name" : "JavadocMissingSeeReference"
+        },
+        {
+          "name" : "JavadocMissingTagDescription"
+        },
+        {
+          "name" : "JavadocMissingThrowsClassName"
+        },
+        {
+          "name" : "JavadocMissingThrowsTag"
+        },
+        {
+          "name" : "JavadocMissingUsesClassName"
+        },
+        {
+          "name" : "JavadocMissingUsesTag"
+        },
+        {
+          "name" : "JavadocNoMessageSendOnArrayType"
+        },
+        {
+          "name" : "JavadocNoMessageSendOnBaseType"
+        },
+        {
+          "name" : "JavadocNonGenericConstructor"
+        },
+        {
+          "name" : "JavadocNonGenericMethod"
+        },
+        {
+          "name" : "JavadocNonStaticTypeFromStaticInvocation"
+        },
+        {
+          "name" : "JavadocNotAccessibleType"
+        },
+        {
+          "name" : "JavadocNotVisibleConstructor"
+        },
+        {
+          "name" : "JavadocNotVisibleField"
+        },
+        {
+          "name" : "JavadocNotVisibleMethod"
+        },
+        {
+          "name" : "JavadocNotVisibleType"
+        },
+        {
+          "name" : "JavadocParameterMismatch"
+        },
+        {
+          "name" : "JavadocParameterizedConstructorArgumentTypeMismatch"
+        },
+        {
+          "name" : "JavadocParameterizedMethodArgumentTypeMismatch"
+        },
+        {
+          "name" : "JavadocTypeArgumentsForRawGenericConstructor"
+        },
+        {
+          "name" : "JavadocTypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "JavadocUndefinedConstructor"
+        },
+        {
+          "name" : "JavadocUndefinedField"
+        },
+        {
+          "name" : "JavadocUndefinedMethod"
+        },
+        {
+          "name" : "JavadocUndefinedType"
+        },
+        {
+          "name" : "JavadocUnexpectedTag"
+        },
+        {
+          "name" : "JavadocUnexpectedText"
+        },
+        {
+          "name" : "JavadocUnterminatedInlineTag"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedConstructor"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedField"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedMethod"
+        },
+        {
+          "name" : "JavadocUsingDeprecatedType"
+        },
+        {
+          "name" : "LambdaDescriptorMentionsUnmentionable"
+        },
+        {
+          "name" : "LambdaExpressionNotBelow18"
+        },
+        {
+          "name" : "LambdaRedeclaresArgument"
+        },
+        {
+          "name" : "LambdaRedeclaresLocal"
+        },
+        {
+          "name" : "LambdaShapeComputationError"
+        },
+        {
+          "name" : "LocalReferencedInGuardMustBeEffectivelyFinal"
+        },
+        {
+          "name" : "LocalStaticsIllegalVisibilityModifierForInterfaceLocalType"
+        },
+        {
+          "name" : "LocalVariableCanOnlyBeNull"
+        },
+        {
+          "name" : "LocalVariableCannotBeNull"
+        },
+        {
+          "name" : "LocalVariableHidingField"
+        },
+        {
+          "name" : "LocalVariableHidingLocalVariable"
+        },
+        {
+          "name" : "LocalVariableIsNeverUsed"
+        },
+        {
+          "name" : "LocalVariableMayBeNull"
+        },
+        {
+          "name" : "MaskedCatch"
+        },
+        {
+          "name" : "MethodButWithConstructorName"
+        },
+        {
+          "name" : "MethodCanBePotentiallyStatic"
+        },
+        {
+          "name" : "MethodCanBeStatic"
+        },
+        {
+          "name" : "MethodMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "MethodMustOverride"
+        },
+        {
+          "name" : "MethodMustOverrideOrImplement"
+        },
+        {
+          "name" : "MethodNameClash"
+        },
+        {
+          "name" : "MethodNameClashHidden"
+        },
+        {
+          "name" : "MethodReducesVisibility"
+        },
+        {
+          "name" : "MethodReferenceNotBelow18"
+        },
+        {
+          "name" : "MethodReferenceSwingsBothWays"
+        },
+        {
+          "name" : "MethodRelated"
+        },
+        {
+          "name" : "MethodRequiresBody"
+        },
+        {
+          "name" : "MethodReturnsVoid"
+        },
+        {
+          "name" : "MethodVarargsArgumentNeedCast"
+        },
+        {
+          "name" : "MisplacedTypeAnnotations"
+        },
+        {
+          "name" : "MissingArgumentsForParameterizedMemberType"
+        },
+        {
+          "name" : "MissingDefaultCase"
+        },
+        {
+          "name" : "MissingEnclosingInstance"
+        },
+        {
+          "name" : "MissingEnclosingInstanceForConstructorCall"
+        },
+        {
+          "name" : "MissingEnumConstantCase"
+        },
+        {
+          "name" : "MissingEnumConstantCaseDespiteDefault"
+        },
+        {
+          "name" : "MissingEnumDefaultCase"
+        },
+        {
+          "name" : "MissingNonNullByDefaultAnnotationOnPackage"
+        },
+        {
+          "name" : "MissingNonNullByDefaultAnnotationOnType"
+        },
+        {
+          "name" : "MissingNullAnnotationImplicitlyUsed"
+        },
+        {
+          "name" : "MissingOverrideAnnotation"
+        },
+        {
+          "name" : "MissingOverrideAnnotationForInterfaceMethodImplementation"
+        },
+        {
+          "name" : "MissingRequiresTransitiveForTypeInAPI"
+        },
+        {
+          "name" : "MissingReturnType"
+        },
+        {
+          "name" : "MissingSemiColon"
+        },
+        {
+          "name" : "MissingSerialVersion"
+        },
+        {
+          "name" : "MissingSynchronizedModifierInInheritedMethod"
+        },
+        {
+          "name" : "MissingTypeInConstructor"
+        },
+        {
+          "name" : "MissingTypeInLambda"
+        },
+        {
+          "name" : "MissingTypeInMethod"
+        },
+        {
+          "name" : "MissingValueForAnnotationMember"
+        },
+        {
+          "name" : "MissingValueFromLambda"
+        },
+        {
+          "name" : "ModuleRelated"
+        },
+        {
+          "name" : "MultiCatchNotBelow17"
+        },
+        {
+          "name" : "MultiConstantCaseLabelsNotSupported"
+        },
+        {
+          "name" : "MultipleFunctionalInterfaces"
+        },
+        {
+          "name" : "MustDefineEitherDimensionExpressionsOrInitializer"
+        },
+        {
+          "name" : "MustSpecifyPackage"
+        },
+        {
+          "name" : "NativeMethodsCannotBeStrictfp"
+        },
+        {
+          "name" : "NeedToEmulateConstructorAccess"
+        },
+        {
+          "name" : "NeedToEmulateFieldReadAccess"
+        },
+        {
+          "name" : "NeedToEmulateFieldWriteAccess"
+        },
+        {
+          "name" : "NeedToEmulateMethodAccess"
+        },
+        {
+          "name" : "NestedServiceImpl"
+        },
+        {
+          "name" : "NoAdditionalBoundAfterTypeVariable"
+        },
+        {
+          "name" : "NoFieldOnBaseType"
+        },
+        {
+          "name" : "NoGenericLambda"
+        },
+        {
+          "name" : "NoImplicitStringConversionForCharArrayExpression"
+        },
+        {
+          "name" : "NoMessageSendOnArrayType"
+        },
+        {
+          "name" : "NoMessageSendOnBaseType"
+        },
+        {
+          "name" : "NoSuperInInterfaceContext"
+        },
+        {
+          "name" : "NonBlankFinalLocalAssignment"
+        },
+        {
+          "name" : "NonConstantExpression"
+        },
+        {
+          "name" : "NonDenotableTypeArgumentForAnonymousDiamond"
+        },
+        {
+          "name" : "NonExternalizedStringLiteral"
+        },
+        {
+          "name" : "NonGenericConstructor"
+        },
+        {
+          "name" : "NonGenericMethod"
+        },
+        {
+          "name" : "NonGenericType"
+        },
+        {
+          "name" : "NonNullDefaultDetailIsNotEvaluated"
+        },
+        {
+          "name" : "NonNullExpressionComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullMessageSendComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullMethodTypeVariableFromLegacyMethod"
+        },
+        {
+          "name" : "NonNullSpecdFieldComparisonYieldsFalse"
+        },
+        {
+          "name" : "NonNullTypeVariableFromLegacyMethod"
+        },
+        {
+          "name" : "NonPublicTypeInAPI"
+        },
+        {
+          "name" : "NonStaticAccessToStaticField"
+        },
+        {
+          "name" : "NonStaticAccessToStaticMethod"
+        },
+        {
+          "name" : "NonStaticContextForEnumMemberType"
+        },
+        {
+          "name" : "NonStaticFieldFromStaticInvocation"
+        },
+        {
+          "name" : "NonStaticOrAlienTypeReceiver"
+        },
+        {
+          "name" : "NonStaticTypeFromStaticInvocation"
+        },
+        {
+          "name" : "NotAccessibleConstructor"
+        },
+        {
+          "name" : "NotAccessibleField"
+        },
+        {
+          "name" : "NotAccessibleMethod"
+        },
+        {
+          "name" : "NotAccessiblePackage"
+        },
+        {
+          "name" : "NotAccessibleType"
+        },
+        {
+          "name" : "NotAnnotationType"
+        },
+        {
+          "name" : "NotExportedTypeInAPI"
+        },
+        {
+          "name" : "NotVisibleConstructor"
+        },
+        {
+          "name" : "NotVisibleConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "NotVisibleConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "NotVisibleField"
+        },
+        {
+          "name" : "NotVisibleMethod"
+        },
+        {
+          "name" : "NotVisibleType"
+        },
+        {
+          "name" : "NullAnnotationAtQualifyingType"
+        },
+        {
+          "name" : "NullAnnotationUnsupportedLocation"
+        },
+        {
+          "name" : "NullAnnotationUnsupportedLocationAtType"
+        },
+        {
+          "name" : "NullExpressionReference"
+        },
+        {
+          "name" : "NullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "NullLocalVariableInstanceofYieldsFalse"
+        },
+        {
+          "name" : "NullLocalVariableReference"
+        },
+        {
+          "name" : "NullNotCompatibleToFreeTypeVariable"
+        },
+        {
+          "name" : "NullSourceString"
+        },
+        {
+          "name" : "NullUnboxing"
+        },
+        {
+          "name" : "NullableFieldReference"
+        },
+        {
+          "name" : "NullityMismatchAgainstFreeTypeVariable"
+        },
+        {
+          "name" : "NullityMismatchTypeArgument"
+        },
+        {
+          "name" : "NullityMismatchingTypeAnnotation"
+        },
+        {
+          "name" : "NullityMismatchingTypeAnnotationSuperHint"
+        },
+        {
+          "name" : "NullityUncheckedTypeAnnotationDetail"
+        },
+        {
+          "name" : "NullityUncheckedTypeAnnotationDetailSuperHint"
+        },
+        {
+          "name" : "NumericValueOutOfRange"
+        },
+        {
+          "name" : "ObjectCannotBeGeneric"
+        },
+        {
+          "name" : "ObjectCannotHaveSuperTypes"
+        },
+        {
+          "name" : "ObjectHasNoSuperclass"
+        },
+        {
+          "name" : "ObjectMustBeClass"
+        },
+        {
+          "name" : "OnlyOnePatternCaseLabelAllowed"
+        },
+        {
+          "name" : "OuterLocalMustBeEffectivelyFinal"
+        },
+        {
+          "name" : "OuterLocalMustBeFinal"
+        },
+        {
+          "name" : "OverridingDeprecatedMethod"
+        },
+        {
+          "name" : "OverridingDeprecatedSinceVersionMethod"
+        },
+        {
+          "name" : "OverridingMethodWithoutSuperInvocation"
+        },
+        {
+          "name" : "OverridingNonVisibleMethod"
+        },
+        {
+          "name" : "OverridingTerminallyDeprecatedMethod"
+        },
+        {
+          "name" : "OverridingTerminallyDeprecatedSinceVersionMethod"
+        },
+        {
+          "name" : "PackageCollidesWithType"
+        },
+        {
+          "name" : "PackageDoesNotExistOrIsEmpty"
+        },
+        {
+          "name" : "PackageIsNotExpectedPackage"
+        },
+        {
+          "name" : "ParameterAssignment"
+        },
+        {
+          "name" : "ParameterLackingNonNullAnnotation"
+        },
+        {
+          "name" : "ParameterLackingNullableAnnotation"
+        },
+        {
+          "name" : "ParameterMismatch"
+        },
+        {
+          "name" : "ParameterizedConstructorArgumentTypeMismatch"
+        },
+        {
+          "name" : "ParameterizedMethodArgumentTypeMismatch"
+        },
+        {
+          "name" : "ParsingError"
+        },
+        {
+          "name" : "ParsingErrorDeleteToken"
+        },
+        {
+          "name" : "ParsingErrorDeleteTokens"
+        },
+        {
+          "name" : "ParsingErrorInsertToComplete"
+        },
+        {
+          "name" : "ParsingErrorInsertToCompletePhrase"
+        },
+        {
+          "name" : "ParsingErrorInsertToCompleteScope"
+        },
+        {
+          "name" : "ParsingErrorInsertTokenAfter"
+        },
+        {
+          "name" : "ParsingErrorInsertTokenBefore"
+        },
+        {
+          "name" : "ParsingErrorInvalidToken"
+        },
+        {
+          "name" : "ParsingErrorMergeTokens"
+        },
+        {
+          "name" : "ParsingErrorMisplacedConstruct"
+        },
+        {
+          "name" : "ParsingErrorNoSuggestion"
+        },
+        {
+          "name" : "ParsingErrorNoSuggestionForTokens"
+        },
+        {
+          "name" : "ParsingErrorOnKeyword"
+        },
+        {
+          "name" : "ParsingErrorOnKeywordNoSuggestion"
+        },
+        {
+          "name" : "ParsingErrorReplaceTokens"
+        },
+        {
+          "name" : "ParsingErrorUnexpectedEOF"
+        },
+        {
+          "name" : "PatternDominated"
+        },
+        {
+          "name" : "PatternSubtypeOfExpression"
+        },
+        {
+          "name" : "PatternVariableNotInScope"
+        },
+        {
+          "name" : "PatternVariableRedeclared"
+        },
+        {
+          "name" : "PatternVariableRedefined"
+        },
+        {
+          "name" : "PolymorphicMethodNotBelow17"
+        },
+        {
+          "name" : "PossibleAccidentalBooleanAssignment"
+        },
+        {
+          "name" : "PotentialHeapPollutionFromVararg"
+        },
+        {
+          "name" : "PotentialNullExpressionReference"
+        },
+        {
+          "name" : "PotentialNullLocalVariableReference"
+        },
+        {
+          "name" : "PotentialNullMessageSendReference"
+        },
+        {
+          "name" : "PotentialNullUnboxing"
+        },
+        {
+          "name" : "PotentiallyUnclosedCloseable"
+        },
+        {
+          "name" : "PotentiallyUnclosedCloseableAtExit"
+        },
+        {
+          "name" : "PreviewAPIUsed"
+        },
+        {
+          "name" : "PreviewFeatureDisabled"
+        },
+        {
+          "name" : "PreviewFeatureNotSupported"
+        },
+        {
+          "name" : "PreviewFeatureUsed"
+        },
+        {
+          "name" : "PreviewFeaturesNotAllowed"
+        },
+        {
+          "name" : "PreviewRelated"
+        },
+        {
+          "name" : "ProblemNotAnalysed"
+        },
+        {
+          "name" : "ProviderMethodOrConstructorRequiredForServiceImpl"
+        },
+        {
+          "name" : "PublicClassMustMatchFileName"
+        },
+        {
+          "name" : "RawMemberTypeCannotBeParameterized"
+        },
+        {
+          "name" : "RawTypeReference"
+        },
+        {
+          "name" : "RecordAccessorMethodHasThrowsClause"
+        },
+        {
+          "name" : "RecordAccessorMethodShouldBePublic"
+        },
+        {
+          "name" : "RecordAccessorMethodShouldNotBeGeneric"
+        },
+        {
+          "name" : "RecordAccessorMethodShouldNotBeStatic"
+        },
+        {
+          "name" : "RecordCannotDefineRecordInLocalType"
+        },
+        {
+          "name" : "RecordCannotExtendRecord"
+        },
+        {
+          "name" : "RecordCanonicalConstructorHasExplicitConstructorCall"
+        },
+        {
+          "name" : "RecordCanonicalConstructorHasReturnStatement"
+        },
+        {
+          "name" : "RecordCanonicalConstructorHasThrowsClause"
+        },
+        {
+          "name" : "RecordCanonicalConstructorShouldNotBeGeneric"
+        },
+        {
+          "name" : "RecordCanonicalConstructorVisibilityReduced"
+        },
+        {
+          "name" : "RecordCompactConstructorHasExplicitConstructorCall"
+        },
+        {
+          "name" : "RecordCompactConstructorHasReturnStatement"
+        },
+        {
+          "name" : "RecordComponentCannotBeVoid"
+        },
+        {
+          "name" : "RecordComponentsCannotHaveModifiers"
+        },
+        {
+          "name" : "RecordDuplicateComponent"
+        },
+        {
+          "name" : "RecordIllegalAccessorReturnType"
+        },
+        {
+          "name" : "RecordIllegalComponentNameInRecord"
+        },
+        {
+          "name" : "RecordIllegalExplicitFinalFieldAssignInCompactConstructor"
+        },
+        {
+          "name" : "RecordIllegalExtendedDimensionsForRecordComponent"
+        },
+        {
+          "name" : "RecordIllegalModifierForInnerRecord"
+        },
+        {
+          "name" : "RecordIllegalModifierForLocalRecord"
+        },
+        {
+          "name" : "RecordIllegalModifierForRecord"
+        },
+        {
+          "name" : "RecordIllegalNativeModifierInRecord"
+        },
+        {
+          "name" : "RecordIllegalParameterNameInCanonicalConstructor"
+        },
+        {
+          "name" : "RecordIllegalStaticModifierForLocalClassOrInterface"
+        },
+        {
+          "name" : "RecordIllegalVararg"
+        },
+        {
+          "name" : "RecordInstanceInitializerBlockInRecord"
+        },
+        {
+          "name" : "RecordMissingExplicitConstructorCallInNonCanonicalConstructor"
+        },
+        {
+          "name" : "RecordMultipleCanonicalConstructors"
+        },
+        {
+          "name" : "RecordNestedRecordInherentlyStatic"
+        },
+        {
+          "name" : "RecordNonStaticFieldDeclarationInRecord"
+        },
+        {
+          "name" : "RecordStaticReferenceToOuterLocalVariable"
+        },
+        {
+          "name" : "RecursiveConstructorInvocation"
+        },
+        {
+          "name" : "RedefinedArgument"
+        },
+        {
+          "name" : "RedefinedLocal"
+        },
+        {
+          "name" : "RedundantLocalVariableNullAssignment"
+        },
+        {
+          "name" : "RedundantNullAnnotation"
+        },
+        {
+          "name" : "RedundantNullCheckAgainstNonNullType"
+        },
+        {
+          "name" : "RedundantNullCheckOnConstNonNullField"
+        },
+        {
+          "name" : "RedundantNullCheckOnField"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullExpression"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullMessageSend"
+        },
+        {
+          "name" : "RedundantNullCheckOnNonNullSpecdField"
+        },
+        {
+          "name" : "RedundantNullCheckOnNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullCheckOnSpecdNonNullLocalVariable"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotation"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationField"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationLocal"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationMethod"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationModule"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationPackage"
+        },
+        {
+          "name" : "RedundantNullDefaultAnnotationType"
+        },
+        {
+          "name" : "RedundantSpecificationOfTypeArguments"
+        },
+        {
+          "name" : "RedundantSuperinterface"
+        },
+        {
+          "name" : "ReferenceExpressionParameterNullityMismatch"
+        },
+        {
+          "name" : "ReferenceExpressionParameterNullityUnchecked"
+        },
+        {
+          "name" : "ReferenceExpressionReturnNullRedef"
+        },
+        {
+          "name" : "ReferenceExpressionReturnNullRedefUnchecked"
+        },
+        {
+          "name" : "ReferenceToForwardField"
+        },
+        {
+          "name" : "ReferenceToForwardTypeVariable"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeIsDocumented"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeIsInherited"
+        },
+        {
+          "name" : "RepeatableAnnotationTypeTargetMismatch"
+        },
+        {
+          "name" : "RepeatableAnnotationWithRepeatingContainerAnnotation"
+        },
+        {
+          "name" : "RepeatedAnnotationWithContainerAnnotation"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedFreeTypeVariable"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedNull"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedPotentialNull"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedSpecdNullable"
+        },
+        {
+          "name" : "RequiredNonNullButProvidedUnknown"
+        },
+        {
+          "name" : "ResourceHasToImplementAutoCloseable"
+        },
+        {
+          "name" : "RestrictedTypeName"
+        },
+        {
+          "name" : "ReturnTypeAmbiguous"
+        },
+        {
+          "name" : "ReturnTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "ReturnTypeInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "ReturnTypeInternalNameProvided"
+        },
+        {
+          "name" : "ReturnTypeMismatch"
+        },
+        {
+          "name" : "ReturnTypeNotFound"
+        },
+        {
+          "name" : "ReturnTypeNotVisible"
+        },
+        {
+          "name" : "SafeVarargsOnFixedArityMethod"
+        },
+        {
+          "name" : "SafeVarargsOnNonFinalInstanceMethod"
+        },
+        {
+          "name" : "SafeVarargsOnSyntheticRecordAccessor"
+        },
+        {
+          "name" : "SealedAnonymousClassCannotExtendSealedType"
+        },
+        {
+          "name" : "SealedDisAllowedNonSealedModifierInClass"
+        },
+        {
+          "name" : "SealedDisAllowedNonSealedModifierInInterface"
+        },
+        {
+          "name" : "SealedDuplicateTypeInPermits"
+        },
+        {
+          "name" : "SealedInterfaceIsSealedAndNonSealed"
+        },
+        {
+          "name" : "SealedLocalDirectSuperTypeSealed"
+        },
+        {
+          "name" : "SealedMissingClassModifier"
+        },
+        {
+          "name" : "SealedMissingInterfaceModifier"
+        },
+        {
+          "name" : "SealedMissingSealedModifier"
+        },
+        {
+          "name" : "SealedNotDirectSuperClass"
+        },
+        {
+          "name" : "SealedNotDirectSuperInterface"
+        },
+        {
+          "name" : "SealedPermittedTypeOutsideOfModule"
+        },
+        {
+          "name" : "SealedPermittedTypeOutsideOfPackage"
+        },
+        {
+          "name" : "SealedSealedTypeMissingPermits"
+        },
+        {
+          "name" : "SealedSuperClassDoesNotPermit"
+        },
+        {
+          "name" : "SealedSuperInterfaceDoesNotPermit"
+        },
+        {
+          "name" : "SealedSuperTypeDisallowed"
+        },
+        {
+          "name" : "SealedSuperTypeInDifferentPackage"
+        },
+        {
+          "name" : "ServiceImplDefaultConstructorNotPublic"
+        },
+        {
+          "name" : "ServiceImplNotDefinedByModule"
+        },
+        {
+          "name" : "ShouldImplementHashcode"
+        },
+        {
+          "name" : "ShouldReturnValue"
+        },
+        {
+          "name" : "ShouldReturnValueHintMissingDefault"
+        },
+        {
+          "name" : "SpecdNonNullLocalVariableComparisonYieldsFalse"
+        },
+        {
+          "name" : "StaticInheritedMethodConflicts"
+        },
+        {
+          "name" : "StaticInterfaceMethodNotBelow18"
+        },
+        {
+          "name" : "StaticMemberOfParameterizedType"
+        },
+        {
+          "name" : "StaticMethodRequested"
+        },
+        {
+          "name" : "StaticMethodShouldBeAccessedStatically"
+        },
+        {
+          "name" : "StrictfpNotRequired"
+        },
+        {
+          "name" : "StringConstantIsExceedingUtf8Limit"
+        },
+        {
+          "name" : "SuperAccessCannotBypassDirectSuper"
+        },
+        {
+          "name" : "SuperCallCannotBypassOverride"
+        },
+        {
+          "name" : "SuperInterfaceMustBeAnInterface"
+        },
+        {
+          "name" : "SuperInterfacesCollide"
+        },
+        {
+          "name" : "SuperTypeUsingWildcard"
+        },
+        {
+          "name" : "SuperclassAmbiguous"
+        },
+        {
+          "name" : "SuperclassInheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "SuperclassInternalNameProvided"
+        },
+        {
+          "name" : "SuperclassMustBeAClass"
+        },
+        {
+          "name" : "SuperclassNotFound"
+        },
+        {
+          "name" : "SuperclassNotVisible"
+        },
+        {
+          "name" : "SuperfluousSemicolon"
+        },
+        {
+          "name" : "SwitchExpressionBreakMissingValue"
+        },
+        {
+          "name" : "SwitchExpressionIllegalLastStatement"
+        },
+        {
+          "name" : "SwitchExpressionLastStatementCompletesNormally"
+        },
+        {
+          "name" : "SwitchExpressionMissingDefaultCase"
+        },
+        {
+          "name" : "SwitchExpressionMissingEnumConstantCase"
+        },
+        {
+          "name" : "SwitchExpressionSwitchLabeledBlockCompletesNormally"
+        },
+        {
+          "name" : "SwitchExpressionTrailingSwitchLabels"
+        },
+        {
+          "name" : "SwitchExpressionaYieldSwitchLabeledBlockCompletesNormally"
+        },
+        {
+          "name" : "SwitchExpressionsBreakOutOfSwitchExpression"
+        },
+        {
+          "name" : "SwitchExpressionsContinueOutOfSwitchExpression"
+        },
+        {
+          "name" : "SwitchExpressionsEmptySwitchBlock"
+        },
+        {
+          "name" : "SwitchExpressionsIncompatibleResultExpressionTypes"
+        },
+        {
+          "name" : "SwitchExpressionsNoResultExpression"
+        },
+        {
+          "name" : "SwitchExpressionsNotSupported"
+        },
+        {
+          "name" : "SwitchExpressionsReturnWithinSwitchExpression"
+        },
+        {
+          "name" : "SwitchExpressionsYieldBreakNotAllowed"
+        },
+        {
+          "name" : "SwitchExpressionsYieldEmptySwitchBlock"
+        },
+        {
+          "name" : "SwitchExpressionsYieldIllegalLastStatement"
+        },
+        {
+          "name" : "SwitchExpressionsYieldIllegalStatement"
+        },
+        {
+          "name" : "SwitchExpressionsYieldIncompatibleResultExpressionTypes"
+        },
+        {
+          "name" : "SwitchExpressionsYieldLastStatementCompletesNormally"
+        },
+        {
+          "name" : "SwitchExpressionsYieldMissingDefaultCase"
+        },
+        {
+          "name" : "SwitchExpressionsYieldMissingEnumConstantCase"
+        },
+        {
+          "name" : "SwitchExpressionsYieldMissingValue"
+        },
+        {
+          "name" : "SwitchExpressionsYieldNoResultExpression"
+        },
+        {
+          "name" : "SwitchExpressionsYieldOutsideSwitchExpression"
+        },
+        {
+          "name" : "SwitchExpressionsYieldRestrictedGeneralWarning"
+        },
+        {
+          "name" : "SwitchExpressionsYieldTrailingSwitchLabels"
+        },
+        {
+          "name" : "SwitchExpressionsYieldTypeDeclarationError"
+        },
+        {
+          "name" : "SwitchExpressionsYieldTypeDeclarationWarning"
+        },
+        {
+          "name" : "SwitchExpressionsYieldUnqualifiedMethodError"
+        },
+        {
+          "name" : "SwitchExpressionsYieldUnqualifiedMethodWarning"
+        },
+        {
+          "name" : "SwitchOnEnumNotBelow15"
+        },
+        {
+          "name" : "SwitchOnStringsNotBelow17"
+        },
+        {
+          "name" : "SwitchPreviewMixedCase"
+        },
+        {
+          "name" : "Syntax"
+        },
+        {
+          "name" : "TargetTypeNotAFunctionalInterface"
+        },
+        {
+          "name" : "Task"
+        },
+        {
+          "name" : "ThisInStaticContext"
+        },
+        {
+          "name" : "ThisSuperDuringConstructorInvocation"
+        },
+        {
+          "name" : "ToleratedMisplacedTypeAnnotations"
+        },
+        {
+          "name" : "TooManyArgumentSlots"
+        },
+        {
+          "name" : "TooManyArrayDimensions"
+        },
+        {
+          "name" : "TooManyBytesForStringConstant"
+        },
+        {
+          "name" : "TooManyConstantsInConstantPool"
+        },
+        {
+          "name" : "TooManyFields"
+        },
+        {
+          "name" : "TooManyLocalVariableSlots"
+        },
+        {
+          "name" : "TooManyMethods"
+        },
+        {
+          "name" : "TooManyParametersForSyntheticMethod"
+        },
+        {
+          "name" : "TooManySyntheticArgumentSlots"
+        },
+        {
+          "name" : "TypeAnnotationAtQualifiedName"
+        },
+        {
+          "name" : "TypeArgumentMismatch"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericConstructor"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "TypeCollidesWithPackage"
+        },
+        {
+          "name" : "TypeHidingType"
+        },
+        {
+          "name" : "TypeHidingTypeParameterFromMethod"
+        },
+        {
+          "name" : "TypeHidingTypeParameterFromType"
+        },
+        {
+          "name" : "TypeMismatch"
+        },
+        {
+          "name" : "TypeMissingDeprecatedAnnotation"
+        },
+        {
+          "name" : "TypeParameterHidingType"
+        },
+        {
+          "name" : "TypeRelated"
+        },
+        {
+          "name" : "UnboxingConversion"
+        },
+        {
+          "name" : "UncheckedAccessOfValueOfFreeTypeVariable"
+        },
+        {
+          "name" : "Unclassified"
+        },
+        {
+          "name" : "UnclosedCloseable"
+        },
+        {
+          "name" : "UnclosedCloseableAtExit"
+        },
+        {
+          "name" : "UndefinedAnnotationMember"
+        },
+        {
+          "name" : "UndefinedConstructor"
+        },
+        {
+          "name" : "UndefinedConstructorInDefaultConstructor"
+        },
+        {
+          "name" : "UndefinedConstructorInImplicitConstructorCall"
+        },
+        {
+          "name" : "UndefinedField"
+        },
+        {
+          "name" : "UndefinedLabel"
+        },
+        {
+          "name" : "UndefinedMethod"
+        },
+        {
+          "name" : "UndefinedModule"
+        },
+        {
+          "name" : "UndefinedModuleAddReads"
+        },
+        {
+          "name" : "UndefinedName"
+        },
+        {
+          "name" : "UndefinedType"
+        },
+        {
+          "name" : "UndefinedTypeVariable"
+        },
+        {
+          "name" : "UnderscoresInLiteralsNotBelow17"
+        },
+        {
+          "name" : "UndocumentedEmptyBlock"
+        },
+        {
+          "name" : "UnexpectedStaticModifierForField"
+        },
+        {
+          "name" : "UnexpectedStaticModifierForMethod"
+        },
+        {
+          "name" : "UnexpectedTypeinSwitchPattern"
+        },
+        {
+          "name" : "UnhandledException"
+        },
+        {
+          "name" : "UnhandledExceptionInDefaultConstructor"
+        },
+        {
+          "name" : "UnhandledExceptionInImplicitConstructorCall"
+        },
+        {
+          "name" : "UnhandledExceptionOnAutoClose"
+        },
+        {
+          "name" : "UnhandledWarningToken"
+        },
+        {
+          "name" : "UninitializedBlankFinalField"
+        },
+        {
+          "name" : "UninitializedBlankFinalFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedFreeTypeVariableField"
+        },
+        {
+          "name" : "UninitializedFreeTypeVariableFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedLocalVariable"
+        },
+        {
+          "name" : "UninitializedLocalVariableHintMissingDefault"
+        },
+        {
+          "name" : "UninitializedNonNullField"
+        },
+        {
+          "name" : "UninitializedNonNullFieldHintMissingDefault"
+        },
+        {
+          "name" : "UninternedIdentityComparison"
+        },
+        {
+          "name" : "UnlikelyCollectionMethodArgumentType"
+        },
+        {
+          "name" : "UnlikelyEqualsArgumentType"
+        },
+        {
+          "name" : "UnmatchedBracket"
+        },
+        {
+          "name" : "UnnamedPackageInNamedModule"
+        },
+        {
+          "name" : "UnnecessaryArgumentCast"
+        },
+        {
+          "name" : "UnnecessaryCast"
+        },
+        {
+          "name" : "UnnecessaryElse"
+        },
+        {
+          "name" : "UnnecessaryInstanceof"
+        },
+        {
+          "name" : "UnnecessaryNLSTag"
+        },
+        {
+          "name" : "UnnecessaryNullCaseInSwitchOverNonNull"
+        },
+        {
+          "name" : "UnqualifiedFieldAccess"
+        },
+        {
+          "name" : "UnreachableCatch"
+        },
+        {
+          "name" : "UnresolvedVariable"
+        },
+        {
+          "name" : "UnsafeCast"
+        },
+        {
+          "name" : "UnsafeElementTypeConversion"
+        },
+        {
+          "name" : "UnsafeGenericArrayForVarargs"
+        },
+        {
+          "name" : "UnsafeGenericCast"
+        },
+        {
+          "name" : "UnsafeNullnessCast"
+        },
+        {
+          "name" : "UnsafeRawConstructorInvocation"
+        },
+        {
+          "name" : "UnsafeRawFieldAssignment"
+        },
+        {
+          "name" : "UnsafeRawGenericConstructorInvocation"
+        },
+        {
+          "name" : "UnsafeRawGenericMethodInvocation"
+        },
+        {
+          "name" : "UnsafeRawMethodInvocation"
+        },
+        {
+          "name" : "UnsafeReturnTypeOverride"
+        },
+        {
+          "name" : "UnsafeTypeConversion"
+        },
+        {
+          "name" : "UnstableAutoModuleName"
+        },
+        {
+          "name" : "UnterminatedComment"
+        },
+        {
+          "name" : "UnterminatedString"
+        },
+        {
+          "name" : "UnterminatedTextBlock"
+        },
+        {
+          "name" : "UnusedConstructorDeclaredThrownException"
+        },
+        {
+          "name" : "UnusedImport"
+        },
+        {
+          "name" : "UnusedLabel"
+        },
+        {
+          "name" : "UnusedMethodDeclaredThrownException"
+        },
+        {
+          "name" : "UnusedObjectAllocation"
+        },
+        {
+          "name" : "UnusedPrivateConstructor"
+        },
+        {
+          "name" : "UnusedPrivateField"
+        },
+        {
+          "name" : "UnusedPrivateMethod"
+        },
+        {
+          "name" : "UnusedPrivateType"
+        },
+        {
+          "name" : "UnusedTypeArgumentsForConstructorInvocation"
+        },
+        {
+          "name" : "UnusedTypeArgumentsForMethodInvocation"
+        },
+        {
+          "name" : "UnusedTypeParameter"
+        },
+        {
+          "name" : "UnusedWarningToken"
+        },
+        {
+          "name" : "UseAssertAsAnIdentifier"
+        },
+        {
+          "name" : "UseEnumAsAnIdentifier"
+        },
+        {
+          "name" : "UsingDeprecatedConstructor"
+        },
+        {
+          "name" : "UsingDeprecatedField"
+        },
+        {
+          "name" : "UsingDeprecatedMethod"
+        },
+        {
+          "name" : "UsingDeprecatedModule"
+        },
+        {
+          "name" : "UsingDeprecatedPackage"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionConstructor"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionField"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionMethod"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionModule"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionPackage"
+        },
+        {
+          "name" : "UsingDeprecatedSinceVersionType"
+        },
+        {
+          "name" : "UsingDeprecatedType"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedConstructor"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedField"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedMethod"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedModule"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedPackage"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionConstructor"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionField"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionMethod"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionModule"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionPackage"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedSinceVersionType"
+        },
+        {
+          "name" : "UsingTerminallyDeprecatedType"
+        },
+        {
+          "name" : "VarCannotBeMixedWithNonVarParams"
+        },
+        {
+          "name" : "VarIsNotAllowedHere"
+        },
+        {
+          "name" : "VarIsReserved"
+        },
+        {
+          "name" : "VarIsReservedInFuture"
+        },
+        {
+          "name" : "VarLocalCannotBeArray"
+        },
+        {
+          "name" : "VarLocalCannotBeArrayInitalizers"
+        },
+        {
+          "name" : "VarLocalCannotBeLambda"
+        },
+        {
+          "name" : "VarLocalCannotBeMethodReference"
+        },
+        {
+          "name" : "VarLocalInitializedToNull"
+        },
+        {
+          "name" : "VarLocalInitializedToVoid"
+        },
+        {
+          "name" : "VarLocalMultipleDeclarators"
+        },
+        {
+          "name" : "VarLocalReferencesItself"
+        },
+        {
+          "name" : "VarLocalWithoutInitizalier"
+        },
+        {
+          "name" : "VarargsConflict"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisible"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisibleForConstructor"
+        },
+        {
+          "name" : "VariableTypeCannotBeVoid"
+        },
+        {
+          "name" : "VariableTypeCannotBeVoidArray"
+        },
+        {
+          "name" : "VoidMethodReturnsValue"
+        },
+        {
+          "name" : "WildcardConstructorInvocation"
+        },
+        {
+          "name" : "WildcardFieldAssignment"
+        },
+        {
+          "name" : "WildcardMethodInvocation"
+        },
+        {
+          "name" : "illFormedParameterizationOfFunctionalInterface"
+        },
+        {
+          "name" : "lambdaParameterTypeMismatched"
+        },
+        {
+          "name" : "lambdaSignatureMismatched"
+        },
+        {
+          "name" : "switchMixedCase"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.impl.IntConstant[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.AnnotationBinding[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.AnnotationMirrorImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.FieldBinding[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.lookup.ProblemReasons",
+      "fields" : [
+        {
+          "name" : "Ambiguous"
+        },
+        {
+          "name" : "ApplicableMethodOverriddenByInapplicable"
+        },
+        {
+          "name" : "AttemptToBypassDirectSuper"
+        },
+        {
+          "name" : "ContradictoryNullAnnotations"
+        },
+        {
+          "name" : "DefectiveContainerAnnotationType"
+        },
+        {
+          "name" : "ErrorAlreadyReported"
+        },
+        {
+          "name" : "IllegalSuperTypeVariable"
+        },
+        {
+          "name" : "InferredApplicableMethodInapplicable"
+        },
+        {
+          "name" : "InheritedNameHidesEnclosingName"
+        },
+        {
+          "name" : "InterfaceMethodInvocationNotBelow18"
+        },
+        {
+          "name" : "InternalNameProvided"
+        },
+        {
+          "name" : "InvalidTypeForAutoManagedResource"
+        },
+        {
+          "name" : "InvalidTypeForStaticImport"
+        },
+        {
+          "name" : "InvocationTypeInferenceFailure"
+        },
+        {
+          "name" : "NoError"
+        },
+        {
+          "name" : "NoProperEnclosingInstance"
+        },
+        {
+          "name" : "NoSuchMethodOnArray"
+        },
+        {
+          "name" : "NoSuchSingleAbstractMethod"
+        },
+        {
+          "name" : "NonStaticOrAlienTypeReceiver"
+        },
+        {
+          "name" : "NonStaticReferenceInConstructorInvocation"
+        },
+        {
+          "name" : "NonStaticReferenceInStaticContext"
+        },
+        {
+          "name" : "NotAWellFormedParameterizedType"
+        },
+        {
+          "name" : "NotAccessible"
+        },
+        {
+          "name" : "NotFound"
+        },
+        {
+          "name" : "NotVisible"
+        },
+        {
+          "name" : "ParameterBoundMismatch"
+        },
+        {
+          "name" : "ParameterizedMethodTypeMismatch"
+        },
+        {
+          "name" : "ReceiverTypeNotVisible"
+        },
+        {
+          "name" : "TypeArgumentsForRawGenericMethod"
+        },
+        {
+          "name" : "TypeParameterArityMismatch"
+        },
+        {
+          "name" : "VarargsElementTypeNotVisible"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchProcessingEnvImpl"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.tool.EclipseCompilerImpl",
+      "fields" : [
+        {
+          "name" : "fileManager"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.util.Messages",
+      "fields" : [
+        {
+          "name" : "abort_againstSourceModel"
+        },
+        {
+          "name" : "abort_externaAnnotationFile"
+        },
+        {
+          "name" : "abort_invalidAttribute"
+        },
+        {
+          "name" : "abort_invalidExceptionAttribute"
+        },
+        {
+          "name" : "abort_invalidOpcode"
+        },
+        {
+          "name" : "abort_missingCode"
+        },
+        {
+          "name" : "accept_cannot"
+        },
+        {
+          "name" : "ast_missingCode"
+        },
+        {
+          "name" : "compilation_beginningToCompile"
+        },
+        {
+          "name" : "compilation_done"
+        },
+        {
+          "name" : "compilation_internalError"
+        },
+        {
+          "name" : "compilation_loadBinary"
+        },
+        {
+          "name" : "compilation_process"
+        },
+        {
+          "name" : "compilation_processing"
+        },
+        {
+          "name" : "compilation_request"
+        },
+        {
+          "name" : "compilation_unit"
+        },
+        {
+          "name" : "compilation_units"
+        },
+        {
+          "name" : "compilation_unresolvedProblem"
+        },
+        {
+          "name" : "compilation_unresolvedProblems"
+        },
+        {
+          "name" : "compilation_write"
+        },
+        {
+          "name" : "constant_cannotCastedInto"
+        },
+        {
+          "name" : "constant_cannotConvertedTo"
+        },
+        {
+          "name" : "output_isFile"
+        },
+        {
+          "name" : "output_notValid"
+        },
+        {
+          "name" : "output_notValidAll"
+        },
+        {
+          "name" : "parser_corruptedFile"
+        },
+        {
+          "name" : "parser_endOfConstructor"
+        },
+        {
+          "name" : "parser_endOfFile"
+        },
+        {
+          "name" : "parser_endOfInitializer"
+        },
+        {
+          "name" : "parser_endOfMethod"
+        },
+        {
+          "name" : "parser_incorrectPath"
+        },
+        {
+          "name" : "parser_missingFile"
+        },
+        {
+          "name" : "parser_moveFiles"
+        },
+        {
+          "name" : "parser_regularParse"
+        },
+        {
+          "name" : "parser_syntaxRecovery"
+        },
+        {
+          "name" : "pattern_matching_instanceof"
+        },
+        {
+          "name" : "pattern_matching_switch"
+        },
+        {
+          "name" : "problem_atLine"
+        },
+        {
+          "name" : "problem_noSourceInformation"
+        },
+        {
+          "name" : "records"
+        },
+        {
+          "name" : "sealed_types"
+        },
+        {
+          "name" : "switch_expression"
+        },
+        {
+          "name" : "text_block"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages$MessagesProperties"
+      },
+      "type" : "org.eclipse.jdt.internal.compiler.util.Messages",
+      "fields" : [
+        {
+          "name" : "abort_againstSourceModel"
+        },
+        {
+          "name" : "abort_externaAnnotationFile"
+        },
+        {
+          "name" : "abort_invalidAttribute"
+        },
+        {
+          "name" : "abort_invalidExceptionAttribute"
+        },
+        {
+          "name" : "abort_invalidOpcode"
+        },
+        {
+          "name" : "abort_missingCode"
+        },
+        {
+          "name" : "accept_cannot"
+        },
+        {
+          "name" : "ast_missingCode"
+        },
+        {
+          "name" : "compilation_beginningToCompile"
+        },
+        {
+          "name" : "compilation_done"
+        },
+        {
+          "name" : "compilation_internalError"
+        },
+        {
+          "name" : "compilation_loadBinary"
+        },
+        {
+          "name" : "compilation_process"
+        },
+        {
+          "name" : "compilation_processing"
+        },
+        {
+          "name" : "compilation_request"
+        },
+        {
+          "name" : "compilation_unit"
+        },
+        {
+          "name" : "compilation_units"
+        },
+        {
+          "name" : "compilation_unresolvedProblem"
+        },
+        {
+          "name" : "compilation_unresolvedProblems"
+        },
+        {
+          "name" : "compilation_write"
+        },
+        {
+          "name" : "constant_cannotCastedInto"
+        },
+        {
+          "name" : "constant_cannotConvertedTo"
+        },
+        {
+          "name" : "output_isFile"
+        },
+        {
+          "name" : "output_notValid"
+        },
+        {
+          "name" : "output_notValidAll"
+        },
+        {
+          "name" : "parser_corruptedFile"
+        },
+        {
+          "name" : "parser_endOfConstructor"
+        },
+        {
+          "name" : "parser_endOfFile"
+        },
+        {
+          "name" : "parser_endOfInitializer"
+        },
+        {
+          "name" : "parser_endOfMethod"
+        },
+        {
+          "name" : "parser_incorrectPath"
+        },
+        {
+          "name" : "parser_missingFile"
+        },
+        {
+          "name" : "parser_moveFiles"
+        },
+        {
+          "name" : "parser_regularParse"
+        },
+        {
+          "name" : "parser_syntaxRecovery"
+        },
+        {
+          "name" : "pattern_matching_instanceof"
+        },
+        {
+          "name" : "pattern_matching_switch"
+        },
+        {
+          "name" : "problem_atLine"
+        },
+        {
+          "name" : "problem_noSourceInformation"
+        },
+        {
+          "name" : "records"
+        },
+        {
+          "name" : "sealed_types"
+        },
+        {
+          "name" : "switch_expression"
+        },
+        {
+          "name" : "text_block"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ClassFilePool"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.CompilationResult"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.Compiler"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.AnnotationDiscoveryVisitor"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BaseProcessingEnvImpl"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchProcessingEnvImpl"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.RoundEnvImpl"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.Factory"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.model.TypeElementImpl"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ast.AllocationExpression"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ast.IntLiteral"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ast.StringLiteral"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.ast.TypeDeclaration"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.ClasspathJrt"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.FileSystem"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$Logger"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.classfmt.AnnotationInfo"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.classfmt.ModuleInfo"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.env.IBinaryType"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.impl.CompilerOptions"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.impl.Constant"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.Binding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ClassScope"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ElementValuePair"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.LookupEnvironment"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ModuleBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.PackageBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeConstants"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeSystem"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeSystem$HashedParameterizedTypes"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Scanner"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.ProblemReporter"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.EclipseCompiler"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.EclipseCompilerImpl"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.EclipseFileManager"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.EclipseFileObject"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.JrtFileSystem"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.ModuleLocationHandler"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.CharArrayHashMap"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.CharDeduplication"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.CharDelegateMap"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.JRTUtil"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.JrtFileSystem"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Util"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.JrtFileSystem"
+      },
+      "glob" : "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "glob" : "META-INF/services/javax.annotation.processing.Processor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.antadapter.AntAdapterMessages"
+      },
+      "glob" : "org/eclipse/jdt/internal/antadapter/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/batch/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.util.Messages"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser10.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser11.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser12.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser13.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser15.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser16.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser17.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser18.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser19.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser20.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser21.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser22.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser23.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser24.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser3.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser4.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser5.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser6.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser7.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser8.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/parser9.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.Parser"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/readableNames.props"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode10/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode11/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode12_1/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/part3.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode13/start3.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode6_2/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/part0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/part1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/part14.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/part2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/start0.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/start1.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.parser.ScannerHelper"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/parser/unicode8/start2.rsc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory"
+      },
+      "glob" : "org/eclipse/jdt/internal/compiler/problem/messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.apt.dispatch.BatchAnnotationProcessorManager"
+      },
+      "glob" : "org_eclipse_jdt/ecj/BatchAnnotationProcessorManagerTest$ServiceDiscoveredProcessor.class"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.antadapter.messages"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.compiler.batch.messages"
+    },
+    {
+      "bundle" : "org.eclipse.jdt.internal.compiler.problem.messages"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jdt/ecj/index.json
+++ b/metadata/org.eclipse.jdt/ecj/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.28.0",
+    "test-version" : "3.26.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/3.28.0/ecj-3.28.0-sources.jar",
+    "repository-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core",
+    "test-code-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core/tree/R4_22/org.eclipse.jdt.core.tests.compiler",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/3.28.0/ecj-3.28.0-javadoc.jar",
+    "description" : "Eclipse Compiler for Java (ECJ) is the Java compiler implementation from the Eclipse JDT project, packaged for standalone use through Maven. It can compile Java source programmatically or from the command line and includes Eclipse's incremental compiler and batch compiler infrastructure.",
+    "tested-versions" : [
+      "3.28.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jdt"
+    ]
+  },
+  {
     "metadata-version" : "3.27.0",
     "test-version" : "3.26.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/3.27.0/ecj-3.27.0-sources.jar",

--- a/stats/org.eclipse.jdt/ecj/3.28.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.28.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.28.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 30,
+          "totalCalls" : 30
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 26,
+          "totalCalls" : 26
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 56,
+      "totalCalls" : 56
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 55365,
+        "missed" : 477574,
+        "ratio" : 0.103886,
+        "total" : 532939
+      },
+      "line" : {
+        "covered" : 12766,
+        "missed" : 108126,
+        "ratio" : 0.105598,
+        "total" : 120892
+      },
+      "method" : {
+        "covered" : 1668,
+        "missed" : 9372,
+        "ratio" : 0.151087,
+        "total" : 11040
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4263

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.28.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.28.0`): 1345
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.28.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.56%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.28.0: 55365/532939 (10.39%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.28.0: 12766/120892 (10.56%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.28.0: 1668/11040 (15.11%)
