### PR TITLE
Print native trace failure log tail on fast-fail

### DIFF
--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -94,6 +94,25 @@ class ReadExitFileTests(unittest.TestCase):
         self.assertIsNone(ntv._read_exit_file(path))
 
 
+class FailureLogTailTests(unittest.TestCase):
+    """Native failure diagnostics print the tail of the Gradle log."""
+
+    def test_extracts_last_300_lines(self) -> None:
+        fd, path = tempfile.mkstemp(suffix=".log")
+        os.close(fd)
+        self.addCleanup(os.unlink, path)
+        Path(path).write_text(
+            "\n".join(f"line-{index}" for index in range(350)),
+            encoding="utf-8",
+        )
+
+        excerpt = ntv._extract_failure_log_tail(path)
+
+        self.assertNotIn("line-49", excerpt)
+        self.assertIn("line-50", excerpt)
+        self.assertIn("line-349", excerpt)
+
+
 class ClassKeyTests(unittest.TestCase):
 
     def test_replaces_dollar_signs(self) -> None:
@@ -353,8 +372,8 @@ class GateRoutingTests(unittest.TestCase):
             stdout = kwargs.get("stdout")
             if hasattr(stdout, "write"):
                 stdout.write(
-                    "some native output\n"
-                    "com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: missing resource\n"
+                    "\n".join(f"native log line {index}" for index in range(305)) +
+                    "\ncom.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: missing resource\n"
                 )
             if "runNativeTraceImage" in cmd:
                 exit_file = next(
@@ -391,6 +410,10 @@ class GateRoutingTests(unittest.TestCase):
         self.assertIn("reachability-metadata.json:", printed)
         self.assertIn("{}", printed)
         self.assertIn("produced no usable trace metadata; failing fast", printed)
+        self.assertIn("failure log tail (last 300 lines)", printed)
+        self.assertNotIn("native log line 5\n", printed)
+        self.assertIn("native log line 6\n", printed)
+        self.assertIn("MissingResourceRegistrationError: missing resource", printed)
 
     def test_failed_when_budget_exhausted_with_only_172(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172])

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -62,7 +62,7 @@ _LOG_TASK_TYPE = "native-test-verify"
 _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 _AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
-_STACKTRACE_EXCERPT_LINE_LIMIT = 160
+_FAILURE_LOG_TAIL_LINE_LIMIT = 300
 
 
 @dataclass
@@ -181,7 +181,7 @@ def verify_native_test_passes(
                     _GATE_STAGE,
                     f"cycle {cycle + 1}: binary exited 172 but produced no usable trace metadata; failing fast",
                 )
-                _print_failure_stacktrace(log_path, cycle + 1)
+                _print_failure_log_tail(log_path, cycle + 1)
                 return _make_result(STATUS_FAILED, cycle + 1)
             log_stage(
                 _GATE_STAGE,
@@ -197,7 +197,7 @@ def verify_native_test_passes(
             "routing to codex (terminal)",
         )
         if not collected_metadata_files:
-            _print_failure_stacktrace(log_path, cycle + 1)
+            _print_failure_log_tail(log_path, cycle + 1)
         codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
             reachability_repo_path,
             coordinate,
@@ -334,19 +334,19 @@ def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
             log_stage(_GATE_STAGE, line, indent_level=3)
 
 
-def _print_failure_stacktrace(log_path: str, cycle_number: int) -> None:
-    """Print the native trace failure stacktrace, or a bounded log tail."""
+def _print_failure_log_tail(log_path: str, cycle_number: int) -> None:
+    """Print the native trace failure log tail."""
     log_stage(
         _GATE_STAGE,
-        f"cycle {cycle_number}: failure stacktrace from {log_path}:",
+        f"cycle {cycle_number}: failure log tail (last {_FAILURE_LOG_TAIL_LINE_LIMIT} lines) from {log_path}:",
         indent_level=1,
     )
-    for line in _extract_failure_stacktrace(log_path).splitlines():
+    for line in _extract_failure_log_tail(log_path).splitlines():
         log_stage(_GATE_STAGE, line, indent_level=2)
 
 
-def _extract_failure_stacktrace(log_path: str) -> str:
-    """Extract a bounded stacktrace-like excerpt from a native trace run log."""
+def _extract_failure_log_tail(log_path: str) -> str:
+    """Extract a bounded tail from a native trace run log."""
     try:
         with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
             lines = handle.read().splitlines()
@@ -356,28 +356,10 @@ def _extract_failure_stacktrace(log_path: str) -> str:
     if not lines:
         return "<empty log>"
 
-    start_index = _find_stacktrace_start(lines)
-    if start_index is None:
-        start_index = max(0, len(lines) - _STACKTRACE_EXCERPT_LINE_LIMIT)
-
-    excerpt = lines[start_index:start_index + _STACKTRACE_EXCERPT_LINE_LIMIT]
+    excerpt = lines[-_FAILURE_LOG_TAIL_LINE_LIMIT:]
     if not excerpt:
-        return "<no stacktrace excerpt available>"
+        return "<no log excerpt available>"
     return "\n".join(excerpt)
-
-
-def _find_stacktrace_start(lines: list[str]) -> int | None:
-    """Return the first likely stacktrace line index in ``lines``."""
-    exception_pattern = re.compile(
-        r"(^Exception in thread|^\S.*(?:Exception|Error)(?::|\s|$)|^Caused by:)"
-    )
-    for index, line in enumerate(lines):
-        stripped = line.strip()
-        if exception_pattern.search(stripped):
-            return max(0, index - 2)
-        if stripped.startswith("at ") and index > 0:
-            return max(0, index - 1)
-    return None
 
 
 def _metadata_files(run_dir: str) -> list[str]:


### PR DESCRIPTION
### Summary

- Print the last 300 lines of the `runNativeTraceImage` Gradle log when native-test verification fails fast after a `172` missing-metadata exit with no usable trace metadata.
- Replace the stacktrace-start heuristic with deterministic tail output so native failure details are visible even when the log format varies.
- Add regression coverage for the 300-line tail and the empty `reachability-metadata.json` fast-fail path.

### Testing

- `python3 -m unittest tests.test_native_test_verification`
- `python3 -m py_compile utility_scripts/native_test_verification.py tests/test_native_test_verification.py`
- `git diff --check origin/master..HEAD`

### Open question

Should a follow-up widen `traceMetadataConditionPackages` for harness packages, or parse missing-registration diagnostics directly? This PR only improves the gate-side diagnostics so the next failing run shows the native failure details.

Follow-up to #4325 and #4326.