### PR TITLE
Fix native trace gate empty metadata loop

### DIFF
--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -209,33 +209,50 @@ class GateRoutingTests(unittest.TestCase):
         )
         self.addCleanup(_rmtree, os.path.dirname(self.output_dir))
 
-    def _fake_run_factory(self, scripted_exits: list[int]):
+    def _fake_run_factory(
+            self,
+            scripted_exits: list[int],
+            metadata_exit_codes: set[int] | None = None,
+            log_text: str = "BUILD SUCCESSFUL\n",
+    ):
         """Build a subprocess.run replacement that consumes ``scripted_exits``.
 
         Each call corresponds to one ``./gradlew`` invocation. When the
         invocation contains ``runNativeTraceImage``, the script writes the
         next scripted exit code to the sentinel file referenced by the
         ``-PtraceBinaryExitFile=`` argument so the gate's reader returns
-        that value.
+        that value. By default, 172 runs also write synthetic trace metadata
+        so tests that exercise the correction loop represent real progress.
         """
         calls: list[list[str]] = []
         remaining = list(scripted_exits)
+        metadata_exit_codes = {172} if metadata_exit_codes is None else metadata_exit_codes
 
         def _fake(cmd, **kwargs):  # type: ignore[no-untyped-def]
             calls.append(list(cmd))
             stdout = kwargs.get("stdout")
             # Write a synthetic Gradle log if the caller asked us to.
             if hasattr(stdout, "write"):
-                stdout.write("BUILD SUCCESSFUL\n")
+                stdout.write(log_text)
             if "runNativeTraceImage" in cmd:
                 exit_file = next(
                     (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceBinaryExitFile=")),
+                    None,
+                )
+                run_dir = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceMetadataPath=")),
                     None,
                 )
                 rc = remaining.pop(0)
                 if exit_file:
                     Path(exit_file).parent.mkdir(parents=True, exist_ok=True)
                     Path(exit_file).write_text(str(rc), encoding="utf-8")
+                if run_dir and rc in metadata_exit_codes:
+                    Path(run_dir).mkdir(parents=True, exist_ok=True)
+                    Path(run_dir, "reachability-metadata.json").write_text(
+                        json.dumps({"reflection": [{"type": f"com.example.Generated{len(calls)}"}]}),
+                        encoding="utf-8",
+                    )
                 # Gradle-side exit is always 0 (Exec uses ignoreExitValue).
                 return subprocess.CompletedProcess(cmd, 0)
             # mergeNativeTraceMetadata or anything else — succeeds.
@@ -255,7 +272,6 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.status, ntv.STATUS_PASSED)
         self.assertEqual(result.iterations_used, 1)
         self.assertEqual(result.last_native_test_exit_code, 0)
-        # First call is runNativeTraceImage; second is mergeNativeTraceMetadata.
         self.assertTrue(any("runNativeTraceImage" in c for c in calls))
 
     def test_continues_on_172_until_pass(self) -> None:
@@ -289,6 +305,48 @@ class GateRoutingTests(unittest.TestCase):
             os.path.join(self.output_dir, "reachability-metadata.json"),
             output.getvalue(),
         )
+
+    def test_merges_final_passing_run_when_it_collected_metadata(self) -> None:
+        fake, calls = self._fake_run_factory([0], metadata_exit_codes={0})
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        merge_calls = [call for call in calls if "mergeNativeTraceMetadata" in call]
+        self.assertEqual(len(merge_calls), 1)
+        input_dirs = next(arg for arg in merge_calls[0] if arg.startswith("-PinputDirs="))
+        self.assertIn("cycle-0", input_dirs)
+
+    def test_fails_fast_and_prints_stacktrace_when_172_produces_no_metadata(self) -> None:
+        fake, _calls = self._fake_run_factory(
+            [172],
+            metadata_exit_codes=set(),
+            log_text=(
+                "some native output\n"
+                "Exception in thread \"main\" com.example.MissingThingException: boom\n"
+                "\tat com.example.App.main(App.java:12)\n"
+            ),
+        )
+        output = io.StringIO()
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=fake,
+        ), redirect_stdout(output):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.iterations_used, 1)
+        printed = output.getvalue()
+        self.assertIn("produced no trace metadata; failing fast", printed)
+        self.assertIn("com.example.MissingThingException: boom", printed)
 
     def test_failed_when_budget_exhausted_with_only_172(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172])

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -62,6 +62,7 @@ _LOG_TASK_TYPE = "native-test-verify"
 _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 _AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
+_STACKTRACE_EXCERPT_LINE_LIMIT = 160
 
 
 @dataclass
