### PR TITLE
[GenAI] Add support for io.lettuce:lettuce-core:6.1.10.RELEASE using gpt-5.5

### DIFF
--- a/metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json
+++ b/metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json
@@ -1,0 +1,916 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.FutureSyncInvocationHandler"
+      },
+      "type": "io.lettuce.core.AbstractRedisAsyncCommands",
+      "methods": [
+        {
+          "name": "eval",
+          "parameterTypes": [
+            "java.lang.String",
+            "io.lettuce.core.ScriptOutputType",
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "eval",
+          "parameterTypes": [
+            "java.lang.String",
+            "io.lettuce.core.ScriptOutputType",
+            "java.lang.Object[]",
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "geoadd",
+          "parameterTypes": [
+            "java.lang.Object",
+            "double",
+            "double",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "geodist",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object",
+            "io.lettuce.core.GeoArgs$Unit"
+          ]
+        },
+        {
+          "name": "geopos",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "get",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "hget",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "hset",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "incr",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "lpush",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "lrange",
+          "parameterTypes": [
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name": "mget",
+          "parameterTypes": [
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "ping",
+          "parameterTypes": []
+        },
+        {
+          "name": "sadd",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object[]"
+          ]
+        },
+        {
+          "name": "set",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "set",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object",
+            "io.lettuce.core.SetArgs"
+          ]
+        },
+        {
+          "name": "smembers",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "zadd",
+          "parameterTypes": [
+            "java.lang.Object",
+            "double",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "zrangeWithScores",
+          "parameterTypes": [
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.ChannelGroupListener"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.ConnectionEventTrigger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.RedisAsyncCommandsImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.RedisChannelHandler"
+      },
+      "type": "io.lettuce.core.RedisChannelHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.RedisPublisher$RedisSubscription"
+      },
+      "type": "io.lettuce.core.RedisPublisher$RedisSubscription"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.BaseRedisCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisAclCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisGeoCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisHLLCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisHashCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisKeyCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisListCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisScriptingCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisServerCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisSetCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisSortedSetCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisStreamCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisStringCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.api.sync.RedisTransactionalCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.internal.AbstractInvocationHandler$MethodTranslator"
+      },
+      "type": "io.lettuce.core.cluster.api.sync.RedisClusterCommands"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.jfr.JfrEventRecorder"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ChannelGroupListener"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionEventSupport"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionEventTrigger"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectionActivatedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionEventSupport"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectionCreatedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionCreatedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionEventTrigger"
+      },
+      "type": "io.lettuce.core.event.connection.JfrConnectionDeactivatedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionEventSupport"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ChannelGroupListener"
+      },
+      "type": "io.lettuce.core.event.connection.JfrDisconnectedEvent",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.lettuce.core.event.connection.ConnectionEventSupport"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.AsyncCommand"
+      },
+      "type": "io.lettuce.core.protocol.AsyncCommand"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.protocol.CommandEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.protocol.CommandHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandWrapper"
+      },
+      "type": "io.lettuce.core.protocol.CommandWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.protocol.ConnectionWatchdog"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.DefaultEndpoint"
+      },
+      "type": "io.lettuce.core.protocol.DefaultEndpoint"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+      },
+      "type": "io.lettuce.core.protocol.RedisHandshakeHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.SharedLock"
+      },
+      "type": "io.lettuce.core.protocol.SharedLock"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandHandler"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.AbstractChannelHandlerContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.ChannelOutboundBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.DefaultChannelConfig"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.EpollProvider"
+      },
+      "type": "io.netty.channel.epoll.Epoll"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.KqueueProvider"
+      },
+      "type": "io.netty.channel.kqueue.KQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.channel.socket.nio.NioSocketChannel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.ConnectionBuilder"
+      },
+      "type": "io.netty.channel.socket.nio.NioSocketChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.IOUringProvider"
+      },
+      "type": "io.netty.incubator.channel.uring.IOUring"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.AddressResolverGroupProvider"
+      },
+      "type": "io.netty.resolver.dns$DnsAddressResolverGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.AddressResolverGroupProvider"
+      },
+      "type": "io.netty.resolver.dns.DnsAddressResolverGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "io.netty.util.DefaultAttributeMap$DefaultAttribute"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.HashedWheelTimer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.RedisHandshakeHandler"
+      },
+      "type": "io.netty.util.HashedWheelTimer$HashedWheelTimeout"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandHandler"
+      },
+      "type": "io.netty.util.Recycler$DefaultHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.RedisHandshake"
+      },
+      "type": "io.netty.util.ReferenceCountUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.ResourceLeakDetector$DefaultResourceLeak"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.protocol.CommandHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "java.lang.ProcessHandle",
+      "methods": [
+        {
+          "name": "current",
+          "parameterTypes": []
+        },
+        {
+          "name": "pid",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.jfr.EventRecorderHolder"
+      },
+      "type": "jdk.jfr.Event"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.HdrHistogram$Histogram"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.HdrHistogram.Histogram"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.LatencyUtils$PauseDetector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+      },
+      "type": "org.LatencyUtils.PauseDetector"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.DirectProcessor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.FluxCreate$BaseSink"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.core.publisher.FluxCreate$SerializedSink"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.Operators"
+      },
+      "type": "reactor.core.publisher.Hooks"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "reactor.core.publisher.LambdaMonoSubscriber"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.AbstractRedisClient"
+      },
+      "type": "reactor.core.publisher.Operators$MonoSubscriber"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.util.concurrent.MpscLinkedQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.DefaultEventBus"
+      },
+      "type": "reactor.util.concurrent.MpscLinkedQueue$LinkedQueueNode"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.Operators"
+      },
+      "type": "reactor.util.concurrent.Queues",
+      "methods": [
+        {
+          "name": "unbounded",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.Operators"
+      },
+      "type": "reactor.util.concurrent.SpscLinkedArrayQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultClientResources"
+      },
+      "type": "sun.misc.VM"
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.resource.DefaultEventLoopGroupProvider"
+      },
+      "type": "sun.nio.ch.SelectorImpl",
+      "fields": [
+        {
+          "name": "publicSelectedKeys"
+        },
+        {
+          "name": "selectedKeys"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.RedisChannelHandler"
+      },
+      "type": {
+        "proxy": [
+          "io.lettuce.core.api.sync.RedisCommands",
+          "io.lettuce.core.cluster.api.sync.RedisClusterCommands"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.lettuce.core.event.connection.JfrConnectionCreatedEvent"
+      },
+      "module": "jdk.jfr",
+      "glob": "jdk/jfr/internal/types/metadata.bin"
+    }
+  ]
+}

