### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-exporter-common:1.28.0 using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.exporter.internal.auth.Authenticator"
+      },
+      "type" : "java.lang.Object"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.28.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v$version$/exporters/common/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-javadoc.jar",
+    "description" : "OpenTelemetry Exporter Common provides shared Java helper code used by OpenTelemetry exporters. It contains common internal exporter utilities for building telemetry export integrations without forcing optional transport dependencies onto every consumer.",
     "tested-versions" : [
       "1.28.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.28.0",
+    "tested-versions" : [
+      "1.28.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.exporter.internal"
+    ]
+  },
+  {
     "metadata-version" : "1.19.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T14:48:27.784660Z",
+    "library": "io.opentelemetry:opentelemetry-exporter-common:1.28.0",
+    "starting_commit": "d5408b45c095142e77866c339c0bddbf276016b5",
+    "ending_commit": "cf0d7f9d1dc4517277427063a7a6e570df6cce0c",
+    "previous_library": "io.opentelemetry:opentelemetry-exporter-common:1.19.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.28.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 145,
+          "missed": 5429,
+          "ratio": 0.026014,
+          "total": 5574
+        },
+        "line": {
+          "covered": 38,
+          "missed": 1305,
+          "ratio": 0.028295,
+          "total": 1343
+        },
+        "method": {
+          "covered": 8,
+          "missed": 312,
+          "ratio": 0.025,
+          "total": 320
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 2,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 0.5,
+        "coveredCalls": 2,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 161,
+          "missed": 5675,
+          "ratio": 0.027587,
+          "total": 5836
+        },
+        "line": {
+          "covered": 40,
+          "missed": 1368,
+          "ratio": 0.028409,
+          "total": 1408
+        },
+        "method": {
+          "covered": 12,
+          "missed": 329,
+          "ratio": 0.035191,
+          "total": 341
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 71155,
+      "cached_input_tokens_used": 370688,
+      "output_tokens_used": 5526,
+      "iterations": 2,
+      "cost_usd": 0.3511,
+      "tested_library_loc": 38,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 2.83,
+      "previous_library_coverage_percent": 2.84
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.28.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 145,
+        "missed" : 5429,
+        "ratio" : 0.026014,
+        "total" : 5574
+      },
+      "line" : {
+        "covered" : 38,
+        "missed" : 1305,
+        "ratio" : 0.028295,
+        "total" : 1343
+      },
+      "method" : {
+        "covered" : 8,
+        "missed" : 312,
+        "ratio" : 0.025,
+        "total" : 320
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-exporter-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry:opentelemetry-exporter-common:1.28.0
+library.version = 1.28.0
+metadata.dir = io.opentelemetry/opentelemetry-exporter-common/1.28.0/

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.opentelemetry-exporter-common_tests'

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class AuthenticatorTest {
+    @Test
+    void installsAuthenticatorOnHttpDelegate() {
+        Authenticator authenticator = () -> Collections.singletonMap("authorization", "Bearer token");
+        HttpDelegateBuilder builder = new HttpDelegateBuilder();
+
+        assertThatCode(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsBuilderWithoutDelegateField() {
+        Authenticator authenticator = Collections::emptyMap;
+
+        assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unable to access delegate reflectively.");
+    }
+
+    private static final class HttpDelegateBuilder {
+        private final HttpExporterBuilder<Marshaler> delegate =
+                new HttpExporterBuilder<>("test", "signal", "http://localhost:4318/v1/traces");
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
+import io.opentelemetry.exporter.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.internal.retry.RetryUtil;
+import org.junit.jupiter.api.Test;
+
+public class RetryUtilTest {
+    @Test
+    void exposesRetryableStatusCodes() {
+        assertThat(RetryUtil.retryableHttpResponseCodes())
+                .containsExactlyInAnyOrder(429, 502, 503, 504);
+        assertThat(RetryUtil.retryableGrpcStatusCodes())
+                .containsExactlyInAnyOrder(
+                        GrpcStatusUtil.GRPC_STATUS_CANCELLED,
+                        GrpcStatusUtil.GRPC_STATUS_DEADLINE_EXCEEDED,
+                        GrpcStatusUtil.GRPC_STATUS_RESOURCE_EXHAUSTED,
+                        GrpcStatusUtil.GRPC_STATUS_ABORTED,
+                        GrpcStatusUtil.GRPC_STATUS_OUT_OF_RANGE,
+                        GrpcStatusUtil.GRPC_STATUS_UNAVAILABLE,
+                        GrpcStatusUtil.GRPC_STATUS_DATA_LOSS);
+    }
+
+    @Test
+    void inspectsDelegateFieldWhenSettingRetryPolicy() {
+        DelegateHolder holder = new DelegateHolder(null);
+
+        assertThatThrownBy(
+                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("delegate field");
+    }
+
+    static final class DelegateHolder {
+        private final Object delegate;
+
+        private DelegateHolder(Object delegate) {
+            this.delegate = delegate;
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
-import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import org.junit.jupiter.api.Test;
 
@@ -31,20 +30,10 @@ public class RetryUtilTest {
     }
 
     @Test
-    void inspectsDelegateFieldWhenSettingRetryPolicy() {
-        DelegateHolder holder = new DelegateHolder(null);
-
-        assertThatThrownBy(
-                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("delegate field");
-    }
-
-    static final class DelegateHolder {
-        private final Object delegate;
-
-        private DelegateHolder(Object delegate) {
-            this.delegate = delegate;
-        }
+    void exposesImmutableRetryableStatusCodeSets() {
+        assertThatThrownBy(() -> RetryUtil.retryableHttpResponseCodes().add(500))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> RetryUtil.retryableGrpcStatusCodes().add("1"))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.exporter.internal.auth.Authenticator"
+      },
+      "type" : "io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest$HttpDelegateBuilder",
+      "fields" : [
+        {
+          "name" : "delegate"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/retry-util-test/reflect-config.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/retry-util-test/reflect-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest$DelegateHolder",
+    "fields": [
+      {
+        "name": "delegate"
+      }
+    ]
+  }
+]

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:44:35">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2565-43141368/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="exposesRetryableStatusCodes()" classname="io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest]/[method:exposesRetryableStatusCodes()]
+display-name: exposesRetryableStatusCodes()
+]]></system-out>
+</testcase>
+<testcase name="exposesImmutableRetryableStatusCodeSets()" classname="io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest]/[method:exposesImmutableRetryableStatusCodeSets()]
+display-name: exposesImmutableRetryableStatusCodeSets()
+]]></system-out>
+</testcase>
+<testcase name="installsAuthenticatorOnHttpDelegate()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest]/[method:installsAuthenticatorOnHttpDelegate()]
+display-name: installsAuthenticatorOnHttpDelegate()
+]]></system-out>
+</testcase>
+<testcase name="rejectsBuilderWithoutDelegateField()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest]/[method:rejectsBuilderWithoutDelegateField()]
+display-name: rejectsBuilderWithoutDelegateField()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:44:35">
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.01" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2565-43141368/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0"/>
@@ -52,7 +51,7 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="exposesRetryableStatusCodes()" classname="io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest" time="0">
+<testcase name="exposesRetryableStatusCodes()" classname="io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest]/[method:exposesRetryableStatusCodes()]
 display-name: exposesRetryableStatusCodes()
@@ -64,13 +63,13 @@ unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter
 display-name: exposesImmutableRetryableStatusCodeSets()
 ]]></system-out>
 </testcase>
-<testcase name="installsAuthenticatorOnHttpDelegate()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0">
+<testcase name="installsAuthenticatorOnHttpDelegate()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest]/[method:installsAuthenticatorOnHttpDelegate()]
 display-name: installsAuthenticatorOnHttpDelegate()
 ]]></system-out>
 </testcase>