@@ -154,21 +155,33 @@ def verify_native_test_passes(
         last_log_path = log_path
         last_binary_rc = binary_rc if binary_rc is not None else gradle_rc
         _print_collected_metadata(run_dir, cycle + 1)
+        collected_metadata_files = _metadata_files(run_dir)
 
         if binary_rc == 0:
             log_stage(
                 _GATE_STAGE,
-                f"cycle {cycle + 1}: binary passed (exit 0); merging accepted trace dirs",
+                f"cycle {cycle + 1}: binary passed (exit 0); merging trace dirs",
             )
-            _merge_into_output(
+            run_dirs_to_merge = list(accepted_run_dirs)
+            if collected_metadata_files:
+                run_dirs_to_merge.append(run_dir)
+            if not _merge_into_output(
                 reachability_repo_path=reachability_repo_path,
-                run_dirs=accepted_run_dirs,
+                run_dirs=run_dirs_to_merge,
                 output_dir=output_dir,
-            )
+            ):
+                return _make_result(STATUS_FAILED, cycle + 1)
             status = STATUS_PASSED_WITH_INTERVENTION if intervention_used else STATUS_PASSED
             return _make_result(status, cycle + 1)
 
         if binary_rc == MISSING_METADATA_EXIT_CODE:
+            if not collected_metadata_files:
+                log_stage(
+                    _GATE_STAGE,
+                    f"cycle {cycle + 1}: binary exited 172 but produced no trace metadata; failing fast",
+                )
+                _print_failure_stacktrace(log_path, cycle + 1)
+                return _make_result(STATUS_FAILED, cycle + 1)
             log_stage(
                 _GATE_STAGE,
                 f"cycle {cycle + 1}: binary exited 172 (missing metadata); "
@@ -182,6 +195,8 @@ def verify_native_test_passes(
             f"cycle {cycle + 1}: binary failed (gradle_exit={gradle_rc}, binary_exit={binary_rc}); "
             "routing to codex (terminal)",
         )
+        if not collected_metadata_files:
+            _print_failure_stacktrace(log_path, cycle + 1)
         codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
             reachability_repo_path,
             coordinate,
@@ -318,6 +333,52 @@ def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
             log_stage(_GATE_STAGE, line, indent_level=3)
 
 
+def _print_failure_stacktrace(log_path: str, cycle_number: int) -> None:
+    """Print the native trace failure stacktrace, or a bounded log tail."""
+    log_stage(
+        _GATE_STAGE,
+        f"cycle {cycle_number}: failure stacktrace from {log_path}:",
+        indent_level=1,
+    )
+    for line in _extract_failure_stacktrace(log_path).splitlines():
+        log_stage(_GATE_STAGE, line, indent_level=2)
+
+
+def _extract_failure_stacktrace(log_path: str) -> str:
+    """Extract a bounded stacktrace-like excerpt from a native trace run log."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+            lines = handle.read().splitlines()
+    except OSError as exc:
+        return f"<unable to read log: {exc}>"
+
+    if not lines:
+        return "<empty log>"
+
+    start_index = _find_stacktrace_start(lines)
+    if start_index is None:
+        start_index = max(0, len(lines) - _STACKTRACE_EXCERPT_LINE_LIMIT)
+
+    excerpt = lines[start_index:start_index + _STACKTRACE_EXCERPT_LINE_LIMIT]
+    if not excerpt:
+        return "<no stacktrace excerpt available>"
+    return "\n".join(excerpt)
+
+
+def _find_stacktrace_start(lines: list[str]) -> int | None:
+    """Return the first likely stacktrace line index in ``lines``."""
+    exception_pattern = re.compile(
+        r"(^Exception in thread|^\S.*(?:Exception|Error)(?::|\s|$)|^Caused by:)"
+    )
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if exception_pattern.search(stripped):
+            return max(0, index - 2)
+        if stripped.startswith("at ") and index > 0:
+            return max(0, index - 1)
+    return None
+
+
 def _metadata_files(run_dir: str) -> list[str]:
     """Return trace metadata files below ``run_dir`` in deterministic order."""
     result: list[str] = []
@@ -400,10 +461,10 @@ def _merge_into_output(
         reachability_repo_path: str,
         run_dirs: list[str],
         output_dir: str,
-) -> None:
+) -> bool:
     """Merge accepted per-cycle trace dirs into the caller's ``output_dir``."""
     if not run_dirs:
-        return
+        return True
     cmd = [
         "./gradlew",
         "mergeNativeTraceMetadata",
@@ -412,19 +473,28 @@ def _merge_into_output(
     ]
     log_stage(_GATE_STAGE, f"$ {' '.join(cmd)}", indent_level=1)
     try:
-        subprocess.run(
+        result = subprocess.run(
             cmd,
             cwd=reachability_repo_path,
             check=False,
             timeout=_MERGE_TIMEOUT_SECONDS,
         )
+        if result.returncode != 0:
+            log_stage(
+                _GATE_STAGE,
+                f"mergeNativeTraceMetadata failed with exit code {result.returncode}",
+                indent_level=1,
+            )
+            return False
         _print_aggregated_metadata_path(output_dir)
+        return True
     except subprocess.TimeoutExpired:
         log_stage(
             _GATE_STAGE,
             f"mergeNativeTraceMetadata exceeded {_MERGE_TIMEOUT_SECONDS}s timeout",
             indent_level=1,
         )
+        return False
 
 
 def _print_aggregated_metadata_path(output_dir: str) -> None:


### PR DESCRIPTION
## Summary

- fail fast when `runNativeTraceImage` exits with missing metadata (`172`) but produces no trace metadata
- print a bounded stacktrace/log excerpt for no-metadata native trace failures
- merge metadata from a final passing trace run when it produced files, and fail the gate when metadata merge fails

Fixes #4301

## Testing

- `python3 -m unittest tests.test_native_test_verification`
- `python3 -m py_compile utility_scripts/native_test_verification.py tests/test_native_test_verification.py`
- `git diff --check`

## Notes

I also ran `python3 -m unittest discover -s tests`; existing `test_forge_metadata` queue/stop-marker expectations failed in this checkout, unrelated to this native trace gate change.