--- a/metadata/io.lettuce/lettuce-core/index.json
+++ b/metadata/io.lettuce/lettuce-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.1.10.RELEASE",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/lettuce/lettuce-core/$version$/lettuce-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/redis/lettuce",
+    "test-code-url" : "https://github.com/redis/lettuce/tree/$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/lettuce/lettuce-core/$version$/lettuce-core-$version$-javadoc.jar",
+    "description" : "Lettuce Core is an advanced, thread-safe Redis client for Java that supports synchronous, asynchronous, and reactive APIs. It also supports Redis Cluster, Sentinel, pipelining, auto-reconnect, codecs, and optional integrations such as Kotlin coroutines and metrics.",
+    "tested-versions" : [
+      "6.1.10.RELEASE"
+    ],
+    "allowed-packages" : [
+      "io.lettuce.core"
+    ]
+  }
+]

--- a/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/execution-metrics.json
+++ b/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/execution-metrics.json
@@ -1,0 +1,50 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T14:59:59.945904Z",
+    "library": "io.lettuce:lettuce-core:6.1.10.RELEASE",
+    "starting_commit": "d33ac14916368fd78ca963df1969d90ae9b718ea",
+    "ending_commit": "f5c961d7cfaa7e8ff13e01b6d556e81fb9468ce4",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.1.10.RELEASE",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15247,
+          "missed": 105084,
+          "ratio": 0.126709,
+          "total": 120331
+        },
+        "line": {
+          "covered": 2936,
+          "missed": 20111,
+          "ratio": 0.127392,
+          "total": 23047
+        },
+        "method": {
+          "covered": 878,
+          "missed": 7443,
+          "ratio": 0.105516,
+          "total": 8321
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 156344,
+      "cached_input_tokens_used": 1203712,
+      "output_tokens_used": 22872,
+      "iterations": 4,
+      "cost_usd": 1.2881,
+      "generated_loc": 577,
+      "tested_library_loc": 2936,
+      "metadata_entries": 152,
+      "code_coverage_percent": 12.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java",
+      "metadata_file": "metadata/io.lettuce/lettuce-core/6.1.10.RELEASE/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/stats.json
+++ b/stats/io.lettuce/lettuce-core/6.1.10.RELEASE/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "6.1.10.RELEASE",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15247,
+        "missed" : 105084,
+        "ratio" : 0.126709,
+        "total" : 120331
+      },
+      "line" : {
+        "covered" : 2936,
+        "missed" : 20111,
+        "ratio" : 0.127392,
+        "total" : 23047
+      },
+      "method" : {
+        "covered" : 878,
+        "missed" : 7443,
+        "ratio" : 0.105516,
+        "total" : 8321
+      }
+    }
+  } ]
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/.gitignore
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/build.gradle
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.lettuce:lettuce-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/gradle.properties
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.lettuce:lettuce-core:6.1.10.RELEASE
+library.version = 6.1.10.RELEASE
+metadata.dir = io.lettuce/lettuce-core/6.1.10.RELEASE/

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/settings.gradle
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.lettuce.lettuce-core_tests'

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_lettuce.lettuce_core;
+
+import org.junit.jupiter.api.Test;
+
+class Lettuce_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -8,8 +8,11 @@ package io_lettuce.lettuce_core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.within;
 
 import io.lettuce.core.ClientOptions;
+import io.lettuce.core.GeoArgs;
+import io.lettuce.core.GeoCoordinates;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisFuture;
@@ -182,6 +185,37 @@ public class Lettuce_coreTest {
     }
 
     @Test
