### PR TITLE
[GenAI] Test fix for jline:jline:3.0.0.M1 using gpt-5.5

### DIFF
--- a/metadata/jline/jline/3.0.0.M1/reachability-metadata.json
+++ b/metadata/jline/jline/3.0.0.M1/reachability-metadata.json
@@ -1,0 +1,75 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jline.utils.Signals"
+      },
+      "type" : "sun.misc.Signal",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "handle",
+          "parameterTypes" : [
+            "sun.misc.Signal",
+            "sun.misc.SignalHandler"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.utils.Signals"
+      },
+      "type" : "sun.misc.SignalHandler",
+      "fields" : [
+        {
+          "name" : "SIG_DFL"
+        },
+        {
+          "name" : "SIG_IGN"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.builtins.Completers$Completer"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.builtins.Completers$Completer"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.utils.Signals"
+      },
+      "type" : {
+        "proxy" : [
+          "sun.misc.SignalHandler"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/jline/jline/index.json
+++ b/metadata/jline/jline/index.json
@@ -1,15 +1,30 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [ "jline", "org.fusesource.hawtjni.runtime", "org.fusesource.jansi" ],
-    "metadata-version": "2.14.6",
-    "source-code-url": "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-sources.jar",
-    "repository-url": "https://github.com/jline/jline2",
-    "test-code-url": "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-tests.jar",
-    "documentation-url": "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-javadoc.jar",
-    "description": "JLine is a Java library for handling console input in interactive command-line applications. It provides line editing, command history, and tab completion across platforms.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "3.0.0.M1",
+    "tested-versions" : [
+      "3.0.0.M1"
+    ],
+    "allowed-packages" : [
+      "jline",
+      "org.fusesource.hawtjni.runtime",
+      "org.fusesource.jansi"
+    ]
+  },
+  {
+    "metadata-version" : "2.14.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-sources.jar",
+    "repository-url" : "https://github.com/jline/jline2",
+    "test-code-url" : "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/jline/jline/$version$/jline-$version$-javadoc.jar",
+    "description" : "JLine is a Java library for handling console input in interactive command-line applications. It provides line editing, command history, and tab completion across platforms.",
+    "tested-versions" : [
       "2.14.6"
+    ],
+    "allowed-packages" : [
+      "jline",
+      "org.fusesource.hawtjni.runtime",
+      "org.fusesource.jansi"
     ]
   }
 ]

--- a/metadata/jline/jline/index.json
+++ b/metadata/jline/jline/index.json
@@ -6,9 +6,7 @@
       "3.0.0.M1"
     ],
     "allowed-packages" : [
-      "jline",
-      "org.fusesource.hawtjni.runtime",
-      "org.fusesource.jansi"
+      "org.jline"
     ]
   },
   {

--- a/stats/jline/jline/3.0.0.M1/execution-metrics.json
+++ b/stats/jline/jline/3.0.0.M1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T14:58:23.177784Z",
+    "library": "jline:jline:3.0.0.M1",
+    "starting_commit": "5e06b05b34443c95e0d8dae9e660524dbdb0227e",
+    "ending_commit": "3a1bad664c09a0f9f5116ff10342ed45743ca66d",
+    "previous_library": "jline:jline:2.14.6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0.M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.833333,
+            "coveredCalls": 5,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.714286,
+        "coveredCalls": 5,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 22523,
+          "missed": 50678,
+          "ratio": 0.307687,
+          "total": 73201
+        },
+        "line": {
+          "covered": 2386,
+          "missed": 9918,
+          "ratio": 0.193921,
+          "total": 12304
+        },
+        "method": {
+          "covered": 314,
+          "missed": 1191,
+          "ratio": 0.208638,
+          "total": 1505
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.14.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 20,
+            "totalCalls": 22
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.92,
+        "coveredCalls": 23,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16479,
+          "missed": 17104,
+          "ratio": 0.490695,
+          "total": 33583
+        },
+        "line": {
+          "covered": 1317,
+          "missed": 3980,
+          "ratio": 0.248631,
+          "total": 5297
+        },
+        "method": {
+          "covered": 214,
+          "missed": 695,
+          "ratio": 0.235424,
+          "total": 909
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 141208,
+      "cached_input_tokens_used": 2532352,
+      "output_tokens_used": 15421,
+      "iterations": 2,
+      "cost_usd": 1.7288,
+      "tested_library_loc": 2386,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 12,
+      "previous_library_metadata_entries": 15,
+      "previous_library_test_only_metadata_entries": 12,
+      "code_coverage_percent": 19.39,
+      "previous_library_coverage_percent": 24.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/jline/jline/3.0.0.M1/src/test/java/com/cloudius/util/Stty.java",
+      "metadata_file": "metadata/jline/jline/3.0.0.M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jline/jline/3.0.0.M1/stats.json
+++ b/stats/jline/jline/3.0.0.M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0.M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.833333,
+          "coveredCalls" : 5,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.714286,
+      "coveredCalls" : 5,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 22523,
+        "missed" : 50678,
+        "ratio" : 0.307687,
+        "total" : 73201
+      },
+      "line" : {
+        "covered" : 2386,
+        "missed" : 9918,
+        "ratio" : 0.193921,
+        "total" : 12304
+      },
+      "method" : {
+        "covered" : 314,
+        "missed" : 1191,
+        "ratio" : 0.208638,
+        "total" : 1505
+      }
+    }
+  } ]
+}

--- a/tests/src/jline/jline/3.0.0.M1/.gitignore
+++ b/tests/src/jline/jline/3.0.0.M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jline/jline/3.0.0.M1/build.gradle
+++ b/tests/src/jline/jline/3.0.0.M1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jline:jline:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/gradle.properties
+++ b/tests/src/jline/jline/3.0.0.M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jline:jline:3.0.0.M1
+library.version = 3.0.0.M1
+metadata.dir = jline/jline/3.0.0.M1/

