### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-socks:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-socks/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-socks/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,75 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "methods": [
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.ByteBuf"
+          ]
+        },
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.CompositeByteBuf"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.MessageToByteEncoder"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ServerDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ServerEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.SocksPortUnificationServerHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5ServerEncoder"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.v4.DefaultSocks4CommandRequest"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.socksx.v4.DefaultSocks4CommandRequest"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-socks/index.json
+++ b/metadata/io.netty/netty-codec-socks/index.json
@@ -1,6 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.79.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.79.Final/netty-codec-socks-4.1.79.Final-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.79.Final/netty-codec-socks-4.1.79.Final-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.79.Final/netty-codec-socks-4.1.79.Final-javadoc.jar",
+    "description" : "Netty Codec SOCKS provides encoders, decoders, and message types for SOCKS protocol support in Netty pipelines. It lets Netty applications implement SOCKS client or server handshakes and proxy-related messaging on top of Netty's asynchronous networking framework.",
+    "test-version" : "4.1.60.Final",
+    "tested-versions" : [
+      "4.1.79.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.buffer",
+      "io.netty.handler.codec"
+    ]
+  },
+  {
     "metadata-version" : "4.1.60.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.60.Final/netty-codec-socks-4.1.60.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/stats/io.netty/netty-codec-socks/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-codec-socks/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2194,
+        "missed" : 3952,
+        "ratio" : 0.35698,
+        "total" : 6146
+      },
+      "line" : {
+        "covered" : 518,
+        "missed" : 784,
+        "ratio" : 0.397849,
+        "total" : 1302
+      },
+      "method" : {
+        "covered" : 133,
+        "missed" : 154,
+        "ratio" : 0.463415,
+        "total" : 287
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4258

This PR provides new metadata needed for the io.netty:netty-codec-socks:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-socks:4.1.60.Final`): 18
- Metadata entries (new `io.netty:netty-codec-socks:4.1.79.Final`): 13
- Library coverage (previous): 39.74%
- Library coverage (new): 39.78%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-socks:4.1.60.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-socks:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-socks:4.1.60.Final: 2194/6156 (35.64%)
- io.netty:netty-codec-socks:4.1.79.Final: 2194/6146 (35.70%)

**Line:**
- io.netty:netty-codec-socks:4.1.60.Final: 519/1306 (39.74%)
- io.netty:netty-codec-socks:4.1.79.Final: 518/1302 (39.78%)

**Method:**
- io.netty:netty-codec-socks:4.1.60.Final: 133/287 (46.34%)
- io.netty:netty-codec-socks:4.1.79.Final: 133/287 (46.34%)