+    void geospatialCommandsDecodeCoordinatesAndDistances() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisCommands<String, String> commands = connection.sync();
+
+                assertThat(commands.geoadd("places", 13.361389, 38.115556, "Palermo")).isEqualTo(1L);
+                assertThat(commands.geoadd("places", 15.087269, 37.502669, "Catania")).isEqualTo(1L);
+
+                List<GeoCoordinates> positions = commands.geopos("places", "Palermo", "Catania");
+                Double distance = commands.geodist("places", "Palermo", "Catania", GeoArgs.Unit.km);
+
+                assertThat(positions).hasSize(2);
+                assertThat(positions.get(0).getX().doubleValue()).isCloseTo(13.361389, within(0.000001));
+                assertThat(positions.get(0).getY().doubleValue()).isCloseTo(38.115556, within(0.000001));
+                assertThat(positions.get(1).getX().doubleValue()).isCloseTo(15.087269, within(0.000001));
+                assertThat(positions.get(1).getY().doubleValue()).isCloseTo(37.502669, within(0.000001));
+                assertThat(distance).isCloseTo(166.0, within(1.0));
+                assertThat(server.commands()).extracting(command -> command.get(0))
+                        .contains("GEOADD", "GEOPOS", "GEODIST");
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
+    @Test
     void sortedSetCommandsMapScoredValues() throws Exception {
         try (FakeRedisServer server = new FakeRedisServer()) {
             RedisClient client = RedisClient.create(server.redisUri());
@@ -256,6 +290,7 @@ public class Lettuce_coreTest {
         private final Map<String, List<String>> lists = Collections.synchronizedMap(new LinkedHashMap<>());
         private final Map<String, Set<String>> sets = Collections.synchronizedMap(new LinkedHashMap<>());
         private final Map<String, Map<String, Double>> sortedSets = Collections.synchronizedMap(new LinkedHashMap<>());
+        private final Map<String, Map<String, GeoCoordinates>> geoIndexes = Collections.synchronizedMap(new LinkedHashMap<>());
         private volatile boolean closed;
 
         FakeRedisServer() throws Exception {
@@ -412,6 +447,15 @@ public class Lettuce_coreTest {
                 case "ZRANGE":
                     writeArray(output, zrange(command));
                     break;
+                case "GEOADD":
+                    writeInteger(output, geoadd(command));
+                    break;
+                case "GEOPOS":
+                    writeGeoPositions(output, command);
+                    break;
+                case "GEODIST":
+                    writeBulk(output, geodist(command));
+                    break;
                 case "EVAL":
                     writeEvalResponse(output, command);
                     break;
@@ -488,6 +532,60 @@ public class Lettuce_coreTest {
                 }
             }
             return response;
+        }
+
+        private long geoadd(List<String> command) {
+            Map<String, GeoCoordinates> index = geoIndexes.computeIfAbsent(command.get(1), unused -> new LinkedHashMap<>());
+            GeoCoordinates coordinates = GeoCoordinates.create(Double.parseDouble(command.get(2)),
+                    Double.parseDouble(command.get(3)));
+            boolean absent = !index.containsKey(command.get(4));
+            index.put(command.get(4), coordinates);
+            return absent ? 1 : 0;
+        }
+
+        private String geodist(List<String> command) {
+            Map<String, GeoCoordinates> index = geoIndexes.getOrDefault(command.get(1), Collections.emptyMap());
+            GeoCoordinates from = index.get(command.get(2));
+            GeoCoordinates to = index.get(command.get(3));
+            if (from == null || to == null) {
+                return null;
+            }
+            double distanceMeters = haversineMeters(from, to);
+            String unit = command.size() > 4 ? command.get(4) : "m";
+            double convertedDistance = switch (unit.toLowerCase()) {
+                case "km" -> distanceMeters / 1_000.0;
+                case "mi" -> distanceMeters / 1_609.344;
+                case "ft" -> distanceMeters * 3.28084;
+                default -> distanceMeters;
+            };
+            return Double.toString(convertedDistance);
+        }
+
+        private double haversineMeters(GeoCoordinates from, GeoCoordinates to) {
+            double earthRadiusMeters = 6_371_000.0;
+            double fromLatitude = Math.toRadians(from.getY().doubleValue());
+            double toLatitude = Math.toRadians(to.getY().doubleValue());
+            double latitudeDelta = Math.toRadians(to.getY().doubleValue() - from.getY().doubleValue());
+            double longitudeDelta = Math.toRadians(to.getX().doubleValue() - from.getX().doubleValue());
+            double a = Math.sin(latitudeDelta / 2) * Math.sin(latitudeDelta / 2)
+                    + Math.cos(fromLatitude) * Math.cos(toLatitude)
+                    * Math.sin(longitudeDelta / 2) * Math.sin(longitudeDelta / 2);
+            return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        }
+
+        private void writeGeoPositions(OutputStream output, List<String> command) throws IOException {
+            Map<String, GeoCoordinates> index = geoIndexes.getOrDefault(command.get(1), Collections.emptyMap());
+            output.write(("*" + (command.size() - 2) + "\r\n").getBytes(StandardCharsets.UTF_8));
+            for (int i = 2; i < command.size(); i++) {
+                GeoCoordinates coordinates = index.get(command.get(i));
+                if (coordinates == null) {
+                    output.write("*-1\r\n".getBytes(StandardCharsets.UTF_8));
+                    continue;
+                }
+                output.write("*2\r\n".getBytes(StandardCharsets.UTF_8));
+                writeBulk(output, coordinates.getX().toString());
+                writeBulk(output, coordinates.getY().toString());
+            }
         }
 
         private void writeEvalResponse(OutputStream output, List<String> command) throws IOException {

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -15,6 +15,7 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.ScoredValue;
+import io.lettuce.core.ScriptOutputType;
 import io.lettuce.core.SetArgs;
 import io.lettuce.core.SocketOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -203,6 +204,38 @@ public class Lettuce_coreTest {
         }
     }
 
+    @Test
+    void scriptingCommandsDecodeRequestedOutputTypes() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisCommands<String, String> commands = connection.sync();
+
+                String selectedKey = commands.eval("return KEYS[1]", ScriptOutputType.VALUE,
+                        new String[] {"script-key"});
+                Long totalInputs = commands.eval("return #KEYS + #ARGV", ScriptOutputType.INTEGER,
+                        new String[] {"first-key", "second-key"}, "argument");
+                List<String> echoedInputs = commands.eval("return {KEYS[1], ARGV[1]}", ScriptOutputType.MULTI,
+                        new String[] {"script-key"}, "script-value");
+
+                assertThat(selectedKey).isEqualTo("script-key");
+                assertThat(totalInputs).isEqualTo(3L);
+                assertThat(echoedInputs).containsExactly("script-key", "script-value");
+                assertThat(server.commands().stream()
+                                .filter(command -> command.get(0).equals("EVAL"))
+                                .toList())
+                        .extracting(command -> command.get(1))
+                        .containsExactly("return KEYS[1]", "return #KEYS + #ARGV", "return {KEYS[1], ARGV[1]}");
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
     private static void shutdown(RedisClient client) {
         client.shutdown(Duration.ZERO, Duration.ofSeconds(2));
     }
@@ -379,6 +412,9 @@ public class Lettuce_coreTest {
                 case "ZRANGE":
                     writeArray(output, zrange(command));
                     break;
+                case "EVAL":
+                    writeEvalResponse(output, command);
+                    break;
                 default:
                     writeSimple(output, "OK");
                     break;
@@ -452,6 +488,20 @@ public class Lettuce_coreTest {
                 }
             }
             return response;
+        }
+
+        private void writeEvalResponse(OutputStream output, List<String> command) throws IOException {
+            String script = command.get(1);
+            int keyCount = Integer.parseInt(command.get(2));
+            List<String> keys = command.subList(3, 3 + keyCount);
+            List<String> arguments = command.subList(3 + keyCount, command.size());
+            if (script.contains("#KEYS")) {
+                writeInteger(output, keys.size() + arguments.size());
+            } else if (script.contains("{")) {
+                writeArray(output, List.of(keys.get(0), arguments.get(0)));
+            } else {
+                writeBulk(output, keys.get(0));
+            }
         }
 
         private void writeSimple(OutputStream output, String value) throws IOException {

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/src/test/java/io_lettuce/lettuce_core/Lettuce_coreTest.java
@@ -6,11 +6,478 @@
  */
 package io_lettuce.lettuce_core;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
-class Lettuce_coreTest {
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.KeyValue;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.ScoredValue;
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+public class Lettuce_coreTest {
+    private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(5);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void redisUriAndClientOptionsCanBeConfiguredWithoutConnecting() {
+        RedisURI uri = RedisURI.Builder.redis("localhost", 6380)
+                .withDatabase(2)
+                .withSsl(false)
+                .withTimeout(COMMAND_TIMEOUT)
+                .build();
+
+        RedisClient client = RedisClient.create(uri);
+        try {
+            SocketOptions socketOptions = SocketOptions.builder()
+                    .connectTimeout(Duration.ofMillis(500))
+                    .keepAlive(true)
+                    .build();
+            ClientOptions clientOptions = ClientOptions.builder()
+                    .autoReconnect(false)
+                    .pingBeforeActivateConnection(true)
+                    .socketOptions(socketOptions)
+                    .build();
+
+            client.setOptions(clientOptions);
+            client.setDefaultTimeout(Duration.ofSeconds(3));
+
+            assertThat(uri.getHost()).isEqualTo("localhost");
+            assertThat(uri.getPort()).isEqualTo(6380);
+            assertThat(uri.getDatabase()).isEqualTo(2);
+            assertThat(uri.getTimeout()).isEqualTo(COMMAND_TIMEOUT);
+            assertThat(client.getOptions()).isSameAs(clientOptions);
+        } finally {
+            shutdown(client);
+        }
+    }
+
+    @Test
+    void synchronousCommandsRoundTripAgainstRedisProtocolServer() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisCommands<String, String> commands = connection.sync();
+
+                assertThat(commands.ping()).isEqualTo("PONG");
+                assertThat(commands.set("message", "hello")).isEqualTo("OK");
+                assertThat(commands.get("message")).isEqualTo("hello");
+                assertThat(commands.incr("counter")).isEqualTo(1L);
+                assertThat(commands.incr("counter")).isEqualTo(2L);
+                assertThat(commands.hset("hash", "field", "value")).isTrue();
+                assertThat(commands.hget("hash", "field")).isEqualTo("value");
+                assertThat(commands.lpush("list", "one", "two")).isEqualTo(2L);
+                assertThat(commands.lrange("list", 0, -1)).containsExactly("two", "one");
+                assertThat(commands.sadd("set", "a", "b", "a")).isEqualTo(2L);
+                assertThat(commands.smembers("set")).containsExactlyInAnyOrder("a", "b");
+
+                assertThat(server.commands()).extracting(command -> command.get(0))
+                        .contains("PING", "SET", "GET", "INCR", "HSET", "HGET", "LPUSH", "LRANGE", "SADD", "SMEMBERS");
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
+    @Test
+    void commandArgumentBuildersEncodeOptionsAndKeyValueResults() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisCommands<String, String> commands = connection.sync();
+
+                SetArgs setArgs = SetArgs.Builder.nx().ex(10);
+                assertThat(commands.set("guarded", "first", setArgs)).isEqualTo("OK");
+                List<KeyValue<String, String>> values = commands.mget("guarded", "missing");
+                assertThat(values).extracting(KeyValue::getKey, KeyValue::hasValue)
+                        .containsExactly(
+                                tuple("guarded", true),
+                                tuple("missing", false));
+                assertThat(values.get(0).getValue()).isEqualTo("first");
+                assertThat(values.get(1).getValueOrElse("fallback")).isEqualTo("fallback");
+
+                List<String> setCommand = server.commands().stream()
+                        .filter(command -> command.size() > 1)
+                        .filter(command -> command.get(0).equals("SET"))
+                        .filter(command -> command.get(1).equals("guarded"))
+                        .findFirst()
+                        .orElseThrow(AssertionError::new);
+                assertThat(setCommand).containsExactly("SET", "guarded", "first", "EX", "10", "NX");
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
+    @Test
+    void asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisAsyncCommands<String, String> async = connection.async();
+
+                RedisFuture<String> set = async.set("async-key", "async-value");
+                RedisFuture<String> get = async.get("async-key");
+                assertThat(set.get(5, TimeUnit.SECONDS)).isEqualTo("OK");
+                assertThat(get.get(5, TimeUnit.SECONDS)).isEqualTo("async-value");
+
+                RedisReactiveCommands<String, String> reactive = connection.reactive();
+                assertThat(reactive.set("reactive-key", "reactive-value").block(COMMAND_TIMEOUT)).isEqualTo("OK");
+                assertThat(reactive.get("reactive-key").block(COMMAND_TIMEOUT)).isEqualTo("reactive-value");
+                assertThat(Flux.from(reactive.mget("async-key", "reactive-key"))
+                                .map(KeyValue::getValue)
+                                .collectList()
+                                .block(COMMAND_TIMEOUT))
+                        .containsExactly("async-value", "reactive-value");
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
+    @Test
+    void sortedSetCommandsMapScoredValues() throws Exception {
+        try (FakeRedisServer server = new FakeRedisServer()) {
+            RedisClient client = RedisClient.create(server.redisUri());
+            StatefulRedisConnection<String, String> connection = null;
+            try {
+                connection = client.connect();
+                connection.setTimeout(COMMAND_TIMEOUT);
+                RedisCommands<String, String> commands = connection.sync();
+
+                assertThat(commands.zadd("leaders", 10.5, "alice")).isEqualTo(1L);
+                assertThat(commands.zadd("leaders", 7.0, "bob")).isEqualTo(1L);
+                List<ScoredValue<String>> leaders = commands.zrangeWithScores("leaders", 0, -1);
+
+                assertThat(leaders).extracting(ScoredValue::getValue).containsExactly("bob", "alice");
+                assertThat(leaders).extracting(ScoredValue::getScore).containsExactly(7.0, 10.5);
+            } finally {
+                closeConnection(connection);
+                shutdown(client);
+            }
+        }
+    }
+
+    private static void shutdown(RedisClient client) {
+        client.shutdown(Duration.ZERO, Duration.ofSeconds(2));
+    }
+
+    private static void closeConnection(StatefulRedisConnection<String, String> connection) {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    private static final class FakeRedisServer implements Closeable {
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final CountDownLatch started = new CountDownLatch(1);
+        private final List<List<String>> commands = new CopyOnWriteArrayList<>();
+        private final Map<String, String> strings = Collections.synchronizedMap(new LinkedHashMap<>());
+        private final Map<String, Map<String, String>> hashes = Collections.synchronizedMap(new LinkedHashMap<>());
+        private final Map<String, List<String>> lists = Collections.synchronizedMap(new LinkedHashMap<>());
+        private final Map<String, Set<String>> sets = Collections.synchronizedMap(new LinkedHashMap<>());
+        private final Map<String, Map<String, Double>> sortedSets = Collections.synchronizedMap(new LinkedHashMap<>());
+        private volatile boolean closed;
+
+        FakeRedisServer() throws Exception {
+            serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+            serverSocket.setSoTimeout(500);
+            thread = new Thread(this::acceptConnections, "fake-redis-server");
+            thread.setDaemon(true);
+            thread.start();
+            assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        RedisURI redisUri() {
+            return RedisURI.Builder.redis(serverSocket.getInetAddress().getHostAddress(), serverSocket.getLocalPort())
+                    .withTimeout(COMMAND_TIMEOUT)
+                    .build();
+        }
+
+        List<List<String>> commands() {
+            return commands;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            serverSocket.close();
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        private void acceptConnections() {
+            started.countDown();
+            while (!closed) {
+                try (Socket socket = serverSocket.accept()) {
+                    socket.setSoTimeout(5_000);
+                    handle(socket);
+                } catch (SocketTimeoutException e) {
+                    continue;
+                } catch (IOException e) {
+                    if (!closed) {
+                        throw new IllegalStateException(e);
+                    }
+                }
+            }
+        }
+
+        private void handle(Socket socket) throws IOException {
+            BufferedInputStream input = new BufferedInputStream(socket.getInputStream());
+            BufferedOutputStream output = new BufferedOutputStream(socket.getOutputStream());
+            while (!closed && !socket.isClosed()) {
+                List<String> command;
+                try {
+                    command = readCommand(input);
+                } catch (EOFException e) {
+                    return;
+                } catch (SocketTimeoutException e) {
+                    return;
+                }
+                commands.add(command);
+                writeResponse(output, command);
+                output.flush();
+            }
+        }
+
+        private List<String> readCommand(BufferedInputStream input) throws IOException {
+            String firstLine = readLine(input);
+            if (!firstLine.startsWith("*")) {
+                throw new IOException("Expected RESP array but got: " + firstLine);
+            }
+            int count = Integer.parseInt(firstLine.substring(1));
+            List<String> command = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                String bulkHeader = readLine(input);
+                if (!bulkHeader.startsWith("$")) {
+                    throw new IOException("Expected RESP bulk string but got: " + bulkHeader);
+                }
+                int length = Integer.parseInt(bulkHeader.substring(1));
+                byte[] bytes = input.readNBytes(length);
+                if (bytes.length != length || input.read() != '\r' || input.read() != '\n') {
+                    throw new EOFException();
+                }
+                String value = new String(bytes, StandardCharsets.UTF_8);
+                command.add(i == 0 ? value.toUpperCase() : value);
+            }
+            return command;
+        }
+
+        private String readLine(BufferedInputStream input) throws IOException {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            while (true) {
+                int next = input.read();
+                if (next == -1) {
+                    throw new EOFException();
+                }
+                if (next == '\r') {
+                    int lineFeed = input.read();
+                    if (lineFeed != '\n') {
+                        throw new IOException("Expected LF after CR");
+                    }
+                    return bytes.toString(StandardCharsets.UTF_8);
+                }
+                bytes.write(next);
+            }
+        }
+
+        private void writeResponse(OutputStream output, List<String> command) throws IOException {
+            String name = command.get(0);
+            switch (name) {
+                case "PING":
+                    writeSimple(output, "PONG");
+                    break;
+                case "AUTH":
+                case "CLIENT":
+                case "SELECT":
+                case "QUIT":
+                    writeSimple(output, "OK");
+                    break;
+                case "SET":
+                    strings.put(command.get(1), command.get(2));
+                    writeSimple(output, "OK");
+                    break;
+                case "GET":
+                    writeBulk(output, strings.get(command.get(1)));
+                    break;
+                case "MGET":
+                    writeArray(output, command.subList(1, command.size()).stream().map(strings::get).toList());
+                    break;
+                case "INCR":
+                    writeInteger(output, increment(command.get(1)));
+                    break;
+                case "HSET":
+                    writeInteger(output, hset(command.get(1), command.get(2), command.get(3)) ? 1 : 0);
+                    break;
+                case "HGET":
+                    writeBulk(output, hashes.getOrDefault(command.get(1), Collections.emptyMap()).get(command.get(2)));
+                    break;
+                case "LPUSH":
+                    writeInteger(output, lpush(command));
+                    break;
+                case "LRANGE":
+                    writeArray(output, lrange(command));
+                    break;
+                case "SADD":
+                    writeInteger(output, sadd(command));
+                    break;
+                case "SMEMBERS":
+                    writeArray(output, new ArrayList<>(sets.getOrDefault(command.get(1), Collections.emptySet())));
+                    break;
+                case "ZADD":
+                    writeInteger(output, zadd(command));
+                    break;
+                case "ZRANGE":
+                    writeArray(output, zrange(command));
+                    break;
+                default:
+                    writeSimple(output, "OK");
+                    break;
+            }
+        }
+
+        private long increment(String key) {
+            long value = Long.parseLong(strings.getOrDefault(key, "0")) + 1;
+            strings.put(key, Long.toString(value));
+            return value;
+        }
+
+        private boolean hset(String key, String field, String value) {
+            Map<String, String> hash = hashes.computeIfAbsent(key, unused -> new LinkedHashMap<>());
+            boolean absent = !hash.containsKey(field);
+            hash.put(field, value);
+            return absent;
+        }
+
+        private long lpush(List<String> command) {
+            List<String> list = lists.computeIfAbsent(command.get(1), unused -> new ArrayList<>());
+            for (int i = 2; i < command.size(); i++) {
+                list.add(0, command.get(i));
+            }
+            return list.size();
+        }
+
+        private List<String> lrange(List<String> command) {
+            List<String> list = lists.getOrDefault(command.get(1), Collections.emptyList());
+            int start = Integer.parseInt(command.get(2));
+            int stop = Integer.parseInt(command.get(3));
+            int normalizedStop = stop < 0 ? list.size() + stop : stop;
+            if (list.isEmpty() || start >= list.size() || normalizedStop < start) {
+                return Collections.emptyList();
+            }
+            return new ArrayList<>(list.subList(start, Math.min(normalizedStop + 1, list.size())));
+        }
+
+        private long sadd(List<String> command) {
+            Set<String> set = sets.computeIfAbsent(command.get(1), unused -> new LinkedHashSet<>());
+            long added = 0;
+            for (int i = 2; i < command.size(); i++) {
+                if (set.add(command.get(i))) {
+                    added++;
+                }
+            }
+            return added;
+        }
+
+        private long zadd(List<String> command) {
+            Map<String, Double> sortedSet = sortedSets.computeIfAbsent(command.get(1), unused -> new LinkedHashMap<>());
+            String member = command.get(3);
+            boolean absent = !sortedSet.containsKey(member);
+            sortedSet.put(member, Double.parseDouble(command.get(2)));
+            return absent ? 1 : 0;
+        }
+
+        private List<String> zrange(List<String> command) {
+            boolean withScores = command.stream().anyMatch("WITHSCORES"::equalsIgnoreCase);
+            Map<String, Double> sortedSet = sortedSets.getOrDefault(command.get(1), Collections.emptyMap());
+            Queue<Map.Entry<String, Double>> entries = new ArrayDeque<>(sortedSet.entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByValue())
+                    .toList());
+            List<String> response = new ArrayList<>();
+            while (!entries.isEmpty()) {
+                Map.Entry<String, Double> entry = entries.remove();
+                response.add(entry.getKey());
+                if (withScores) {
+                    response.add(Double.toString(entry.getValue()));
+                }
+            }
+            return response;
+        }
+
+        private void writeSimple(OutputStream output, String value) throws IOException {
+            output.write(("+" + value + "\r\n").getBytes(StandardCharsets.UTF_8));
+        }
+
+        private void writeInteger(OutputStream output, long value) throws IOException {
+            output.write((":" + Long.toString(value) + "\r\n").getBytes(StandardCharsets.UTF_8));
+        }
+
+        private void writeBulk(OutputStream output, String value) throws IOException {
+            if (value == null) {
+                output.write("$-1\r\n".getBytes(StandardCharsets.UTF_8));
+                return;
+            }
+            byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+            output.write(("$" + bytes.length + "\r\n").getBytes(StandardCharsets.UTF_8));
+            output.write(bytes);
+            output.write("\r\n".getBytes(StandardCharsets.UTF_8));
+        }
+
+        private void writeArray(OutputStream output, List<String> values) throws IOException {
+            output.write(("*" + values.size() + "\r\n").getBytes(StandardCharsets.UTF_8));
+            for (String value : values) {
+                writeBulk(output, value);
+            }
+        }
     }
 }

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.069" hostname="kung-fu-workstation" timestamp="2026-05-02T16:51:38">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.131" hostname="kung-fu-workstation" timestamp="2026-05-02T16:58:45">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3649-e5f0666d/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE"/>
@@ -52,43 +51,43 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="geospatialCommandsDecodeCoordinatesAndDistances()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<testcase name="geospatialCommandsDecodeCoordinatesAndDistances()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:geospatialCommandsDecodeCoordinatesAndDistances()]
 display-name: geospatialCommandsDecodeCoordinatesAndDistances()
 ]]></system-out>
 </testcase>
-<testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.011">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:sortedSetCommandsMapScoredValues()]
 display-name: sortedSetCommandsMapScoredValues()
 ]]></system-out>
 </testcase>