--- a/tests/src/jline/jline/3.0.0.M1/settings.gradle
+++ b/tests/src/jline/jline/3.0.0.M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jline.jline_tests'

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/com/cloudius/util/Stty.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/com/cloudius/util/Stty.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.cloudius.util;
+
+public class Stty {
+
+    public static int jlineModeCalls;
+    public static int resetCalls;
+
+    public static void clear() {
+        jlineModeCalls = 0;
+        resetCalls = 0;
+    }
+
+    public void jlineMode() {
+        jlineModeCalls++;
+    }
+
+    public void reset() {
+        resetCalls++;
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import jline.UnsupportedTerminal;
+import jline.console.ConsoleReader;
+import jline.console.completer.CandidateListCompletionHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CandidateListCompletionHandlerMessagesTest {
+
+    private Locale originalLocale;
+
+    @BeforeEach
+    void setUp() {
+        originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Locale.setDefault(originalLocale);
+    }
+
+    @Test
+    void printCandidatesLoadsTheMessagesBundleWhenPromptingForConfirmation() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (ConsoleReader reader = new ConsoleReader(
+                "candidate-list-completion-handler",
+                new ByteArrayInputStream("y".getBytes(StandardCharsets.UTF_8)),
+                output,
+                new UnsupportedTerminal())) {
+            reader.setAutoprintThreshold(1);
+
+            CandidateListCompletionHandler.printCandidates(reader, Arrays.<CharSequence>asList("alpha", "beta"));
+            reader.flush();
+        }
+
+        String consoleOutput = output.toString(StandardCharsets.UTF_8.name());
+        assertThat(consoleOutput)
+                .contains("Display all 2 possibilities? (y or n)")
+                .contains("alpha")
+                .contains("beta");
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
@@ -6,55 +6,157 @@
  */
 package org.graalvm.jline;
 
-import jline.UnsupportedTerminal;
-import jline.console.ConsoleReader;
-import jline.console.completer.CandidateListCompletionHandler;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.builtins.Completers;
+import org.jline.reader.Candidate;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Locale;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CandidateListCompletionHandlerMessagesTest {
 
-    private Locale originalLocale;
-
-    @BeforeEach
-    void setUp() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault(Locale.ENGLISH);
-    }
-
-    @AfterEach
-    void tearDown() {
-        Locale.setDefault(originalLocale);
-    }
-
     @Test
-    void printCandidatesLoadsTheMessagesBundleWhenPromptingForConfirmation() throws Exception {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+    @Timeout(10)
+    void builtinCompleterAddsCommandsAliasesOptionsAndArguments() {
+        CompletionEnvironment environment = new CompletionEnvironment();
+        Completers.Completer completer = new Completers.Completer(environment);
+        List<Candidate> candidates = new ArrayList<Candidate>();
 
-        try (ConsoleReader reader = new ConsoleReader(
-                "candidate-list-completion-handler",
-                new ByteArrayInputStream("y".getBytes(StandardCharsets.UTF_8)),
-                output,
-                new UnsupportedTerminal())) {
-            reader.setAutoprintThreshold(1);
+        completer.complete(null, new TestParsedLine("", 0, Collections.singletonList("")), candidates);
 
-            CandidateListCompletionHandler.printCandidates(reader, Arrays.<CharSequence>asList("alpha", "beta"));
-            reader.flush();
+        assertThat(candidateValues(candidates)).contains("commit", "ci").doesNotContain("_internal");
+        assertThat(candidates)
+                .filteredOn(candidate -> "commit".equals(candidate.value()))
+                .singleElement()
+                .extracting(Candidate::descr)
+                .isEqualTo("record changes");
+
+        candidates.clear();
+        completer.complete(null, new TestParsedLine("commit -", 1, Arrays.asList("commit", "-")), candidates);
+
+        assertThat(candidates)
+                .singleElement()
+                .satisfies(candidate -> {
+                    assertThat(candidate.value()).isEqualTo("--message");
+                    assertThat(candidate.group()).isEqualTo("options");
+                    assertThat(candidate.descr()).isEqualTo("commit message");
+                });
+
+        candidates.clear();
+        completer.complete(null, new TestParsedLine("commit --message ", 2, Arrays.asList("commit", "--message", "")), candidates);
+
+        assertThat(candidateValues(candidates)).containsExactly("initial commit", "metadata update");
+    }
+
+    private static List<String> candidateValues(final List<Candidate> candidates) {
+        List<String> values = new ArrayList<String>();
+        for (Candidate candidate : candidates) {
+            values.add(candidate.value());
+        }
+        return values;
+    }
+
+    private static final class CompletionEnvironment implements Completers.CompletionEnvironment {
+
+        private final Map<String, List<Completers.CompletionData>> completions;
+
+        private CompletionEnvironment() {
+            completions = new HashMap<String, List<Completers.CompletionData>>();
+            completions.put("commit", Arrays.asList(
+                    new Completers.CompletionData(null, "record changes", null, null),
+                    new Completers.CompletionData(
+                            Collections.singletonList("--message"),
+                            "commit message",
+                            "messages",
+                            null)));
         }
 
-        String consoleOutput = output.toString(StandardCharsets.UTF_8.name());
-        assertThat(consoleOutput)
-                .contains("Display all 2 possibilities? (y or n)")
-                .contains("alpha")
-                .contains("beta");
+        @Override
+        public Map<String, List<Completers.CompletionData>> getCompletions() {
+            return completions;
+        }
+
+        @Override
+        public Set<String> getCommands() {
+            return new HashSet<String>(Arrays.asList("commit", "_internal"));
+        }
+
+        @Override
+        public String resolveCommand(final String command) {
+            if ("ci".equals(command)) {
+                return "commit";
+            }
+            return command;
+        }
+
+        @Override
+        public String commandName(final String command) {
+            if ("commit".equals(command)) {
+                return "ci";
+            }
+            return command;
+        }
+
+        @Override
+        public Object evaluate(final LineReader reader, final ParsedLine line, final String function) {
+            if ("messages".equals(function)) {
+                return Arrays.asList("initial commit", "metadata update");
+            }
+            return Boolean.FALSE;
+        }
+    }
+
+    private static final class TestParsedLine implements ParsedLine {
+
+        private final String line;
+        private final int wordIndex;
+        private final List<String> words;
+
+        private TestParsedLine(final String line, final int wordIndex, final List<String> words) {
+            this.line = line;
+            this.wordIndex = wordIndex;
+            this.words = words;
+        }
+
+        @Override
+        public String word() {
+            return words.get(wordIndex);
+        }
+
+        @Override
+        public int wordCursor() {
+            return word().length();
+        }
+
+        @Override
+        public int wordIndex() {
+            return wordIndex;
+        }
+
+        @Override
+        public List<String> words() {
+            return words;
+        }
+
+        @Override
+        public String line() {
+            return line;
+        }
+
+        @Override
+        public int cursor() {
+            return line.length();
+        }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import jline.UnixTerminal;
+import jline.console.ConsoleReader;
+import jline.internal.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class ConsoleReaderTest {
+
+    private String originalSigCont;
+    private String originalShellCommand;
+    private String originalSttyCommand;
+    private String originalUserHome;
+    private Path temporaryDirectory;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalSigCont = System.getProperty("jline.sigcont");
+        originalShellCommand = System.getProperty("jline.sh");
+        originalSttyCommand = System.getProperty("jline.stty");
+        originalUserHome = System.getProperty("user.home");
+
+        temporaryDirectory = Files.createTempDirectory("jline-console-reader-");
+        Path shellScript = writeFakeShell(temporaryDirectory.resolve("fake-sh"));
+
+        System.setProperty("jline.sigcont", Boolean.TRUE.toString());
+        System.setProperty("jline.sh", shellScript.toString());
+        System.setProperty("jline.stty", shellScript.toString());
+        System.setProperty("user.home", temporaryDirectory.toString());
+        Configuration.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        restoreProperty("jline.sigcont", originalSigCont);
+        restoreProperty("jline.sh", originalShellCommand);
+        restoreProperty("jline.stty", originalSttyCommand);
+        restoreProperty("user.home", originalUserHome);
+        Configuration.reset();
+    }
+
+    @Test
+    void constructorRegistersTheSigContHandlerWhenEnabledForTheDefaultUnixTerminal() throws Exception {
+        assumeTrue(!System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+
+        UnixTerminal terminal = new UnixTerminal();
+
+        try (ConsoleReader reader = new ConsoleReader(
+                "console-reader-test",
+                new ByteArrayInputStream(new byte[0]),
+                new ByteArrayOutputStream(),
+                terminal)) {
+            assertThat(reader.getTerminal()).isSameAs(terminal);
+        }
+    }
+
+    private Path writeFakeShell(final Path shellScript) throws Exception {
+        Files.writeString(shellScript, "#!/bin/sh\n"
+                + "command=\"$1\"\n"
+                + "if [ \"$1\" = \"-c\" ]; then\n"
+                + "  command=\"$2\"\n"
+                + "fi\n"
+                + "case \"$command\" in\n"
+                + "  -g|*\"-g\"*)\n"
+                + "    printf 'mock-terminal-state\\n'\n"
+                + "    ;;\n"
+                + "  -a|*\"-a\"*)\n"
+                + "    printf 'speed 9600 baud; 24 rows; 80 columns;\\nintr = ^C; lnext = ^V;\\n'\n"
+                + "    ;;\n"
+                + "  *)\n"
+                + "    exit 0\n"
+                + "    ;;\n"
+                + "esac\n");
+        assertThat(shellScript.toFile().setExecutable(true)).isTrue();
+        return shellScript;
+    }
+
+    private static void restoreProperty(final String name, final String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
@@ -6,97 +6,46 @@
  */
 package org.graalvm.jline;
 
-import jline.UnixTerminal;
-import jline.console.ConsoleReader;
-import jline.internal.Configuration;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ConsoleReaderTest {
 
-    private String originalSigCont;
-    private String originalShellCommand;
-    private String originalSttyCommand;
-    private String originalUserHome;
-    private Path temporaryDirectory;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        originalSigCont = System.getProperty("jline.sigcont");
-        originalShellCommand = System.getProperty("jline.sh");
-        originalSttyCommand = System.getProperty("jline.stty");
-        originalUserHome = System.getProperty("user.home");
-
-        temporaryDirectory = Files.createTempDirectory("jline-console-reader-");
-        Path shellScript = writeFakeShell(temporaryDirectory.resolve("fake-sh"));
-
-        System.setProperty("jline.sigcont", Boolean.TRUE.toString());
-        System.setProperty("jline.sh", shellScript.toString());
-        System.setProperty("jline.stty", shellScript.toString());
-        System.setProperty("user.home", temporaryDirectory.toString());
-        Configuration.reset();
-    }
-
-    @AfterEach
-    void tearDown() {
-        restoreProperty("jline.sigcont", originalSigCont);
-        restoreProperty("jline.sh", originalShellCommand);
-        restoreProperty("jline.stty", originalSttyCommand);
-        restoreProperty("user.home", originalUserHome);
-        Configuration.reset();
-    }
-
     @Test
-    void constructorRegistersTheSigContHandlerWhenEnabledForTheDefaultUnixTerminal() throws Exception {
-        assumeTrue(!System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+    @Timeout(10)
+    void lineReaderReadsALineFromTheConfiguredTerminalStreams() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream("alpha beta\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        UnixTerminal terminal = new UnixTerminal();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("line-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("line-reader-test")
+                    .variable(LineReader.DISABLE_HISTORY, Boolean.TRUE)
+                    .build();
 
-        try (ConsoleReader reader = new ConsoleReader(
-                "console-reader-test",
-                new ByteArrayInputStream(new byte[0]),
-                new ByteArrayOutputStream(),
-                terminal)) {
+            String line = reader.readLine("prompt> ");
+
+            assertThat(line).isEqualTo("alpha beta");
             assertThat(reader.getTerminal()).isSameAs(terminal);
-        }
-    }
-
-    private Path writeFakeShell(final Path shellScript) throws Exception {
-        Files.writeString(shellScript, "#!/bin/sh\n"
-                + "command=\"$1\"\n"
-                + "if [ \"$1\" = \"-c\" ]; then\n"
-                + "  command=\"$2\"\n"
-                + "fi\n"
-                + "case \"$command\" in\n"
-                + "  -g|*\"-g\"*)\n"
-                + "    printf 'mock-terminal-state\\n'\n"
-                + "    ;;\n"
-                + "  -a|*\"-a\"*)\n"
-                + "    printf 'speed 9600 baud; 24 rows; 80 columns;\\nintr = ^C; lnext = ^V;\\n'\n"
-                + "    ;;\n"
-                + "  *)\n"
-                + "    exit 0\n"
-                + "    ;;\n"
-                + "esac\n");
-        assertThat(shellScript.toFile().setExecutable(true)).isTrue();
-        return shellScript;
-    }
-
-    private static void restoreProperty(final String name, final String value) {
-        if (value == null) {
-            System.clearProperty(name);
-        } else {
-            System.setProperty(name, value);
+            assertThat(terminal.getName()).isEqualTo("line-reader-test");
+            assertThat(terminal.getType()).isEqualTo("ansi");
+            assertThat(output.toString(StandardCharsets.UTF_8.name())).contains("prompt> ");
         }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import jline.TerminalFactory;
+import jline.console.completer.Completer;
+import jline.console.internal.ConsoleRunner;
+import jline.internal.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsoleRunnerTest {
+
+    private String originalCompleters;
+    private String originalHistoryName;
+    private String originalTerminalType;
+    private String originalUserHome;
+    private InputStream originalSystemIn;
+
+    @TempDir
+    Path temporaryHome;
+
+    @BeforeEach
+    void setUp() {
+        originalCompleters = System.getProperty(ConsoleRunner.class.getName() + ".completers");
+        originalHistoryName = System.getProperty(ConsoleRunner.property);
+        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
+        originalUserHome = System.getProperty("user.home");
+        originalSystemIn = System.in;
+
+        TrackingCompleter.constructorCalls = 0;
+        TargetApplication.invocationCount = 0;
+        TargetApplication.lastArguments = null;
+        TargetApplication.systemInClassName = null;
+
+        System.setProperty(ConsoleRunner.class.getName() + ".completers", TrackingCompleter.class.getName());
+        System.setProperty(ConsoleRunner.property, "console-runner");
+        System.setProperty(TerminalFactory.JLINE_TERMINAL, TerminalFactory.NONE);
+        System.setProperty("user.home", temporaryHome.toString());
+        System.setIn(new ByteArrayInputStream(new byte[0]));
+
+        Configuration.reset();
+        TerminalFactory.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        restoreProperty(ConsoleRunner.class.getName() + ".completers", originalCompleters);
+        restoreProperty(ConsoleRunner.property, originalHistoryName);
+        restoreProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
+        restoreProperty("user.home", originalUserHome);
+        System.setIn(originalSystemIn);
+
+        Configuration.reset();
+        TerminalFactory.reset();
+    }
+
+    @Test
+    void mainLoadsConfiguredCompleterAndInvokesTheTargetMainMethod() throws Exception {
+        ConsoleRunner.main(new String[]{TargetApplication.class.getName(), "alpha", "beta"});
+
+        assertThat(TrackingCompleter.constructorCalls).isEqualTo(1);
+        assertThat(TargetApplication.invocationCount).isEqualTo(1);
+        assertThat(TargetApplication.lastArguments).containsExactly("alpha", "beta");
+        assertThat(TargetApplication.systemInClassName).contains("ConsoleReaderInputStream");
+        assertThat(System.in.getClass().getName()).doesNotContain("ConsoleReaderInputStream");
+        assertThat(temporaryHome.resolve(".jline-" + TargetApplication.class.getName() + ".console-runner.history"))
+                .exists();
+    }
+
+    private static void restoreProperty(final String name, final String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    public static final class TrackingCompleter implements Completer {
+
+        private static int constructorCalls;
+
+        public TrackingCompleter() {
+            constructorCalls++;
+        }
+
+        @Override
+        public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+            candidates.add("candidate");
+            return 0;
+        }
+    }
+
+    public static final class TargetApplication {
+
+        private static int invocationCount;
+        private static String[] lastArguments;
+        private static String systemInClassName;
+
+        public static void main(final String[] args) {
+            invocationCount++;
+            lastArguments = args.clone();
+            systemInClassName = System.in.getClass().getName();
+        }
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
@@ -6,114 +6,102 @@
  */
 package org.graalvm.jline;
 
-import jline.TerminalFactory;
-import jline.console.completer.Completer;
-import jline.console.internal.ConsoleRunner;
-import jline.internal.Configuration;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.file.Path;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleRunnerTest {
 
-    private String originalCompleters;
-    private String originalHistoryName;
-    private String originalTerminalType;
-    private String originalUserHome;
-    private InputStream originalSystemIn;
-
-    @TempDir
-    Path temporaryHome;
-
-    @BeforeEach
-    void setUp() {
-        originalCompleters = System.getProperty(ConsoleRunner.class.getName() + ".completers");
-        originalHistoryName = System.getProperty(ConsoleRunner.property);
-        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
-        originalUserHome = System.getProperty("user.home");
-        originalSystemIn = System.in;
-
-        TrackingCompleter.constructorCalls = 0;
-        TargetApplication.invocationCount = 0;
-        TargetApplication.lastArguments = null;
-        TargetApplication.systemInClassName = null;
-
-        System.setProperty(ConsoleRunner.class.getName() + ".completers", TrackingCompleter.class.getName());
-        System.setProperty(ConsoleRunner.property, "console-runner");
-        System.setProperty(TerminalFactory.JLINE_TERMINAL, TerminalFactory.NONE);
-        System.setProperty("user.home", temporaryHome.toString());
-        System.setIn(new ByteArrayInputStream(new byte[0]));
-
-        Configuration.reset();
-        TerminalFactory.reset();
-    }
-
-    @AfterEach
-    void tearDown() {
-        restoreProperty(ConsoleRunner.class.getName() + ".completers", originalCompleters);
-        restoreProperty(ConsoleRunner.property, originalHistoryName);
-        restoreProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
-        restoreProperty("user.home", originalUserHome);
-        System.setIn(originalSystemIn);
-
-        Configuration.reset();
-        TerminalFactory.reset();
-    }
-
     @Test
-    void mainLoadsConfiguredCompleterAndInvokesTheTargetMainMethod() throws Exception {
-        ConsoleRunner.main(new String[]{TargetApplication.class.getName(), "alpha", "beta"});
+    @Timeout(10)
+    void lineReaderBuilderInstallsTheConfiguredCompleter() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TrackingCompleter completer = new TrackingCompleter();
 
-        assertThat(TrackingCompleter.constructorCalls).isEqualTo(1);
-        assertThat(TargetApplication.invocationCount).isEqualTo(1);
-        assertThat(TargetApplication.lastArguments).containsExactly("alpha", "beta");
-        assertThat(TargetApplication.systemInClassName).contains("ConsoleReaderInputStream");
-        assertThat(System.in.getClass().getName()).doesNotContain("ConsoleReaderInputStream");
-        assertThat(temporaryHome.resolve(".jline-" + TargetApplication.class.getName() + ".console-runner.history"))
-                .exists();
-    }
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("completion-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("completion-reader-test")
+                    .completer(completer)
+                    .variable(LineReader.DISABLE_HISTORY, Boolean.TRUE)
+                    .build();
+            List<Candidate> candidates = new ArrayList<Candidate>();
 
-    private static void restoreProperty(final String name, final String value) {
-        if (value == null) {
-            System.clearProperty(name);
-        } else {
-            System.setProperty(name, value);
+            completer.complete(reader, new TestParsedLine("can"), candidates);
+
+            assertThat(reader.getTerminal()).isSameAs(terminal);
+            assertThat(completer.completedLines).containsExactly("can");
+            assertThat(candidates).singleElement().extracting(Candidate::value).isEqualTo("candidate");
         }
     }
 
     public static final class TrackingCompleter implements Completer {
 
-        private static int constructorCalls;
-
-        public TrackingCompleter() {
-            constructorCalls++;
-        }
+        private final List<String> completedLines = new ArrayList<String>();
 
         @Override
-        public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
-            candidates.add("candidate");
-            return 0;
+        public void complete(final LineReader reader, final ParsedLine line, final List<Candidate> candidates) {
+            completedLines.add(line.line());
+            candidates.add(new Candidate("candidate"));
         }
     }
 
-    public static final class TargetApplication {
+    private static final class TestParsedLine implements ParsedLine {
 
-        private static int invocationCount;
-        private static String[] lastArguments;
-        private static String systemInClassName;
+        private final String line;
 
-        public static void main(final String[] args) {
-            invocationCount++;
-            lastArguments = args.clone();
-            systemInClassName = System.in.getClass().getName();
+        private TestParsedLine(final String line) {
+            this.line = line;
+        }
+
+        @Override
+        public String word() {
+            return line;
+        }
+
+        @Override
+        public int wordCursor() {
+            return line.length();
+        }
+
+        @Override
+        public int wordIndex() {
+            return 0;
+        }
+
+        @Override
+        public List<String> words() {
+            return Collections.singletonList(line);
+        }
+
+        @Override
+        public String line() {
+            return line;
+        }
+
+        @Override
+        public int cursor() {
+            return line.length();
         }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class HawtjniRuntimeLibraryTest {
+
+    private static final String LIBRARY_NAME = "graalvmjlinemissingnative";
+
+    @Test
+    void loadChecksClassLoaderResourcesWhenNativeLibraryLookupFails() {
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(HawtjniRuntimeLibraryTest.class.getClassLoader());
+        Library library = new Library(LIBRARY_NAME, "integration-test", classLoader);
+
+        assertThatThrownBy(library::load)
+                .isInstanceOf(UnsatisfiedLinkError.class)
+                .hasMessageContaining("Could not load library. Reasons:");
+
+        assertThat(classLoader.requestedResources).containsExactly(
+                library.getPlatformSpecifcResourcePath(),
+                library.getOperatingSystemSpecifcResourcePath(),
+                library.getResorucePath());
+    }
+
+    public static final class TrackingResourceClassLoader extends ClassLoader {
+
+        private final List<String> requestedResources = new ArrayList<String>();
+
+        public TrackingResourceClassLoader(final ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResources.add(name);
+            return null;
+        }
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
@@ -6,47 +6,46 @@
  */
 package org.graalvm.jline;
 
-import org.fusesource.hawtjni.runtime.Library;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HawtjniRuntimeLibraryTest {
 
-    private static final String LIBRARY_NAME = "graalvmjlinemissingnative";
-
     @Test
-    void loadChecksClassLoaderResourcesWhenNativeLibraryLookupFails() {
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(HawtjniRuntimeLibraryTest.class.getClassLoader());
-        Library library = new Library(LIBRARY_NAME, "integration-test", classLoader);
+    @Timeout(10)
+    void lineReaderRecordsAcceptedLinesInHistory() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream("first\nsecond\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        assertThatThrownBy(library::load)
-                .isInstanceOf(UnsatisfiedLinkError.class)
-                .hasMessageContaining("Could not load library. Reasons:");
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("history-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("history-reader-test")
+                    .build();
 
-        assertThat(classLoader.requestedResources).containsExactly(
-                library.getPlatformSpecifcResourcePath(),
-                library.getOperatingSystemSpecifcResourcePath(),
-                library.getResorucePath());
-    }
+            assertThat(reader.readLine()).isEqualTo("first");
+            assertThat(reader.readLine()).isEqualTo("second");
 
-    public static final class TrackingResourceClassLoader extends ClassLoader {
-
-        private final List<String> requestedResources = new ArrayList<String>();
-
-        public TrackingResourceClassLoader(final ClassLoader parent) {
-            super(parent);
-        }
-
-        @Override
-        public URL getResource(final String name) {
-            requestedResources.add(name);
-            return null;
+            History history = reader.getHistory();
+            assertThat(history.size()).isEqualTo(2);
+            assertThat(history.get(0)).isEqualTo("first");
+            assertThat(history.get(1)).isEqualTo("second");
         }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import com.cloudius.util.Stty;
+import jline.OSvTerminal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OSvTerminalTest {
+
+    @BeforeEach
+    void setUp() {
+        Stty.clear();
+    }
+
+    @Test
+    void initAndRestoreInvokeTheLoadedSttyMethods() throws Exception {
+        OSvTerminal terminal = new OSvTerminal();
+
+        assertThat(terminal.sttyClass).isEqualTo(Stty.class);
+        assertThat(terminal.stty).isInstanceOf(Stty.class);
+        assertThat(terminal.isAnsiSupported()).isTrue();
+
+        terminal.init();
+        terminal.restore();
+
+        assertThat(Stty.jlineModeCalls).isEqualTo(1);
+        assertThat(Stty.resetCalls).isEqualTo(1);
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
@@ -6,32 +6,45 @@
  */
 package org.graalvm.jline;
 
-import com.cloudius.util.Stty;
-import jline.OSvTerminal;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OSvTerminalTest {
 
-    @BeforeEach
-    void setUp() {
-        Stty.clear();
-    }
-
     @Test
-    void initAndRestoreInvokeTheLoadedSttyMethods() throws Exception {
-        OSvTerminal terminal = new OSvTerminal();
+    @Timeout(10)
+    void terminalAttributesRoundTripInputOutputAndLocalFlags() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        assertThat(terminal.sttyClass).isEqualTo(Stty.class);
-        assertThat(terminal.stty).isInstanceOf(Stty.class);
-        assertThat(terminal.isAnsiSupported()).isTrue();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("attributes-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            Attributes attributes = terminal.getAttributes();
+            attributes.setInputFlags(EnumSet.of(Attributes.InputFlag.IGNCR));
+            attributes.setOutputFlags(EnumSet.of(Attributes.OutputFlag.OPOST));
+            attributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
 
-        terminal.init();
-        terminal.restore();
+            terminal.setAttributes(attributes);
+            Attributes updatedAttributes = terminal.getAttributes();
 
-        assertThat(Stty.jlineModeCalls).isEqualTo(1);
-        assertThat(Stty.resetCalls).isEqualTo(1);
+            assertThat(updatedAttributes.getInputFlag(Attributes.InputFlag.IGNCR)).isTrue();
+            assertThat(updatedAttributes.getOutputFlag(Attributes.OutputFlag.OPOST)).isTrue();
+            assertThat(updatedAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isTrue();
+            assertThat(terminal.echo(false)).isTrue();
+            assertThat(terminal.echo()).isFalse();
+        }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/SignalsTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/SignalsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import org.jline.utils.Signals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SignalsTest {
+
+    @Test
+    @Timeout(10)
+    void signalHandlersCanBeRegisteredIgnoredAndRestoredToDefault() {
+        AtomicInteger invocations = new AtomicInteger();
+
+        try {
+            assertDoesNotThrow(() -> Signals.register("WINCH", invocations::incrementAndGet));
+            assertDoesNotThrow(() -> Signals.registerIgnore("WINCH"));
+        } finally {
+            assertDoesNotThrow(() -> Signals.registerDefault("WINCH"));
+        }
+
+        assertThat(invocations.get()).isZero();
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import jline.AnsiWindowsTerminal;
+import jline.OSvTerminal;
+import jline.Terminal;
+import jline.TerminalFactory;
+import jline.TerminalSupport;
+import jline.UnixTerminal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TerminalFactoryTest {
+
+    private String originalTerminalType;
+    private ClassLoader originalContextClassLoader;
+
+    @BeforeEach
+    void setUp() {
+        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
+        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        NonPublicStringConstructorTerminal.noArgConstructorCalls = 0;
+        TerminalFactory.reset();
+        restoreDefaultFlavors();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (originalTerminalType == null) {
+            System.clearProperty(TerminalFactory.JLINE_TERMINAL);
+        } else {
+            System.setProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
+        }
+        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        TerminalFactory.reset();
+        restoreDefaultFlavors();
+    }
+
+    @Test
+    void createLoadsConfiguredTerminalThroughTheContextClassLoader() {
+        TrackingClassLoader trackingClassLoader = new TrackingClassLoader(TerminalFactoryTest.class.getClassLoader());
+        Thread.currentThread().setContextClassLoader(trackingClassLoader);
+        TerminalFactory.configure(ClassLoaderTerminal.class.getName());
+
+        Terminal terminal = TerminalFactory.create();
+
+        assertThat(trackingClassLoader.loadedClassNames).contains(ClassLoaderTerminal.class.getName());
+        assertThat(terminal).isInstanceOf(ClassLoaderTerminal.class);
+        assertThat(((ClassLoaderTerminal) terminal).initialized).isTrue();
+    }
+
+    @Test
+    void getFlavorUsesTheTtyDeviceConstructorWhenATtyDeviceIsProvided() throws Exception {
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, TtyDeviceTerminal.class);
+
+        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.UNIX, "/dev/tty-test");
+
+        assertThat(terminal).isInstanceOf(TtyDeviceTerminal.class);
+        assertThat(((TtyDeviceTerminal) terminal).ttyDevice).isEqualTo("/dev/tty-test");
+    }
+
+    @Test
+    void getFlavorUsesTheNoArgConstructorWhenNoTtyDeviceIsProvided() throws Exception {
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, NoArgTerminal.class);
+
+        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.OSV);
+
+        assertThat(terminal).isInstanceOf(NoArgTerminal.class);
+        assertThat(((NoArgTerminal) terminal).constructed).isTrue();
+    }
+
+    @Test
+    void getFlavorDoesNotFallBackToTheNoArgConstructorWhenTheTtyDeviceConstructorIsNotPublic() {
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, NonPublicStringConstructorTerminal.class);
+
+        // `Class#getConstructor` throws when the public `String` constructor is absent,
+        // so this path never falls back to the no-arg constructor.
+        assertThatThrownBy(() -> TerminalFactory.getFlavor(TerminalFactory.Flavor.WINDOWS, "/dev/tty-test"))
+                .isInstanceOf(NoSuchMethodException.class);
+        assertThat(NonPublicStringConstructorTerminal.noArgConstructorCalls).isZero();
+    }
+
+    private static void restoreDefaultFlavors() {
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, AnsiWindowsTerminal.class);
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, UnixTerminal.class);
+        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, OSvTerminal.class);
+    }
+
+    public static final class TrackingClassLoader extends ClassLoader {
+
+        private final List<String> loadedClassNames = new ArrayList<String>();
+
+        public TrackingClassLoader(final ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Class<?> loadClass(final String name) throws ClassNotFoundException {
+            loadedClassNames.add(name);
+            return super.loadClass(name);
+        }
+    }
+
+    public static final class ClassLoaderTerminal extends TerminalSupport {
+
+        private boolean initialized;
+
+        public ClassLoaderTerminal() {
+            super(true);
+        }
+
+        @Override
+        public void init() {
+            initialized = true;
+        }
+    }
+
+    public static final class TtyDeviceTerminal extends TerminalSupport {
+
+        private final String ttyDevice;
+
+        public TtyDeviceTerminal(final String ttyDevice) {
+            super(true);
+            this.ttyDevice = ttyDevice;
+        }
+    }
+
+    public static final class NoArgTerminal extends TerminalSupport {
+
+        private final boolean constructed;
+
+        public NoArgTerminal() {
+            super(true);
+            constructed = true;
+        }
+    }
+
+    public static final class NonPublicStringConstructorTerminal extends TerminalSupport {
+
+        private static int noArgConstructorCalls;
+
+        public NonPublicStringConstructorTerminal() {
+            super(true);
+            noArgConstructorCalls++;
+        }
+
+        private NonPublicStringConstructorTerminal(final String ttyDevice) {
+            super(true);
+        }
+    }
+}

--- a/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
@@ -6,158 +6,71 @@
  */
 package org.graalvm.jline;
 
-import jline.AnsiWindowsTerminal;
-import jline.OSvTerminal;
-import jline.Terminal;
-import jline.TerminalFactory;
-import jline.TerminalSupport;
-import jline.UnixTerminal;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TerminalFactoryTest {
 
-    private String originalTerminalType;
-    private ClassLoader originalContextClassLoader;
+    @Test
+    @Timeout(10)
+    void terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Attributes attributes = new Attributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
+        Size size = new Size(132, 43);
 
-    @BeforeEach
-    void setUp() {
-        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
-        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-        NonPublicStringConstructorTerminal.noArgConstructorCalls = 0;
-        TerminalFactory.reset();
-        restoreDefaultFlavors();
-    }
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("external-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            terminal.setAttributes(attributes);
+            terminal.setSize(size);
+            terminal.writer().print("terminal output");
+            terminal.flush();
 
-    @AfterEach
-    void tearDown() {
-        if (originalTerminalType == null) {
-            System.clearProperty(TerminalFactory.JLINE_TERMINAL);
-        } else {
-            System.setProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
+            assertThat(terminal.getName()).isEqualTo("external-terminal-test");
+            assertThat(terminal.getType()).isEqualTo("ansi");
+            assertThat(terminal.echo()).isTrue();
+            assertThat(terminal.getSize().getColumns()).isEqualTo(132);
+            assertThat(terminal.getSize().getRows()).isEqualTo(43);
+            assertThat(output.toString(StandardCharsets.UTF_8.name())).contains("terminal output");
         }
-        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
-        TerminalFactory.reset();
-        restoreDefaultFlavors();
     }
 
     @Test
-    void createLoadsConfiguredTerminalThroughTheContextClassLoader() {
-        TrackingClassLoader trackingClassLoader = new TrackingClassLoader(TerminalFactoryTest.class.getClassLoader());
-        Thread.currentThread().setContextClassLoader(trackingClassLoader);
-        TerminalFactory.configure(ClassLoaderTerminal.class.getName());
+    @Timeout(10)
+    void terminalSignalHandlersCanBeRegisteredAndRaised() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        List<Terminal.Signal> handledSignals = new ArrayList<Terminal.Signal>();
 
-        Terminal terminal = TerminalFactory.create();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("signal-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            Terminal.SignalHandler previous = terminal.handle(Terminal.Signal.WINCH, handledSignals::add);
 
-        assertThat(trackingClassLoader.loadedClassNames).contains(ClassLoaderTerminal.class.getName());
-        assertThat(terminal).isInstanceOf(ClassLoaderTerminal.class);
-        assertThat(((ClassLoaderTerminal) terminal).initialized).isTrue();
-    }
+            terminal.raise(Terminal.Signal.WINCH);
 
-    @Test
-    void getFlavorUsesTheTtyDeviceConstructorWhenATtyDeviceIsProvided() throws Exception {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, TtyDeviceTerminal.class);
-
-        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.UNIX, "/dev/tty-test");
-
-        assertThat(terminal).isInstanceOf(TtyDeviceTerminal.class);
-        assertThat(((TtyDeviceTerminal) terminal).ttyDevice).isEqualTo("/dev/tty-test");
-    }
-
-    @Test
-    void getFlavorUsesTheNoArgConstructorWhenNoTtyDeviceIsProvided() throws Exception {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, NoArgTerminal.class);
-
-        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.OSV);
-
-        assertThat(terminal).isInstanceOf(NoArgTerminal.class);
-        assertThat(((NoArgTerminal) terminal).constructed).isTrue();
-    }
-
-    @Test
-    void getFlavorDoesNotFallBackToTheNoArgConstructorWhenTheTtyDeviceConstructorIsNotPublic() {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, NonPublicStringConstructorTerminal.class);
-
-        // `Class#getConstructor` throws when the public `String` constructor is absent,
-        // so this path never falls back to the no-arg constructor.
-        assertThatThrownBy(() -> TerminalFactory.getFlavor(TerminalFactory.Flavor.WINDOWS, "/dev/tty-test"))
-                .isInstanceOf(NoSuchMethodException.class);
-        assertThat(NonPublicStringConstructorTerminal.noArgConstructorCalls).isZero();
-    }
-
-    private static void restoreDefaultFlavors() {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, AnsiWindowsTerminal.class);
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, UnixTerminal.class);
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, OSvTerminal.class);
-    }
-
-    public static final class TrackingClassLoader extends ClassLoader {
-
-        private final List<String> loadedClassNames = new ArrayList<String>();
-
-        public TrackingClassLoader(final ClassLoader parent) {
-            super(parent);
-        }
-
-        @Override
-        public Class<?> loadClass(final String name) throws ClassNotFoundException {
-            loadedClassNames.add(name);
-            return super.loadClass(name);
-        }
-    }
-
-    public static final class ClassLoaderTerminal extends TerminalSupport {
-
-        private boolean initialized;
-
-        public ClassLoaderTerminal() {
-            super(true);
-        }
-
-        @Override
-        public void init() {
-            initialized = true;
-        }
-    }
-
-    public static final class TtyDeviceTerminal extends TerminalSupport {
-
-        private final String ttyDevice;
-
-        public TtyDeviceTerminal(final String ttyDevice) {
-            super(true);
-            this.ttyDevice = ttyDevice;
-        }
-    }
-
-    public static final class NoArgTerminal extends TerminalSupport {
-
-        private final boolean constructed;
-
-        public NoArgTerminal() {
-            super(true);
-            constructed = true;
-        }
-    }
-
-    public static final class NonPublicStringConstructorTerminal extends TerminalSupport {
-
-        private static int noArgConstructorCalls;
-
-        public NonPublicStringConstructorTerminal() {
-            super(true);
-            noArgConstructorCalls++;
-        }
-
-        private NonPublicStringConstructorTerminal(final String ttyDevice) {
-            super(true);
+            assertThat(previous).isNotNull();
+            assertThat(handledSignals).containsExactly(Terminal.Signal.WINCH);
         }
     }
 }

--- a/tests/src/jline/jline/3.0.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jline/jline/3.0.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,74 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "jline.OSvTerminal"
+      },
+      "type" : "com.cloudius.util.Stty",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "jlineMode",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "reset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jline.console.internal.ConsoleRunner"
+      },
+      "type" : "org.graalvm.jline.ConsoleRunnerTest$TargetApplication",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jline.console.internal.ConsoleRunner"
+      },
+      "type" : "org.graalvm.jline.ConsoleRunnerTest$TrackingCompleter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jline.TerminalFactory"
+      },
+      "type" : "org.graalvm.jline.TerminalFactoryTest$ClassLoaderTerminal",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jline.TerminalFactory"
+      },
+      "type" : "org.graalvm.jline.TerminalFactoryTest$NoArgTerminal",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-02T16:52:30">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.016" hostname="kung-fu-workstation" timestamp="2026-05-02T16:55:44">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2014-545e05f6/tests/src/jline/jline/3.0.0.M1"/>
@@ -70,7 +69,7 @@ unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.OSvTerminalTest]/[met
 display-name: terminalAttributesRoundTripInputOutputAndLocalFlags()
 ]]></system-out>
 </testcase>
-<testcase name="lineReaderRecordsAcceptedLinesInHistory()" classname="org.graalvm.jline.HawtjniRuntimeLibraryTest" time="0.001">
+<testcase name="lineReaderRecordsAcceptedLinesInHistory()" classname="org.graalvm.jline.HawtjniRuntimeLibraryTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.HawtjniRuntimeLibraryTest]/[method:lineReaderRecordsAcceptedLinesInHistory()]
 display-name: lineReaderRecordsAcceptedLinesInHistory()
@@ -94,7 +93,7 @@ unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.TerminalFactoryTest]/
 display-name: terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize()
 ]]></system-out>
 </testcase>
-<testcase name="lineReaderReadsALineFromTheConfiguredTerminalStreams()" classname="org.graalvm.jline.ConsoleReaderTest" time="0.001">
+<testcase name="lineReaderReadsALineFromTheConfiguredTerminalStreams()" classname="org.graalvm.jline.ConsoleReaderTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.ConsoleReaderTest]/[method:lineReaderReadsALineFromTheConfiguredTerminalStreams()]
 display-name: lineReaderReadsALineFromTheConfiguredTerminalStreams()

--- a/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-02T16:52:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2014-545e05f6/tests/src/jline/jline/3.0.0.M1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="builtinCompleterAddsCommandsAliasesOptionsAndArguments()" classname="org.graalvm.jline.CandidateListCompletionHandlerMessagesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.CandidateListCompletionHandlerMessagesTest]/[method:builtinCompleterAddsCommandsAliasesOptionsAndArguments()]
+display-name: builtinCompleterAddsCommandsAliasesOptionsAndArguments()
+]]></system-out>
+</testcase>
+<testcase name="signalHandlersCanBeRegisteredIgnoredAndRestoredToDefault()" classname="org.graalvm.jline.SignalsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.SignalsTest]/[method:signalHandlersCanBeRegisteredIgnoredAndRestoredToDefault()]
+display-name: signalHandlersCanBeRegisteredIgnoredAndRestoredToDefault()
+]]></system-out>
+</testcase>
+<testcase name="terminalAttributesRoundTripInputOutputAndLocalFlags()" classname="org.graalvm.jline.OSvTerminalTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.OSvTerminalTest]/[method:terminalAttributesRoundTripInputOutputAndLocalFlags()]
+display-name: terminalAttributesRoundTripInputOutputAndLocalFlags()
+]]></system-out>
+</testcase>
+<testcase name="lineReaderRecordsAcceptedLinesInHistory()" classname="org.graalvm.jline.HawtjniRuntimeLibraryTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.HawtjniRuntimeLibraryTest]/[method:lineReaderRecordsAcceptedLinesInHistory()]
+display-name: lineReaderRecordsAcceptedLinesInHistory()
+]]></system-out>
+</testcase>
+<testcase name="lineReaderBuilderInstallsTheConfiguredCompleter()" classname="org.graalvm.jline.ConsoleRunnerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.ConsoleRunnerTest]/[method:lineReaderBuilderInstallsTheConfiguredCompleter()]
+display-name: lineReaderBuilderInstallsTheConfiguredCompleter()
+]]></system-out>
+</testcase>
+<testcase name="terminalSignalHandlersCanBeRegisteredAndRaised()" classname="org.graalvm.jline.TerminalFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.TerminalFactoryTest]/[method:terminalSignalHandlersCanBeRegisteredAndRaised()]
+display-name: terminalSignalHandlersCanBeRegisteredAndRaised()
+]]></system-out>
+</testcase>
+<testcase name="terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize()" classname="org.graalvm.jline.TerminalFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.TerminalFactoryTest]/[method:terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize()]
+display-name: terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize()
+]]></system-out>
+</testcase>
+<testcase name="lineReaderReadsALineFromTheConfiguredTerminalStreams()" classname="org.graalvm.jline.ConsoleReaderTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.jline.ConsoleReaderTest]/[method:lineReaderReadsALineFromTheConfiguredTerminalStreams()]
+display-name: lineReaderReadsALineFromTheConfiguredTerminalStreams()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:52:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2014-545e05f6/tests/src/jline/jline/3.0.0.M1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/jline/jline/3.0.0.M1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:52:30">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:55:44">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2014-545e05f6/tests/src/jline/jline/3.0.0.M1"/>

