### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-io:9.4.19.v20190610 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-io/9.4.19.v20190610/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-io/9.4.19.v20190610/reachability-metadata.json
@@ -1,0 +1,87 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getUptime",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "org.eclipse.jetty.util.log.Slf4jLog"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "glob": "jetty-logging-linux.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "glob": "jetty-logging.properties"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-io/index.json
+++ b/metadata/org.eclipse.jetty/jetty-io/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "9.4.19.v20190610",
+    "tested-versions" : [
+      "9.4.19.v20190610"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.io"
+    ]
+  },
+  {
     "metadata-version" : "9.4.0.RC0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/$version$/jetty-io-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-io/index.json
+++ b/metadata/org.eclipse.jetty/jetty-io/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "9.4.19.v20190610",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/$version$/jetty-io-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-$version$/jetty-io/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/$version$/jetty-io-$version$-javadoc.jar",
+    "description" : "Jetty IO Utility provides core non-blocking I/O abstractions and utilities for Eclipse Jetty, including buffers, endpoints, and connection support. It underpins Jetty's network transport layer for Java applications that embed or extend the server.",
     "tested-versions" : [
       "9.4.19.v20190610"
     ],

--- a/stats/org.eclipse.jetty/jetty-io/9.4.19.v20190610/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-io/9.4.19.v20190610/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T14:00:47.672572Z",
+    "library": "org.eclipse.jetty:jetty-io:9.4.19.v20190610",
+    "starting_commit": "70d06f962ac2a33bfcba4f62a8e37792cdeeeb5f",
+    "ending_commit": "a34ffc44d92d6a140eafafd3051db99f69216d9c",
+    "previous_library": "org.eclipse.jetty:jetty-io:9.4.0.RC0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "9.4.19.v20190610",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2731,
+          "missed": 9180,
+          "ratio": 0.229284,
+          "total": 11911
+        },
+        "line": {
+          "covered": 696,
+          "missed": 2063,
+          "ratio": 0.252265,
+          "total": 2759
+        },
+        "method": {
+          "covered": 189,
+          "missed": 375,
+          "ratio": 0.335106,
+          "total": 564
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.4.0.RC0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2397,
+          "missed": 6964,
+          "ratio": 0.256062,
+          "total": 9361
+        },
+        "line": {
+          "covered": 607,
+          "missed": 1560,
+          "ratio": 0.280111,
+          "total": 2167
+        },
+        "method": {
+          "covered": 166,
+          "missed": 285,
+          "ratio": 0.368071,
+          "total": 451
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 29599,
+      "cached_input_tokens_used": 129024,
+      "output_tokens_used": 1515,
+      "iterations": 1,
+      "cost_usd": 0.11,
+      "tested_library_loc": 696,
+      "metadata_entries": 18,
+      "previous_library_metadata_entries": 19,
+      "code_coverage_percent": 25.23,
+      "previous_library_coverage_percent": 28.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-io/9.4.19.v20190610/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-io/9.4.19.v20190610/stats.json
+++ b/stats/org.eclipse.jetty/jetty-io/9.4.19.v20190610/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "9.4.19.v20190610",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2731,
+        "missed" : 9180,
+        "ratio" : 0.229284,
+        "total" : 11911
+      },
+      "line" : {
+        "covered" : 696,
+        "missed" : 2063,
+        "ratio" : 0.252265,
+        "total" : 2759
+      },
+      "method" : {
+        "covered" : 189,
+        "missed" : 375,
+        "ratio" : 0.335106,
+        "total" : 564
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-io:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-io:9.4.19.v20190610
+library.version = 9.4.19.v20190610
+metadata.dir = org.eclipse.jetty/jetty-io/9.4.19.v20190610/

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-io_tests'

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.ChannelEndPoint;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.io.IdleTimeout;
+import org.eclipse.jetty.io.LeakTrackingByteBufferPool;
+import org.eclipse.jetty.io.MappedByteBufferPool;
+import org.eclipse.jetty.io.RuntimeIOException;
+import org.eclipse.jetty.io.SocketChannelEndPoint;
+import org.eclipse.jetty.io.WriterOutputStream;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.io.ssl.SslHandshakeListener;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FutureCallback;
+import org.eclipse.jetty.util.thread.TimerScheduler;
+import org.junit.jupiter.api.Test;
+
+public class Jetty_ioTest {
+    @Test
+    void arrayByteBufferPoolReusesHeapAndDirectBuffers() {
+        ArrayByteBufferPool pool = new ArrayByteBufferPool(0, 16, 64, 4);
+
+        ByteBuffer heap = pool.acquire(13, false);
+        assertFalse(heap.isDirect());
+        assertTrue(heap.capacity() >= 13);
+        BufferUtil.clearToFill(heap);
+        heap.put("abc".getBytes(StandardCharsets.UTF_8));
+        pool.release(heap);
+
+        ByteBuffer reusedHeap = pool.acquire(8, false);
+        assertFalse(reusedHeap.isDirect());
+        assertEquals(0, reusedHeap.position());
+        assertEquals(0, reusedHeap.limit());
+        assertTrue(reusedHeap.capacity() >= 8);
+        pool.release(reusedHeap);
+
+        ByteBuffer direct = pool.acquire(18, true);
+        assertTrue(direct.isDirect());
+        assertTrue(direct.capacity() >= 18);
+        pool.release(direct);
+
+        pool.clear();
+        ByteBuffer fresh = pool.acquire(4, false);
+        assertFalse(fresh.isDirect());
+        pool.release(fresh);
+    }
+
+    @Test
+    void mappedPoolAndLeakTrackingPoolExposeExpectedBufferLifecycle() {
+        MappedByteBufferPool mappedPool = new MappedByteBufferPool(16, 4);
+        ByteBuffer heap = mappedPool.acquire(17, false);
+        ByteBuffer direct = mappedPool.acquire(17, true);
+
+        assertFalse(heap.isDirect());
+        assertTrue(heap.capacity() >= 17);
+        assertTrue(direct.isDirect());
+        assertTrue(direct.capacity() >= 17);
+
+        mappedPool.release(heap);
+        mappedPool.release(direct);
+        mappedPool.clear();
+
+        LeakTrackingByteBufferPool trackingPool = new LeakTrackingByteBufferPool(new ArrayByteBufferPool());
+        ByteBuffer tracked = trackingPool.acquire(32, false);
+        assertNotNull(tracked);
+        trackingPool.release(tracked);
+        trackingPool.clearTracking();
+
+        assertEquals(0, trackingPool.getLeakedAcquires());
+        assertEquals(0, trackingPool.getLeakedReleases());
+        assertEquals(0, trackingPool.getLeakedResources());
+    }
+
+    @Test
+    void byteBufferPoolLeaseAggregatesAndRecyclesBuffers() {
+        ArrayByteBufferPool pool = new ArrayByteBufferPool(0, 16, 64, 4);
+        ByteBufferPool.Lease lease = new ByteBufferPool.Lease(pool);
+
+        ByteBuffer first = lease.acquire(16, false);
+        first.put("world".getBytes(StandardCharsets.UTF_8));
+        first.flip();
+        lease.append(first, true);
+
+        ByteBuffer second = lease.acquire(16, false);
+        second.put("hello ".getBytes(StandardCharsets.UTF_8));
+        second.flip();
+        lease.insert(0, second, true);
+
+        List<ByteBuffer> buffers = lease.getByteBuffers();
+        assertEquals(2, lease.getSize());
+        assertEquals(11, lease.getTotalLength());
+        assertEquals("hello ", BufferUtil.toString(buffers.get(0), StandardCharsets.UTF_8));
+        assertEquals("world", BufferUtil.toString(buffers.get(1), StandardCharsets.UTF_8));
+
+        lease.recycle();
+        assertEquals(0, lease.getSize());
+        assertEquals(0, lease.getTotalLength());
+    }
+
+    @Test
+    void byteArrayEndPointFillsFlushesAndTracksShutdownState() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint("hello", 4);
+        endPoint.setGrowOutput(true);
+
+        ByteBuffer input = BufferUtil.allocate(16);
+        assertEquals(5, endPoint.fill(input));
+        assertEquals("hello", BufferUtil.toString(input, StandardCharsets.UTF_8));
+        assertFalse(endPoint.hasMore());
+
+        endPoint.addInput(" jetty", StandardCharsets.UTF_8);
+        ByteBuffer moreInput = BufferUtil.allocate(16);
+        assertEquals(6, endPoint.fill(moreInput));
+        assertEquals(" jetty", BufferUtil.toString(moreInput, StandardCharsets.UTF_8));
+
+        assertTrue(endPoint.flush(BufferUtil.toBuffer("out"), BufferUtil.toBuffer("put")));
+        assertEquals("output", endPoint.getOutputString(StandardCharsets.UTF_8));
+        assertEquals("output", endPoint.takeOutputString(StandardCharsets.UTF_8));
+        assertEquals("", endPoint.takeOutputString(StandardCharsets.UTF_8));
+
+        endPoint.addInputEOF();
+        assertEquals(-1, endPoint.fill(BufferUtil.allocate(1)));
+        assertTrue(endPoint.isInputShutdown());
+
+        endPoint.shutdownOutput();
+        assertTrue(endPoint.isOutputShutdown());
+        endPoint.close();
+        assertFalse(endPoint.isOpen());
+    }
+
+    @Test
+    void byteArrayEndPointFillInterestAndWriteCallbacksComplete() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        endPoint.setGrowOutput(true);
+
+        RecordingCallback readCallback = new RecordingCallback();
+        endPoint.fillInterested(readCallback);
+        assertTrue(endPoint.isFillInterested());
+        endPoint.addInputAndExecute(BufferUtil.toBuffer("data"));
+        assertTrue(readCallback.awaitSuccess());
+        assertFalse(endPoint.isFillInterested());
+
+        ByteBuffer input = BufferUtil.allocate(8);
+        assertEquals(4, endPoint.fill(input));
+        assertEquals("data", BufferUtil.toString(input, StandardCharsets.UTF_8));
+
+        FutureCallback writeCallback = new FutureCallback();
+        endPoint.write(writeCallback, BufferUtil.toBuffer("async"), BufferUtil.toBuffer(" write"));
+        writeCallback.get(2, TimeUnit.SECONDS);
+        assertEquals("async write", endPoint.takeOutputString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void byteArrayEndPointReportsEofAndRuntimeIoFailures() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        endPoint.addInputEOF();
+
+        assertEquals(-1, endPoint.fill(BufferUtil.allocate(1)));
+        assertThrows(RuntimeIOException.class, () -> endPoint.addInput("after-eof"));
+
+        endPoint.close();
+        assertThrows(EofException.class, () -> endPoint.fill(BufferUtil.allocate(1)));
+        assertThrows(IOException.class, () -> endPoint.flush(BufferUtil.toBuffer("closed")));
+    }
+
+    @Test
+    void channelEndPointTransfersDataOverSocketChannel() throws Exception {
+        TimerScheduler scheduler = new TimerScheduler();
+        scheduler.start();
+        try (ServerSocketChannel server = ServerSocketChannel.open()) {
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+            try (SocketChannel client = SocketChannel.open((InetSocketAddress) server.getLocalAddress());
+                    SocketChannel accepted = server.accept()) {
+                ChannelEndPoint endPoint = new SocketChannelEndPoint(accepted, null, null, scheduler);
+
+                assertTrue(client.write(BufferUtil.toBuffer("ping")) > 0);
+                ByteBuffer input = BufferUtil.allocate(8);
+                assertEquals(4, endPoint.fill(input));
+                assertEquals("ping", BufferUtil.toString(input, StandardCharsets.UTF_8));
+
+                assertTrue(endPoint.flush(BufferUtil.toBuffer("pong")));
+                ByteBuffer reply = ByteBuffer.allocate(4);
+                assertEquals(4, client.read(reply));
+                reply.flip();
+                assertEquals("pong", StandardCharsets.UTF_8.decode(reply).toString());
+
+                client.shutdownOutput();
+                assertEquals(-1, endPoint.fill(BufferUtil.allocate(1)));
+                assertTrue(endPoint.isInputShutdown());
+
+                endPoint.shutdownOutput();
+                assertTrue(endPoint.isOutputShutdown());
+                endPoint.close();
+                assertFalse(endPoint.isOpen());
+            }
+        } finally {
+            scheduler.stop();
+        }
+    }
+
+    @Test
+    void idleTimeoutExpiresAfterConfiguredInactivity() throws Exception {
+        TimerScheduler scheduler = new TimerScheduler();
+        scheduler.start();
+        try {
+            RecordingIdleTimeout idleTimeout = new RecordingIdleTimeout(scheduler);
+            idleTimeout.setIdleTimeout(100);
+            idleTimeout.onOpen();
+
+            assertTrue(idleTimeout.isOpen());
+            assertEquals(100, idleTimeout.getIdleTimeout());
+            assertTrue(idleTimeout.getIdleTimestamp() > 0);
+            assertTrue(idleTimeout.awaitExpiration());
+            assertNotNull(idleTimeout.expiration.get());
+            assertTrue(idleTimeout.getIdleFor() >= 0);
+
+            idleTimeout.onClose();
+            assertFalse(idleTimeout.isOpen());
+        } finally {
+            scheduler.stop();
+        }
+    }
+
+    @Test
+    void writerOutputStreamDecodesBytesThroughWriter() throws Exception {
+        StringWriter writer = new StringWriter();
+        byte[] utf8Bytes = "UTF-8: \u03C0, \u0416, \u4E2D".getBytes(StandardCharsets.UTF_8);
+        byte[] decoratedTail = "--tail--".getBytes(StandardCharsets.UTF_8);
+
+        try (WriterOutputStream stream = new WriterOutputStream(writer, StandardCharsets.UTF_8.name())) {
+            for (byte value : "ASCII and ".getBytes(StandardCharsets.US_ASCII)) {
+                stream.write(value & 0xFF);
+            }
+            stream.write(utf8Bytes);
+            stream.write('\n');
+            stream.write(decoratedTail, 2, 4);
+            stream.flush();
+        }
+
+        assertEquals("ASCII and UTF-8: \u03C0, \u0416, \u4E2D\ntail", writer.toString());
+    }
+
+    @Test
+    void connectionListenerReceivesOpenCloseCallbacksAndTrafficAccessorsWork() {
+        TestConnection connection = new TestConnection(200, 80, 3, 1);
+        RecordingConnectionListener listener = new RecordingConnectionListener();
+
+        connection.addListener(listener);
+        connection.onOpen();
+        assertSame(connection, listener.opened.get());
+        assertNull(listener.closed.get());
+
+        assertEquals(200, connection.getBytesIn());
+        assertEquals(80, connection.getBytesOut());
+        assertEquals(3, connection.getMessagesIn());
+        assertEquals(1, connection.getMessagesOut());
+        assertTrue(connection.getCreatedTimeStamp() <= System.currentTimeMillis());
+
+        connection.close();
+        assertSame(connection, listener.closed.get());
+
+        connection.removeListener(listener);
+        listener.opened.set(null);
+        listener.closed.set(null);
+        connection.onOpen();
+        connection.onClose();
+        assertNull(listener.opened.get());
+        assertNull(listener.closed.get());
+    }
+
+    @Test
+    void sslConnectionExposesEngineDecryptedEndpointAndHandshakeListeners() throws Exception {
+        ByteArrayEndPoint networkEndPoint = new ByteArrayEndPoint();
+        SSLEngine engine = SSLContext.getDefault().createSSLEngine("localhost", 8443);
+        SslConnection sslConnection = new SslConnection(
+                new ArrayByteBufferPool(), Runnable::run, networkEndPoint, engine);
+        RecordingHandshakeListener listener = new RecordingHandshakeListener();
+        SslHandshakeListener.Event event = new SslHandshakeListener.Event(engine);
+
+        IOException handshakeFailure = new IOException("handshake-failed");
+        listener.handshakeSucceeded(event);
+        listener.handshakeFailed(event, handshakeFailure);
+        assertSame(engine, event.getSSLEngine());
+        assertSame(event, listener.successfulEvent.get());
+        assertSame(event, listener.failedEvent.get());
+        assertSame(handshakeFailure, listener.failure.get());
+
+        sslConnection.addHandshakeListener(listener);
+        assertTrue(sslConnection.removeHandshakeListener(listener));
+        assertFalse(sslConnection.removeHandshakeListener(listener));
+        assertSame(engine, sslConnection.getSSLEngine());
+        assertSame(sslConnection, sslConnection.getDecryptedEndPoint().getSslConnection());
+
+        sslConnection.setRenegotiationAllowed(false);
+        assertFalse(sslConnection.isRenegotiationAllowed());
+        sslConnection.setRenegotiationAllowed(true);
+        assertTrue(sslConnection.isRenegotiationAllowed());
+
+        sslConnection.getDecryptedEndPoint().setConnection(new TestConnection(0, 0, 0, 0));
+        assertDoesNotThrow(sslConnection::close);
+    }
+
+    private static final class RecordingIdleTimeout extends IdleTimeout {
+        private final CountDownLatch expirationLatch = new CountDownLatch(1);
+        private final AtomicReference<TimeoutException> expiration = new AtomicReference<>();
+        private boolean open;
+
+        private RecordingIdleTimeout(TimerScheduler scheduler) {
+            super(scheduler);
+        }
+
+        @Override
+        public void onOpen() {
+            open = true;
+            super.onOpen();
+        }
+
+        @Override
+        public void onClose() {
+            open = false;
+            super.onClose();
+        }
+
+        @Override
+        protected void onIdleExpired(TimeoutException timeout) {
+            expiration.set(timeout);
+            expirationLatch.countDown();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        boolean awaitExpiration() throws InterruptedException {
+            boolean expired = expirationLatch.await(2, TimeUnit.SECONDS);
+            assertTrue(expired);
+            return true;
+        }
+    }
+
+    private static final class RecordingHandshakeListener implements SslHandshakeListener {
+        private final AtomicReference<SslHandshakeListener.Event> successfulEvent = new AtomicReference<>();
+        private final AtomicReference<SslHandshakeListener.Event> failedEvent = new AtomicReference<>();
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void handshakeSucceeded(SslHandshakeListener.Event event) {
+            successfulEvent.set(event);
+        }
+
+        @Override
+        public void handshakeFailed(SslHandshakeListener.Event event, Throwable failure) {
+            failedEvent.set(event);
+            this.failure.set(failure);
+        }
+    }
+
+    private static final class RecordingConnectionListener implements Connection.Listener {
+        private final AtomicReference<Connection> opened = new AtomicReference<>();
+        private final AtomicReference<Connection> closed = new AtomicReference<>();
+
+        @Override
+        public void onOpened(Connection connection) {
+            opened.set(connection);
+        }
+
+        @Override
+        public void onClosed(Connection connection) {
+            closed.set(connection);
+        }
+    }
+
+    private static final class RecordingCallback implements Callback {
+        private final CountDownLatch successLatch = new CountDownLatch(1);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void succeeded() {
+            successLatch.countDown();
+        }
+
+        @Override
+        public void failed(Throwable x) {
+            failure.set(x);
+            successLatch.countDown();
+        }
+
+        boolean awaitSuccess() throws InterruptedException {
+            boolean completed = successLatch.await(2, TimeUnit.SECONDS);
+            assertTrue(completed);
+            assertNull(failure.get());
+            return true;
+        }
+    }
+
+    private static final class TestConnection implements Connection {
+        private final EndPoint endPoint = new ByteArrayEndPoint();
+        private final long createdTimeStamp = System.currentTimeMillis() - 5;
+        private final long bytesIn;
+        private final long bytesOut;
+        private final long messagesIn;
+        private final long messagesOut;
+        private final List<Connection.Listener> listeners = new ArrayList<>();
+
+        private TestConnection(long bytesIn, long bytesOut, long messagesIn, long messagesOut) {
+            this.bytesIn = bytesIn;
+            this.bytesOut = bytesOut;
+            this.messagesIn = messagesIn;
+            this.messagesOut = messagesOut;
+        }
+
+        @Override
+        public void addListener(Connection.Listener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(Connection.Listener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void onOpen() {
+            listeners.forEach(listener -> listener.onOpened(this));
+        }
+
+        @Override
+        public void onClose() {
+            listeners.forEach(listener -> listener.onClosed(this));
+        }
+
+        @Override
+        public EndPoint getEndPoint() {
+            return endPoint;
+        }
+
+        @Override
+        public void close() {
+            onClose();
+        }
+
+        @Override
+        public boolean onIdleExpired() {
+            return true;
+        }
+
+        @Override
+        public long getMessagesIn() {
+            return messagesIn;
+        }
+
+        @Override
+        public long getMessagesOut() {
+            return messagesOut;
+        }
+
+        @Override
+        public long getBytesIn() {
+            return bytesIn;
+        }
+
+        @Override
+        public long getBytesOut() {
+            return bytesOut;
+        }
+
+        @Override
+        public long getCreatedTimeStamp() {
+            return createdTimeStamp;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
@@ -248,7 +248,8 @@ public class Jetty_ioTest {
 
             assertTrue(idleTimeout.isOpen());
             assertEquals(100, idleTimeout.getIdleTimeout());
-            assertTrue(idleTimeout.getIdleTimestamp() > 0);
+            idleTimeout.notIdle();
+            assertTrue(idleTimeout.getIdleFor() >= 0);
             assertTrue(idleTimeout.awaitExpiration());
             assertNotNull(idleTimeout.expiration.get());
             assertTrue(idleTimeout.getIdleFor() >= 0);

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="0" time="0.116" hostname="kung-fu-workstation" timestamp="2026-05-02T15:59:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4313-33e6107b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="byteArrayEndPointFillsFlushesAndTracksShutdownState()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:byteArrayEndPointFillsFlushesAndTracksShutdownState()]
+display-name: byteArrayEndPointFillsFlushesAndTracksShutdownState()
+]]></system-out>
+</testcase>
+<testcase name="writerOutputStreamDecodesBytesThroughWriter()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:writerOutputStreamDecodesBytesThroughWriter()]
+display-name: writerOutputStreamDecodesBytesThroughWriter()
+]]></system-out>
+</testcase>
+<testcase name="byteBufferPoolLeaseAggregatesAndRecyclesBuffers()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:byteBufferPoolLeaseAggregatesAndRecyclesBuffers()]
+display-name: byteBufferPoolLeaseAggregatesAndRecyclesBuffers()
+]]></system-out>
+</testcase>
+<testcase name="byteArrayEndPointReportsEofAndRuntimeIoFailures()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:byteArrayEndPointReportsEofAndRuntimeIoFailures()]
+display-name: byteArrayEndPointReportsEofAndRuntimeIoFailures()
+]]></system-out>
+</testcase>
+<testcase name="arrayByteBufferPoolReusesHeapAndDirectBuffers()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:arrayByteBufferPoolReusesHeapAndDirectBuffers()]
+display-name: arrayByteBufferPoolReusesHeapAndDirectBuffers()
+]]></system-out>
+</testcase>
+<testcase name="idleTimeoutExpiresAfterConfiguredInactivity()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0.101">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:idleTimeoutExpiresAfterConfiguredInactivity()]
+display-name: idleTimeoutExpiresAfterConfiguredInactivity()
+]]></system-out>
+</testcase>
+<testcase name="sslConnectionExposesEngineDecryptedEndpointAndHandshakeListeners()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:sslConnectionExposesEngineDecryptedEndpointAndHandshakeListeners()]
+display-name: sslConnectionExposesEngineDecryptedEndpointAndHandshakeListeners()
+]]></system-out>
+</testcase>
+<testcase name="mappedPoolAndLeakTrackingPoolExposeExpectedBufferLifecycle()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:mappedPoolAndLeakTrackingPoolExposeExpectedBufferLifecycle()]
+display-name: mappedPoolAndLeakTrackingPoolExposeExpectedBufferLifecycle()
+]]></system-out>
+</testcase>
+<testcase name="channelEndPointTransfersDataOverSocketChannel()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:channelEndPointTransfersDataOverSocketChannel()]
+display-name: channelEndPointTransfersDataOverSocketChannel()
+]]></system-out>
+</testcase>
+<testcase name="byteArrayEndPointFillInterestAndWriteCallbacksComplete()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:byteArrayEndPointFillInterestAndWriteCallbacksComplete()]
+display-name: byteArrayEndPointFillInterestAndWriteCallbacksComplete()
+]]></system-out>
+</testcase>
+<testcase name="connectionListenerReceivesOpenCloseCallbacksAndTrafficAccessorsWork()" classname="org_eclipse_jetty.jetty_io.Jetty_ioTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_io.Jetty_ioTest]/[method:connectionListenerReceivesOpenCloseCallbacksAndTrafficAccessorsWork()]
+display-name: connectionListenerReceivesOpenCloseCallbacksAndTrafficAccessorsWork()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T15:59:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4313-33e6107b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.io.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4313

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-io:9.4.19.v20190610, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 29599
- Cached input tokens: 129024
- Output tokens: 1515
- Metadata entries: 18
- Iterations: 1
- Library coverage percentage: 25.23
- Previous library version metadata entries: 19
- Previous library version coverage percentage: 28.01

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7b3abf68bd8f035e1849e25bc9eb139ad4e59bd5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-io:9.4.0.RC0: 0/0 covered calls (100.00%)
- org.eclipse.jetty:jetty-io:9.4.19.v20190610: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-io:9.4.0.RC0: 2397/9361 (25.61%)
- org.eclipse.jetty:jetty-io:9.4.19.v20190610: 2731/11911 (22.93%)

