### PR TITLE
[GenAI] Test fix for org.apache.xbean:xbean-asm9-shaded:4.22 using gpt-5.5

### DIFF
--- a/metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.LinkedList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.Set"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassReader"
+      },
+      "glob": "org/apache/xbean/asm9/ClassReader.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.Constants"
+      },
+      "glob": "org/apache/xbean/asm9/tree/ClassNode.class"
+    }
+  ]
+}

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.22",
+    "tested-versions" : [
+      "4.22"
+    ],
+    "allowed-packages" : [
+      "org.apache.xbean.asm9"
+    ]
+  },
+  {
     "metadata-version" : "4.20",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.20/xbean-asm9-shaded-4.20-sources.jar",
     "repository-url" : "https://github.com/apache/geronimo-xbean",

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.22",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.22/xbean-asm9-shaded-4.22-sources.jar",
+    "repository-url" : "https://github.com/apache/geronimo-xbean",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://javadoc.io/doc/org.apache.xbean/xbean-asm9-shaded/4.22",
+    "description" : "Apache XBean xbean-asm9-shaded repackages and shades ASM 9 classes under the org.apache.xbean.asm9 namespace. It provides an isolated bytecode manipulation dependency for XBean and consumers that need ASM without package conflicts.",
     "tested-versions" : [
       "4.22"
     ],

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.22/execution-metrics.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.22/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T12:17:02.244421Z",
+    "library": "org.apache.xbean:xbean-asm9-shaded:4.22",
+    "starting_commit": "38619f7fb7ed48185dc98fc07cf52c794428d014",
+    "ending_commit": "959b1f1d97713165e90c135e5ccef1874a477818",
+    "previous_library": "org.apache.xbean:xbean-asm9-shaded:4.20",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.22",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5390,
+          "missed": 35735,
+          "ratio": 0.131064,
+          "total": 41125
+        },
+        "line": {
+          "covered": 1166,
+          "missed": 8537,
+          "ratio": 0.120169,
+          "total": 9703
+        },
+        "method": {
+          "covered": 161,
+          "missed": 1189,
+          "ratio": 0.119259,
+          "total": 1350
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.20",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.833333,
+        "coveredCalls": 5,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1237,
+          "missed": 44456,
+          "ratio": 0.027072,
+          "total": 45693
+        },
+        "line": {
+          "covered": 287,
+          "missed": 10485,
+          "ratio": 0.026643,
+          "total": 10772
+        },
+        "method": {
+          "covered": 61,
+          "missed": 1403,
+          "ratio": 0.041667,
+          "total": 1464
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 170558,
+      "cached_input_tokens_used": 2331648,
+      "output_tokens_used": 23756,
+      "iterations": 3,
+      "cost_usd": 1.8785,
+      "tested_library_loc": 1166,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 11,
+      "code_coverage_percent": 12.02,
+      "previous_library_coverage_percent": 2.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java",
+      "metadata_file": "metadata/org.apache.xbean/xbean-asm9-shaded/4.22/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.22/stats.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.22/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.22",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5390,
+        "missed" : 35735,
+        "ratio" : 0.131064,
+        "total" : 41125
+      },
+      "line" : {
+        "covered" : 1166,
+        "missed" : 8537,
+        "ratio" : 0.120169,
+        "total" : 9703
+      },
+      "method" : {
+        "covered" : 161,
+        "missed" : 1189,
+        "ratio" : 0.119259,
+        "total" : 1350
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/.gitignore
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/build.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.xbean:xbean-asm9-shaded:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/gradle.properties
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.xbean:xbean-asm9-shaded:4.22
+library.version = 4.22
+metadata.dir = org.apache.xbean/xbean-asm9-shaded/4.22/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/settings.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.xbean.xbean-asm9-shaded_tests'

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.io.IOException;
+
+import org.apache.xbean.asm9.ClassReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReaderTest {
+    @Test
+    void readsClassBytesFromTheSystemClassLoader() throws IOException {
+        ClassReader classReader = new ClassReader(ClassReader.class.getName());
+
+        assertThat(classReader.getClassName()).isEqualTo("org/apache/xbean/asm9/ClassReader");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import org.apache.xbean.asm9.ClassWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassWriterTest {
+    @Test
+    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+
+        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+    }
+
+    @Test
+    void returnsObjectWhenEitherLoadedTypeIsAnInterface() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/List", "java/util/Set");
+
+        assertThat(commonSuperClass).isEqualTo("java/lang/Object");
+    }
+
+    private static final class TestableClassWriter extends ClassWriter {
+        private TestableClassWriter() {
+            super(0);
+        }
+
+        private String commonSuperClass(String firstType, String secondType) {
+            return super.getCommonSuperClass(firstType, secondType);
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class ConstantsTest {
+    @Test
+    void experimentalApiChecksTheCallerClassBytecodeResource() {
+        assertThatIllegalStateException()
+                .isThrownBy(() -> createExperimentalClassNode());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ClassNode createExperimentalClassNode() {
+        return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -6,21 +6,158 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.xbean.asm9.ClassVisitor;
 import org.apache.xbean.asm9.Opcodes;
 import org.apache.xbean.asm9.tree.ClassNode;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
+    private static final String EXPERIMENTAL_API_REJECTION_MESSAGE =
+            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+    private static final String GENERATED_VISITOR_NAME =
+            "org_apache_xbean.xbean_asm9_shaded.ConstantsPreviewVisitor";
+    private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');
+    private static final String GENERATED_VISITOR_RESOURCE = GENERATED_VISITOR_INTERNAL_NAME + ".class";
+    private static final byte[] PREVIEW_CLASS_HEADER = {
+            (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
-    void experimentalApiChecksTheCallerClassBytecodeResource() {
+    void experimentalClassNodeChecksTheShadedTreeClassResource() {
         assertThatIllegalStateException()
-                .isThrownBy(() -> createExperimentalClassNode());
+                .isThrownBy(() -> createExperimentalClassNode())
+                .withMessage(EXPERIMENTAL_API_REJECTION_MESSAGE);
+    }
+
+    @Test
+    void experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader() throws Exception {
+        try {
+            PreviewResourceClassLoader classLoader = new PreviewResourceClassLoader();
+            Class<? extends ClassVisitor> visitorClass = classLoader.definePreviewVisitor();
+            ClassVisitor visitor = visitorClass.getConstructor().newInstance();
+
+            assertThat(visitor.getClass().getName()).isEqualTo(GENERATED_VISITOR_NAME);
+        } catch (InvocationTargetException exception) {
+            rethrowUnlessUnsupportedFeatureError(exception.getCause());
+        } catch (Error error) {
+            rethrowUnlessUnsupportedFeatureError(error);
+        }
     }
 
     @SuppressWarnings("deprecation")
     private static ClassNode createExperimentalClassNode() {
         return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] createPreviewVisitorClassBytes() throws IOException {
+        ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(classBytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            output.writeShort(14);
+            writeUtf8(output, GENERATED_VISITOR_INTERNAL_NAME);
+            output.writeByte(7);
+            output.writeShort(1);
+            writeUtf8(output, "org/apache/xbean/asm9/ClassVisitor");
+            output.writeByte(7);
+            output.writeShort(3);
+            writeUtf8(output, "<init>");
+            writeUtf8(output, "(I)V");
+            output.writeByte(12);
+            output.writeShort(5);
+            output.writeShort(6);
+            output.writeByte(10);
+            output.writeShort(4);
+            output.writeShort(7);
+            output.writeByte(3);
+            output.writeInt(Opcodes.ASM10_EXPERIMENTAL);
+            writeUtf8(output, "Code");
+            writeUtf8(output, "()V");
+            writeUtf8(output, "SourceFile");
+            writeUtf8(output, "ConstantsPreviewVisitor.java");
+            output.writeShort(0x0021);
+            output.writeShort(2);
+            output.writeShort(4);
+            output.writeShort(0);
+            output.writeShort(0);
+            output.writeShort(1);
+            writeDefaultConstructor(output);
+            output.writeShort(1);
+            output.writeShort(12);
+            output.writeInt(2);
+            output.writeShort(13);
+        }
+        return classBytes.toByteArray();
+    }
+
+    private static void writeDefaultConstructor(DataOutputStream output) throws IOException {
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(11);
+        output.writeShort(1);
+        output.writeShort(10);
+        output.writeInt(19);
+        output.writeShort(2);
+        output.writeShort(1);
+        output.writeInt(7);
+        output.writeByte(0x2A);
+        output.writeByte(0x12);
+        output.writeByte(9);
+        output.writeByte(0xB7);
+        output.writeShort(8);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+    }
+
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static void rethrowUnlessUnsupportedFeatureError(Throwable throwable) {
+        if (throwable instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+            return;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    private static final class PreviewResourceClassLoader extends ClassLoader {
+        private PreviewResourceClassLoader() {
+            super(ConstantsTest.class.getClassLoader());
+        }
+
+        private Class<? extends ClassVisitor> definePreviewVisitor() throws IOException {
+            byte[] classBytes = createPreviewVisitorClassBytes();
+            Class<?> visitorClass = defineClass(GENERATED_VISITOR_NAME, classBytes, 0, classBytes.length);
+            return visitorClass.asSubclass(ClassVisitor.class);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (GENERATED_VISITOR_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(PREVIEW_CLASS_HEADER);
+            }
+            return super.getResourceAsStream(name);
+        }
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import org.apache.xbean.asm9.Type;
+import org.apache.xbean.asm9.tree.analysis.BasicValue;
+import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleVerifierTest {
+    @Test
+    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
+        SimpleVerifier verifier = new SimpleVerifier();
+        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
+        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
+
+        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
+
+        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+    }
+
+    @Test
+    void recognizesAssignableArrayValues() {
+        SimpleVerifier verifier = new SimpleVerifier();
+        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
+        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+
+        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+
+        assertThat(mergedValue).isEqualTo(objectArrayValue);
+        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -6,38 +6,88 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
-import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.List;
 
-import org.apache.xbean.asm9.Type;
-import org.apache.xbean.asm9.tree.analysis.BasicValue;
-import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.apache.xbean.asm9.ClassReader;
+import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.AbstractInsnNode;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.apache.xbean.asm9.tree.InsnList;
+import org.apache.xbean.asm9.tree.InsnNode;
+import org.apache.xbean.asm9.tree.LdcInsnNode;
+import org.apache.xbean.asm9.tree.MethodInsnNode;
+import org.apache.xbean.asm9.tree.MethodNode;
+import org.apache.xbean.asm9.tree.VarInsnNode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleVerifierTest {
     @Test
-    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
-        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
+    void writesAndReadsClassNodeWithGeneratedMethods() {
+        ClassNode generatedClass = createGeneratedClassNode();
 
-        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        generatedClass.accept(classWriter);
 
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+        ClassNode parsedClass = new ClassNode();
+        new ClassReader(classWriter.toByteArray()).accept(parsedClass, 0);
+
+        assertThat(parsedClass.name).isEqualTo("org/apache/xbean/generated/Greeter");
+        assertThat(parsedClass.superName).isEqualTo("java/lang/Object");
+        assertThat(parsedClass.methods)
+                .extracting(methodNode -> methodNode.name + methodNode.desc)
+                .containsExactly("<init>()V", "message()Ljava/lang/String;");
+        assertThat(instructionOpcodes(method(parsedClass, "message")))
+                .containsExactly(Opcodes.LDC, Opcodes.ARETURN);
     }
 
-    @Test
-    void recognizesAssignableArrayValues() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
-        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+    private static ClassNode createGeneratedClassNode() {
+        ClassNode classNode = new ClassNode();
+        classNode.version = Opcodes.V17;
+        classNode.access = Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL;
+        classNode.name = "org/apache/xbean/generated/Greeter";
+        classNode.superName = "java/lang/Object";
+        classNode.methods.add(createConstructor());
+        classNode.methods.add(createMessageMethod());
+        return classNode;
+    }
 
-        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+    private static MethodNode createConstructor() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        instructions.add(new MethodInsnNode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false));
+        instructions.add(new InsnNode(Opcodes.RETURN));
+        return methodNode;
+    }
 
-        assertThat(mergedValue).isEqualTo(objectArrayValue);
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+    private static MethodNode createMessageMethod() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "message", "()Ljava/lang/String;", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new LdcInsnNode("xbean-asm9-shaded"));
+        instructions.add(new InsnNode(Opcodes.ARETURN));
+        return methodNode;
+    }
+
+    private static MethodNode method(ClassNode classNode, String name) {
+        return classNode.methods.stream()
+                .filter(methodNode -> methodNode.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static List<Integer> instructionOpcodes(MethodNode methodNode) {
+        List<Integer> opcodes = new ArrayList<>();
+        for (int index = 0; index < methodNode.instructions.size(); index++) {
+            AbstractInsnNode instruction = methodNode.instructions.get(index);
+            int opcode = instruction.getOpcode();
+            if (opcode >= 0) {
+                opcodes.add(opcode);
+            }
+        }
+        return opcodes;
     }
 }

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/user-code-filter.json
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.xbean.asm9.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #3552

This PR provides test fixes and new metadata for org.apache.xbean:xbean-asm9-shaded:4.22, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 170558
- Cached input tokens: 2331648
- Output tokens: 23756
- Metadata entries: 6
- Iterations: 3
- Library coverage percentage: 12.02
- Previous library version metadata entries: 11
- Previous library version coverage percentage: 2.66

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.xbean:xbean-asm9-shaded:4.20: 5/6 covered calls (83.33%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 4/4 covered calls (100.00%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 2/2 covered calls (100.00%)

**Resources:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 1/2 covered calls (50.00%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 1237/45693 (2.71%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 5390/41125 (13.11%)

**Line:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 287/10772 (2.66%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 1166/9703 (12.02%)

**Method:**
- org.apache.xbean:xbean-asm9-shaded:4.20: 61/1464 (4.17%)
- org.apache.xbean:xbean-asm9-shaded:4.22: 161/1350 (11.93%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
index 48d7212d03..7ba6a91c01 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -6,21 +6,158 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.xbean.asm9.ClassVisitor;
 import org.apache.xbean.asm9.Opcodes;
 import org.apache.xbean.asm9.tree.ClassNode;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
+    private static final String EXPERIMENTAL_API_REJECTION_MESSAGE =
+            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+    private static final String GENERATED_VISITOR_NAME =
+            "org_apache_xbean.xbean_asm9_shaded.ConstantsPreviewVisitor";
+    private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');
+    private static final String GENERATED_VISITOR_RESOURCE = GENERATED_VISITOR_INTERNAL_NAME + ".class";
+    private static final byte[] PREVIEW_CLASS_HEADER = {
+            (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
-    void experimentalApiChecksTheCallerClassBytecodeResource() {
+    void experimentalClassNodeChecksTheShadedTreeClassResource() {
         assertThatIllegalStateException()
-                .isThrownBy(() -> createExperimentalClassNode());
+                .isThrownBy(() -> createExperimentalClassNode())
+                .withMessage(EXPERIMENTAL_API_REJECTION_MESSAGE);
+    }
+
+    @Test
+    void experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader() throws Exception {
+        try {
+            PreviewResourceClassLoader classLoader = new PreviewResourceClassLoader();
+            Class<? extends ClassVisitor> visitorClass = classLoader.definePreviewVisitor();
+            ClassVisitor visitor = visitorClass.getConstructor().newInstance();
+
+            assertThat(visitor.getClass().getName()).isEqualTo(GENERATED_VISITOR_NAME);
+        } catch (InvocationTargetException exception) {
+            rethrowUnlessUnsupportedFeatureError(exception.getCause());
+        } catch (Error error) {
+            rethrowUnlessUnsupportedFeatureError(error);
+        }
     }
 
     @SuppressWarnings("deprecation")
     private static ClassNode createExperimentalClassNode() {
         return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
     }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] createPreviewVisitorClassBytes() throws IOException {
+        ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(classBytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            output.writeShort(14);
+            writeUtf8(output, GENERATED_VISITOR_INTERNAL_NAME);
+            output.writeByte(7);
+            output.writeShort(1);
+            writeUtf8(output, "org/apache/xbean/asm9/ClassVisitor");
+            output.writeByte(7);
+            output.writeShort(3);
+            writeUtf8(output, "<init>");
+            writeUtf8(output, "(I)V");
+            output.writeByte(12);
+            output.writeShort(5);
+            output.writeShort(6);
+            output.writeByte(10);
+            output.writeShort(4);
+            output.writeShort(7);
+            output.writeByte(3);
+            output.writeInt(Opcodes.ASM10_EXPERIMENTAL);
+            writeUtf8(output, "Code");
+            writeUtf8(output, "()V");
+            writeUtf8(output, "SourceFile");
+            writeUtf8(output, "ConstantsPreviewVisitor.java");
+            output.writeShort(0x0021);
+            output.writeShort(2);
+            output.writeShort(4);
+            output.writeShort(0);
+            output.writeShort(0);
+            output.writeShort(1);
+            writeDefaultConstructor(output);
+            output.writeShort(1);
+            output.writeShort(12);
+            output.writeInt(2);
+            output.writeShort(13);
+        }
+        return classBytes.toByteArray();
+    }
+
+    private static void writeDefaultConstructor(DataOutputStream output) throws IOException {
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(11);
+        output.writeShort(1);
+        output.writeShort(10);
+        output.writeInt(19);
+        output.writeShort(2);
+        output.writeShort(1);
+        output.writeInt(7);
+        output.writeByte(0x2A);
+        output.writeByte(0x12);
+        output.writeByte(9);
+        output.writeByte(0xB7);
+        output.writeShort(8);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+    }
+
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static void rethrowUnlessUnsupportedFeatureError(Throwable throwable) {
+        if (throwable instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+            return;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    private static final class PreviewResourceClassLoader extends ClassLoader {
+        private PreviewResourceClassLoader() {
+            super(ConstantsTest.class.getClassLoader());
+        }
+
+        private Class<? extends ClassVisitor> definePreviewVisitor() throws IOException {
+            byte[] classBytes = createPreviewVisitorClassBytes();
+            Class<?> visitorClass = defineClass(GENERATED_VISITOR_NAME, classBytes, 0, classBytes.length);
+            return visitorClass.asSubclass(ClassVisitor.class);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (GENERATED_VISITOR_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(PREVIEW_CLASS_HEADER);
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
 }
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
index 0b51b23a35..cd9811c467 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.20/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -6,38 +6,88 @@
  */
 package org_apache_xbean.xbean_asm9_shaded;
 
-import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.List;
 
-import org.apache.xbean.asm9.Type;
-import org.apache.xbean.asm9.tree.analysis.BasicValue;
-import org.apache.xbean.asm9.tree.analysis.SimpleVerifier;
+import org.apache.xbean.asm9.ClassReader;
+import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.AbstractInsnNode;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.apache.xbean.asm9.tree.InsnList;
+import org.apache.xbean.asm9.tree.InsnNode;
+import org.apache.xbean.asm9.tree.LdcInsnNode;
+import org.apache.xbean.asm9.tree.MethodInsnNode;
+import org.apache.xbean.asm9.tree.MethodNode;
+import org.apache.xbean.asm9.tree.VarInsnNode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleVerifierTest {
     @Test
-    void mergesConcreteObjectValuesToTheirCommonSuperclass() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue arrayListValue = verifier.newValue(Type.getType(ArrayList.class));
-        BasicValue linkedListValue = verifier.newValue(Type.getType(LinkedList.class));
+    void writesAndReadsClassNodeWithGeneratedMethods() {
+        ClassNode generatedClass = createGeneratedClassNode();
 
-        BasicValue mergedValue = verifier.merge(arrayListValue, linkedListValue);
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        generatedClass.accept(classWriter);
 
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(AbstractList.class));
+        ClassNode parsedClass = new ClassNode();
+        new ClassReader(classWriter.toByteArray()).accept(parsedClass, 0);
+
+        assertThat(parsedClass.name).isEqualTo("org/apache/xbean/generated/Greeter");
+        assertThat(parsedClass.superName).isEqualTo("java/lang/Object");
+        assertThat(parsedClass.methods)
+                .extracting(methodNode -> methodNode.name + methodNode.desc)
+                .containsExactly("<init>()V", "message()Ljava/lang/String;");
+        assertThat(instructionOpcodes(method(parsedClass, "message")))
+                .containsExactly(Opcodes.LDC, Opcodes.ARETURN);
     }
 
-    @Test
-    void recognizesAssignableArrayValues() {
-        SimpleVerifier verifier = new SimpleVerifier();
-        BasicValue objectArrayValue = verifier.newValue(Type.getType(Object[].class));
-        BasicValue stringArrayValue = verifier.newValue(Type.getType(String[].class));
+    private static ClassNode createGeneratedClassNode() {
+        ClassNode classNode = new ClassNode();
+        classNode.version = Opcodes.V17;
+        classNode.access = Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL;
+        classNode.name = "org/apache/xbean/generated/Greeter";
+        classNode.superName = "java/lang/Object";
+        classNode.methods.add(createConstructor());
+        classNode.methods.add(createMessageMethod());
+        return classNode;
+    }
+
+    private static MethodNode createConstructor() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        instructions.add(new MethodInsnNode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false));
+        instructions.add(new InsnNode(Opcodes.RETURN));
+        return methodNode;
+    }
+
+    private static MethodNode createMessageMethod() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "message", "()Ljava/lang/String;", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new LdcInsnNode("xbean-asm9-shaded"));
+        instructions.add(new InsnNode(Opcodes.ARETURN));
+        return methodNode;
+    }
 
-        BasicValue mergedValue = verifier.merge(objectArrayValue, stringArrayValue);
+    private static MethodNode method(ClassNode classNode, String name) {
+        return classNode.methods.stream()
+                .filter(methodNode -> methodNode.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
 
-        assertThat(mergedValue).isEqualTo(objectArrayValue);
-        assertThat(mergedValue.getType()).isEqualTo(Type.getType(Object[].class));
+    private static List<Integer> instructionOpcodes(MethodNode methodNode) {
+        List<Integer> opcodes = new ArrayList<>();
+        for (int index = 0; index < methodNode.instructions.size(); index++) {
+            AbstractInsnNode instruction = methodNode.instructions.get(index);
+            int opcode = instruction.getOpcode();
+            if (opcode >= 0) {
+                opcodes.add(opcode);
+            }
+        }
+        return opcodes;
     }
 }

```
