### PR TITLE
[GenAI] Test fix for org.mongodb:mongo-java-driver:3.9.0 using gpt-5.5

### DIFF
--- a/metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json
+++ b/metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json
@@ -1,0 +1,136 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.DBCollectionObjectFactory"
+      },
+      "type" : "com.mongodb.BasicDBObject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.ReflectionDBObject$JavaWrapper"
+      },
+      "type" : "com.mongodb.ReflectionDBObject",
+      "methods" : [
+        {
+          "name" : "get_id",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "set_id",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.WriteConcern"
+      },
+      "type" : "com.mongodb.WriteConcern",
+      "fields" : [
+        {
+          "name" : "ACKNOWLEDGED"
+        },
+        {
+          "name" : "FSYNCED"
+        },
+        {
+          "name" : "FSYNC_SAFE"
+        },
+        {
+          "name" : "JOURNALED"
+        },
+        {
+          "name" : "JOURNAL_SAFE"
+        },
+        {
+          "name" : "MAJORITY"
+        },
+        {
+          "name" : "NORMAL"
+        },
+        {
+          "name" : "REPLICAS_SAFE"
+        },
+        {
+          "name" : "REPLICA_ACKNOWLEDGED"
+        },
+        {
+          "name" : "SAFE"
+        },
+        {
+          "name" : "UNACKNOWLEDGED"
+        },
+        {
+          "name" : "W1"
+        },
+        {
+          "name" : "W2"
+        },
+        {
+          "name" : "W3"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.SslHelper"
+      },
+      "type" : "com.mongodb.internal.connection.Java8SniSslHelper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.types.StringRangeSet"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "type" : "javax.net.ssl.SNIHostName"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.diagnostics.Loggers"
+      },
+      "type" : "org.slf4j.Logger"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.Java8SniSslHelper"
+      },
+      "module" : "java.base",
+      "glob" : "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/org.mongodb/mongo-java-driver/index.json
+++ b/metadata/org.mongodb/mongo-java-driver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.9.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.9.0/mongo-java-driver-3.9.0-sources.jar",
+    "repository-url" : "https://github.com/mongodb/mongo-java-driver",
+    "test-code-url" : "https://github.com/mongodb/mongo-java-driver/tree/r3.9.0",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.9.0/mongo-java-driver-3.9.0-javadoc.jar",
+    "description" : "MongoDB Java Driver provides Java APIs for connecting applications to MongoDB and performing database, collection, query, and write operations. The 3.9.0 uber-artifact bundles the legacy driver, mongodb-driver, mongodb-driver-core, and bson, including client APIs, protocol support, and BSON encoding and decoding.",
     "tested-versions" : [
       "3.9.0"
     ],