**Line:**
- org.eclipse.jetty:jetty-io:9.4.0.RC0: 607/2167 (28.01%)
- org.eclipse.jetty:jetty-io:9.4.19.v20190610: 696/2759 (25.23%)

**Method:**
- org.eclipse.jetty:jetty-io:9.4.0.RC0: 166/451 (36.81%)
- org.eclipse.jetty:jetty-io:9.4.19.v20190610: 189/564 (33.51%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-io/9.4.0.RC0/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java 2/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
index a335c4577e..def7eda84f 100644
--- 1/tests/src/org.eclipse.jetty/jetty-io/9.4.0.RC0/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-io/9.4.19.v20190610/src/test/java/org_eclipse_jetty/jetty_io/Jetty_ioTest.java
@@ -248,7 +248,8 @@ public class Jetty_ioTest {
 
             assertTrue(idleTimeout.isOpen());
             assertEquals(100, idleTimeout.getIdleTimeout());
-            assertTrue(idleTimeout.getIdleTimestamp() > 0);
+            idleTimeout.notIdle();
+            assertTrue(idleTimeout.getIdleFor() >= 0);
             assertTrue(idleTimeout.awaitExpiration());
             assertNotNull(idleTimeout.expiration.get());
             assertTrue(idleTimeout.getIdleFor() >= 0);

```
