### PR TITLE
[GenAI] Mark io.netty:netty-resolver-dns-native-macos as not for Native Image

### DIFF
--- a/metadata/io.netty/netty-resolver-dns-native-macos/index.json
+++ b/metadata/io.netty/netty-resolver-dns-native-macos/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The default and macOS classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.",
+    "replacement": "io.netty:netty-resolver-dns-classes-macos:4.1.74.Final"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #1446

This PR records `io.netty:netty-resolver-dns-native-macos` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The default and macOS classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.

Replacement guidance:
- io.netty:netty-resolver-dns-classes-macos:4.1.74.Final

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`
