### PR TITLE
[Automation] Generated metadata for org.apache.commons:commons-configuration2:2.6

### DIFF
--- a/metadata/org.apache.commons/commons-configuration2/2.6/reachability-metadata.json
+++ b/metadata/org.apache.commons/commons-configuration2/2.6/reachability-metadata.json
@@ -1,0 +1,381 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.XMLPropertiesConfiguration"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.plist.XMLPropertyListConfiguration"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.convert.DefaultConversionHandler"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.convert.PropertyConverter"
+      },
+      "type" : "java.lang.Integer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.convert.DefaultConversionHandler"
+      },
+      "type" : "java.lang.Integer[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ExprLookup$Variable"
+      },
+      "type" : "java.lang.StringBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.convert.DefaultConversionHandler"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ImmutableConfigurationInvocationHandler"
+      },
+      "type" : "org.apache.commons.configuration2.ImmutableConfiguration",
+      "methods" : [
+        {
+          "name" : "getString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.BuilderConfigurationWrapperFactory$BuilderConfigurationWrapperInvocationHandler"
+      },
+      "type" : "org.apache.commons.configuration2.ImmutableConfiguration",
+      "methods" : [
+        {
+          "name" : "containsKey",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "getBoolean",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "getString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.combined.BaseConfigurationBuilderProvider"
+      },
+      "type" : "org.apache.commons.configuration2.SystemConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.configuration2.builder.BasicBuilderParameters",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.combined.BaseConfigurationBuilderProvider"
+      },
+      "type" : "org.apache.commons.configuration2.builder.BasicBuilderParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.combined.BaseConfigurationBuilderProvider"
+      },
+      "type" : "org.apache.commons.configuration2.builder.BasicConfigurationBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.util.Map",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.fluent.Parameters$ParametersIfcInvocationHandler"
+      },
+      "type" : "org.apache.commons.configuration2.builder.FileBasedBuilderProperties",
+      "methods" : [
+        {
+          "name" : "setFileName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.BuilderConfigurationWrapperFactory$BuilderConfigurationWrapperInvocationHandler"
+      },
+      "type" : "org.apache.commons.configuration2.event.EventSource",
+      "methods" : [
+        {
+          "name" : "addEventListener",
+          "parameterTypes" : [
+            "org.apache.commons.configuration2.event.EventType",
+            "org.apache.commons.configuration2.event.EventListener"
+          ]
+        },
+        {
+          "name" : "removeEventListener",
+          "parameterTypes" : [
+            "org.apache.commons.configuration2.event.EventType",
+            "org.apache.commons.configuration2.event.EventListener"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.configuration2.sync.ReadWriteSynchronizer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.io.FileLocatorUtils"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4JLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.BuilderConfigurationWrapperFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "org.apache.commons.configuration2.Configuration"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.configuration2.ConfigurationUtils"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.ConfigurationUtils"
+      },
+      "type" : {
+        "proxy" : [
+          "org.apache.commons.configuration2.ImmutableConfiguration"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.fluent.Parameters"
+      },
+      "type" : {
+        "proxy" : [
+          "org.apache.commons.configuration2.builder.fluent.FileBasedBuilderParameters"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.builder.BuilderConfigurationWrapperFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "org.apache.commons.configuration2.event.EventSource",
+          "org.apache.commons.configuration2.Configuration"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.XMLPropertiesConfiguration"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.plist.XMLPropertyListConfiguration"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.plist.XMLPropertyListConfiguration"
+      },
+      "glob" : "PropertyList-1.0.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.interpol.ConstantLookup"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.io.FileLocatorUtils"
+      },
+      "glob" : "org_apache_commons/commons_configuration2/io/missing-file-locator-resource.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration2.XMLPropertiesConfiguration"
+      },
+      "glob" : "properties.dtd"
+    }
+  ]
+}

--- a/metadata/org.apache.commons/commons-configuration2/index.json
+++ b/metadata/org.apache.commons/commons-configuration2/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-configuration2/2.6/commons-configuration2-2.6-sources.jar",
+    "repository-url" : "https://github.com/apache/commons-configuration",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-configuration2/2.6/commons-configuration2-2.6-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-configuration2/2.6/commons-configuration2-2.6-javadoc.jar",
+    "description" : "Apache Commons Configuration provides APIs for reading and writing configuration data from formats such as properties, XML, INI, and other hierarchical sources. It also supports configuration builders, interpolation, conversion, reloading, and combined configurations for Java applications.",
+    "test-version" : "2.1.1",
+    "tested-versions" : [
+      "2.6"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.configuration2"
+    ]
+  },
+  {
     "metadata-version" : "2.1.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-configuration2/2.1.1/commons-configuration2-2.1.1-sources.jar",
     "repository-url" : "https://github.com/apache/commons-configuration",

--- a/stats/org.apache.commons/commons-configuration2/2.6/stats.json
+++ b/stats/org.apache.commons/commons-configuration2/2.6/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.6",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 26,
+          "totalCalls" : 26
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 30,
+      "totalCalls" : 30
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6212,
+        "missed" : 41828,
+        "ratio" : 0.129309,
+        "total" : 48040
+      },
+      "line" : {
+        "covered" : 1616,
+        "missed" : 10048,
+        "ratio" : 0.138546,
+        "total" : 11664
+      },
+      "method" : {
+        "covered" : 523,
+        "missed" : 2446,
+        "ratio" : 0.176154,
+        "total" : 2969
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4212

This PR provides new metadata needed for the org.apache.commons:commons-configuration2:2.6, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.commons:commons-configuration2:2.1.1`): 56
- Test-only metadata entries (previous `org.apache.commons:commons-configuration2:2.1.1`): 4
- Metadata entries (new `org.apache.commons:commons-configuration2:2.6`): 56
- Test-only metadata entries (new `org.apache.commons:commons-configuration2:2.6`): 4
- Library coverage (previous): 14.12%
- Library coverage (new): 13.85%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4da20652e7c1162d1e721698219f8372af2ce359`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.commons:commons-configuration2:2.1.1: 30/30 covered calls (100.00%)
- org.apache.commons:commons-configuration2:2.6: 30/30 covered calls (100.00%)

**Reflection:**
- org.apache.commons:commons-configuration2:2.1.1: 26/26 covered calls (100.00%)
- org.apache.commons:commons-configuration2:2.6: 26/26 covered calls (100.00%)

**Resources:**
- org.apache.commons:commons-configuration2:2.1.1: 4/4 covered calls (100.00%)
- org.apache.commons:commons-configuration2:2.6: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.commons:commons-configuration2:2.1.1: 6007/46477 (12.92%)
- org.apache.commons:commons-configuration2:2.6: 6212/48040 (12.93%)

**Line:**
- org.apache.commons:commons-configuration2:2.1.1: 1594/11288 (14.12%)
- org.apache.commons:commons-configuration2:2.6: 1616/11664 (13.85%)

**Method:**
- org.apache.commons:commons-configuration2:2.1.1: 529/2895 (18.27%)
- org.apache.commons:commons-configuration2:2.6: 523/2969 (17.62%)