--- a/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
+++ b/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "jline.**"
+    },
+    {
+      "includeClasses": "org.fusesource.hawtjni.runtime.**"
+    },
+    {
+      "includeClasses": "org.fusesource.jansi.**"
+    },
+    {
+      "includeClasses": "com.cloudius.util.**"
+    }
+  ]
+}

--- a/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
+++ b/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
@@ -1,19 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "jline.**"
-    },
-    {
-      "includeClasses": "org.fusesource.hawtjni.runtime.**"
-    },
-    {
-      "includeClasses": "org.fusesource.jansi.**"
-    },
-    {
-      "includeClasses": "com.cloudius.util.**"
+      "includeClasses" : "org.jline.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #2014

This PR provides test fixes and new metadata for jline:jline:3.0.0.M1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 141208
- Cached input tokens: 2532352
- Output tokens: 15421
- Metadata entries: 11
- Test-only metadata entries: 12
- Iterations: 2
- Library coverage percentage: 19.39
- Previous library version metadata entries: 15
- Previous library version test-only metadata entries: 12
- Previous library version coverage percentage: 24.86

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jline:jline:2.14.6: 23/25 covered calls (92.00%)
- jline:jline:3.0.0.M1: 5/7 covered calls (71.43%)

**Reflection:**
- jline:jline:2.14.6: 20/22 covered calls (90.91%)
- jline:jline:3.0.0.M1: 5/6 covered calls (83.33%)

**Resources:**
- jline:jline:2.14.6: 3/3 covered calls (100.00%)
- jline:jline:3.0.0.M1: 0/1 covered calls (0.00%)

#### Library coverage

**Instruction:**
- jline:jline:2.14.6: 16479/33583 (49.07%)
- jline:jline:3.0.0.M1: 22523/73201 (30.77%)

**Line:**
- jline:jline:2.14.6: 1317/5297 (24.86%)
- jline:jline:3.0.0.M1: 2386/12304 (19.39%)

**Method:**
- jline:jline:2.14.6: 214/909 (23.54%)
- jline:jline:3.0.0.M1: 314/1505 (20.86%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
index b386b2779d..3fb329e041 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/CandidateListCompletionHandlerMessagesTest.java
@@ -6,55 +6,157 @@
  */
 package org.graalvm.jline;
 
-import jline.UnsupportedTerminal;
-import jline.console.ConsoleReader;
-import jline.console.completer.CandidateListCompletionHandler;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.builtins.Completers;
+import org.jline.reader.Candidate;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Locale;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CandidateListCompletionHandlerMessagesTest {
 
-    private Locale originalLocale;
+    @Test
+    @Timeout(10)
+    void builtinCompleterAddsCommandsAliasesOptionsAndArguments() {
+        CompletionEnvironment environment = new CompletionEnvironment();
+        Completers.Completer completer = new Completers.Completer(environment);
+        List<Candidate> candidates = new ArrayList<Candidate>();
+
+        completer.complete(null, new TestParsedLine("", 0, Collections.singletonList("")), candidates);
+
+        assertThat(candidateValues(candidates)).contains("commit", "ci").doesNotContain("_internal");
+        assertThat(candidates)
+                .filteredOn(candidate -> "commit".equals(candidate.value()))
+                .singleElement()
+                .extracting(Candidate::descr)
+                .isEqualTo("record changes");
+
+        candidates.clear();
+        completer.complete(null, new TestParsedLine("commit -", 1, Arrays.asList("commit", "-")), candidates);
+
+        assertThat(candidates)
+                .singleElement()
+                .satisfies(candidate -> {
+                    assertThat(candidate.value()).isEqualTo("--message");
+                    assertThat(candidate.group()).isEqualTo("options");
+                    assertThat(candidate.descr()).isEqualTo("commit message");
+                });
 
-    @BeforeEach
-    void setUp() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault(Locale.ENGLISH);
+        candidates.clear();
+        completer.complete(null, new TestParsedLine("commit --message ", 2, Arrays.asList("commit", "--message", "")), candidates);
+
+        assertThat(candidateValues(candidates)).containsExactly("initial commit", "metadata update");
     }
 
-    @AfterEach
-    void tearDown() {
-        Locale.setDefault(originalLocale);
+    private static List<String> candidateValues(final List<Candidate> candidates) {
+        List<String> values = new ArrayList<String>();
+        for (Candidate candidate : candidates) {
+            values.add(candidate.value());
+        }
+        return values;
     }
 
-    @Test
-    void printCandidatesLoadsTheMessagesBundleWhenPromptingForConfirmation() throws Exception {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private static final class CompletionEnvironment implements Completers.CompletionEnvironment {
+
+        private final Map<String, List<Completers.CompletionData>> completions;
+
+        private CompletionEnvironment() {
+            completions = new HashMap<String, List<Completers.CompletionData>>();
+            completions.put("commit", Arrays.asList(
+                    new Completers.CompletionData(null, "record changes", null, null),
+                    new Completers.CompletionData(
+                            Collections.singletonList("--message"),
+                            "commit message",
+                            "messages",
+                            null)));
+        }
+
+        @Override
+        public Map<String, List<Completers.CompletionData>> getCompletions() {
+            return completions;
+        }
+
+        @Override
+        public Set<String> getCommands() {
+            return new HashSet<String>(Arrays.asList("commit", "_internal"));
+        }
+
+        @Override
+        public String resolveCommand(final String command) {
+            if ("ci".equals(command)) {
+                return "commit";
+            }
+            return command;
+        }
 
-        try (ConsoleReader reader = new ConsoleReader(
-                "candidate-list-completion-handler",
-                new ByteArrayInputStream("y".getBytes(StandardCharsets.UTF_8)),
-                output,
-                new UnsupportedTerminal())) {
-            reader.setAutoprintThreshold(1);
+        @Override
+        public String commandName(final String command) {
+            if ("commit".equals(command)) {
+                return "ci";
+            }
+            return command;
+        }
 
-            CandidateListCompletionHandler.printCandidates(reader, Arrays.<CharSequence>asList("alpha", "beta"));
-            reader.flush();
+        @Override
+        public Object evaluate(final LineReader reader, final ParsedLine line, final String function) {
+            if ("messages".equals(function)) {
+                return Arrays.asList("initial commit", "metadata update");
+            }
+            return Boolean.FALSE;
         }
+    }
+
+    private static final class TestParsedLine implements ParsedLine {
 
-        String consoleOutput = output.toString(StandardCharsets.UTF_8.name());
-        assertThat(consoleOutput)
-                .contains("Display all 2 possibilities? (y or n)")
-                .contains("alpha")
-                .contains("beta");
+        private final String line;
+        private final int wordIndex;
+        private final List<String> words;
+
+        private TestParsedLine(final String line, final int wordIndex, final List<String> words) {
+            this.line = line;
+            this.wordIndex = wordIndex;
+            this.words = words;
+        }
+
+        @Override
+        public String word() {
+            return words.get(wordIndex);
+        }
+
+        @Override
+        public int wordCursor() {
+            return word().length();
+        }
+
+        @Override
+        public int wordIndex() {
+            return wordIndex;
+        }
+
+        @Override
+        public List<String> words() {
+            return words;
+        }
+
+        @Override
+        public String line() {
+            return line;
+        }
+
+        @Override
+        public int cursor() {
+            return line.length();
+        }
     }
 }
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/ConsoleReaderTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
index b8b722cace..35b11ab909 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleReaderTest.java
@@ -6,97 +6,46 @@
  */
 package org.graalvm.jline;
 
-import jline.UnixTerminal;
-import jline.console.ConsoleReader;
-import jline.internal.Configuration;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ConsoleReaderTest {
 
-    private String originalSigCont;
-    private String originalShellCommand;
-    private String originalSttyCommand;
-    private String originalUserHome;
-    private Path temporaryDirectory;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        originalSigCont = System.getProperty("jline.sigcont");
-        originalShellCommand = System.getProperty("jline.sh");
-        originalSttyCommand = System.getProperty("jline.stty");
-        originalUserHome = System.getProperty("user.home");
-
-        temporaryDirectory = Files.createTempDirectory("jline-console-reader-");
-        Path shellScript = writeFakeShell(temporaryDirectory.resolve("fake-sh"));
-
-        System.setProperty("jline.sigcont", Boolean.TRUE.toString());
-        System.setProperty("jline.sh", shellScript.toString());
-        System.setProperty("jline.stty", shellScript.toString());
-        System.setProperty("user.home", temporaryDirectory.toString());
-        Configuration.reset();
-    }
-
-    @AfterEach
-    void tearDown() {
-        restoreProperty("jline.sigcont", originalSigCont);
-        restoreProperty("jline.sh", originalShellCommand);
-        restoreProperty("jline.stty", originalSttyCommand);
-        restoreProperty("user.home", originalUserHome);
-        Configuration.reset();
-    }
-
     @Test
-    void constructorRegistersTheSigContHandlerWhenEnabledForTheDefaultUnixTerminal() throws Exception {
-        assumeTrue(!System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
-
-        UnixTerminal terminal = new UnixTerminal();
-
-        try (ConsoleReader reader = new ConsoleReader(
-                "console-reader-test",
-                new ByteArrayInputStream(new byte[0]),
-                new ByteArrayOutputStream(),
-                terminal)) {
+    @Timeout(10)
+    void lineReaderReadsALineFromTheConfiguredTerminalStreams() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream("alpha beta\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("line-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("line-reader-test")
+                    .variable(LineReader.DISABLE_HISTORY, Boolean.TRUE)
+                    .build();
+
+            String line = reader.readLine("prompt> ");
+
+            assertThat(line).isEqualTo("alpha beta");
             assertThat(reader.getTerminal()).isSameAs(terminal);
-        }
-    }
-
-    private Path writeFakeShell(final Path shellScript) throws Exception {
-        Files.writeString(shellScript, "#!/bin/sh\n"
-                + "command=\"$1\"\n"
-                + "if [ \"$1\" = \"-c\" ]; then\n"
-                + "  command=\"$2\"\n"
-                + "fi\n"
-                + "case \"$command\" in\n"
-                + "  -g|*\"-g\"*)\n"
-                + "    printf 'mock-terminal-state\\n'\n"
-                + "    ;;\n"
-                + "  -a|*\"-a\"*)\n"
-                + "    printf 'speed 9600 baud; 24 rows; 80 columns;\\nintr = ^C; lnext = ^V;\\n'\n"
-                + "    ;;\n"
-                + "  *)\n"
-                + "    exit 0\n"
-                + "    ;;\n"
-                + "esac\n");
-        assertThat(shellScript.toFile().setExecutable(true)).isTrue();
-        return shellScript;
-    }
-
-    private static void restoreProperty(final String name, final String value) {
-        if (value == null) {
-            System.clearProperty(name);
-        } else {
-            System.setProperty(name, value);
+            assertThat(terminal.getName()).isEqualTo("line-reader-test");
+            assertThat(terminal.getType()).isEqualTo("ansi");
+            assertThat(output.toString(StandardCharsets.UTF_8.name())).contains("prompt> ");
         }
     }
 }
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
index f366f0f078..24def047fc 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/ConsoleRunnerTest.java
@@ -6,114 +6,102 @@
  */
 package org.graalvm.jline;
 
-import jline.TerminalFactory;
-import jline.console.completer.Completer;
-import jline.console.internal.ConsoleRunner;
-import jline.internal.Configuration;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.file.Path;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleRunnerTest {
 
-    private String originalCompleters;
-    private String originalHistoryName;
-    private String originalTerminalType;
-    private String originalUserHome;
-    private InputStream originalSystemIn;
-
-    @TempDir
-    Path temporaryHome;
-
-    @BeforeEach
-    void setUp() {
-        originalCompleters = System.getProperty(ConsoleRunner.class.getName() + ".completers");
-        originalHistoryName = System.getProperty(ConsoleRunner.property);
-        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
-        originalUserHome = System.getProperty("user.home");
-        originalSystemIn = System.in;
-
-        TrackingCompleter.constructorCalls = 0;
-        TargetApplication.invocationCount = 0;
-        TargetApplication.lastArguments = null;
-        TargetApplication.systemInClassName = null;
-
-        System.setProperty(ConsoleRunner.class.getName() + ".completers", TrackingCompleter.class.getName());
-        System.setProperty(ConsoleRunner.property, "console-runner");
-        System.setProperty(TerminalFactory.JLINE_TERMINAL, TerminalFactory.NONE);
-        System.setProperty("user.home", temporaryHome.toString());
-        System.setIn(new ByteArrayInputStream(new byte[0]));
-
-        Configuration.reset();
-        TerminalFactory.reset();
+    @Test
+    @Timeout(10)
+    void lineReaderBuilderInstallsTheConfiguredCompleter() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TrackingCompleter completer = new TrackingCompleter();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("completion-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("completion-reader-test")
+                    .completer(completer)
+                    .variable(LineReader.DISABLE_HISTORY, Boolean.TRUE)
+                    .build();
+            List<Candidate> candidates = new ArrayList<Candidate>();
+
+            completer.complete(reader, new TestParsedLine("can"), candidates);
+
+            assertThat(reader.getTerminal()).isSameAs(terminal);
+            assertThat(completer.completedLines).containsExactly("can");
+            assertThat(candidates).singleElement().extracting(Candidate::value).isEqualTo("candidate");
+        }
     }
 
-    @AfterEach
-    void tearDown() {
-        restoreProperty(ConsoleRunner.class.getName() + ".completers", originalCompleters);
-        restoreProperty(ConsoleRunner.property, originalHistoryName);
-        restoreProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
-        restoreProperty("user.home", originalUserHome);
-        System.setIn(originalSystemIn);
+    public static final class TrackingCompleter implements Completer {
 
-        Configuration.reset();
-        TerminalFactory.reset();
-    }
+        private final List<String> completedLines = new ArrayList<String>();
 
-    @Test
-    void mainLoadsConfiguredCompleterAndInvokesTheTargetMainMethod() throws Exception {
-        ConsoleRunner.main(new String[]{TargetApplication.class.getName(), "alpha", "beta"});
-
-        assertThat(TrackingCompleter.constructorCalls).isEqualTo(1);
-        assertThat(TargetApplication.invocationCount).isEqualTo(1);
-        assertThat(TargetApplication.lastArguments).containsExactly("alpha", "beta");
-        assertThat(TargetApplication.systemInClassName).contains("ConsoleReaderInputStream");
-        assertThat(System.in.getClass().getName()).doesNotContain("ConsoleReaderInputStream");
-        assertThat(temporaryHome.resolve(".jline-" + TargetApplication.class.getName() + ".console-runner.history"))
-                .exists();
-    }
-
-    private static void restoreProperty(final String name, final String value) {
-        if (value == null) {
-            System.clearProperty(name);
-        } else {
-            System.setProperty(name, value);
+        @Override
+        public void complete(final LineReader reader, final ParsedLine line, final List<Candidate> candidates) {
+            completedLines.add(line.line());
+            candidates.add(new Candidate("candidate"));
         }
     }
 
-    public static final class TrackingCompleter implements Completer {
+    private static final class TestParsedLine implements ParsedLine {
 
-        private static int constructorCalls;
+        private final String line;
 
-        public TrackingCompleter() {
-            constructorCalls++;
+        private TestParsedLine(final String line) {
+            this.line = line;
         }
 
         @Override
-        public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
-            candidates.add("candidate");
+        public String word() {
+            return line;
+        }
+
+        @Override
+        public int wordCursor() {
+            return line.length();
+        }
+
+        @Override
+        public int wordIndex() {
             return 0;
         }
-    }
 
-    public static final class TargetApplication {
+        @Override
+        public List<String> words() {
+            return Collections.singletonList(line);
+        }
 
-        private static int invocationCount;
-        private static String[] lastArguments;
-        private static String systemInClassName;
+        @Override
+        public String line() {
+            return line;
+        }
 
-        public static void main(final String[] args) {
-            invocationCount++;
-            lastArguments = args.clone();
-            systemInClassName = System.in.getClass().getName();
+        @Override
+        public int cursor() {
+            return line.length();
         }
     }
 }
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
index a2610a3669..61b4051220 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/HawtjniRuntimeLibraryTest.java
@@ -6,47 +6,46 @@
  */
 package org.graalvm.jline;
 
-import org.fusesource.hawtjni.runtime.Library;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HawtjniRuntimeLibraryTest {
 
-    private static final String LIBRARY_NAME = "graalvmjlinemissingnative";
-
     @Test
-    void loadChecksClassLoaderResourcesWhenNativeLibraryLookupFails() {
-        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(HawtjniRuntimeLibraryTest.class.getClassLoader());
-        Library library = new Library(LIBRARY_NAME, "integration-test", classLoader);
-
-        assertThatThrownBy(library::load)
-                .isInstanceOf(UnsatisfiedLinkError.class)
-                .hasMessageContaining("Could not load library. Reasons:");
-
-        assertThat(classLoader.requestedResources).containsExactly(
-                library.getPlatformSpecifcResourcePath(),
-                library.getOperatingSystemSpecifcResourcePath(),
-                library.getResorucePath());
-    }
-
-    public static final class TrackingResourceClassLoader extends ClassLoader {
-
-        private final List<String> requestedResources = new ArrayList<String>();
-
-        public TrackingResourceClassLoader(final ClassLoader parent) {
-            super(parent);
-        }
-
-        @Override
-        public URL getResource(final String name) {
-            requestedResources.add(name);
-            return null;
+    @Timeout(10)
+    void lineReaderRecordsAcceptedLinesInHistory() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream("first\nsecond\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("history-reader-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("history-reader-test")
+                    .build();
+
+            assertThat(reader.readLine()).isEqualTo("first");
+            assertThat(reader.readLine()).isEqualTo("second");
+
+            History history = reader.getHistory();
+            assertThat(history.size()).isEqualTo(2);
+            assertThat(history.get(0)).isEqualTo("first");
+            assertThat(history.get(1)).isEqualTo("second");
         }
     }
 }
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/OSvTerminalTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
index 49777d9d9e..a16ea6ebe0 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/OSvTerminalTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/OSvTerminalTest.java
@@ -6,32 +6,45 @@
  */
 package org.graalvm.jline;
 
-import com.cloudius.util.Stty;
-import jline.OSvTerminal;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OSvTerminalTest {
 
-    @BeforeEach
-    void setUp() {
-        Stty.clear();
-    }
-
     @Test
-    void initAndRestoreInvokeTheLoadedSttyMethods() throws Exception {
-        OSvTerminal terminal = new OSvTerminal();
-
-        assertThat(terminal.sttyClass).isEqualTo(Stty.class);
-        assertThat(terminal.stty).isInstanceOf(Stty.class);
-        assertThat(terminal.isAnsiSupported()).isTrue();
-
-        terminal.init();
-        terminal.restore();
-
-        assertThat(Stty.jlineModeCalls).isEqualTo(1);
-        assertThat(Stty.resetCalls).isEqualTo(1);
+    @Timeout(10)
+    void terminalAttributesRoundTripInputOutputAndLocalFlags() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("attributes-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            Attributes attributes = terminal.getAttributes();
+            attributes.setInputFlags(EnumSet.of(Attributes.InputFlag.IGNCR));
+            attributes.setOutputFlags(EnumSet.of(Attributes.OutputFlag.OPOST));
+            attributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
+
+            terminal.setAttributes(attributes);
+            Attributes updatedAttributes = terminal.getAttributes();
+
+            assertThat(updatedAttributes.getInputFlag(Attributes.InputFlag.IGNCR)).isTrue();
+            assertThat(updatedAttributes.getOutputFlag(Attributes.OutputFlag.OPOST)).isTrue();
+            assertThat(updatedAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isTrue();
+            assertThat(terminal.echo(false)).isTrue();
+            assertThat(terminal.echo()).isFalse();
+        }
     }
 }
diff --git 1/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/SignalsTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/SignalsTest.java
new file mode 100644
index 0000000000..0aacdab836
--- /dev/null
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/SignalsTest.java
@@ -0,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import org.jline.utils.Signals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SignalsTest {
+
+    @Test
+    @Timeout(10)
+    void signalHandlersCanBeRegisteredIgnoredAndRestoredToDefault() {
+        AtomicInteger invocations = new AtomicInteger();
+
+        try {
+            assertDoesNotThrow(() -> Signals.register("WINCH", invocations::incrementAndGet));
+            assertDoesNotThrow(() -> Signals.registerIgnore("WINCH"));
+        } finally {
+            assertDoesNotThrow(() -> Signals.registerDefault("WINCH"));
+        }
+
+        assertThat(invocations.get()).isZero();
+    }
+}
diff --git 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/TerminalFactoryTest.java 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
index bfb3ee18e4..741ea9f4fa 100644
--- 1/tests/src/jline/jline/2.14.6/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
+++ 2/tests/src/jline/jline/3.0.0.M1/src/test/java/org/graalvm/jline/TerminalFactoryTest.java
@@ -6,158 +6,71 @@
  */
 package org.graalvm.jline;
 
-import jline.AnsiWindowsTerminal;
-import jline.OSvTerminal;
-import jline.Terminal;
-import jline.TerminalFactory;
-import jline.TerminalSupport;
-import jline.UnixTerminal;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TerminalFactoryTest {
 
-    private String originalTerminalType;
-    private ClassLoader originalContextClassLoader;
-
-    @BeforeEach
-    void setUp() {
-        originalTerminalType = System.getProperty(TerminalFactory.JLINE_TERMINAL);
-        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-        NonPublicStringConstructorTerminal.noArgConstructorCalls = 0;
-        TerminalFactory.reset();
-        restoreDefaultFlavors();
-    }
-
-    @AfterEach
-    void tearDown() {
-        if (originalTerminalType == null) {
-            System.clearProperty(TerminalFactory.JLINE_TERMINAL);
-        } else {
-            System.setProperty(TerminalFactory.JLINE_TERMINAL, originalTerminalType);
-        }
-        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
-        TerminalFactory.reset();
-        restoreDefaultFlavors();
-    }
-
-    @Test
-    void createLoadsConfiguredTerminalThroughTheContextClassLoader() {
-        TrackingClassLoader trackingClassLoader = new TrackingClassLoader(TerminalFactoryTest.class.getClassLoader());
-        Thread.currentThread().setContextClassLoader(trackingClassLoader);
-        TerminalFactory.configure(ClassLoaderTerminal.class.getName());
-
-        Terminal terminal = TerminalFactory.create();
-
-        assertThat(trackingClassLoader.loadedClassNames).contains(ClassLoaderTerminal.class.getName());
-        assertThat(terminal).isInstanceOf(ClassLoaderTerminal.class);
-        assertThat(((ClassLoaderTerminal) terminal).initialized).isTrue();
-    }
-
-    @Test
-    void getFlavorUsesTheTtyDeviceConstructorWhenATtyDeviceIsProvided() throws Exception {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, TtyDeviceTerminal.class);
-
-        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.UNIX, "/dev/tty-test");
-
-        assertThat(terminal).isInstanceOf(TtyDeviceTerminal.class);
-        assertThat(((TtyDeviceTerminal) terminal).ttyDevice).isEqualTo("/dev/tty-test");
-    }
-
     @Test
-    void getFlavorUsesTheNoArgConstructorWhenNoTtyDeviceIsProvided() throws Exception {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, NoArgTerminal.class);
-
-        Terminal terminal = TerminalFactory.getFlavor(TerminalFactory.Flavor.OSV);
-
-        assertThat(terminal).isInstanceOf(NoArgTerminal.class);
-        assertThat(((NoArgTerminal) terminal).constructed).isTrue();
-    }
-
-    @Test
-    void getFlavorDoesNotFallBackToTheNoArgConstructorWhenTheTtyDeviceConstructorIsNotPublic() {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, NonPublicStringConstructorTerminal.class);
-
-        // `Class#getConstructor` throws when the public `String` constructor is absent,
-        // so this path never falls back to the no-arg constructor.
-        assertThatThrownBy(() -> TerminalFactory.getFlavor(TerminalFactory.Flavor.WINDOWS, "/dev/tty-test"))
-                .isInstanceOf(NoSuchMethodException.class);
-        assertThat(NonPublicStringConstructorTerminal.noArgConstructorCalls).isZero();
-    }
-
-    private static void restoreDefaultFlavors() {
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.WINDOWS, AnsiWindowsTerminal.class);
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.UNIX, UnixTerminal.class);
-        TerminalFactory.registerFlavor(TerminalFactory.Flavor.OSV, OSvTerminal.class);
-    }
-
-    public static final class TrackingClassLoader extends ClassLoader {
-
-        private final List<String> loadedClassNames = new ArrayList<String>();
-
-        public TrackingClassLoader(final ClassLoader parent) {
-            super(parent);
-        }
-
-        @Override
-        public Class<?> loadClass(final String name) throws ClassNotFoundException {
-            loadedClassNames.add(name);
-            return super.loadClass(name);
-        }
-    }
-
-    public static final class ClassLoaderTerminal extends TerminalSupport {
-
-        private boolean initialized;
-
-        public ClassLoaderTerminal() {
-            super(true);
-        }
-
-        @Override
-        public void init() {
-            initialized = true;
-        }
-    }
-
-    public static final class TtyDeviceTerminal extends TerminalSupport {
-
-        private final String ttyDevice;
-
-        public TtyDeviceTerminal(final String ttyDevice) {
-            super(true);
-            this.ttyDevice = ttyDevice;
+    @Timeout(10)
+    void terminalBuilderCreatesANonSystemTerminalWithConfiguredAttributesAndSize() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Attributes attributes = new Attributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
+        Size size = new Size(132, 43);
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("external-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            terminal.setAttributes(attributes);
+            terminal.setSize(size);
+            terminal.writer().print("terminal output");
+            terminal.flush();
+
+            assertThat(terminal.getName()).isEqualTo("external-terminal-test");
+            assertThat(terminal.getType()).isEqualTo("ansi");
+            assertThat(terminal.echo()).isTrue();
+            assertThat(terminal.getSize().getColumns()).isEqualTo(132);
+            assertThat(terminal.getSize().getRows()).isEqualTo(43);
+            assertThat(output.toString(StandardCharsets.UTF_8.name())).contains("terminal output");
         }
     }
 
-    public static final class NoArgTerminal extends TerminalSupport {
-
-        private final boolean constructed;
-
-        public NoArgTerminal() {
-            super(true);
-            constructed = true;
-        }
-    }
-
-    public static final class NonPublicStringConstructorTerminal extends TerminalSupport {
-
-        private static int noArgConstructorCalls;
-
-        public NonPublicStringConstructorTerminal() {
-            super(true);
-            noArgConstructorCalls++;
-        }
-
-        private NonPublicStringConstructorTerminal(final String ttyDevice) {
-            super(true);
+    @Test
+    @Timeout(10)
+    void terminalSignalHandlersCanBeRegisteredAndRaised() throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        List<Terminal.Signal> handledSignals = new ArrayList<Terminal.Signal>();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("signal-terminal-test")
+                .type("ansi")
+                .streams(input, output)
+                .system(false)
+                .build()) {
+            Terminal.SignalHandler previous = terminal.handle(Terminal.Signal.WINCH, handledSignals::add);
+
+            terminal.raise(Terminal.Signal.WINCH);
+
+            assertThat(previous).isNotNull();
+            assertThat(handledSignals).containsExactly(Terminal.Signal.WINCH);
         }
     }
 }
diff --git 1/tests/src/jline/jline/2.14.6/user-code-filter.json 2/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
index ebe5a43e0b..8c5ad957de 100644
--- 1/tests/src/jline/jline/2.14.6/user-code-filter.json
+++ 2/tests/src/jline/jline/3.0.0.M1/user-code-filter.json
@@ -1,19 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "jline.**"
-    },
-    {
-      "includeClasses": "org.fusesource.hawtjni.runtime.**"
-    },
-    {
-      "includeClasses": "org.fusesource.jansi.**"
-    },
-    {
-      "includeClasses": "com.cloudius.util.**"
+      "includeClasses" : "org.jline.**"
     }
   ]
 }

```
