### PR TITLE
Print native trace metadata after each verification run

### DIFF
--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -271,6 +271,25 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.iterations_used, 3)
         self.assertEqual(len(result.accepted_run_dirs), 2)
 
+    def test_prints_aggregated_metadata_path_after_merge(self) -> None:
+        fake, _calls = self._fake_run_factory([172, 0])
+        output = io.StringIO()
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=fake,
+        ), redirect_stdout(output):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        self.assertIn(
+            os.path.join(self.output_dir, "reachability-metadata.json"),
+            output.getvalue(),
+        )
+
     def test_failed_when_budget_exhausted_with_only_172(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172])
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -12,12 +12,14 @@ The Gradle / native-image side is intentionally not exercised here.
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -144,6 +146,51 @@ class CollectEntriesTests(unittest.TestCase):
         a = self._make_run({"opaque.bin": b"AAA"})
         b = self._make_run({"opaque.bin": b"BBB"})
         self.assertNotEqual(nme._collect_entries(a), nme._collect_entries(b))
+
+
+class PrintCollectedMetadataTests(unittest.TestCase):
+    """Readable logging of per-cycle trace metadata."""
+
+    def test_prints_pretty_json_metadata(self) -> None:
+        run_dir = tempfile.mkdtemp(prefix="trace-run-")
+        self.addCleanup(_rmtree, run_dir)
+        metadata_file = Path(run_dir) / "reachability-metadata.json"
+        metadata_file.write_text(
+            json.dumps({"reflection": [{"type": "com.example.Foo"}]}),
+            encoding="utf-8",
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            ntv._print_collected_metadata(run_dir, 2)
+
+        printed = output.getvalue()
+        self.assertIn("cycle 2: collected metadata from 1 file(s)", printed)
+        self.assertIn("reachability-metadata.json:", printed)
+        self.assertIn('"type": "com.example.Foo"', printed)
+
+    def test_prints_none_for_empty_trace_dir(self) -> None:
+        run_dir = tempfile.mkdtemp(prefix="trace-run-")
+        self.addCleanup(_rmtree, run_dir)
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            ntv._print_collected_metadata(run_dir, 1)
+
+        self.assertIn("cycle 1: collected metadata: none", output.getvalue())
+
+    def test_ignores_binary_exit_sentinel(self) -> None:
+        run_dir = tempfile.mkdtemp(prefix="trace-run-")
+        self.addCleanup(_rmtree, run_dir)
+        Path(run_dir, "binary-exit-code").write_text("172", encoding="utf-8")
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            ntv._print_collected_metadata(run_dir, 1)
+
+        printed = output.getvalue()
+        self.assertIn("cycle 1: collected metadata: none", printed)
+        self.assertNotIn("binary-exit-code:", printed)
 
 
 class GateRoutingTests(unittest.TestCase):

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -61,6 +61,7 @@ _LOG_TASK_TYPE = "native-test-verify"
 # Gradle's own exit code does not include it.
 _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
+_AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
 
 
 @dataclass
@@ -417,12 +418,22 @@ def _merge_into_output(
             check=False,
             timeout=_MERGE_TIMEOUT_SECONDS,
         )
+        _print_aggregated_metadata_path(output_dir)
     except subprocess.TimeoutExpired:
         log_stage(
             _GATE_STAGE,
             f"mergeNativeTraceMetadata exceeded {_MERGE_TIMEOUT_SECONDS}s timeout",
             indent_level=1,
         )
+
+
+def _print_aggregated_metadata_path(output_dir: str) -> None:
+    """Print only the path to the merged reachability metadata file."""
+    log_stage(
+        _GATE_STAGE,
+        os.path.join(output_dir, _AGGREGATED_METADATA_FILE_NAME),
+        indent_level=1,
+    )
 
 
 def _reset_directory(path: str) -> None:

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -27,6 +27,7 @@ must surface to the coding agent. See
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -59,6 +60,7 @@ _LOG_TASK_TYPE = "native-test-verify"
 # from this line because the Exec itself runs with ignoreExitValue=true and
 # Gradle's own exit code does not include it.
 _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
+_TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 
 
 @dataclass
@@ -150,6 +152,7 @@ def verify_native_test_passes(
         )
         last_log_path = log_path
         last_binary_rc = binary_rc if binary_rc is not None else gradle_rc
+        _print_collected_metadata(run_dir, cycle + 1)
 
         if binary_rc == 0:
             log_stage(
@@ -289,6 +292,66 @@ def _run_native_trace_image(
         # exit value; the binary must have returned 0.
         binary_rc = 0
     return result.returncode, binary_rc
+
+
+def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
+    """Print the trace metadata collected in ``run_dir`` for one gate cycle."""
+    metadata_files = _metadata_files(run_dir)
+    if not metadata_files:
+        log_stage(
+            _GATE_STAGE,
+            f"cycle {cycle_number}: collected metadata: none ({run_dir})",
+            indent_level=1,
+        )
+        return
+
+    log_stage(
+        _GATE_STAGE,
+        f"cycle {cycle_number}: collected metadata from {len(metadata_files)} file(s) ({run_dir})",
+        indent_level=1,
+    )
+    for metadata_file in metadata_files:
+        relative = os.path.relpath(metadata_file, run_dir)
+        log_stage(_GATE_STAGE, f"{relative}:", indent_level=2)
+        for line in _format_metadata_file(metadata_file).splitlines():
+            log_stage(_GATE_STAGE, line, indent_level=3)
+
+
+def _metadata_files(run_dir: str) -> list[str]:
+    """Return trace metadata files below ``run_dir`` in deterministic order."""
+    result: list[str] = []
+    for root, _dirs, files in os.walk(run_dir):
+        for name in files:
+            if name in _TRACE_SENTINEL_FILE_NAMES:
+                continue
+            result.append(os.path.join(root, name))
+    return sorted(result, key=lambda path: os.path.relpath(path, run_dir))
+
+
+def _format_metadata_file(path: str) -> str:
+    """Return a readable representation of one collected metadata file."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return _read_text_or_binary_summary(path)
+    except OSError as exc:
+        return f"<unreadable: {exc}>"
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+def _read_text_or_binary_summary(path: str) -> str:
+    """Return text content for UTF-8 files, or a compact summary for binary files."""
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    except OSError as exc:
+        return f"<unreadable: {exc}>"
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return f"<binary metadata file: {len(raw)} bytes>"
+    return text if text else "<empty>"
 
 
 def _read_exit_file(path: str) -> int | None:


### PR DESCRIPTION
## What does this PR do?

Closes #4298.

Prints collected trace metadata after each native-test verification cycle. The gate now logs either that no metadata was collected or prints each collected file with JSON formatted for readability. The `binary-exit-code` sentinel remains excluded because it is gate bookkeeping, not trace metadata.

Adds focused unit coverage for pretty-printed JSON metadata, empty trace directories, and sentinel exclusion.

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/native_test_verification.py`: reads local per-cycle trace metadata files from the `runNativeTraceImage` output directory and prints them to the workflow log.

## Verification

- `python3 -m unittest forge.tests.test_native_test_verification`