-<testcase name="rejectsBuilderWithoutDelegateField()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0">
+<testcase name="rejectsBuilderWithoutDelegateField()" classname="io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest]/[method:rejectsBuilderWithoutDelegateField()]
 display-name: rejectsBuilderWithoutDelegateField()

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:44:35">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2565-43141368/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0"/>

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:44:35">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2565-43141368/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.exporter.internal.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2565

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-exporter-common:1.28.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71155
- Cached input tokens: 370688
- Output tokens: 5526
- Metadata entries: 1
- Test-only metadata entries: 2
- Iterations: 2
- Library coverage percentage: 2.83
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 2.84

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 2/4 covered calls (50.00%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 2/2 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 2/4 covered calls (50.00%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 161/5836 (2.76%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 145/5574 (2.60%)

**Line:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 40/1408 (2.84%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 38/1343 (2.83%)

**Method:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 12/341 (3.52%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 8/320 (2.50%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
new file mode 100644
index 0000000000..28b2bdb0af
--- /dev/null
+++ 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
@@ -0,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class AuthenticatorTest {
+    @Test
+    void installsAuthenticatorOnHttpDelegate() {
+        Authenticator authenticator = () -> Collections.singletonMap("authorization", "Bearer token");
+        HttpDelegateBuilder builder = new HttpDelegateBuilder();
+
+        assertThatCode(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsBuilderWithoutDelegateField() {
+        Authenticator authenticator = Collections::emptyMap;
+
+        assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(new Object(), authenticator))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unable to access delegate reflectively.");
+    }
+
+    private static final class HttpDelegateBuilder {
+        private final HttpExporterBuilder<Marshaler> delegate =
+                new HttpExporterBuilder<>("test", "signal", "http://localhost:4318/v1/traces");
+    }
+}
diff --git 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
index 836aaf4c3b..2de3e2f479 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
-import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import org.junit.jupiter.api.Test;
 
@@ -31,20 +30,10 @@ public class RetryUtilTest {
     }
 
     @Test
-    void inspectsDelegateFieldWhenSettingRetryPolicy() {
-        DelegateHolder holder = new DelegateHolder(null);
-
-        assertThatThrownBy(
-                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("delegate field");
-    }
-
-    static final class DelegateHolder {
-        private final Object delegate;
-
-        private DelegateHolder(Object delegate) {
-            this.delegate = delegate;
-        }
+    void exposesImmutableRetryableStatusCodeSets() {
+        assertThatThrownBy(() -> RetryUtil.retryableHttpResponseCodes().add(500))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> RetryUtil.retryableGrpcStatusCodes().add("1"))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

```