-<testcase name="scriptingCommandsDecodeRequestedOutputTypes()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<testcase name="scriptingCommandsDecodeRequestedOutputTypes()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.008">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:scriptingCommandsDecodeRequestedOutputTypes()]
 display-name: scriptingCommandsDecodeRequestedOutputTypes()
 ]]></system-out>
 </testcase>
-<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.045">
+<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.056">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()]
 display-name: asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()
 ]]></system-out>
 </testcase>
-<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:synchronousCommandsRoundTripAgainstRedisProtocolServer()]
 display-name: synchronousCommandsRoundTripAgainstRedisProtocolServer()
 ]]></system-out>
 </testcase>
-<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0">
+<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()]
 display-name: redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()
 ]]></system-out>
 </testcase>
-<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.016">
+<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.032">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:commandArgumentBuildersEncodeOptionsAndKeyValueResults()]
 display-name: commandArgumentBuildersEncodeOptionsAndKeyValueResults()

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.141" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3649-e5f0666d/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.007">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:sortedSetCommandsMapScoredValues()]
+display-name: sortedSetCommandsMapScoredValues()
+]]></system-out>
+</testcase>
+<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.055">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()]
+display-name: asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()
+]]></system-out>
+</testcase>
+<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.035">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:synchronousCommandsRoundTripAgainstRedisProtocolServer()]
+display-name: synchronousCommandsRoundTripAgainstRedisProtocolServer()
+]]></system-out>
+</testcase>
+<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.007">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()]
+display-name: redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()
+]]></system-out>
+</testcase>
+<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.035">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:commandArgumentBuildersEncodeOptionsAndKeyValueResults()]
+display-name: commandArgumentBuildersEncodeOptionsAndKeyValueResults()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.141" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.065" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:43">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,31 +52,37 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.007">
+<testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:sortedSetCommandsMapScoredValues()]
 display-name: sortedSetCommandsMapScoredValues()
 ]]></system-out>
 </testcase>
