### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-dns:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-dns/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-dns/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,177 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "methods": [
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.ByteBuf"
+          ]
+        },
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.CompositeByteBuf"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.DefaultDnsRawRecord"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.AbstractDnsRecord"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-dns/index.json
+++ b/metadata/io.netty/netty-codec-dns/index.json
@@ -1,16 +1,32 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-javadoc.jar",
-    "description" : "Netty Codec DNS provides DNS protocol message types, encoders, and decoders for Netty's asynchronous networking framework. It supports building and parsing DNS queries and responses for resolver and DNS-related network components.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.1.79.Final",
+    "test-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.79.Final/netty-codec-dns-4.1.79.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.79.Final/netty-codec-dns-4.1.79.Final-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.79.Final/netty-codec-dns-4.1.79.Final-javadoc.jar",
+    "description": "Netty Codec DNS provides DNS protocol message types, encoders, and decoders for Netty's asynchronous networking framework. It supports building and parsing DNS queries and responses for resolver and DNS-related network components.",
+    "tested-versions": [
+      "4.1.79.Final"
+    ],
+    "allowed-packages": [
+      "io.netty.handler.codec.dns",
+      "io.netty.buffer"
+    ]
+  },
+  {
+    "metadata-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/4.1.74.Final/netty-codec-dns-4.1.74.Final-javadoc.jar",
+    "description": "Netty Codec DNS provides DNS protocol message types, encoders, and decoders for Netty's asynchronous networking framework. It supports building and parsing DNS queries and responses for resolver and DNS-related network components.",
+    "tested-versions": [
       "4.1.74.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.netty.handler.codec.dns"
     ]
   }

--- a/stats/io.netty/netty-codec-dns/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-codec-dns/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2942,
+        "missed" : 2009,
+        "ratio" : 0.594223,
+        "total" : 4951
+      },
+      "line" : {
+        "covered" : 647,
+        "missed" : 501,
+        "ratio" : 0.563589,
+        "total" : 1148
+      },
+      "method" : {
+        "covered" : 194,
+        "missed" : 98,
+        "ratio" : 0.664384,
+        "total" : 292
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4257

This PR provides new metadata needed for the io.netty:netty-codec-dns:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-dns:4.1.74.Final`): 37
- Metadata entries (new `io.netty:netty-codec-dns:4.1.79.Final`): 34
- Library coverage (previous): 56.21%
- Library coverage (new): 56.36%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-dns:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-dns:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-dns:4.1.74.Final: 2942/4953 (59.40%)
- io.netty:netty-codec-dns:4.1.79.Final: 2942/4951 (59.42%)

**Line:**
- io.netty:netty-codec-dns:4.1.74.Final: 647/1151 (56.21%)
- io.netty:netty-codec-dns:4.1.79.Final: 647/1148 (56.36%)

**Method:**
- io.netty:netty-codec-dns:4.1.74.Final: 194/292 (66.44%)
- io.netty:netty-codec-dns:4.1.79.Final: 194/292 (66.44%)
