### PR TITLE
Fix empty native trace metadata progress detection

### DIFF
--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -345,8 +345,52 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.status, ntv.STATUS_FAILED)
         self.assertEqual(result.iterations_used, 1)
         printed = output.getvalue()
-        self.assertIn("produced no trace metadata; failing fast", printed)
+        self.assertIn("produced no usable trace metadata; failing fast", printed)
         self.assertIn("com.example.MissingThingException: boom", printed)
+
+    def test_fails_fast_when_172_produces_empty_metadata_json(self) -> None:
+        def _fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            stdout = kwargs.get("stdout")
+            if hasattr(stdout, "write"):
+                stdout.write(
+                    "some native output\n"
+                    "com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: missing resource\n"
+                )
+            if "runNativeTraceImage" in cmd:
+                exit_file = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceBinaryExitFile=")),
+                    None,
+                )
+                run_dir = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceMetadataPath=")),
+                    None,
+                )
+                if exit_file:
+                    Path(exit_file).parent.mkdir(parents=True, exist_ok=True)
+                    Path(exit_file).write_text(str(ntv.MISSING_METADATA_EXIT_CODE), encoding="utf-8")
+                if run_dir:
+                    Path(run_dir).mkdir(parents=True, exist_ok=True)
+                    Path(run_dir, "reachability-metadata.json").write_text("{}", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        output = io.StringIO()
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=_fake_run,
+        ), redirect_stdout(output):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.iterations_used, 1)
+        printed = output.getvalue()
+        self.assertIn("reachability-metadata.json:", printed)
+        self.assertIn("{}", printed)
+        self.assertIn("produced no usable trace metadata; failing fast", printed)
 
     def test_failed_when_budget_exhausted_with_only_172(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172])

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -156,6 +156,7 @@ def verify_native_test_passes(
         last_binary_rc = binary_rc if binary_rc is not None else gradle_rc
         _print_collected_metadata(run_dir, cycle + 1)
         collected_metadata_files = _metadata_files(run_dir)
+        usable_metadata_files = _usable_metadata_files(run_dir)
 
         if binary_rc == 0:
             log_stage(
@@ -163,7 +164,7 @@ def verify_native_test_passes(
                 f"cycle {cycle + 1}: binary passed (exit 0); merging trace dirs",
             )
             run_dirs_to_merge = list(accepted_run_dirs)
-            if collected_metadata_files:
+            if usable_metadata_files:
                 run_dirs_to_merge.append(run_dir)
             if not _merge_into_output(
                 reachability_repo_path=reachability_repo_path,
@@ -175,10 +176,10 @@ def verify_native_test_passes(
             return _make_result(status, cycle + 1)
 
         if binary_rc == MISSING_METADATA_EXIT_CODE:
-            if not collected_metadata_files:
+            if not usable_metadata_files:
                 log_stage(
                     _GATE_STAGE,
-                    f"cycle {cycle + 1}: binary exited 172 but produced no trace metadata; failing fast",
+                    f"cycle {cycle + 1}: binary exited 172 but produced no usable trace metadata; failing fast",
                 )
                 _print_failure_stacktrace(log_path, cycle + 1)
                 return _make_result(STATUS_FAILED, cycle + 1)
@@ -388,6 +389,35 @@ def _metadata_files(run_dir: str) -> list[str]:
                 continue
             result.append(os.path.join(root, name))
     return sorted(result, key=lambda path: os.path.relpath(path, run_dir))
+
+
+def _usable_metadata_files(run_dir: str) -> list[str]:
+    """Return trace metadata files that contain at least one metadata entry."""
+    return [path for path in _metadata_files(run_dir) if _metadata_file_has_entries(path)]
+
+
+def _metadata_file_has_entries(path: str) -> bool:
+    """Return true when ``path`` contains usable trace metadata."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        try:
+            return os.path.getsize(path) > 0
+        except OSError:
+            return False
+    except OSError:
+        return False
+    return _json_has_entries(data)
+
+
+def _json_has_entries(value: object) -> bool:
+    """Return true when a parsed JSON value contains a non-empty entry."""
+    if isinstance(value, dict):
+        return any(_json_has_entries(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_json_has_entries(child) for child in value)
+    return value is not None
 
 
 def _format_metadata_file(path: str) -> str:


### PR DESCRIPTION
### Summary

- Treat trace metadata files with no entries, such as `{}`, as no usable progress in the native-test verification gate.
- Avoid appending empty trace directories to `metadataConfigDirs` after a `172` missing-metadata exit.
- Print the last 300 lines of the `runNativeTraceImage` Gradle log when the gate fails fast so the native failure is visible in stage output.
- Add regression tests for the empty `reachability-metadata.json` case and the 300-line failure log tail.

### Testing

- `python3 -m unittest tests.test_native_test_verification`
- `python3 -m py_compile utility_scripts/native_test_verification.py tests/test_native_test_verification.py`
- `git diff --check`

### Open question

Should a follow-up widen `traceMetadataConditionPackages` for harness packages, or parse missing-registration diagnostics directly? This PR only fixes the gate-side progress detection so empty trace output fails fast instead of looping.

Closes #4325