-<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.055">
+<testcase name="scriptingCommandsDecodeRequestedOutputTypes()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:scriptingCommandsDecodeRequestedOutputTypes()]
+display-name: scriptingCommandsDecodeRequestedOutputTypes()
+]]></system-out>
+</testcase>
+<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.041">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()]
 display-name: asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()
 ]]></system-out>
 </testcase>
-<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.035">
+<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:synchronousCommandsRoundTripAgainstRedisProtocolServer()]
 display-name: synchronousCommandsRoundTripAgainstRedisProtocolServer()
 ]]></system-out>
 </testcase>
-<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.007">
+<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()]
 display-name: redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()
 ]]></system-out>
 </testcase>
-<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.035">
+<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.015">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:commandArgumentBuildersEncodeOptionsAndKeyValueResults()]
 display-name: commandArgumentBuildersEncodeOptionsAndKeyValueResults()

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.065" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:43">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.069" hostname="kung-fu-workstation" timestamp="2026-05-02T16:51:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,6 +52,12 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
+<testcase name="geospatialCommandsDecodeCoordinatesAndDistances()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:geospatialCommandsDecodeCoordinatesAndDistances()]
+display-name: geospatialCommandsDecodeCoordinatesAndDistances()
+]]></system-out>
+</testcase>
 <testcase name="sortedSetCommandsMapScoredValues()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:sortedSetCommandsMapScoredValues()]