--- a/metadata/org.mongodb/mongo-java-driver/index.json
+++ b/metadata/org.mongodb/mongo-java-driver/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.9.0",
+    "tested-versions" : [
+      "3.9.0"
+    ],
+    "allowed-packages" : [
+      "com.mongodb",
+      "org.bson"
+    ]
+  },
+  {
     "metadata-version" : "3.4.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongo-java-driver/3.4.0/mongo-java-driver-3.4.0-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/stats/org.mongodb/mongo-java-driver/3.9.0/execution-metrics.json
+++ b/stats/org.mongodb/mongo-java-driver/3.9.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T12:08:29.528149Z",
+    "library": "org.mongodb:mongo-java-driver:3.9.0",
+    "starting_commit": "cef72c7d6a10f23e395519125b89e39bd8ff8661",
+    "ending_commit": "2dc7791a13a06d1130d57915d930d529fc49aeb8",
+    "previous_library": "org.mongodb:mongo-java-driver:3.4.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.575758,
+            "coveredCalls": 19,
+            "totalCalls": 33
+          }
+        },
+        "coverageRatio": 0.575758,
+        "coveredCalls": 19,
+        "totalCalls": 33
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5533,
+          "missed": 143866,
+          "ratio": 0.037035,
+          "total": 149399
+        },
+        "line": {
+          "covered": 1284,
+          "missed": 30793,
+          "ratio": 0.040029,
+          "total": 32077
+        },
+        "method": {
+          "covered": 403,
+          "missed": 9148,
+          "ratio": 0.042195,
+          "total": 9551
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1321,
+          "missed": 119926,
+          "ratio": 0.010895,
+          "total": 121247
+        },
+        "line": {
+          "covered": 296,
+          "missed": 25553,
+          "ratio": 0.011451,
+          "total": 25849
+        },
+        "method": {
+          "covered": 92,
+          "missed": 7654,
+          "ratio": 0.011877,
+          "total": 7746
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 71189,
+      "cached_input_tokens_used": 764416,
+      "output_tokens_used": 8978,
+      "iterations": 2,
+      "cost_usd": 0.6515,
+      "tested_library_loc": 1284,
+      "metadata_entries": 30,
+      "test_only_metadata_entries": 24,
+      "previous_library_metadata_entries": 28,
+      "code_coverage_percent": 4.0,
+      "previous_library_coverage_percent": 1.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java",
+      "metadata_file": "metadata/org.mongodb/mongo-java-driver/3.9.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.mongodb/mongo-java-driver/3.9.0/stats.json
+++ b/stats/org.mongodb/mongo-java-driver/3.9.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.9.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.575758,
+          "coveredCalls" : 19,
+          "totalCalls" : 33
+        }
+      },
+      "coverageRatio" : 0.575758,
+      "coveredCalls" : 19,
+      "totalCalls" : 33
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5533,
+        "missed" : 143866,
+        "ratio" : 0.037035,
+        "total" : 149399
+      },
+      "line" : {
+        "covered" : 1284,
+        "missed" : 30793,
+        "ratio" : 0.040029,
+        "total" : 32077
+      },
+      "method" : {
+        "covered" : 403,
+        "missed" : 9148,
+        "ratio" : 0.042195,
+        "total" : 9551
+      }
+    }
+  } ]
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/.gitignore
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.mongodb:mongo-java-driver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/gradle.properties
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.mongodb:mongo-java-driver:3.9.0
+library.version = 3.9.0
+metadata.dir = org.mongodb/mongo-java-driver/3.9.0/

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/settings.gradle
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.mongodb.mongo-java-driver_tests'

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+public class CreatorExecutableTest {
+    @Test
+    void decodesWithAnnotatedNoArgumentConstructor() {
+        final NoArgumentConstructorPojo decoded = decode(NoArgumentConstructorPojo.class, new BsonDocument());
+
+        assertThat(decoded.getSource()).isEqualTo("constructor");
+    }
+
+    @Test
+    void decodesWithAnnotatedConstructorParameters() {
+        final BsonDocument document = new BsonDocument()
+                .append("name", new BsonString("alpha"))
+                .append("count", new BsonInt32(7));
+
+        final ConstructorParametersPojo decoded = decode(ConstructorParametersPojo.class, document);
+
+        assertThat(decoded.getName()).isEqualTo("alpha");
+        assertThat(decoded.getCount()).isEqualTo(7);
+    }
+
+    @Test
+    void decodesWithAnnotatedNoArgumentStaticFactory() {
+        final NoArgumentFactoryPojo decoded = decode(NoArgumentFactoryPojo.class, new BsonDocument());
+
+        assertThat(decoded.getSource()).isEqualTo("factory");
+    }
+
+    @Test
+    void decodesWithAnnotatedStaticFactoryParameters() {
+        final BsonDocument document = new BsonDocument()
+                .append("value", new BsonString("bravo"))
+                .append("quantity", new BsonInt32(11));
+
+        final FactoryParametersPojo decoded = decode(FactoryParametersPojo.class, document);
+
+        assertThat(decoded.getValue()).isEqualTo("bravo");
+        assertThat(decoded.getQuantity()).isEqualTo(11);
+    }
+
+    private static <T> T decode(final Class<T> type, final BsonDocument document) {
+        final PojoCodecProvider pojoCodecProvider = PojoCodecProvider.builder().register(type).build();
+        final CodecRegistry registry = fromProviders(new ValueCodecProvider(), pojoCodecProvider);
+        final Codec<T> codec = registry.get(type);
+
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static final class NoArgumentConstructorPojo {
+        private final String source;
+
+        @BsonCreator
+        public NoArgumentConstructorPojo() {
+            this.source = "constructor";
+        }
+
+        public String getSource() {
+            return source;
+        }
+    }
+
+    public static final class ConstructorParametersPojo {
+        private String name;
+        private int count;
+
+        @BsonCreator
+        public ConstructorParametersPojo(@BsonProperty("name") final String name,
+                                         @BsonProperty("count") final int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+    }
+
+    public static final class NoArgumentFactoryPojo {
+        private final String source;
+
+        private NoArgumentFactoryPojo(final String source) {
+            this.source = source;
+        }
+
+        @BsonCreator
+        public static NoArgumentFactoryPojo create() {
+            return new NoArgumentFactoryPojo("factory");
+        }
+
+        public String getSource() {
+            return source;
+        }
+    }
+
+    public static final class FactoryParametersPojo {
+        private String value;
+        private Integer quantity;
+
+        private FactoryParametersPojo(final String value, final Integer quantity) {
+            this.value = value;
+            this.quantity = quantity;
+        }
+
+        @BsonCreator
+        public static FactoryParametersPojo from(@BsonProperty("value") final String value,
+                                                 @BsonProperty("quantity") final Integer quantity) {
+            return new FactoryParametersPojo(value, quantity);
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(final String value) {
+            this.value = value;
+        }
+
+        public Integer getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(final Integer quantity) {
+            this.quantity = quantity;
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DBCollectionObjectFactoryTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/DBCollectionObjectFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DefaultDBCallback;
+import org.bson.BSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DBCollectionObjectFactoryTest {
+    @Test
+    void defaultCallbackCreatesBasicDBObjectInstances() {
+        final DefaultDBCallback callback = new DefaultDBCallback(null);
+
+        final BSONObject document = callback.create();
+
+        document.put("name", "mongo");
+        assertThat(document).isInstanceOf(BasicDBObject.class);
+        assertThat(document.get("name")).isEqualTo("mongo");
+    }
+
+    @Test
+    void defaultCallbackCreatesBasicDBObjectForNestedDocumentPath() {
+        final DefaultDBCallback callback = new DefaultDBCallback(null);
+
+        final BSONObject document = callback.create(false, Arrays.asList("outer", "inner"));
+
+        document.put("nested", true);
+        assertThat(document).isInstanceOf(BasicDBObject.class);
+        assertThat(document.get("nested")).isEqualTo(true);
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ReflectionDBObjectInnerJavaWrapperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/ReflectionDBObjectInnerJavaWrapperTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.ReflectionDBObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionDBObjectInnerJavaWrapperTest {
+    @Test
+    void wrapperDiscoversAndInvokesReflectionDBObjectAccessors() {
+        final ReflectionDBObject.JavaWrapper wrapper = ReflectionDBObject.getWrapper(ReflectionDBObject.class);
+        final ReflectionDocument document = new ReflectionDocument();
+
+        final Object setterResult = wrapper.set(document, "_id", "document-1");
+        final Object value = wrapper.get(document, "_id");
+
+        assertThat(wrapper.keySet()).contains("_id");
+        assertThat(setterResult).isNull();
+        assertThat(value).isEqualTo("document-1");
+        assertThat(document.get_id()).isEqualTo("document-1");
+    }
+
+    private static final class ReflectionDocument extends ReflectionDBObject {
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.internal.connection.SslHelper;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SslHelperTest {
+    @Test
+    void enablesHostNameVerificationForSslParameters() {
+        final SSLParameters sslParameters = new SSLParameters();
+
+        SslHelper.enableHostNameVerification(sslParameters);
+
+        assertThat(sslParameters.getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void enablesServerNameIndicationForHostNames() {
+        final SSLParameters sslParameters = new SSLParameters();
+        final ServerAddress address = new ServerAddress("example.mongodb.local");
+
+        SslHelper.enableSni(address, sslParameters);
+
+        final List<SNIServerName> serverNames = sslParameters.getServerNames();
+        assertThat(serverNames).hasSize(1);
+        assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
+        final SNIHostName serverName = (SNIHostName) serverNames.get(0);
+        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -6,7 +6,6 @@
  */
 package org_mongodb.mongo_java_driver;
 
-import com.mongodb.ServerAddress;
 import com.mongodb.internal.connection.SslHelper;
 import org.junit.jupiter.api.Test;
 
@@ -31,14 +30,14 @@ public class SslHelperTest {
     @Test
     void enablesServerNameIndicationForHostNames() {
         final SSLParameters sslParameters = new SSLParameters();
-        final ServerAddress address = new ServerAddress("example.mongodb.local");
+        final String host = "example.mongodb.local";
 
-        SslHelper.enableSni(address, sslParameters);
+        SslHelper.enableSni(host, sslParameters);
 
         final List<SNIServerName> serverNames = sslParameters.getServerNames();
         assertThat(serverNames).hasSize(1);
         assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
         final SNIHostName serverName = (SNIHostName) serverNames.get(0);
-        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+        assertThat(serverName.getAsciiName()).isEqualTo(host);
     }
 }

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/StringRangeSetTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/StringRangeSetTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.types.BasicBSONList;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringRangeSetTest {
+    @Test
+    void keySetCanCreateTypedArrayForAllListIndexes() {
+        final BasicBSONList list = new BasicBSONList();
+        list.put(0, "zero");
+        list.put(3, "three");
+
+        final Set<String> keys = list.keySet();
+        final String[] keyArray = keys.toArray(new String[0]);
+
+        assertThat(keyArray).containsExactly("0", "1", "2", "3");
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/WriteConcernTest.java
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/WriteConcernTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import com.mongodb.WriteConcern;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WriteConcernTest {
+    @Test
+    void namedWriteConcernsAreDiscoveredCaseInsensitively() {
+        assertThat(WriteConcern.valueOf("acknowledged")).isSameAs(WriteConcern.ACKNOWLEDGED);
+        assertThat(WriteConcern.valueOf("W1")).isSameAs(WriteConcern.W1);
+        assertThat(WriteConcern.valueOf("w2")).isSameAs(WriteConcern.W2);
+        assertThat(WriteConcern.valueOf("w3")).isSameAs(WriteConcern.W3);
+        assertThat(WriteConcern.valueOf("unacknowledged")).isSameAs(WriteConcern.UNACKNOWLEDGED);
+        assertThat(WriteConcern.valueOf("majority")).isSameAs(WriteConcern.MAJORITY);
+        assertThat(WriteConcern.valueOf("unknown")).isNull();
+    }
+
+    @Test
+    void writeConcernOptionsProduceExpectedDocument() {
+        final WriteConcern concern = WriteConcern.MAJORITY
+                .withWTimeout(2, TimeUnit.SECONDS)
+                .withJournal(true);
+
+        final BsonDocument document = concern.asDocument();
+
+        assertThat(concern.isAcknowledged()).isTrue();
+        assertThat(concern.getWString()).isEqualTo("majority");
+        assertThat(concern.getWTimeout(TimeUnit.MILLISECONDS)).isEqualTo(2000);
+        assertThat(concern.getJournal()).isTrue();
+        assertThat(document.getString("w")).isEqualTo(new BsonString("majority"));
+        assertThat(document.getInt32("wtimeout").getValue()).isEqualTo(2000);
+        assertThat(document.getBoolean("j").getValue()).isTrue();
+    }
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,158 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorParametersPojo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoBuilderHelper"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyAccessorImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorParametersPojo",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyReflectionUtils"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$ConstructorParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$FactoryParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$FactoryParametersPojo",
+      "methods" : [
+        {
+          "name" : "from",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Integer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoBuilderHelper"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$FactoryParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyAccessorImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$FactoryParametersPojo",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyReflectionUtils"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$FactoryParametersPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentConstructorPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentConstructorPojo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoBuilderHelper"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentConstructorPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyReflectionUtils"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentConstructorPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.ConventionAnnotationImpl"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentFactoryPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.CreatorExecutable"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentFactoryPojo",
+      "methods" : [
+        {
+          "name" : "create",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PojoBuilderHelper"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentFactoryPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.bson.codecs.pojo.PropertyReflectionUtils"
+      },
+      "type" : "org_mongodb.mongo_java_driver.CreatorExecutableTest$NoArgumentFactoryPojo"
+    }
+  ]
+}

--- a/tests/src/org.mongodb/mongo-java-driver/3.9.0/user-code-filter.json
+++ b/tests/src/org.mongodb/mongo-java-driver/3.9.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.mongodb.**"
+    },
+    {
+      "includeClasses" : "org.bson.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4180

This PR provides test fixes and new metadata for org.mongodb:mongo-java-driver:3.9.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71189
- Cached input tokens: 764416
- Output tokens: 8978
- Metadata entries: 30
- Test-only metadata entries: 24
- Iterations: 2
- Library coverage percentage: 4.0
- Previous library version metadata entries: 28
- Previous library version coverage percentage: 1.15

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.mongodb:mongo-java-driver:3.4.0: 8/8 covered calls (100.00%)
- org.mongodb:mongo-java-driver:3.9.0: 19/33 covered calls (57.58%)

**Reflection:**
- org.mongodb:mongo-java-driver:3.4.0: 8/8 covered calls (100.00%)
- org.mongodb:mongo-java-driver:3.9.0: 19/33 covered calls (57.58%)

#### Library coverage

**Instruction:**
- org.mongodb:mongo-java-driver:3.4.0: 1321/121247 (1.09%)
- org.mongodb:mongo-java-driver:3.9.0: 5533/149399 (3.70%)

**Line:**
- org.mongodb:mongo-java-driver:3.4.0: 296/25849 (1.15%)
- org.mongodb:mongo-java-driver:3.9.0: 1284/32077 (4.00%)

**Method:**
- org.mongodb:mongo-java-driver:3.4.0: 92/7746 (1.19%)
- org.mongodb:mongo-java-driver:3.9.0: 403/9551 (4.22%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
new file mode 100644
index 0000000000..df8bb99026
--- /dev/null
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/CreatorExecutableTest.java
@@ -0,0 +1,161 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongo_java_driver;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+public class CreatorExecutableTest {
+    @Test
+    void decodesWithAnnotatedNoArgumentConstructor() {
+        final NoArgumentConstructorPojo decoded = decode(NoArgumentConstructorPojo.class, new BsonDocument());
+
+        assertThat(decoded.getSource()).isEqualTo("constructor");
+    }
+
+    @Test
+    void decodesWithAnnotatedConstructorParameters() {
+        final BsonDocument document = new BsonDocument()
+                .append("name", new BsonString("alpha"))
+                .append("count", new BsonInt32(7));
+
+        final ConstructorParametersPojo decoded = decode(ConstructorParametersPojo.class, document);
+
+        assertThat(decoded.getName()).isEqualTo("alpha");
+        assertThat(decoded.getCount()).isEqualTo(7);
+    }
+
+    @Test
+    void decodesWithAnnotatedNoArgumentStaticFactory() {
+        final NoArgumentFactoryPojo decoded = decode(NoArgumentFactoryPojo.class, new BsonDocument());
+
+        assertThat(decoded.getSource()).isEqualTo("factory");
+    }
+
+    @Test
+    void decodesWithAnnotatedStaticFactoryParameters() {
+        final BsonDocument document = new BsonDocument()
+                .append("value", new BsonString("bravo"))
+                .append("quantity", new BsonInt32(11));
+
+        final FactoryParametersPojo decoded = decode(FactoryParametersPojo.class, document);
+
+        assertThat(decoded.getValue()).isEqualTo("bravo");
+        assertThat(decoded.getQuantity()).isEqualTo(11);
+    }
+
+    private static <T> T decode(final Class<T> type, final BsonDocument document) {
+        final PojoCodecProvider pojoCodecProvider = PojoCodecProvider.builder().register(type).build();
+        final CodecRegistry registry = fromProviders(new ValueCodecProvider(), pojoCodecProvider);
+        final Codec<T> codec = registry.get(type);
+
+        return codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+    }
+
+    public static final class NoArgumentConstructorPojo {
+        private final String source;
+
+        @BsonCreator
+        public NoArgumentConstructorPojo() {
+            this.source = "constructor";
+        }
+
+        public String getSource() {
+            return source;
+        }
+    }
+
+    public static final class ConstructorParametersPojo {
+        private String name;
+        private int count;
+
+        @BsonCreator
+        public ConstructorParametersPojo(@BsonProperty("name") final String name,
+                                         @BsonProperty("count") final int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(final int count) {
+            this.count = count;
+        }
+    }
+
+    public static final class NoArgumentFactoryPojo {
+        private final String source;
+
+        private NoArgumentFactoryPojo(final String source) {
+            this.source = source;
+        }
+
+        @BsonCreator
+        public static NoArgumentFactoryPojo create() {
+            return new NoArgumentFactoryPojo("factory");
+        }
+
+        public String getSource() {
+            return source;
+        }
+    }
+
+    public static final class FactoryParametersPojo {
+        private String value;
+        private Integer quantity;
+
+        private FactoryParametersPojo(final String value, final Integer quantity) {
+            this.value = value;
+            this.quantity = quantity;
+        }
+
+        @BsonCreator
+        public static FactoryParametersPojo from(@BsonProperty("value") final String value,
+                                                 @BsonProperty("quantity") final Integer quantity) {
+            return new FactoryParametersPojo(value, quantity);
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(final String value) {
+            this.value = value;
+        }
+
+        public Integer getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(final Integer quantity) {
+            this.quantity = quantity;
+        }
+    }
+}
diff --git 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
index 6760917d95..e967d2067f 100644
--- 1/tests/src/org.mongodb/mongo-java-driver/3.4.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
+++ 2/tests/src/org.mongodb/mongo-java-driver/3.9.0/src/test/java/org_mongodb/mongo_java_driver/SslHelperTest.java
@@ -6,7 +6,6 @@
  */
 package org_mongodb.mongo_java_driver;
 
-import com.mongodb.ServerAddress;
 import com.mongodb.internal.connection.SslHelper;
 import org.junit.jupiter.api.Test;
 
@@ -31,14 +30,14 @@ public class SslHelperTest {
     @Test
     void enablesServerNameIndicationForHostNames() {
         final SSLParameters sslParameters = new SSLParameters();
-        final ServerAddress address = new ServerAddress("example.mongodb.local");
+        final String host = "example.mongodb.local";
 
-        SslHelper.enableSni(address, sslParameters);
+        SslHelper.enableSni(host, sslParameters);
 
         final List<SNIServerName> serverNames = sslParameters.getServerNames();
         assertThat(serverNames).hasSize(1);
         assertThat(serverNames.get(0)).isInstanceOf(SNIHostName.class);
         final SNIHostName serverName = (SNIHostName) serverNames.get(0);
-        assertThat(serverName.getAsciiName()).isEqualTo(address.getHost());
+        assertThat(serverName.getAsciiName()).isEqualTo(host);
     }
 }

```
