### PR TITLE
Downgrade scaffold placeholder gate to warning

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -486,7 +486,6 @@ def main(argv=None):
         checkpoint_commit_hash=checkpoint_commit_hash,
     )
 
-    scaffold_placeholder_quality_gate_failed = False
     if workflow_status == RUN_STATUS_SUCCESS:
         placeholder_cleanup = cleanup_scaffold_placeholder_tests(
             test_source_layout.source_root,
@@ -500,13 +499,11 @@ def main(argv=None):
             )
         if placeholder_cleanup.remaining_placeholders:
             for occurrence in placeholder_cleanup.remaining_placeholders:
-                print(
-                    "ERROR: Scaffold placeholder test remains in generated sources: "
+                log_stage(
+                    "scaffold-cleanup",
+                    f"WARNING: Scaffold placeholder test remains in generated sources: "
                     f"{format_placeholder_occurrence(occurrence, reachability_repo_path)}",
-                    file=sys.stderr,
                 )
-            scaffold_placeholder_quality_gate_failed = True
-            workflow_status = RUN_STATUS_FAILURE
 
     if workflow_status == RUN_STATUS_SUCCESS:
         if is_benchmark_mode:
@@ -538,20 +535,7 @@ def main(argv=None):
     else:
         log_stage("status", "Test generation failed")
 
-    if scaffold_placeholder_quality_gate_failed:
-        log_stage("status", "Generated tests failed scaffold placeholder quality gate")
-        run_metrics = create_failure_run_metrics_output(
-            package=package,
-            artifact=artifact,
-            library_version=library_version,
-            agent=agent,
-            model_name=model_name,
-            global_iterations=global_iterations,
-            strategy_name=strategy_name,
-            starting_commit=checkpoint_commit_hash,
-            ending_commit=ending_commit_hash,
-        )
-    elif unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS:
+    if unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS:
         log_stage("status", "No valid unit test generated")
         run_metrics = create_failure_run_metrics_output(
             package=package,

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -351,7 +351,7 @@ def cleanup_generated_test_scaffold(coordinates: str, repo_path: str, metrics_re
             format_placeholder_occurrence(occurrence, repo_path)
             for occurrence in cleanup_result.remaining_placeholders
         )
-        raise ValueError(f"Refusing to create PR for {coordinates}: scaffold placeholder remains in {details}")
+        print(f"WARNING: Scaffold placeholder remains in {details} for {coordinates}")
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary

Closes #4289

- Downgrade the scaffold placeholder quality gate from a hard failure to a warning in both the workflow (`add_new_library_support.py`) and PR creation (`make_pr_new_library_support.py`)
- Auto-cleanup of untouched scaffold files is preserved
- Remaining placeholders are still logged so reviewers are aware

## Motivation

Libraries that achieve full coverage fail without producing a PR just because the AI agent modified the scaffold test file without fully removing the placeholder text. This triggers the full failure/revert flow and wastes a processing cycle. Since placeholder presence is already caught during PR review, the hard gate is unnecessary.