@@ -64,25 +70,25 @@ unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTes
 display-name: scriptingCommandsDecodeRequestedOutputTypes()
 ]]></system-out>
 </testcase>
-<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.041">
+<testcase name="asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.045">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()]
 display-name: asynchronousAndReactiveCommandsUseTheSameConnectionInfrastructure()
 ]]></system-out>
 </testcase>
-<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.002">
+<testcase name="synchronousCommandsRoundTripAgainstRedisProtocolServer()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:synchronousCommandsRoundTripAgainstRedisProtocolServer()]
 display-name: synchronousCommandsRoundTripAgainstRedisProtocolServer()
 ]]></system-out>
 </testcase>
-<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.001">
+<testcase name="redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()]
 display-name: redisUriAndClientOptionsCanBeConfiguredWithoutConnecting()
 ]]></system-out>
 </testcase>
-<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.015">
+<testcase name="commandArgumentBuildersEncodeOptionsAndKeyValueResults()" classname="io_lettuce.lettuce_core.Lettuce_coreTest" time="0.016">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_lettuce.lettuce_core.Lettuce_coreTest]/[method:commandArgumentBuildersEncodeOptionsAndKeyValueResults()]
 display-name: commandArgumentBuildersEncodeOptionsAndKeyValueResults()

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:43">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:51:38">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:58:44">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3649-e5f0666d/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE"/>

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:47:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3649-e5f0666d/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:43">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:51:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.lettuce.core.**"
+      "includeClasses" : "io.lettuce.core.**"
     }
   ]
 }

--- a/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
+++ b/tests/src/io.lettuce/lettuce-core/6.1.10.RELEASE/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.lettuce.core.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3649

This PR introduces tests and metadata for io.lettuce:lettuce-core:6.1.10.RELEASE, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 156344
- Cached input tokens: 1203712
- Output tokens: 22872
- Metadata entries: 152
- Iterations: 4
- Library coverage percentage: 12.74
- Generated lines of code: 577
- Tested library lines of code: 2936

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 15247/120331 (12.67%)
- Line: 2936/23047 (12.74%)
- Method: 878/8321 (10.55%)
